### PR TITLE
Roll out stable 41.20241027.3.0, testing 41.20241109.2.0, next 41.20241109.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-10-29T16:07:03Z",
+        "last-modified": "2024-11-12T20:28:59Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "695337b0d0c04fdf8b78817262c1306524490174adb502c764535cb9d324cdd5",
-                                "uncompressed-sha256": "baf9273ae3fae1dc4c38a62dcb5f05cee927a8831798d4641598ed04491879a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f4d73a6f14154d1e246975b404658135b49f70a92e7f33ee25a91e693c094532",
+                                "uncompressed-sha256": "da4558bd620c659204dfc1478bc26fcaef564c20340424e02a2ad3c143384872"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ec54f019f5c729fd75ffe543660cff2e77c6ad2e7263500ef21637698875ae17",
-                                "uncompressed-sha256": "98fe67825c2fb44689bd4fb078d57843b918cbf84be175d69a22b659f4888ac2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "376ee26e1080ee9e16e881d68e4bf4446e155cf1e4420d6bd3c9a2644084be82",
+                                "uncompressed-sha256": "c38920e35941bf0a3adbc16262ac945d45a746f921d0b76ecccc13ff48bf33a1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "58f6f8f829d3b3b8be6c0f31ae0823aacb44f7a0c0e7e7d03c022c26ea8964d1",
-                                "uncompressed-sha256": "e46a8b0486b044d98acbfb077ff4113f81e60a4206706bf9bcfc5bcc312444f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "2a61683422025c0929891a3ca11dafa2c59fa0a80d545507e97a0f97d320b43f",
+                                "uncompressed-sha256": "566baaf75aca55c8ccdce2dd2753c6a63c77fe4cda3e7d8360fc099c240df68e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0ce847b4c09bb972d1c7d99305a910d45523dc623596faa645cab6f251f28725",
-                                "uncompressed-sha256": "68600fcc4cdae13719f2eee36af73d4f8bdc096add8a86b4a38ee4c338fd1da5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "fcdd81ae87589aec471b256b695cd56c65c35798b64c1be08dd2855408fb4826",
+                                "uncompressed-sha256": "8c88bf9f5436d49db60f7e45ac441f391a83a701685952c8fb2f7adb14bf09fe"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "ca1c134678333bc011ca9f981a3df837f10bb665d31283090d77adad50e03087",
-                                "uncompressed-sha256": "9abc839ed80722571fa1fc2907353b7719cb0e48735ae678971cfc46ccc6e82d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "7e666540d7114100afd731477fd411e48ca9cbf768e775253c7a29e745688de4",
+                                "uncompressed-sha256": "9b15f21ce1039cf59ab6c060f30ce5009df0da5e4ca30e8ed0e697c2ea3d581b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "11b69fcc1d738c64f46b07b0e7035969b85ae4fad6c54728e49f621d57c01ecc",
-                                "uncompressed-sha256": "b81c7c4dc03d4eb4bf9d1f78070767b0727e179d07805078db1e41378ac6710c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d93373e4ae4ce14b56e9a13ccca84d5a5fb9df9eda6ce9fa623f77527ff49def",
+                                "uncompressed-sha256": "bcccb0beff7112970f76cbb8682c7c4cb1e7446ae1956e2699f46148a00ff4d6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live.aarch64.iso.sig",
-                                "sha256": "9286056bdd4dffecac31bdd32eb1eb9bd5923846a47dbdea17c73ac1f649361c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live.aarch64.iso.sig",
+                                "sha256": "ac54e6be56e07e93d939afb2afafb993e61975f116b407f0e74b16a63d4a48df"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-kernel-aarch64.sig",
-                                "sha256": "b7593504d57829cb34817c4bca93d6ae8feb923a46518fea4e6ea02d91e89c5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-kernel-aarch64.sig",
+                                "sha256": "9bbc0c304cdc2bbbe539c6ab63d3f7b173ae92a18c880f8b5d840ce5d36298a9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "70eb853b15d200a87736d84e212a58e6704d62f227b6212689a0b81c9db5eb50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "16527eb859b0e2d5703a013a6060f5c92fd84745f1d127218a8ae356d1e486ec"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "6a400c05b5426f5b6606b1e85b5b932b7e399f86d39842b1b60c11912d292e97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "13a3171f71cfc1db0772a6c57075c0d85c91748947dcdff3a4537b8f18cdb245"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "46e92583daf2738c8b587b24a56c7bc1691a98a1f38e7fa6fefc2cd4d7c7612c",
-                                "uncompressed-sha256": "717853d35916edb93ebdd2f75d5f3f3d6c4eea1e5c08d1df3411d0c4e22ea526"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "bfe9c35f19d1261050264ace52cf81f4c19795354d2df74d3343187acdcdf438",
+                                "uncompressed-sha256": "567e5c5af413b5c2b3c2365351917dff0c6dafa28965a2553930160a1aca0c75"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4cc321d3bc94ac58806a2e2bf13de3b717969ede67fce289fe2c7cf604f10bf3",
-                                "uncompressed-sha256": "3cf228d19a93b088a863ff6b1346ecb2b2f21307a470acb6df9d63e38f7fd713"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "ff0df1a1a30b423a8308fc58d331e71d0b67d7a5bb6afd45047d5ce021bbfb50",
+                                "uncompressed-sha256": "a78e922a164f34fe66935970cd99b76edba7d7deb0d80603c17fbadc502dcc9a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/aarch64/fedora-coreos-41.20241027.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "ac76144df558e84c6c7034007bc39707e855adcf9dda998a11e292d4614f80ca",
-                                "uncompressed-sha256": "8b2615c87b45490bb36b5bc3792f35b7b222c58c2d7b68e49e5bead6fe9d1ea6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1979a68160f7d4175c19351f872fcf69ef1e6262dde17915448b2e2c9e1b0df5",
+                                "uncompressed-sha256": "e7bf03dad25b4c687b746fd6bbd07c7e40ba77d1f72b2b0f7dbd6fbd160e4029"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0052c4a9ce764de60"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-082d3dfe2795cf636"
                         },
                         "ap-east-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0c23a460c7a325d8f"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0ac500410e844849a"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0653ed7eceff299ca"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0bd00af6ce37d5890"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-00f7223a9764da663"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-066bce52e5fffd941"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-02be959086dc501de"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-03a753c41d56c01be"
                         },
                         "ap-south-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-047bb167f0bc3dc3f"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-02451cf92fe23a693"
                         },
                         "ap-south-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-010823ec0cfb7e4ce"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-00b030cc38d1830bf"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0d91a0b5b6ed39bbb"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0197a6f7d4ad967c6"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-096e07bac59d1bf17"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0e963541bc066a7f7"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0fbfd5b5e418cfa97"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-04c13a0c75faa4c92"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-069e815bb8707f774"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-091f47f55ae3e7a56"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-026500fd7ee72bb5f"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0957d2cb193cdd735"
                         },
                         "ca-central-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-03d6494a87a68917b"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-031baf4d384865042"
                         },
                         "ca-west-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0deaa1d0cd45548d0"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0f892e8f6930ab37b"
                         },
                         "eu-central-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-01f4d241daa2a4c88"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-04f41ccedc5428f6b"
                         },
                         "eu-central-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0610b7c50505a5577"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0c65057d53c570305"
                         },
                         "eu-north-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-07798c27c5ad88900"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0661afe01a0a7e664"
                         },
                         "eu-south-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0c74912d80008f239"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-050c846376c35b081"
                         },
                         "eu-south-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-06e196587a8493e89"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0cd50cf11050a4d7b"
                         },
                         "eu-west-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0bc720a26c15bae8c"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-08d3627a362654f11"
                         },
                         "eu-west-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0e02b9c093c683c79"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0fc509266546893bb"
                         },
                         "eu-west-3": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-058eb2255d647d67b"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0f31895504ebe7388"
                         },
                         "il-central-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0cd4230cf9c39d231"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0e7489f43e741f83f"
                         },
                         "me-central-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0771896a038d820db"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0b2e3d8cd45870027"
                         },
                         "me-south-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0ebf2fd48cc8c951a"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0945d393285a1802e"
                         },
                         "sa-east-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-04e2a7fde931ec528"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-08e9accff5c38af72"
                         },
                         "us-east-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-03e519bf1d5dd75e3"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0d72680922e7aa5cb"
                         },
                         "us-east-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0a6860474ec2f61ae"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0c17f72ad87834f29"
                         },
                         "us-west-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-02ee1efdf02f543e2"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-04d2d360e02008f66"
                         },
                         "us-west-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-054e75cb2fa2d9d35"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-069d5f4ad656bbdb6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20241027-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241109-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "0cd948c280087de7d9aa3735b8ac2c47fc9f513202f77931cf2e2c8cf16e020f",
-                                "uncompressed-sha256": "8eaf947e507d88e3cef44c7182d31bca19784258dddb24ed4d0d2cb887bd058d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "8b0cff1bf88e15d134bb33137812c2d2597f5637f5f285d5e4b1b6cfa14f379e",
+                                "uncompressed-sha256": "9d3a6e90af8fdcaba198733449eab6d5cb5720c47d12e0b9f1782de98f3419ee"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live.ppc64le.iso.sig",
-                                "sha256": "f6b7c2cb1fc089a769ff93befc55be36ccb795786266344711558ae1258ea6c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live.ppc64le.iso.sig",
+                                "sha256": "101a5774c73b23c3d88e7c4c995205c9e20faa4bbf4e7124fcd121ccea7acd69"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "5c3a59742a992e2778dd5f06757cb90f5e616525b56f2e1ea07ce2831cb56b5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "be45daaec2933f2ec16ec24fd6a6f5b367def5039cd68587c463ca84c5e631ab"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "4dd25352ace4466e29ee92c21fd60baacc90a5459edc417f02441312611eaa87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "532b1a37e6afcd4c88b81ecedb5e483fe385a23844f09ce6801c6c1cb9fe64fb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "2c863c237a2a87622afd4a621f0c47245291f30ffb4c34b3b84dce97beedf498"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a33a4db62260469cba575aace8741f309cde2e5142c762593b3030bd2cffb23f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "567f43a2968ccac240db429722f5b2d65b98acc733ae2c8498a33c9c41582d01",
-                                "uncompressed-sha256": "ff96dcf1810beef9d2e5cca4642a65b1422720e657efcdd9efc9173058d0b807"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "77a905ac3e3686efa4320778f0694a0cf11909a6e6effbaddf47237e92dba62d",
+                                "uncompressed-sha256": "f3337ca63d86b342e570070fa9401b79bfa3966d5086223cf295bb29f4329c50"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e5a133988d70b1cdfba005525dfedf8d1b9e4ca1a5674c00927cc5dbb2fa65db",
-                                "uncompressed-sha256": "a145b81ca30278af4c02add057c3f357e55b0681ba806f8dfdfe5676d796ce59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f44dbad140df13f7ccecd03e82d3c0a71c4cf90821119192f07a1d004b6a1be3",
+                                "uncompressed-sha256": "fc4a09658a81f0b21e9639aa3f56f73e029cb1c5ababf8ba41aece114fc6857c"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "660e704b35b0b3693410127af85b2b8a459e608b4d4fe0dfa5613542fbbba336",
-                                "uncompressed-sha256": "80e789dc514c3633ba4051d149691f089897cc1ebce076e305db5ed35deab63a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "48d22c0d81e952449f62bd67ddf8e2c4a490382955566b9384e19d12f7e5bd75",
+                                "uncompressed-sha256": "4ac48b25c42fca89fef96bd65f524c1172e1067b69ea8785d16e3016cc76facc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/ppc64le/fedora-coreos-41.20241027.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "e748b50e38008689538e6fe0652f7b79a41f395c331cc7a60eed661e783f34b1",
-                                "uncompressed-sha256": "373058b8ec0c3c3621c7f390bf9b71795f1b13ef12affa45f5a29f3ea2de9db9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "f28b7dad55069a99f61e3f0ff34924bf7337a3285878b6d4f2b7baf751c733d2",
+                                "uncompressed-sha256": "5faa13f345cc6dc3f65a686c15bab04f377a7ce3cc81fc2429c20a0f8d15ae58"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "aee24f73b89d5b24ba6cfdf8200fd2aec7c5c2d47873876b8caded2d4eb6a35a",
-                                "uncompressed-sha256": "7967e960c0bc65471f246cf118888d95bcc6f10b073c1b502b4c2c611b3ca0d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a4b47f38d51eeb07a0fbbc9991e10cd06ac087968f595250d3d8383f2d346327",
+                                "uncompressed-sha256": "e80f97f6bc5f5b33ecac15692ad1752e7c790bd2e274d15ffd5b3a2661edac7d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "60e841b9b34f12aa2064a6e355bec34628a02f84b5ab650dbfe5ac1b739ce0e4",
-                                "uncompressed-sha256": "ea6c8ffe5fb1765027e6dc8de2f9b42e0331fc66cef25c0eaa2c4fecc1f3c9e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "cb3ccc894400ea4b868763368b53737611bfa622b7d638220bed228957d0df41",
+                                "uncompressed-sha256": "ae0c24b8c4163194ef2f76ba95f24066d00f04429e27feff8fc362b5356cf30f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live.s390x.iso.sig",
-                                "sha256": "cddd875cb8b885c5aad291646428b1db6504b69d43c645fbd82ff3cd2973cbb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live.s390x.iso.sig",
+                                "sha256": "ed5e01536fed8f179ef576cb58fa0b4ee27e3340723b876e16b043fde057e863"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-kernel-s390x.sig",
-                                "sha256": "e470d5ee058c8bc9439d44e3338f569b76012d7f588b31e5fe5073bb9ad3b770"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-kernel-s390x.sig",
+                                "sha256": "8e1100819d5840b74d59cf37e4e2fa3679ba8a5b733ea15b63d43f98604703df"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ada1833467239217d990f271730942b5376ad15a611a975189f829f6de7623c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "08ca2db82c30b34411289bb443dc80de98f404d3c68373c43d3b3fc265f9d8da"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "139d5f9c1275cd2efacb3a6c487570dcc2e8e328ecf081852dbbc84ed715279e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "88f177601003ffc882c678b1f84557ff5cd6622f380d3909edd316fdda0927f8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "2ae9478f9c561ff8141ecf3616c3019fda97498c96deb18ef9855b8ab09974ca",
-                                "uncompressed-sha256": "0de528da7113d0352bbed19d22d2fbc763796285f139d061c22a247f46f0df18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e288e64d0ad23ffd306ae19fafd9ed1602de8ac5a82d4d91c3e71c86babf862c",
+                                "uncompressed-sha256": "b3155aa82d6b30a174c4db7d397091f6cae692149793f0a773d0b83b7fbd7f64"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "80d5b822cc83d64bcc07c4aef9a09f6ca7b7e1802ea485b30477e9e644a4172e",
-                                "uncompressed-sha256": "36917de7a56cb06b1953c43cac5864a2128d1da86158312640df9cbd65e9e05e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "684686d6b38c24089311729a2ed9dc7f24a0499cf32e51bc78eb00f20dd8a960",
+                                "uncompressed-sha256": "4f85a2c545e952017dfa8f1f079d30f7af460de96354d565051f531aa261ec9a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/s390x/fedora-coreos-41.20241027.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9ecff791204a5f2021949635215fdfcecfe33b65bc49f5616dde3f5331d7a6c4",
-                                "uncompressed-sha256": "570b2492dbf5fc4fd1f46e64874fc2a83e83716117d26872829e8c0fafd6910e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "194537f8edadbe0fa06e3d709acd9f566dbd915368df6008f4abd88e03e2b274",
+                                "uncompressed-sha256": "6212c9227e751e7be9624fea05b74ff500e5a4e03fa4874bb671edea5d4d502f"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cd692cb82506dca1390782c52af435595f1e6c89a8f72cd98ef038e244e0ee97",
-                                "uncompressed-sha256": "10a75207a552d0c67ab28f5981b8a900b8670d1bde5498b6e6ded89a1dcd901b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4caed02d536b2d39caecccf0a539b75e63e3428ae4b9450cedf1a8f682f5a5ee",
+                                "uncompressed-sha256": "051a8c75c4dface9f196aa2995fb02648b5ea40bc372d2b8af586be268f12d26"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "8303477fddc9f89fc2a977c3d4ad6888c3683e2ed75398688a67a727cc5ede76",
-                                "uncompressed-sha256": "e2ff240be747f287166490a626e6c6f6abcad86e6665ca91580a0c4966d36b90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "475b4dbe650ab8f7dd437e03aad64225aa205f927457d00f5cbcc2629991714d",
+                                "uncompressed-sha256": "120053979680ebcfd7b24be1ebda13c52bc3d37eef36510be7a209bfb1434946"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "cc624e722af04292d78641e5927612d0ead94a3297b227571e76774167534f46",
-                                "uncompressed-sha256": "5954f333590b7bc6b76fc1590d4fe94a75c5b10ac1ee050a97f3902fcf4dee0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1b69428c9d545c7d93bf2a273ecffc64263be7a26838e7ba575565bace57f806",
+                                "uncompressed-sha256": "e1c8f9d420aad1d7d155e0ad8e8055b3b836adf5bece063358e6a025b352d8c1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "eabc2d0ccc186bf8704fe19eb9ea221e2349aae4f65cf8eb59aa766e5697c88c",
-                                "uncompressed-sha256": "00f463bbf0ef774fdc420910154fc3fe4a006ec623a36ace1210c246f069b64b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a542fcc5a4b33a62de5c8c9c1bdfad1ee3a9d85975963a670e1b1977ba9890c5",
+                                "uncompressed-sha256": "3bcf102bc5b9ca30e8ed618e640df0c0a67ec001e7560cd3d302ce44df04c122"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "93d25988e6133ae28138f2a213ae3f0f2fa31826c4e86c053ee5c2e9bfb5fe3b",
-                                "uncompressed-sha256": "e2e5ecfb7f38749d630078c649c1971c5607c94acd23a2e3c2bdbc5d1473ad33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7c7c8c139c6998f9393532d3a980cf3cb3b977bcfb3284420615d43a6ee2d910",
+                                "uncompressed-sha256": "6db872386efa22a21298d0be8cc9ce6b22739bb1d0d94e5b11cb15dbe3bde150"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "378f2017d94d3a19ff899d43dc46c769f4bffdc8f5b5a21ad3afd09f77d7046b",
-                                "uncompressed-sha256": "35ebb8319f7a5fb0b34ea919851298bef8e1a18dd17f2ed5917ecea5f902106b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "52d55b3f7dfa65a6e875ae58ca3ef249c6809c68023152f18576c514454452cc",
+                                "uncompressed-sha256": "03b6a29009e325d7c6b95958f05fd41f7ba3bc411dbeba4929306bdb9c0470bd"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "732bd8e6bb13dc2382386051a2321609b183c587ef194e8ac0b3baf2cfced13d",
-                                "uncompressed-sha256": "0ee8854b457b72381255707cb89cc266d39ecb61368610b786d4967784b1a597"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d20224f1df05b3a12cb9a401a5b692a59210da85d3ad35b41a5914c725ca06b8",
+                                "uncompressed-sha256": "b6ccc4c10cdf2dcfeb729f095b4a3dbd212b6c948e5cf59c82ce8eddd013338d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2cb91fa7b472f8d434d814f18659013117db0fa8838fd0d2d07bd80a82c63064",
-                                "uncompressed-sha256": "45a7b288e29055f32de314cd8e27ae7b917ee9888c9bd52028c5c430db52aca5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9cb91fe762952464d670127264cc8e73ec69540f0b6fe064ceb2d1fee83d0850",
+                                "uncompressed-sha256": "195f5babfa97bec631b453af9aed59a461b51d67156283f61f73cb7a35d3f3c4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "61c5c880329d469f1f47bc0cb19442953b1702724666010ed09f661e9d2109b5",
-                                "uncompressed-sha256": "9434cd5699bedfe1633726bd7b2c10c120b4fa19c0f7874e51a37a19d36c89b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e45af0578c63f095cb8d2b3c9246c94e32aa0ebb2746f69ec249f3dfdd24a0f1",
+                                "uncompressed-sha256": "caacc4603c6d0d90d7b0ba89f6938ca719d43dafca43ec70286de494a9a76c95"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3abd17813efdc097f951bd6149d5da82c8551fc2435aea2763f7ccb1dd76d8d9",
-                                "uncompressed-sha256": "78c457ff1838266628db9d7bf4fb4cd0719772f5a8f75875c9515af8b1f8038b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "85a0893667ec9dba59874c49f10e6368df1ebf8e4ac56c73c477d3c027eb8081",
+                                "uncompressed-sha256": "0ccf3fa71ddb5d78b39c14c8e70b140e69bc31900d55ff2855b27dbd618d5c3c"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "56e1e1ee0cf63f5d33c811269a16b4bae0affd2b0c80bf025cd733a0f1aea85e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b2b40b70cc1959f52e3b61a822a39d49ff887800c0413c9753e32f91af55f137"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3f498f8fa5c159d37b47d7369ce4a90dcb661be757ee85616614af99f6ebb4a1",
-                                "uncompressed-sha256": "391b61318f8de5fe96c78f6559cc6abe16b9d8e2fed9ddc2ed6a4f3644358b42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "91d39e0161aa23877a7cff3304447daf97a8b91207ec1b1dfec31bb104c2e1c1",
+                                "uncompressed-sha256": "62611e0a86d8bc28994a436af6a598bdf6f112e0ddd49d7ce17764b376e1297b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live.x86_64.iso.sig",
-                                "sha256": "c487964c53243c49272709b58d79afc47e130b8a95fda56f72569771914f9bfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live.x86_64.iso.sig",
+                                "sha256": "46bc10a249243029648578f4430db27e105d623cab750034bb263822a8b41c0c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-kernel-x86_64.sig",
-                                "sha256": "4a8f189eb2dddfca6495f5e951a0099882e1453e9f6629ad4d961f99428e12c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-kernel-x86_64.sig",
+                                "sha256": "65e863770c2e40c9221b8e55623dc12372ffc1c01784a9b8103122e9f19556ac"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "393bbad4ac42ecd31db1bcde8e94b032e3544bd61b881ec6014384a1b8d86341"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7267ce9527a98a8468742f0e6cc46e10b96c62dfa138dcfeaad4ab8b52e612b8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "73e7d4079eb40ba4bea09e264d0e4670fd70545ab9b0354e818ae45bcb816244"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "bb758e7483f1a4b7e13c0488790b544fef81e9044e12ff403e62bb633aaaab64"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f9fff745521ee0ba15c83f8bd8257bb38807e8778aba2681fb8cb93e0c620e20",
-                                "uncompressed-sha256": "55c64a53641b68b474b0a726bce93495f55c21349b8e401e14815e37711ea6e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1d4a1b235b0d15f966fcc1ac54e054918a0ede3cc3f6d454c64d03c737c9128b",
+                                "uncompressed-sha256": "18e10ab619d0fee57859c009612e44810ab9937c3a102b1f4e9b8c5702ed742e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9dcc80749cda6dc0a75f8399f1ede8c929a38146eed9742b04683365ed83dd27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c6d5a07abb7d3ee3ad6178ece8b014d9b995a8bb32f550b09f894c6256c2f8f0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8ee41430934ec3f07c115c015f952c99a67be6eeb506aa44f41bcb8c4a3c97bf",
-                                "uncompressed-sha256": "267c4073f869628e7c1fea1a9e0d279ba7dae902049a6a2acbe18d0e18b476a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "03256c8da86b69dd81595b0dcc2af58371d8dfa6439647a889c8a0a9143659ea",
+                                "uncompressed-sha256": "a651f9e809ef8f78d9ed66ca3bf534258bddf88372662a620cf2b6fdfce1801a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8b418b7ad18a26c31ad91b52f5155305da143c7bb0624d6619f8f0a709ebb421",
-                                "uncompressed-sha256": "0ce6c0072c4ab562dad1d1f47e9eee9f4bdf8aac7ea30a177742f670290c4961"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "13e695334fba5fabdb77da4990eca6aa5b34be1f39bca2be404bcb6b8914f4a5",
+                                "uncompressed-sha256": "4b1ca880f78f54a987b4346e69d7d70e1f91459146d2ce9e4dbbded39f7adf17"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b2ed1a4db2242e328d9248ab22338d11e7d378209cf2d8c64cda13ab0119fbfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "66a363a8343eeea9fa56b625b52ca204072e45c8ee4d00863ebb1396065030ab"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "8009fac73ed72edc4cd0a39ca9b9f08377cc1f7fd65d5fb3d1b5a5ffd5fa367b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "fe71225df3bb2a90b00a3bd72538bf831e9f647a9bee1da6637efcee207e407c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241027.1.0/x86_64/fedora-coreos-41.20241027.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a989d9d4b191c1cd395542e032872cbef7e6506817557d8fef3e5ac2b5b995dd",
-                                "uncompressed-sha256": "16ec2c1308a5fe797a0444a9e874a0f9a5b6ba258dfb0048ef205208d0d4643b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "22b5886f6f9f4aca56a2211d1ec6ed4721fb080fa209e208eb2acbf537da412b",
+                                "uncompressed-sha256": "278fd3754e3be103d2d422f9ddc9d0c265b3d4d2a79540ac822b138347e30199"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-022f2520cb31c6b0f"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-04f28162a1fbf9473"
                         },
                         "ap-east-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0b92a3fa47667bb4f"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0a6d887945ece7c56"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0a5304a75700faf77"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0d3f8c07364d4d8b4"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0e0d44570a550e900"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0ce35f2ce0095b808"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0832e6ae897193108"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-05deaf1d684d6df2e"
                         },
                         "ap-south-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0a2d42193d9e06913"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0ac7a8375bd4a486b"
                         },
                         "ap-south-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-09a4a484f39726d38"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-038b4134c0b44016f"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0adfca117292f6215"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0636c8961eff4830b"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0fc04373eadeda8a4"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0e3f9176d4b0a5503"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-00afefd6e63dbbaa4"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0c3df8231bbd41406"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0a7d277ffd27810b0"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0835b21dbcd528011"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-048f8e1b8c36b1076"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0947a4a8734bcbbbb"
                         },
                         "ca-central-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-025554c4c3bdf0449"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-02f8d7b4ff7b49eff"
                         },
                         "ca-west-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0ab50aa6b90862a9d"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-01a5cd49a33e076f4"
                         },
                         "eu-central-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-044f7e5a111f9e2c4"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-091a7078abbd79226"
                         },
                         "eu-central-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-03845d7021ac7ac0c"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0e3d6607740624268"
                         },
                         "eu-north-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-013b696d73916eaee"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-07b88834171e83655"
                         },
                         "eu-south-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0bd9031cd2456fc0a"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0dff3e5025975447d"
                         },
                         "eu-south-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0d5db36f3ca9a6107"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-004906f21427973ae"
                         },
                         "eu-west-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-019408d38e9406a8c"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-089625db614db5eea"
                         },
                         "eu-west-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0e9bda5530495c105"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0c4e89497b2457269"
                         },
                         "eu-west-3": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0291dd86f2bf073b2"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0bebf025b51cbd512"
                         },
                         "il-central-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0f109379977debbfa"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0ab64dcea6bfa65b2"
                         },
                         "me-central-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0901a6d6fd6e05667"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0e2bd5e79779290e8"
                         },
                         "me-south-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0bb9ff0a893fbd016"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-086c1e294b30a128f"
                         },
                         "sa-east-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0b5ac1d26a9b4a2b9"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0dffc9e64f76f07a1"
                         },
                         "us-east-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-069e702aef921d353"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0879cbb5532f58251"
                         },
                         "us-east-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-05c3be060514aa2f6"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-03ce0938e3df96957"
                         },
                         "us-west-1": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0df83060f8d088b7e"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-0795144c21c1ae0e8"
                         },
                         "us-west-2": {
-                            "release": "41.20241027.1.0",
-                            "image": "ami-0c20b79262f439ff6"
+                            "release": "41.20241109.1.0",
+                            "image": "ami-07e1bd65512c94dcc"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20241027-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241109-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241027.1.0",
+                    "release": "41.20241109.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d60dbaac9b620ede6275f7a93f32583ae7bb0b3dc81800aa527fafb566ef3e0d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:97fcdbd301c5cdce0e0f83f4ab208d09db9f05ceabd7a0d61ee41fc66381f177"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-10-29T16:07:01Z",
+        "last-modified": "2024-11-12T20:28:55Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "8bd0e85a5c886ab44ffbbab273b2df21c590d03efe0e62a1dc2c2eb00c4340d1",
-                                "uncompressed-sha256": "6e1799a0526f317b14db3ac21c2f8ccc1bf81d356d9e4c80236d497900a5bb0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "9c1373e7d046de4f3028e5a74f437a79ed02fa5d18a5afaac466149ef1bbc948",
+                                "uncompressed-sha256": "0f4fbd9d114af6d2b8c3c22877348c195b0857b6202176f5a26028483613dea6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "7e7f9f4fd281a80bc29dc4535ac8f916347b4614587135c1a735a0624f9cf6dc",
-                                "uncompressed-sha256": "6c7c999e63431dd2f463db1c1550e3ca3ded26b727eb72d4959251473557bea0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ed7a7a5d7b7083e5e0dfb82d75488c99b2d2c68698dbc3ce411b1a5ac7758606",
+                                "uncompressed-sha256": "b24f5a180ae2f56a5d7006caddcc929832553829a4a944edc619be1caeea0cad"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "1c5501f79e0aa7c736813ee5543bf3551233681420d5a9db2cbeb56077f875d9",
-                                "uncompressed-sha256": "d914336303e91d2b97435d85398f8b4d8798ef2ba1a80779d9474e6bf15feef3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9341aeca7dda296094955319a6a5991b41db2ba6e7ee984e8489c23f199c60d9",
+                                "uncompressed-sha256": "2d964c83c6d31a17869bb884fb23a2f2183c23955f6a2c1684a0b059ea8a883b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0322ef3901f3d6bdd61b9c5e6933cea3eb80f0ccaff327505961beee4ebea159",
-                                "uncompressed-sha256": "e8e291019c2528f0405af7e08a54e8646f717d2608cd4cc13b6659c50a42f78e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "e49e8890f38fe20f734e4934e87c4f591f7db69819c2e0355bb4f653633a6697",
+                                "uncompressed-sha256": "581b2c39c615e9561695d6bc49020487b3af8d66cdee625ddf7b6224c7ba8ca8"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "d2708280833caf1d6156195d896b8614c3e4f045b139886987d6394be32ecafe",
-                                "uncompressed-sha256": "b765eb58c4777b24523610bcca6f0dc4af7c3c345d7ab593b9bb0b84b0401d46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "0d6f356f1464b4b16f8dc2de89e18bbf73dee66b4549823cd7a93347c37ddf1e",
+                                "uncompressed-sha256": "ae4ff8bcad59b93900b83e5794fd0eabc285a8db36c5ba180a285cc93789daa0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "8052cb0a615319b99206401ec361bc65779ef4286f5563625abf7bd671f4741c",
-                                "uncompressed-sha256": "3df44e626a1219f8f8abb7e3cff550bc3e1162aef4acb3acd770ae7d8be56924"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "1eb69380c1fca9157f3338fdfeb83c5a5ceb3a2689c54a186f82fad28bbe93ea",
+                                "uncompressed-sha256": "c797905af619c6f510145556a69f5a42a29d37146e805a16a59b7f3250a4ee3b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live.aarch64.iso.sig",
-                                "sha256": "c5b5e916ee147d5e812f841374b84c8843de3da4f1b6694a64f6d23d6f7e70db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live.aarch64.iso.sig",
+                                "sha256": "f90a2c252eeb61695b751f31865dc662222fc53966f0016d982e4cb8c9273fb4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-kernel-aarch64.sig",
-                                "sha256": "6c0b0b237412921c48ff83fa5f787463479c4ae539a77c647ee25f27608546b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-kernel-aarch64.sig",
+                                "sha256": "b7593504d57829cb34817c4bca93d6ae8feb923a46518fea4e6ea02d91e89c5a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "23e3e32ddeb231ff63c644873244d75338099d9e1eec25d70bab90871c9a2ccf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "066823fab2a06f55191d999db1357c8d5043231ee65f7cd633493354ae354c34"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "376cee3253531639142541668863d1c8086c06cb4cd33642846dbe1b0e7dd2cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "15ef82582d35540cec9e2ecb19874ac6d91e06f69c5a879dd7948de6941ba938"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "98747123f81ff1c21bb82b7ca2d49a406b3a1e7bb3f6a8537494eee0433ffc54",
-                                "uncompressed-sha256": "c0063caaf48a1751e8a7157b8d12be056d83ec1ca26f647b213818fb00011097"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "4bd703dd49b8aeeffddeb957d19c86bd2528733cf9a3f4799b22fde06f7009af",
+                                "uncompressed-sha256": "42fc3c169e4ba9fae07b6bf43105ce1df85d9aaecee1ec37b8735d473e9f2922"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "03604a6c1ad717f6f0a8c09f07f58d88c8989ebf5cdf25a974a77103c8f50733",
-                                "uncompressed-sha256": "49aef8901185ce30eb39bb13e80c27bf52b733bfd95ad1af90f1aa59fa304320"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "f32b9ad724932f17385374a4ded1c46b60c1a2e6159a6e0aebc58b82d75f4202",
+                                "uncompressed-sha256": "da86bcec921652cfd49a192936480fd550843ccc6d988715e08a381857da1e0d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/aarch64/fedora-coreos-40.20241019.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "692cc0ca76a3165b292a27ab716068788b66444d3f197cbacb41f2e6157c8c45",
-                                "uncompressed-sha256": "74b51876dd2c1e6d800fdb3ea7ba4b4220c521acbae6aa9219eb75c25cee40df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6c1d137d06bfcbc829f08647f444d4a0847f902779983945c5280b829ee044ca",
+                                "uncompressed-sha256": "3147e88c3f0f9c0e829e5eea85dbf8353225bfacd7618d53f6943154d3a6c945"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0c98d8de9caf23380"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0d8684ee8b9ef02a1"
                         },
                         "ap-east-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0771aced057a8eea5"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0e6c88c82632f2396"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-08438e3afa7ad557e"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0eeb0566ecbfb009e"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-00d4a2351eecee7d2"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-069c313c5f0c585fb"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-00231bc37a2f23617"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-066f294dd8690156b"
                         },
                         "ap-south-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0dc792c7ebdde8b0c"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0d470451187bef771"
                         },
                         "ap-south-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0b78acb9e408d0999"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-00924226fd603c114"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-067ad6ddba7bcc2ae"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0a8257b03a4726fd1"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0e33df29657755758"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0c28728089e75a4f0"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-071228d6de97b6618"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-015cb5015d6f66e97"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0b9502d9c5537fc35"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0d776f99dddbad5ce"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0d9a63b8cb452cfc3"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0fef4f723cd026312"
                         },
                         "ca-central-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-063e930a18c96d141"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0cc61c1e9dfdaf4fe"
                         },
                         "ca-west-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-090614a38b8f1bb03"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-09bc74cd1806f5bac"
                         },
                         "eu-central-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-03d7abf2ff00c9a39"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0ceefd6010d12f8ea"
                         },
                         "eu-central-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-05650cbf4cc67f006"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0c401c3d5b4159389"
                         },
                         "eu-north-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-09cf4aca18801baf0"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0effc13a7c9defceb"
                         },
                         "eu-south-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0663821a91fb486b8"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0dd5fc44ba7be89e4"
                         },
                         "eu-south-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0229032834cf7cdef"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0a4120b5478c0c344"
                         },
                         "eu-west-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0b331918c7d8cba86"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-09a82458e40ffde07"
                         },
                         "eu-west-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0550e109f95fad9cd"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-01f99deee18de1d0d"
                         },
                         "eu-west-3": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0f629a198d4465fd5"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-048470b13121f9043"
                         },
                         "il-central-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0192a00cf2fbeedd3"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-055e5803d2dfd903a"
                         },
                         "me-central-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-049843d2430045ee0"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-04975baeb8daf1e44"
                         },
                         "me-south-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0cf52992567807cff"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-016905336acbb249d"
                         },
                         "sa-east-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-08d57aade92b345dc"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0a3f789251d67002a"
                         },
                         "us-east-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-07ee160bba3bf6138"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0e37f372c54b69f34"
                         },
                         "us-east-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-064f39f3d427627a8"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-03488d76e1a8a8389"
                         },
                         "us-west-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-033793052cefc36c4"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-052ae089ed932cb28"
                         },
                         "us-west-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-09e942c71d289e3cb"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0b6cfbf5b1b41a005"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-40-20241019-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241027-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c2c4d319426337c14d95b2b63e4ea3efe2daf34071eb836a7dd7625dbf404ce2",
-                                "uncompressed-sha256": "d5801bdb8a1df43149dbe8291a6058ca599c5bac43167b0b5c5ff0865ad48d84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6c4fc1cb199fd5dece367d72c0d558d879767a0ad19801ebc90bf18615a61bc1",
+                                "uncompressed-sha256": "4fe092f342d3610e44da46911a7a11569e31acc2640d1e8c687ce490ff75d136"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live.ppc64le.iso.sig",
-                                "sha256": "ece35d250a90a61d561fe8f7cef8df05dd0ddebfdf3db200a7228fe0d64bed68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live.ppc64le.iso.sig",
+                                "sha256": "1a19ecce5c9ad0a91c154ba96312fc2503fbbc6d6962e74adfa08d8e586d6ab7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "c3e753b8c82592436727b0cc0717a55d5909fcd3c5ae3b4db7a36082ac5fd6c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "5c3a59742a992e2778dd5f06757cb90f5e616525b56f2e1ea07ce2831cb56b5b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "fd6687fdee323963f2908cc79c4f3e69829093e4921a796d91b55019be5b2d2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "a371d6927a77d7eb77a15ef5bcbf25a2a0f1f7afba000fcc88c32a2c0d999dc4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "9c7d4d067ff9355573a686bd96df7d8b6cbc95e72caf44a508eb2b14448ea551"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "5aabdf4060a863070bceaa8286944638ae6ae03cf08308a96e3dea17ea08c001"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "175417fa2a14521fe956c1d43fe0115afa0b9c0f4764c5c7719b46cb0a3f94ae",
-                                "uncompressed-sha256": "9ccb36bfb24db9c6180e6a8e44cc8711d64245a48c19f8ae1bc1a8df9135ffbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "eb1bee3543725a59d5d2c64583b1350dc295107126fea58a4a0c8e5ceffed9f8",
+                                "uncompressed-sha256": "eedf744ed0e65591bdf524181107e0a3d2ec1b8f271482411d78f5b2597f2927"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "04736ddf98b5ee779ab470988b10a4aa9a902bf4ab38dafe5992e9036591b32c",
-                                "uncompressed-sha256": "3e4da458cf817f75731c7b1dd0b173aa209a68f3bb68b1421d088b9657dd5abf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "02e4c65ca75610f775c5cf81bac7a5ad2f9419d3f5046e5e01d803b928d0a66f",
+                                "uncompressed-sha256": "84c7f10f81e1915784f80fb1887f4fca572920c9ee8374d5121eb98c4a771f90"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "711d40e0a18065e861407fc3324ef729d21d172b8c6b07f08670c15e313bb695",
-                                "uncompressed-sha256": "e919a7e9b26250cd6d1f036af5d4014e6895cf0b447af529c7e84d385c0de7e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "65447f83acfe58ce58cec2b0fc2f360a45d158dc18fb9aef0ff6144c5230a38b",
+                                "uncompressed-sha256": "616b386579121f50eb3cef4437c3ea0092ccda526f0d4e4f1dc7067d86846eca"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/ppc64le/fedora-coreos-40.20241019.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "f68bdccc3314d6968ad370514a6a97ad171c35767dba8f0b4081118fffedda6e",
-                                "uncompressed-sha256": "17d9708a446c78c845d09f57adff0ef01aa8606714d8579accd9d1dcf1e42cb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "a614be6b27ccdd1b8bec9d8a991ecf84070efee7e879c0d498e6147fce1d9242",
+                                "uncompressed-sha256": "46a34e064f3fb53c2dbbcc3d5daa08aa72e278bcfe6f3857896835485065d65e"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "de99ee4846bb99a4d081fc9d3f09150cd2b71ad38c5f95f7d46b63612cc38071",
-                                "uncompressed-sha256": "4cdfdf137616ad3f30bd88bb7566db7996f8bdee4f6f54582e95a0fcd52d594c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "2855eb9858c9703fc3798c8755293a23f28d06587bfdaf8a5eb7406d5ec2ce07",
+                                "uncompressed-sha256": "d5799842fe3519fe18bc9d36d2d8924eac82a16d831f62288d96716f81f4b17d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "bb0f248fb21951d961e74e5568fa4ebe3919a1669a04940697013d847b8ff2b2",
-                                "uncompressed-sha256": "103c0b345671f9c35d766a4f7fb782f76a4a015f4aabb0ef9d2dfd25fbc90f76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "fe5bad2da9947b653682c66233e68eb141b2c7f969ae8e2d1fe4e6afb8fe8ae6",
+                                "uncompressed-sha256": "481a5efc499588ec93cdc2120e3d04a5fe563a2166c95daec49a6c0eed7825dc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live.s390x.iso.sig",
-                                "sha256": "e2838fbfd2ae5b020befc9e08553a0c649ab9884e6f3bbf561cff37c028e84d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live.s390x.iso.sig",
+                                "sha256": "ac58b46bc662c7e3cbb006d5c6142f96d75201c32d126c263137e6e20eff7e02"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-kernel-s390x.sig",
-                                "sha256": "ef6d3d73ddf9b5f77f46cc5e2ebfce15488e1e9a714b94855d7764dedd4b6ec9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-kernel-s390x.sig",
+                                "sha256": "e470d5ee058c8bc9439d44e3338f569b76012d7f588b31e5fe5073bb9ad3b770"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "bfdc6e2fb7c2772738d8f27c4007f0f38629ef95200fd7ee6c3bdc8a31b98906"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "66a432775eefef6d6b896806fef94238c5c96aa4ba0535f1ca8f4b55bc15a237"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "c8141bd0477c09249075d05149637e42a7fcc354ad87eeedaf5ed52ce6a9613b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "5711c04c8da10de1e20e1d5075b03ac97a542c31522b540dabd0c7ccefa1cfe2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "476706d47401f76674ddfc34fdf6ccd46348bd3dc9d7dd13aac9cc9ac6af7585",
-                                "uncompressed-sha256": "cc3f4588f715252d9b45909571af58b19e475eb2ff6bab9db55e4306230a70fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "bbe6a458e61971bcb20067324f8960e0d2af6679d95af06258de821588378089",
+                                "uncompressed-sha256": "fa731344d690baae057e45cc03f0121a0b1552095f8a1bd4dd31b304db48e62a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ac5055f6719ffd66dc785161d68977192b824437eece02de5509736df4179ab8",
-                                "uncompressed-sha256": "72c35d1f646c0765fdcd909f46b1db302e206df1b5a743f3e10c872173a2082c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c58d718c9d02e7e0180ce5260d56a0e5ad5eb6d81e59841d15d023b885113cb3",
+                                "uncompressed-sha256": "f6b2040ec9be8c2a4856cb91d275ecec52e23f31e0d8b2a797ccf279e9af8d2d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/s390x/fedora-coreos-40.20241019.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ff01d2354737c93b4dbf294f4ae85f9d506aace5f8e7d2bae76e5d94633105c0",
-                                "uncompressed-sha256": "c6d5269ce23b68e98899aa6164c3ae8f4a1573545348168e08ab7503b895dd41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d78efc23a77c6da96a4d93217944b51654ba787743c7fc4fedab6ef82566000a",
+                                "uncompressed-sha256": "03d29426d849e59f45877507adf9257ae36ec0a381d5b237e4538e35d80a935c"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4383e8779b1186e52da08cee2dc737b9124a38795a82f397ed5ffb61f9090058",
-                                "uncompressed-sha256": "295fc33b65903e4958e02741317c0bbea5e21980fb6f6f2f9d40df23edd557c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "74d117c28e95952f101ea66cdec906d0399bf8ef158a00935b2483f1c5317ae5",
+                                "uncompressed-sha256": "557b340e70696bb56b5211a9181d1be66c9783e455efd57520b6d31ebd0270aa"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "1d86d7e10b062211c96bb71e406d155bcfd91e0a15e89d9eb6caf64594705053",
-                                "uncompressed-sha256": "5832624a68c494ae41f76fd86e712e0d40e1c7a4b84c0de586edd18d28519f05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "3cc0ecd71667cc2d3c84f919aee690eb71f4a57e036c8c8eb141b082bdcd7567",
+                                "uncompressed-sha256": "cf8fb15d100335306386aa2d598b231d7d490dcec2245eada4ffbc9818190f5b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ac8e93dbf213b62d37d92d7111e6ce9cefbb8e66637fe28874dea363c597ae93",
-                                "uncompressed-sha256": "c0d8e95be849deb0d31e12bf0934ee298711ffeff00e09cf1686ac0693f5ece9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "70507ca0393e2d8d7374ff3d9a1c763057d62edd35a02a9790908741d7e59f8a",
+                                "uncompressed-sha256": "8ffd94842af6b96411ebd06ac9fe5edf3bb253dbd797dced9fba08c1aafd0992"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8bb05e8de44aab58a5ddc6bc2becdae9d0f7ca16836326cb2a5130bc0d23f317",
-                                "uncompressed-sha256": "4e27ed10b33818c1231009980c98a2372893d0bca5d8f73cc3b899911bcc9bc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e8f5ecbe0a8c236a6198a4e85195cf5eb9e9f01ccf6994bf0e38a922392db5e1",
+                                "uncompressed-sha256": "3b411d977c9444a04ebe031cbb140407edaef0dd32dbcea40ed3a1a00136d829"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "d6b6e97814688c419ade95eadd59d7993327dc9496ae058da411c7fa451fe19e",
-                                "uncompressed-sha256": "68459f199f8787d17bff5bfe0e4dedcd45b96f4940bd59f95685a56c631225bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "972cf4a288e456bf96424e99cc4a3afde700b390a86c4057b2dcc59587318101",
+                                "uncompressed-sha256": "cf082c26322ddbe646bd6c5d738d3c77429a9d3a577460df2c716e9cc1a49d9b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4db60e73d943fd543d5f9094588342d76483140e01f89510e64baeedbc1f2fb1",
-                                "uncompressed-sha256": "7923d41689eae0857d951544226b864489267b99ca8f156978c242068300cd12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c06084ede43852eee5b9b1356d6d98b6538400bfe322b1995096201653cd38e9",
+                                "uncompressed-sha256": "fafd966f3fc443031da6a1faa70e7bca3c53ef4ea211c55bc019791390024a84"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4c4fc4be5c6846763476c5e46a1d77255cfbdcf87afe77817f50d599aa61bbe8",
-                                "uncompressed-sha256": "9d3508cdab015430fc295c6dca7186aecf00b18f6eac1ff1aa991b06fed84408"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1d82760546d8b6642299fcf1cb539fae1a26d7ae6c0676e59646a1f81ab43f4c",
+                                "uncompressed-sha256": "123d35426685c1fbdea0c1a5276ff557c9a13494a376220ebdbef7b277b4cf6f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "e0cc4c6a74ab10e7bdb26b7a0149292788a18c97f5c232de5d8c050ddecd2a66",
-                                "uncompressed-sha256": "87a57cdecca91f8573ad6e119671c3c78ff0713af18e0d9b6b4c7fb88e698b95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f38df19b6c609a6b358d32935d8d4b2f7d0fd4ff920f1a012bba36b28e1ed6c9",
+                                "uncompressed-sha256": "1e4e79b82823c7c5846bfa50a7f422744f43b3843dae5f9feb7711ecc4e383a0"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e939f4574d8c88c5ad62e4716b7af7bf2d72152ed84a9662808243f9af108a32",
-                                "uncompressed-sha256": "5a5651ac6f9ce271047e9b17eef06e57d64a337d5d678ff17564faeed68303b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "1227d7bad30721e9360d18426cb569a6fce9035c02874e5b56ec9fa81517fdf6",
+                                "uncompressed-sha256": "47005a6fb9ef3f48cd96f9d929e604852fa6809d3516042c3968d9cb15fa2237"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a422e8f7740625b3744681c99b2190e0b30b19103d36a7633c0f8edb357e12ed",
-                                "uncompressed-sha256": "c5728a85650a946691b73b332b73914493300cbe6f7576e916b96cdabb806509"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "92cb09afe970d7467e5d6b821bb05333d7989d13e3846ffc42ca39b5e53a3d70",
+                                "uncompressed-sha256": "b9f2dbb47632d959b061bb62c7b13e9e5cbb84626a15b2ed1fe52fab5b31845e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "0ab04ef2f0a852bae37cb7f834ffac5ce4e7eed00eb1ec7d3e8eb6d0736793b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "af4fa7c98f04eb31fd19ab1b5c7fc41aeb2c6b921be059d16d2c40cee0df951b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6e82d31844ce91189e371baf072771dfba51c61e6a55101ec2ef75781b70ce4e",
-                                "uncompressed-sha256": "7a07bf26fff1ba37cb2f457411efb9a8f72ed89a4975e36ce963ec69ecc336df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a435695737035340c205bd88b5583acc93131ccb8464da7d7e7cf08988444d2d",
+                                "uncompressed-sha256": "e0ed55291f575d7ab7447456665cc0883337aab4961ae1b309b03a79027bbca2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live.x86_64.iso.sig",
-                                "sha256": "f4ac09328ac019a62f71b7939d12734401af1ff57dfc090310b0ed1b255b2a98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live.x86_64.iso.sig",
+                                "sha256": "fcb99dd0ab593ee5f56c9ab62d8a03b40f527e5291ac195721d3b69a6fb86e02"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-kernel-x86_64.sig",
-                                "sha256": "cd069acfe4dc025d51cd716de66211d55ca2facf32808f9ae5aa2f66097a513c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-kernel-x86_64.sig",
+                                "sha256": "4a8f189eb2dddfca6495f5e951a0099882e1453e9f6629ad4d961f99428e12c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "d9790ccece83e15b2e938de8feb14a6606ab305974131787736f6e4236eaeb33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e762701e21a0142143a6b70d9108b5918c6e49aefc6fadca131d14b64b67a10a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "8cb090b2c164bf4575d26d38f6fa993a3c54147acea8d9700e413da753d05435"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3593d5f55cdcf9150459401f23ff3e66f22b2505b659b7a7b46c2accec811fe2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "bd9b522421a5d0c805aa521638c449ac326b4b9015e90022e58d3e71d5ddb085",
-                                "uncompressed-sha256": "a36e372228cebcfdd455cd21aa1794a6756463502beffd23c80eaddbc3ce7f36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "786058fe79911bad9ea40b71034433cd01aff3c131dbee01d23fdd503e2f2d05",
+                                "uncompressed-sha256": "6e8d506bf6b7da44bd926e5f45363acdda2f4c7c49767a242e7ff892f22d6ed0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "867668b06d93197852fac15f2b3b7920faf40899b1b7e7b49fcadb20ef36259c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e20d22c68f4085bca60512bd86311e66be9bd6b9683d734857ffac862e6898a5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "c02ce0d103c0ddd4683578d6dc44153b60cf7c05e207fcd10e4712312b33afb3",
-                                "uncompressed-sha256": "d35df9407bd88cf4682ae4da33c5ddeac41a6cb60a5baef4ff09779144c7681e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7f43c2c2a47f5e0fff7b78eaf728bffaaef253225de607c3a14858893f08370f",
+                                "uncompressed-sha256": "36f9761e8da3c2fb52987381171109411316ee2be45154c47d65fc9158100ca5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "022eb0c53da4d83d00a6a95cf3bd1690fda1e556925b2232ae321ed32c1e94ae",
-                                "uncompressed-sha256": "2a63677935adf7b081a73319fab74e6bb843610c3eb50d1ae1e53de379c573ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "923df6c83d8ed6dfe39f41ba4c6e32a7baa0f796b2061398feefa02f7a900dbf",
+                                "uncompressed-sha256": "d6dc471906e994ddc6c7a54f477f893bfbf719a86d0602d0b3be5cca8fd51dc2"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f868a6495aaf9943dbb5c748730aeee990c81df65280bcf7ec8fbdc917d8f017"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "4cc8fb39d1c7044bff09d62cc9e57363addd92e13b7547a13bdbdfec02c24580"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "34c0bdbcaed97a8100151298492a6e337e49af3607a978918a68d5aac32f2554"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "088f4aecbd50a44afb59cf0a1b89f73d424c61be2e60393b4a10eef63b7fd217"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/40.20241019.3.0/x86_64/fedora-coreos-40.20241019.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a576401079bf933bfd44b75ac40c712947cfd026004bc940f722a022976ec911",
-                                "uncompressed-sha256": "16490ba7712a43e550ae02f95ae874d828d16c5693f17016e60eb3eee41d4075"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4b61f54398ecb2d31cbf6de8c3c0109a20e779ffad2abfb592f5eb764fc07e5b",
+                                "uncompressed-sha256": "5b89a0b13cae1d7dd2be24ad5f1345537e96afac17289b57944f8aea34b5d4c6"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-09e70997bebe86110"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0b9140fdb33145e65"
                         },
                         "ap-east-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-01c76958d6783ff64"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0db022ac97aa6cc07"
                         },
                         "ap-northeast-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-04fda739af23c3d52"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-061147b37cdf17e65"
                         },
                         "ap-northeast-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-05c4263871218a187"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-09a8ec1954ee5cef0"
                         },
                         "ap-northeast-3": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-00d7488903d50b23e"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0e70764df9b922a15"
                         },
                         "ap-south-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-056787c2f91d34a4e"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-00faa5e85acb049d9"
                         },
                         "ap-south-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0160184ddf241c42f"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-030b42a61179d10c6"
                         },
                         "ap-southeast-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-043457bfc64cc409f"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-04ec3a51efef04c94"
                         },
                         "ap-southeast-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-072901c8e2ec43e1f"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0e713c707d94e43b2"
                         },
                         "ap-southeast-3": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0583988d157e5f6c9"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-08f8053e425e0212e"
                         },
                         "ap-southeast-4": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0abd6dff54f8cdbb5"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-04799313d341eb188"
                         },
                         "ap-southeast-5": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-09de185856794438e"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-01a387521733f7a4a"
                         },
                         "ca-central-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0cbda5d8a6dfedaaa"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-05d20ff45cecb0108"
                         },
                         "ca-west-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-00b46a887960ffe4f"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0ad6027e712338056"
                         },
                         "eu-central-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-07e2ccb46b627b686"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0eebc7dccf64fa6d6"
                         },
                         "eu-central-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0200903b9bc73d116"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0deac50f9951fe1f3"
                         },
                         "eu-north-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0ac6db9928c2061c6"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0b2ba1e66305c1ee1"
                         },
                         "eu-south-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-042b4796dc83c3e1e"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-001ace1f9f4950dd1"
                         },
                         "eu-south-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-094e1536891ef294a"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-05919804fc1fc7e32"
                         },
                         "eu-west-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-048bdbc041cff8ef6"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-07b533dbd76716e85"
                         },
                         "eu-west-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0c16aea531460cb44"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-085426defd2933a48"
                         },
                         "eu-west-3": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0339433037dd3b9c3"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0283978425f898620"
                         },
                         "il-central-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-02f7baebbe7864c1c"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-04d032ebd4a7fe334"
                         },
                         "me-central-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0c05a4d6844947bad"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0bc3b26ca81e48d13"
                         },
                         "me-south-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0a3422f256f9a3a07"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-02bec4c89eef7dc25"
                         },
                         "sa-east-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0bcdfcf44344492db"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-03a4d540923a0ebfb"
                         },
                         "us-east-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0b8ded38c9da07b13"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-038bd0e6543e58caa"
                         },
                         "us-east-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0dcb90d7b83356230"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-08237145c1888110f"
                         },
                         "us-west-1": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-0963883196cbc2a0d"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0ea4fe9019600cb4b"
                         },
                         "us-west-2": {
-                            "release": "40.20241019.3.0",
-                            "image": "ami-045bc915191be70ff"
+                            "release": "41.20241027.3.0",
+                            "image": "ami-0423221dbf56a3d4e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-40-20241019-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241027-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "40.20241019.3.0",
+                    "release": "41.20241027.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:aa9f9d12f8a1659004036f5adba02abe6b8d8c0951e181496c4e6d3e349a6552"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d44ec678bc1a1259e98fe2eed9743871d814f9ca5efa5833a619b0abbbfacf0e"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-10-29T16:07:02Z",
+        "last-modified": "2024-11-12T20:28:57Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "4be9375a0ea714411fe85bef25b051552400311504318aada36e4c77fecdda8b",
-                                "uncompressed-sha256": "d96523012a645c11b329103f8d6fb0434aac2f20ff45f02c6393c948b8266864"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "2a75365b645388b147f9c584eee43dc783dd43da292d0e348714dcef855ab7a4",
+                                "uncompressed-sha256": "1aeddf72214545969eb30fceb8bea4f759610aaef39523061321499de6145b1b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fc11a208922a2db30a38e7c7851b6b8dc80bb198dc82999718f6fb1fecf3fc13",
-                                "uncompressed-sha256": "82cd69f60235b9fe19bf15875d15c85ada5bbeb70758a7708e2f6711a996478d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "88111cf70ef074ffb49cf3aff6ae495ca6bc2aeccfcbbd7adb08af4b1f6166e8",
+                                "uncompressed-sha256": "f2aac515df59b33bc278aa97ca06d5e293451fe2d55fc8e75f9a0f2d3115e351"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "070b2e4eb96b62d382cd4cbf85a398035e0ee6848e0cf42ac22d735271d68d2f",
-                                "uncompressed-sha256": "fba7872b341e19a77ae622811c6c78c37be71d7d1fda22fd88de035017ca339c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "35b6c488d9c096312005fdda46fab505b657dd6043fd8e761440731cf4cc7c58",
+                                "uncompressed-sha256": "160b54ad87db0b8e67ab8b0e87753128c0a205fef79b3d290347d094c944a297"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "b8d4df90ac115a4ab9c7ddf8f8af0b9d8e0a2d504d625b4074b1f431a48099be",
-                                "uncompressed-sha256": "e59b704a6cd22a479c2e534be73342399e3145b76606ed26f09c20578125bda6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "f10bb5cb20481d386d2473dd95dce5c0a18ad020d2c6e36fcf3645a48670fd19",
+                                "uncompressed-sha256": "9460d64a9fc5a9720a870865977ffcf3ecba7e4ac5574bce97d700ef5fb2547b"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "3b3b255de228846336eef8afb643e8e027286005e6cfdd24805418901880789e",
-                                "uncompressed-sha256": "fcb7c3ac60282fe53519e85244a91b1dce6cba5e9db0e45a946cac03cde34b36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "cd07646ed7b3fd6dab5ca4d5c2aa33dc13977d40921068b0fa8ab72372c1f223",
+                                "uncompressed-sha256": "216bcb2223ffb9878a8270e713088b052e02bcc3826338e848d604718b43944b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "8411ccf019ecb06b33ca869fd9c31323c8baa1185546e9a460880e67ecf45557",
-                                "uncompressed-sha256": "a03b08ef5f144a5234f8e3f3a178658fdf2177d770d2e3b1175b5662815cfb64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c427f2f3bcaa34debdbc0567da03517f1afcf0a47abbe95f3d7df623fc222c6d",
+                                "uncompressed-sha256": "61fc795a936e49eff50ee96bb5fa10ccd65628791cf16bbd2c3add9ab4b22025"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live.aarch64.iso.sig",
-                                "sha256": "cd19bffb6549b15263902160ddee6718972352e1bae78c2e4ab47e60fbd36c7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live.aarch64.iso.sig",
+                                "sha256": "9ebac68f11c441d07429de2d41f2ba94c1e0d9364b08566c8bb4d5f5fc9f395f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-kernel-aarch64.sig",
-                                "sha256": "b7593504d57829cb34817c4bca93d6ae8feb923a46518fea4e6ea02d91e89c5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-kernel-aarch64.sig",
+                                "sha256": "9bbc0c304cdc2bbbe539c6ab63d3f7b173ae92a18c880f8b5d840ce5d36298a9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "61168063bbfad5e0118af856a2901071d8ee69a74e17b9569b75416973d006f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "0de86d029e85ee31a0dd5bb848c3ba788f52c974382fe7bf83fe0125bfd1740a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "6683c65943bd3df5a10a2484b5b35c5d083abd56c1be0304e8f2fc4586fa0708"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "b0a1c80bea1190632ced1907d14e9a2ae6ca0cc702e700396c9a719e0b92eb44"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "30e945737d0c28630337cbce7beba4fe0603c5a1f7103ccaf45a6c5281fa953a",
-                                "uncompressed-sha256": "db740e15f2517a9704919b0a5ec59b4d62769cdc134941aeaa3b5493b8d5fb57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "75376181a8a39eda8329710a83a7f8fbac1b63903bb8a40cd3c4c58ecdacdcdd",
+                                "uncompressed-sha256": "99956bb43b0ea0ddadbc046ca716d63221647febadd4a345693d173a672ad8c6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5391fdf94bcc1b6970bf5200cc8c8d901b51ff04cd8106baa21e9c9225cd002c",
-                                "uncompressed-sha256": "e91a4a2a2b0deb79482f357b283f8a2f779503a8d807da1c644da90cd13b6502"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "74699c38de18dedffff4d04e2f9591157d30ae5537757d74fc38eb0c2724bc67",
+                                "uncompressed-sha256": "dbe1dcfbc1de497b149e50d6b1315d37ca468d80f29a4c1bb7188f8c8af22030"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/aarch64/fedora-coreos-41.20241027.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0c73b74a87cd33f6d0930a8d23acea1805c5d92a7084d38e736cfa87126d1e1c",
-                                "uncompressed-sha256": "7002fcaebdd0c97540b0ef10fc1139a08cdd51fe7db2f4ec20175a22df16e4aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "3c0d658db3a1a34b21d3f826ee962c1777a12c5547684cd4d19bdd1911e6bf15",
+                                "uncompressed-sha256": "2dd0d1cf047b641e4bc0646703eaa27025efda524a3813a483400121bd52fb59"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-01df8650d4ba8d03b"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0495f871858894a28"
                         },
                         "ap-east-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0be0f636252b5d000"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-01465e938d9601b80"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0b7b3cc50a0279bb1"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-07e22a9912ca8a599"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-043d729073b861246"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-09e7c67637c81f603"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-036eec653a5b57db5"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-01e773e40a7de1d45"
                         },
                         "ap-south-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0d9ea773cf5ff532f"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-071418c8537586c11"
                         },
                         "ap-south-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0ab41f7ba47136824"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0948e344d2e226a21"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-00256f26d67ddd586"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-032e51d19d4ff1beb"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-04a9eab4f5b0d15c2"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-02e46c303860e1a57"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-02fd8b4c89aea2ae4"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-05efd37a4e71cf051"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-037c0f3233709eafc"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-012f72749e3693c05"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-027b928570d472195"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-02325924bca6e4d2a"
                         },
                         "ca-central-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0234002af4c4ae677"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-08baba569aa42174e"
                         },
                         "ca-west-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-09367e56ded3943e5"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0a292b82bd82d3fca"
                         },
                         "eu-central-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0a182ea10b0f8c1d5"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-082a0bec1f3d74e6a"
                         },
                         "eu-central-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0051abb40a91ff688"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-01f6c24c26626ee3a"
                         },
                         "eu-north-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0e4758cc7d5c92356"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-09a2799444b2102b3"
                         },
                         "eu-south-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-08088dbe7cb7c7037"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0d34ebacaa5e76551"
                         },
                         "eu-south-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0b53961153fdae90b"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-08127adf1b962c3c4"
                         },
                         "eu-west-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-074f728ce87ae439e"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-087e63a56abc88966"
                         },
                         "eu-west-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-07a7b6b5bf0d5c606"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-077df2abfdd8b969c"
                         },
                         "eu-west-3": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-08e9eff13ed006b52"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-07733b359f49562e4"
                         },
                         "il-central-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-061369e10dd53b1fb"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0c0d3913f8c2c1825"
                         },
                         "me-central-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-033a9e86b7c4d43c3"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0c41761554904d9a6"
                         },
                         "me-south-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-08b9571d0e3ae15c1"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-048d2c4c41e49ddc4"
                         },
                         "sa-east-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0e29bff5214a5a3ef"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0af89d6762e3ff1f3"
                         },
                         "us-east-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-09f3b21c59a7a33bd"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-09eae17cf5ab21b1b"
                         },
                         "us-east-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-096a6d2194c062a71"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0c489420efba9a77c"
                         },
                         "us-west-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0c64918b27206f031"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0025480cb472a54a0"
                         },
                         "us-west-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0ae31a5838ef6d39d"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0e41b7bbc18807037"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20241027-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241109-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6297b8ed82dd170c65666b1c9ec666c7746abff4168f551aecae2c7572eaa44b",
-                                "uncompressed-sha256": "47ed5a2830110efedfdfbc981a6f306d800acf54d5acff03a164b98bdec18865"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "03146ce2616aadf30c23dd97dc6de8ca1df9d1d556c7ea7323ad0b72e46573c3",
+                                "uncompressed-sha256": "edc0dfbc28b08904fbe85898657fcf16bd68f88515412396d17921c5fff31159"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live.ppc64le.iso.sig",
-                                "sha256": "acc7874e8623b71355ddcb5def563dde52956b916ef40a8e6901cbb1c2df7892"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live.ppc64le.iso.sig",
+                                "sha256": "1aee8d49985a7f65656b225c68319fa50026e9d0c5df1a387fd93fe0baf3c9ef"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "5c3a59742a992e2778dd5f06757cb90f5e616525b56f2e1ea07ce2831cb56b5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "be45daaec2933f2ec16ec24fd6a6f5b367def5039cd68587c463ca84c5e631ab"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "9dd9a64259e1f1c82113c560e5d4c7b85e94916c07ab5e2f882a432895de395b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "730f3eb2e885da5216a2a5bc0bcf4c472f9dfff0cd50cbba21625d3cbec47d0a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "7d603f9895d9cf3c5d0ef05f8dd861d372b3a292b504592421b48aeb779d359f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "63d234db85ee5d797ec1a5f1850a0a806e7b27ebf343a4801dfd504be6efe6bf"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "a33cc03f42621a0a2ca7af482a42f04d23e4b34b44c4f2a0e61246076ee47a88",
-                                "uncompressed-sha256": "12062a3d959cffeb6cbb0a2002d0a6f17abb4fd962bf6d0eff955a00cb3daf0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "f51e06a396062bc33480dc66060b4705dd1987ef50617a7d12a1f531204c0e53",
+                                "uncompressed-sha256": "04c424352d6afd9bcf106c684d63e902b18498c17cacc477a6a2305463d7c7cf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "1eeb085418265b3b0a76003989f3cbe7456ff5a717fa7b5af81a833121b296f6",
-                                "uncompressed-sha256": "505bef82e5cfb04efbe379bbcacf61951f5099dc833953ce6d74eb737bb2e3ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "989df43f15747ef890bb81d865e012284879e273d1e48e4cbfa53a5880c96e8e",
+                                "uncompressed-sha256": "c28ac250596f159da40a3306cb8163213b22cc32a15b7e6659a55bbac4c3e6cb"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "28f7ca15f92a882a1ea4bdb1a63d988f2769f7bfe65f7e1698b2469899ae386c",
-                                "uncompressed-sha256": "fce7be1297ce58e8a4b434b7e79820e99690ee66b8a5ef2071708bb0fe22e191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "25d1842b8cef3f462df455c7a7aaf6ed06de65a620dfd9286cea77fbf6be021f",
+                                "uncompressed-sha256": "e7b9306d3902e738487b9ad9135ec00cade2bac8cbf7fe1a3c36b76e652fea71"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/ppc64le/fedora-coreos-41.20241027.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "7db747f4b67b95fdde134920d379bddd11b69fd54009d0c92887674f93bc5d7a",
-                                "uncompressed-sha256": "235cd79aee99821770eb1366303a11d0a6fca06c29e247b4e321808aed756f4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "cbf3584b23d3a1cd09f0544e62aecde094744c6f17ace99d499439c513bd0faa",
+                                "uncompressed-sha256": "15aaaa466ed8b71bc132b611ff1b50884b2c417ae39828f99f644c37df99fa62"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d05c533e5ce65474a52161e24bda32b1bc4cffeeced1dbf4630da9c17e019441",
-                                "uncompressed-sha256": "92fea5bd56a9433108766eb054ccdca9aa6097189cc1dc2ae0bc9e170ccabde1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4e6efd97b2ae0540e5ecb89a312adf397e8057180823b3d967fd1ee241374d97",
+                                "uncompressed-sha256": "c1a7d754fc82de3e13cd7cffc8e97fc91032e8b5e8eb9279ce47a29e7ebbbbde"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "42bc762375d3ed7073d8050ba0062cad256ed23eb2447ac64952e91368f031f4",
-                                "uncompressed-sha256": "f9d47033969be42762f90c498fb27e70850e27351f685a05d86bd4f3b93a3b36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "a74a8f5f5be8a058bf179f93c39d3f0d2b83e452ea2aa4c13d2e612e50b1d6c3",
+                                "uncompressed-sha256": "fdf6e783f4b1c4050c2c5bb350f9279fca1fec817959f5efb86bc7981a9b2b6b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live.s390x.iso.sig",
-                                "sha256": "bc4f7296c277a398aaa268ba7ac960af9641ded325996acee6943ab2a5099917"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live.s390x.iso.sig",
+                                "sha256": "570192d928057834cdb381e7cd2a132f7fed672fd033efd446599f0e74341e35"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-kernel-s390x.sig",
-                                "sha256": "e470d5ee058c8bc9439d44e3338f569b76012d7f588b31e5fe5073bb9ad3b770"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-kernel-s390x.sig",
+                                "sha256": "8e1100819d5840b74d59cf37e4e2fa3679ba8a5b733ea15b63d43f98604703df"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "c036e81245f99d3efb94ecbea3fda6d96ac62e93fe67aa2bbd6626b76967243a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "805aa86c4e71e912c56b374a5897ad247e6b709da5d9aa11c5a68d76da82f390"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "03240b4b25d53274377f71f02c080473a309536cb2b94e9265358ea7ee952bc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "7955529f0fe7f12dffabd99050068b00931828f3eb3a84c3ff5dea0046a34b8e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "ea06a6562ebe0f459c49b6316d61b4ac0e0a42b0ba1b9995d4eff248260b76aa",
-                                "uncompressed-sha256": "0a5e877292eae91dc28f7da8dc050d9bb0ea14fef1cf52527962eecec6965373"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "34648e360de702e4c292f6ad7544071bd7b4ae46bc1ef9c238a332ed34388acf",
+                                "uncompressed-sha256": "72c119ff95c131c5eaecb158b1ad95955eb16ac305d175860e2372782e91f190"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ea8a30ac17183eb974ab4b3d883bb9b40c03223508480252f633331e38bc7f3d",
-                                "uncompressed-sha256": "38a0f6b86e28ebdfdbd959b901635ed0cc07c486a2ae34e39429854a2b16ae29"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b3a2fff9062856d5acffb375a812e570fb8ffa3548c720b711e19cfe82ebe93f",
+                                "uncompressed-sha256": "e2effd2810af2e2356872d80ce017e7d0dab2f8ae59069a3d0c644c4b5634816"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/s390x/fedora-coreos-41.20241027.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "7fca0c289031613d2c09d6e10f5163a51da95e258d41e90d922d2b26fe0c6743",
-                                "uncompressed-sha256": "8fbbcac5b097ac51c6b839716056655288227cd12c0351eca5dcf8ce018c9585"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "b65e19b66d76e6d6093063e077b67b373136e45884ac5e9df83a12a4ac4fbe67",
+                                "uncompressed-sha256": "784a9a2abaab1603583946d1e58a2b2407f80959bd84c5ffda651e72f3e5a18f"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "dbf3c11b63b4fd85071deef3a5e60e296e79401d5ea9d1974e64e9f820582c6c",
-                                "uncompressed-sha256": "82643864efabfe8fb7de04803ed50579ae8221cd104b625533d02f5882ed3847"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "34b33aee9e04c195719c268b1fb05d431e1c7461ac729da88ad3e764376865a1",
+                                "uncompressed-sha256": "486014409b6f8b632462c46b40feaa501665899b3bd63bdd793d7a1a20bc52ed"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "daa68ca3a9f0680db53205841931715c9ee0cae6ba2946cfb203d63a0b39790c",
-                                "uncompressed-sha256": "1c0365e031f35f08e2077df8bb76b1cbbb6bbc61f0fa76f341b698f51119524c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "027a6157fa34da80fc698af88393bc911b6523b8f91e9032b427c360a7119807",
+                                "uncompressed-sha256": "d1fe10e100c9a69e78f1d537a7817a218b97830122b36ed07a63a6026f2b28bf"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2a411c704c67604c49ff58ecf2fef6cf4ce0eda8c2bebd05169db9ebe2071a5a",
-                                "uncompressed-sha256": "29c69856d482dc5287e3d0d071e6c74a42641befa2b3f5f33bd94397bb257c3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e549c11b45733ef55ad07b90f3954eb9240e3e5b6f7dc44acec0ecf47692eead",
+                                "uncompressed-sha256": "5d0f233c8866c326be4469b25006f5d961b078cbdd1bd72a3e0edb028fd15620"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6d4713611654c6d43b9d24d7cf253d342e2c5d2588b62a93d84578252abd1451",
-                                "uncompressed-sha256": "46220f605e53539d1ad285b743e68c42dffc2072c415cef2a4ad12e34fd95de7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8b339b1320c8499c4348b17a58d76f0ac90f0b250231af1f9c873e501aa0b142",
+                                "uncompressed-sha256": "c7a5a3f02b6acfdb3fc6506ec09bbcb5d9323690e63bcafe17c164e791270d04"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "d1d5ffbf0ee6b8e5f72988448d126144dc21e27e0991e4f33f80b8c5b6a83054",
-                                "uncompressed-sha256": "8ed3279a337d6e3a737d37cbfeec2c1930a39e056af05d00cc75946b77e81d97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "fdfbabfcd9e528d4adf9106d2478cbaf400795a8878ae71c987a4ab49aa514ca",
+                                "uncompressed-sha256": "6258e32f2a69f08e27f05b66272437d22a59527abc1809437e637b1014e31f02"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "00a9e22aed9ee8759292cd56cba1c75bd340211325e5206ae3a45ca7d5a369c9",
-                                "uncompressed-sha256": "1c718b4b4fb131546ab73c2266c011dd40f2c47a9fa2bc0754f44fac0cf7d7cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4ba9e94526e70e7be0968eec681790fbb7f33b327580a00b5efd4a33b6f934c7",
+                                "uncompressed-sha256": "a83418715085f9e4b312ffcf0d32f0484216e206fd76d3c8b20051479f4c97e0"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3ee5541562e4cccc62b1ea1e358bce472e999cd88ce162779bcedef5b4730d88",
-                                "uncompressed-sha256": "a07bf5d0c23c72bc2bfd2cbacdc94ee8566dad8824e3bca5237f660a361dc978"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e3ff4de22e087beca8ee960b6781518b7d596e5b2dc67d30df95debf4f563cc5",
+                                "uncompressed-sha256": "8d7e9666055e695d8785f00016b88be762778f8b81a4809da300d75af1ca8d4f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "fe9f7f28946ea2a54aaf42fa19f79114e7c2d6539de5749d43af13cbcab59c38",
-                                "uncompressed-sha256": "c01f94a4a836e3434364560a2265b3c16be03ebae41bd27e2bc412e0bb987dc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2f71a1593716d39347ca96e6c6246489888b5fe0f84ecc638add443010ee9cc2",
+                                "uncompressed-sha256": "91a681474c95c8ac4158e233aaa5b57bccc848dff70e7372b9adc4979e9c2cee"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "f36bbddb32d7ae2fffc4ad856ebcdb79e0915b08905a00e77c3d79cc1194ee85",
-                                "uncompressed-sha256": "08e8f3ab5133c9fc7d733bd1be96d20256c2d15b88648f83994bb40565e48c53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "28bda853d6bf8c6021aaf892a772e1e3b02a858bd01e44ea600d1cee68924242",
+                                "uncompressed-sha256": "69f30140a15414a9eac5810654be4d34006e7c449209f82965d0f16343aace0d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "cb2d8d8c24c12ff1c3bd43bcc5a956b925f32472449dae8c8b1c7611517ae38f",
-                                "uncompressed-sha256": "5eb4bbfd3a1e54cb6c1b6cd9db321f8b6a7442ce30a43255356f0d723aef76a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "bf9aad8e38bdc58033a5231a6578d540028f72cd0c686f4d6f1af2372584c271",
+                                "uncompressed-sha256": "5057422b0057d73b244e921a8dd8f72da464ad17ffaa8ef7cb83db7c556cb428"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "70c1f181da3dc0a3ba0bebfa26a254fbe120df2d8d52a92b5d6de5d4dfe38c6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "159a3223be0afa8cfd87a07b7cf356713833009fb597bdbb9f75ffc5eb21ac1f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cd0e39ee2b9fe464d60b3f8f6a215c4f8fc853bc5f066b14072456d90f7aa59e",
-                                "uncompressed-sha256": "c2e3eaec9d0f23ad83570a6bbab9127fb00667cb4c35c471823396ee2a931e56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f0cf6e9fcbc9285d461cb38a8c13e2f7802a115e3a8870fe4a99c5ac61694900",
+                                "uncompressed-sha256": "82f2f8346b3ce2ded9ac0b58ef38757a7dc5f3d3c1525413e083c7abcdb59931"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live.x86_64.iso.sig",
-                                "sha256": "d12fe6922e6e3b7559920addd49045e7e873ccac2af93421840bb6f29d70ae52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live.x86_64.iso.sig",
+                                "sha256": "3b8ef678e5930ad4db33960779851e13e42d9193b0529cbf68f1c18bb8b00028"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-kernel-x86_64.sig",
-                                "sha256": "4a8f189eb2dddfca6495f5e951a0099882e1453e9f6629ad4d961f99428e12c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-kernel-x86_64.sig",
+                                "sha256": "65e863770c2e40c9221b8e55623dc12372ffc1c01784a9b8103122e9f19556ac"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "c9e06b63e89259c07b7daba0055f29372d2a34cf9b70f37aba40b4a71762ea1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e97f46a17f7e5d600fddae5dcae4fb2d70b60e36c3f601a80d0ec085076f182c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f57211ed9886329abdae7e0361c7315b0a59420135ef84c93f09e499f795f511"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "8a5a22d26fc9f312cfaf321440963a287b5ca63ee17bf58a500e3f4a81ab4cab"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "92b30c714ec3f48f2ec32ee37b5a27be6831cd8ed4de9857a151ab9718824f02",
-                                "uncompressed-sha256": "c913df8448da0c262c7fcba55cff28e43825c40a4ba97737559ee63fc7644516"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3b65391bf705d49bdd3db8110d288fa01deba9958d55d40469f3afeb6f88b7fb",
+                                "uncompressed-sha256": "c8b9f90c759d9182ca2fc52c264b541c22334c7988cf9a3ec92643f89707e80e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e214e1dd9041ad57ff6d14c43e1b0167ef953bd0c364f72654ce2cf72b4fb0b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e6668377db6a3253fb47493231e437d1b28ab1f7bb43887b2d2fe2c796bee579"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0d3021e94a5bddafbfe538c74460597268879729788db659b0609b928112585b",
-                                "uncompressed-sha256": "1bbe777f3ed37d77448ab176d4a2d4cc74ccf822f1e9e3e178f0d38d26ab0363"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "139dda291e88437ad4f861fa93b01704e19c75b0b2a81d063acfb7762976b8d7",
+                                "uncompressed-sha256": "7ea2f0f3082d43f12a14a5118b4c98cee4a5f775d5cd5ed49eaf0b0ed48a2a30"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ce95bf8e63e4523a61956fa25a451602b97d55a7afbdfc50be044fceb9aea578",
-                                "uncompressed-sha256": "e608d0940339fe63f1b8169da3afec5465e70fdb443800112679dbbb6e118ecf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "fac83a205c3e7caf468a079cde0dd7af299cdfc00cb17fc84d70fb3dd6c7feea",
+                                "uncompressed-sha256": "1c639fdc7b96304a53ccf53ac7be1b0e64d338a0be98c7e03297e8609bd784df"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "d1088ef59dac2c8e0663be17ad4ffeda0b477839a24ba0fc665f0ba971706427"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "8eef1f83dd4d5458d7f4fe4568dd2393a6a542a2150427f1db076d8dc3c67545"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "6c85e585a2c365491a09cf1022986a4c13d42412131b9853cc26b798486cd5c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "99b2019b0152b8a0edaf2d7bce5222da4788a9e36bcf9fd480c349c4b64b3ec8"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241027.2.0/x86_64/fedora-coreos-41.20241027.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "438586eb598fd6451be04e5db58199a87579f2e2eafd6fef1311b7618233850d",
-                                "uncompressed-sha256": "c142d97bc187188d6bbcb4ce296358ccb060b77c6e03b636c975705e465c0195"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d6fc3605f775aa2320465f4c52b50f827093c173e7444e1ed462f19ee4092c00",
+                                "uncompressed-sha256": "05c886271e9bc3723eedce76285684be53b307b85c12c4c02f35144beda6dfb3"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0b81e8b321b7ae0f8"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-04d2e7013a1c8300e"
                         },
                         "ap-east-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0d664f8319e4c03fc"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-02638b148691839b9"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0ec2b6594fe740435"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0711658794e557932"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-01a50c8fa29a48bc3"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0f797ea202477273c"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-01edc9fc217d56b0e"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0fa7f3ac1024cd407"
                         },
                         "ap-south-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-021e1bd0d70e61b4e"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0b88d811a1b16a882"
                         },
                         "ap-south-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0ea83a2b7b53d4e72"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0d51ceb9ad2af192c"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-00afd806a5642bbf1"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0abf5bd66b1b739a9"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0a1dbade908855474"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0fe8eb3ec7fb95f90"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0b592a9ebbfcfabf8"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-06b8f09ce5d117044"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0083963cb099eb767"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0c926727ab035ef83"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0a12719bf996331a8"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-03f1a1d13afe70cea"
                         },
                         "ca-central-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-083790e730fb5ae61"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-08caace5fb21f5393"
                         },
                         "ca-west-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-01a630bc0ce01db93"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-08b7e883d2e8f57a8"
                         },
                         "eu-central-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0795b50a863dd2031"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0221ec0a767c77d19"
                         },
                         "eu-central-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0ba0853721e9120e7"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-05c04375c4da1d1e6"
                         },
                         "eu-north-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-056950cc4296ffef9"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-01d4b70d821bd0d5c"
                         },
                         "eu-south-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-070c7f7d8b84e41d6"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0a5200d1c970a60e4"
                         },
                         "eu-south-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0394fa699237e0293"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-075f58f51593ab400"
                         },
                         "eu-west-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0f5d5d2d508dd9b04"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-00cb1359ad17b7c58"
                         },
                         "eu-west-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-048526c56aa224bde"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-08f231dbf7cf71fc1"
                         },
                         "eu-west-3": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0f057aa6447a5b904"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-036f70e13796ba2e4"
                         },
                         "il-central-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-08286d464109eb0dd"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0f5189ac003082cf1"
                         },
                         "me-central-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-04a65957f3387dac5"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0409ef8333273c0fb"
                         },
                         "me-south-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0543521b65b24911c"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0649b325f6e244074"
                         },
                         "sa-east-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-01604a586ce250775"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-086147c59f1d216cf"
                         },
                         "us-east-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-013251ac3beb178ec"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-00f74224bc1a5e4f2"
                         },
                         "us-east-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-05a7df9532a4e404e"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-00e18af14638ae570"
                         },
                         "us-west-1": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0637c63fec52f5126"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0a2c9a9a615aca30f"
                         },
                         "us-west-2": {
-                            "release": "41.20241027.2.0",
-                            "image": "ami-0b5b22b783bd9ba7d"
+                            "release": "41.20241109.2.0",
+                            "image": "ami-0ee45d48c06fa6be6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20241027-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241109-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241027.2.0",
+                    "release": "41.20241109.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bf4745bb0b8e205845c8d210bf62fa62f8bb17fc1097c3a58bb9b8bb0983acda"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6a2cb345b2373adc1f1cf140a626bdfabcc57ff1468fc324ff42aefdb49a2249"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-10-29T16:07:04Z"
+    "last-modified": "2024-11-12T20:29:00Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20241024.1.0",
+      "version": "41.20241027.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20241027.1.0",
+      "version": "41.20241109.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1730219400,
+          "start_epoch": 1731502800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-10-29T16:07:02Z"
+    "last-modified": "2024-11-12T20:28:57Z"
   },
   "releases": [
     {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "version": "40.20241006.3.0",
+      "version": "40.20241019.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -117,11 +117,11 @@
       }
     },
     {
-      "version": "40.20241019.3.0",
+      "version": "41.20241027.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1730219400,
+          "start_epoch": 1731502800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -113,6 +113,9 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-10-29T16:07:03Z"
+    "last-modified": "2024-11-12T20:28:58Z"
   },
   "releases": [
     {
@@ -127,9 +127,6 @@
     {
       "version": "40.20241019.2.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -139,8 +136,16 @@
       "version": "41.20241027.2.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "41.20241109.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1730219400,
+          "start_epoch": 1731502800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).