### PR TITLE
Roll out stable 41.20241109.3.0, testing 41.20241122.2.0, next 41.20241122.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-11-12T20:28:59Z",
+        "last-modified": "2024-11-25T18:17:18Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "f4d73a6f14154d1e246975b404658135b49f70a92e7f33ee25a91e693c094532",
-                                "uncompressed-sha256": "da4558bd620c659204dfc1478bc26fcaef564c20340424e02a2ad3c143384872"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "700dba36890b3a11ea5e8c6e35d241129ff3d4430c1bcaef8b65826e56354866",
+                                "uncompressed-sha256": "5028add057c8735362b64241e7cb751d5b7cae3d4ec856e0b7dbf3da54736757"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "376ee26e1080ee9e16e881d68e4bf4446e155cf1e4420d6bd3c9a2644084be82",
-                                "uncompressed-sha256": "c38920e35941bf0a3adbc16262ac945d45a746f921d0b76ecccc13ff48bf33a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a140510eee22098ac16e8f770d5ea80e9f582ee48702c57d8d69a1d7cb1516f0",
+                                "uncompressed-sha256": "18a6a223b5821f5cd19c7845ebc9995f3ef4e5a4a3b8d874f456e416b008c823"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "2a61683422025c0929891a3ca11dafa2c59fa0a80d545507e97a0f97d320b43f",
-                                "uncompressed-sha256": "566baaf75aca55c8ccdce2dd2753c6a63c77fe4cda3e7d8360fc099c240df68e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "db037e2a82b770f8b84821a6fefad84288d2f6d1018aefb9fad5cef75bb4cbf0",
+                                "uncompressed-sha256": "9a433f13c018a6656bf071d8773ea151935e05790baf36069b16eab3b6175629"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "fcdd81ae87589aec471b256b695cd56c65c35798b64c1be08dd2855408fb4826",
-                                "uncompressed-sha256": "8c88bf9f5436d49db60f7e45ac441f391a83a701685952c8fb2f7adb14bf09fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "143a89569c4eac0efdb50239210aca769bc12ca447cabdea1e0a534ec13f2316",
+                                "uncompressed-sha256": "e65b857fbc152db5bf8d798c79bc7c911b8b7ca472e062f7a3a5ff83eef90973"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "7e666540d7114100afd731477fd411e48ca9cbf768e775253c7a29e745688de4",
-                                "uncompressed-sha256": "9b15f21ce1039cf59ab6c060f30ce5009df0da5e4ca30e8ed0e697c2ea3d581b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "4abe625fc1a49d0801dad827b88bf732bd865ddd4ca644c6bb3a68bbf347cc4f",
+                                "uncompressed-sha256": "39bd58000e11d6c4bf896fa9f58d267cc068c1e418b6b692199526b0841eb19e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d93373e4ae4ce14b56e9a13ccca84d5a5fb9df9eda6ce9fa623f77527ff49def",
-                                "uncompressed-sha256": "bcccb0beff7112970f76cbb8682c7c4cb1e7446ae1956e2699f46148a00ff4d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "60590b2915a45a54fb121d813cbdeab070041875225d38c8e7d308c8df7af8d1",
+                                "uncompressed-sha256": "3f0d5deb30ec6e97fc25f8d6e8bd531dd22a1373282465f7f1ffa169dd6c9f30"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live.aarch64.iso.sig",
-                                "sha256": "ac54e6be56e07e93d939afb2afafb993e61975f116b407f0e74b16a63d4a48df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live.aarch64.iso.sig",
+                                "sha256": "996138910e19745f8857af22c56aeaf3ae3c3a2a9699502d26fcf21e90afe791"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-kernel-aarch64.sig",
-                                "sha256": "9bbc0c304cdc2bbbe539c6ab63d3f7b173ae92a18c880f8b5d840ce5d36298a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-kernel-aarch64.sig",
+                                "sha256": "2528f9394bc537b9e2a0d5631b3aa751ec3ec4ba4dc04461a9f27282a24d9a66"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "16527eb859b0e2d5703a013a6060f5c92fd84745f1d127218a8ae356d1e486ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "c9548664d3fad16c9059a48adea7234133c4df561a12ef7c74eb873dcdee705a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "13a3171f71cfc1db0772a6c57075c0d85c91748947dcdff3a4537b8f18cdb245"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "16d269fd6f5434176e679954dd4642840959106ec619a424a2366cca7419f2ef"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "bfe9c35f19d1261050264ace52cf81f4c19795354d2df74d3343187acdcdf438",
-                                "uncompressed-sha256": "567e5c5af413b5c2b3c2365351917dff0c6dafa28965a2553930160a1aca0c75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "6af85a11751d5fb79939cd779cf54c96a71f2bef88c93963911c7c30a1b38cb1",
+                                "uncompressed-sha256": "8c0e99e47157a09ac744bad47f75eab2a9f8b492a53b8894b190098b70799ee6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "ff0df1a1a30b423a8308fc58d331e71d0b67d7a5bb6afd45047d5ce021bbfb50",
-                                "uncompressed-sha256": "a78e922a164f34fe66935970cd99b76edba7d7deb0d80603c17fbadc502dcc9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3e6e3082ba32aa9e9e0d5c4e6f2f207213b8fed9988e9609b24824ce1e316aa0",
+                                "uncompressed-sha256": "336f7d657da15470b8c467508b886936ecb13f95d2772ba86885bb48f993f0d7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/aarch64/fedora-coreos-41.20241109.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1979a68160f7d4175c19351f872fcf69ef1e6262dde17915448b2e2c9e1b0df5",
-                                "uncompressed-sha256": "e7bf03dad25b4c687b746fd6bbd07c7e40ba77d1f72b2b0f7dbd6fbd160e4029"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "3f9ef4cd5eb197f223b480307c5a6cb4b2dd5be998964adac65a9f37e6836105",
+                                "uncompressed-sha256": "d7dab8659124ef269044bcd8503391ddf25fd0e17d18b1a2fd5dc75ad8cd23d1"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-082d3dfe2795cf636"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0f26094d67ea065ba"
                         },
                         "ap-east-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0ac500410e844849a"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-003b13363e2a66294"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0bd00af6ce37d5890"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-08ecf74efa431ca6e"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-066bce52e5fffd941"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-05109bc5a267bba22"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-03a753c41d56c01be"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-093c4e8bf5385f97f"
                         },
                         "ap-south-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-02451cf92fe23a693"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-07855b56eed73a3d7"
                         },
                         "ap-south-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-00b030cc38d1830bf"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-02f68678b2872a81d"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0197a6f7d4ad967c6"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0729978dce756907d"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0e963541bc066a7f7"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0cbebab2efe64a0ea"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-04c13a0c75faa4c92"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-034d036e496f43966"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-091f47f55ae3e7a56"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0305f0f24ee6ca6d4"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0957d2cb193cdd735"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0e9dacf160e6e6445"
                         },
                         "ca-central-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-031baf4d384865042"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0233fd3bae7574a61"
                         },
                         "ca-west-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0f892e8f6930ab37b"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0e75a0e6794f5a34d"
                         },
                         "eu-central-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-04f41ccedc5428f6b"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-07f9751e3e9733dc3"
                         },
                         "eu-central-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0c65057d53c570305"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-07eb0c8c5fba246fd"
                         },
                         "eu-north-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0661afe01a0a7e664"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-09e3b8c47840e2f4f"
                         },
                         "eu-south-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-050c846376c35b081"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0c2611e99d59fac6c"
                         },
                         "eu-south-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0cd50cf11050a4d7b"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0a186369f6b6239f6"
                         },
                         "eu-west-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-08d3627a362654f11"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-037b3eb42fac3afea"
                         },
                         "eu-west-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0fc509266546893bb"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0d23f86e12f136e2b"
                         },
                         "eu-west-3": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0f31895504ebe7388"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-09df49dcef4702689"
                         },
                         "il-central-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0e7489f43e741f83f"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-02176abca79d02f22"
                         },
                         "me-central-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0b2e3d8cd45870027"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-042bad3ca16b30484"
                         },
                         "me-south-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0945d393285a1802e"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0b5886dd0e8bdc8e4"
                         },
                         "sa-east-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-08e9accff5c38af72"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0d0c451b96446c6c8"
                         },
                         "us-east-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0d72680922e7aa5cb"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0d373818310ed2140"
                         },
                         "us-east-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0c17f72ad87834f29"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0fb6478ad5274ec03"
                         },
                         "us-west-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-04d2d360e02008f66"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-027a5a17fa6334b96"
                         },
                         "us-west-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-069d5f4ad656bbdb6"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0c22c550987875878"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20241109-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241122-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "8b0cff1bf88e15d134bb33137812c2d2597f5637f5f285d5e4b1b6cfa14f379e",
-                                "uncompressed-sha256": "9d3a6e90af8fdcaba198733449eab6d5cb5720c47d12e0b9f1782de98f3419ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "e301a8f5912f834cb3e96b3a234b1c26619ec50358aee721e0ecf0c80a1d553d",
+                                "uncompressed-sha256": "e625a5f361f0506e5ac0116dfa250920c20efa90d455e266a2170eb5a8dc8f3a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live.ppc64le.iso.sig",
-                                "sha256": "101a5774c73b23c3d88e7c4c995205c9e20faa4bbf4e7124fcd121ccea7acd69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live.ppc64le.iso.sig",
+                                "sha256": "d051932c3cf8fae4a7272668056951b0b0158ce64035345d75472e297ffc572e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "be45daaec2933f2ec16ec24fd6a6f5b367def5039cd68587c463ca84c5e631ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "65a7d7c8d37c79132477d06f3cae97bf6fd90593022d36b71550c21e2bb49eba"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "532b1a37e6afcd4c88b81ecedb5e483fe385a23844f09ce6801c6c1cb9fe64fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e6bf87397817ceb499f7e113eb4a141131ae1311938e096491e7855630d5210d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "a33a4db62260469cba575aace8741f309cde2e5142c762593b3030bd2cffb23f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "b26ec435f7e2d4e0af257ccbb7f3d7c48e47e943ca28149136fdf951290179b0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "77a905ac3e3686efa4320778f0694a0cf11909a6e6effbaddf47237e92dba62d",
-                                "uncompressed-sha256": "f3337ca63d86b342e570070fa9401b79bfa3966d5086223cf295bb29f4329c50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "7c93ec8ac7c04fe916f8ebfbd62eaa8c4ae6963843ceea87ebee2abb80fe0574",
+                                "uncompressed-sha256": "393a2cc839c3cbb0bfc30dab79b623d0d945f457527637b7560c1f6259110d8f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "f44dbad140df13f7ccecd03e82d3c0a71c4cf90821119192f07a1d004b6a1be3",
-                                "uncompressed-sha256": "fc4a09658a81f0b21e9639aa3f56f73e029cb1c5ababf8ba41aece114fc6857c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "87549caf110e5f1c2f99522a356ae3c52131e954b59ef2a698bdfca898dbd2cd",
+                                "uncompressed-sha256": "902805309f4e2b1c81b2b0f45526fdfe0de9c673eb9701ea456594a869377c01"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "48d22c0d81e952449f62bd67ddf8e2c4a490382955566b9384e19d12f7e5bd75",
-                                "uncompressed-sha256": "4ac48b25c42fca89fef96bd65f524c1172e1067b69ea8785d16e3016cc76facc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "67d474cef8550fddfb1cf2b52ffdf73945502b044e25ed394b9c514c4a54e338",
+                                "uncompressed-sha256": "3caf3afbbd520245c5fef09cd79505f70525ef7431f039cb5fbfeaa444ad6c41"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/ppc64le/fedora-coreos-41.20241109.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "f28b7dad55069a99f61e3f0ff34924bf7337a3285878b6d4f2b7baf751c733d2",
-                                "uncompressed-sha256": "5faa13f345cc6dc3f65a686c15bab04f377a7ce3cc81fc2429c20a0f8d15ae58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "f32e7db6d2f982e3eeaa50eca4907b6963b2bff9240ee07fea5ea7770df26f8d",
+                                "uncompressed-sha256": "496a834645a9b84c6b2fea894086166257829bd8b80b42f81e3a2fa772381c9b"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a4b47f38d51eeb07a0fbbc9991e10cd06ac087968f595250d3d8383f2d346327",
-                                "uncompressed-sha256": "e80f97f6bc5f5b33ecac15692ad1752e7c790bd2e274d15ffd5b3a2661edac7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4feeb94b051ebd995217eed95776a7b18e23a70e5a810fda2bc123e12b9f6027",
+                                "uncompressed-sha256": "5d6c62f534dcb7e898703c939cba43da75e5ae85aa2852858f56a953730d3b88"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "cb3ccc894400ea4b868763368b53737611bfa622b7d638220bed228957d0df41",
-                                "uncompressed-sha256": "ae0c24b8c4163194ef2f76ba95f24066d00f04429e27feff8fc362b5356cf30f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b8cade87bedb950854fc08b76a7c2c605ef3a86ac06d7ca24ab0b353e842a62f",
+                                "uncompressed-sha256": "2493fb6b36dd3a3cd03b3ed890fb07fcda9fb7fee0787833008f2bdcd832d839"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live.s390x.iso.sig",
-                                "sha256": "ed5e01536fed8f179ef576cb58fa0b4ee27e3340723b876e16b043fde057e863"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live.s390x.iso.sig",
+                                "sha256": "aaa0ddd2a2301cde86642a469ba14c860c57ed4bbda944a6dfa1f998e852e540"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-kernel-s390x.sig",
-                                "sha256": "8e1100819d5840b74d59cf37e4e2fa3679ba8a5b733ea15b63d43f98604703df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-kernel-s390x.sig",
+                                "sha256": "8bb336e20b321ac5a7ba733d3e29e339893f1e1c3bc5bba40b26f75a18b8250a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "08ca2db82c30b34411289bb443dc80de98f404d3c68373c43d3b3fc265f9d8da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "28d5ef2bed660c09d9548b3f4d12439ca6518b718195e61d272c72baf4ca12c5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "88f177601003ffc882c678b1f84557ff5cd6622f380d3909edd316fdda0927f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "c0d940054bacfbc880162aba53dd00e86cea7a2c8f2da22cf265b191e7d0f4c8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e288e64d0ad23ffd306ae19fafd9ed1602de8ac5a82d4d91c3e71c86babf862c",
-                                "uncompressed-sha256": "b3155aa82d6b30a174c4db7d397091f6cae692149793f0a773d0b83b7fbd7f64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "f4d3c268cfe5c243135b46f97da9f15bbb298968d8fe38530d7f01f470abc379",
+                                "uncompressed-sha256": "aa97e90a73ed3463db2e9dfff961cdf192ce96c5544ff144dc48f07e2523c761"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "684686d6b38c24089311729a2ed9dc7f24a0499cf32e51bc78eb00f20dd8a960",
-                                "uncompressed-sha256": "4f85a2c545e952017dfa8f1f079d30f7af460de96354d565051f531aa261ec9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "0fea61f9d85bad381b23af151c3d923ab3ef36b1d18e23590cc3f25b4ddd02ae",
+                                "uncompressed-sha256": "09305589db4206bd9164cc6bd7abd2481ec221d73b46975a6f9b7a94f1ff4049"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/s390x/fedora-coreos-41.20241109.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "194537f8edadbe0fa06e3d709acd9f566dbd915368df6008f4abd88e03e2b274",
-                                "uncompressed-sha256": "6212c9227e751e7be9624fea05b74ff500e5a4e03fa4874bb671edea5d4d502f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6d9356a1ca20533df8df3013a938b48fd42a552de1b58f16645a3ec0accf0ce3",
+                                "uncompressed-sha256": "dcc0d25d494181cebda2930db33d8c500bf0aa7c203c8cf9162d29c65dcd9857"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4caed02d536b2d39caecccf0a539b75e63e3428ae4b9450cedf1a8f682f5a5ee",
-                                "uncompressed-sha256": "051a8c75c4dface9f196aa2995fb02648b5ea40bc372d2b8af586be268f12d26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "dfc6e4444a462547b7c668465667875120f6a7ae5de7bf5fb020ff724cddf10f",
+                                "uncompressed-sha256": "2bd8d87e6e5a39430c1675faeff9f307dbf0287dd26eadf524d7f7d49305cb62"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "475b4dbe650ab8f7dd437e03aad64225aa205f927457d00f5cbcc2629991714d",
-                                "uncompressed-sha256": "120053979680ebcfd7b24be1ebda13c52bc3d37eef36510be7a209bfb1434946"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "07df20b9f955bcb3ad16e474e7a54f1f963fd4c8dccafd5ab43a0e084f159e4e",
+                                "uncompressed-sha256": "1422b10a414ce701725f747568240e776d3a861ca4606b31901b7494849d6256"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1b69428c9d545c7d93bf2a273ecffc64263be7a26838e7ba575565bace57f806",
-                                "uncompressed-sha256": "e1c8f9d420aad1d7d155e0ad8e8055b3b836adf5bece063358e6a025b352d8c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "16cb3558eb4c5488df7c56f755cb6618a14177f32e168f2334183cda74273d40",
+                                "uncompressed-sha256": "def437c67d421c6312c5685082c4da519055c38bf21843d4460345f622c6fe05"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a542fcc5a4b33a62de5c8c9c1bdfad1ee3a9d85975963a670e1b1977ba9890c5",
-                                "uncompressed-sha256": "3bcf102bc5b9ca30e8ed618e640df0c0a67ec001e7560cd3d302ce44df04c122"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e9de2fa8f606bb642210cfa0bad5c3ed3f9cf76340a74f81b7423481da04cb0b",
+                                "uncompressed-sha256": "cefb9edb7637163ad2e10b43e085367c30302d62375cffcb9c8a26981f9d377b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7c7c8c139c6998f9393532d3a980cf3cb3b977bcfb3284420615d43a6ee2d910",
-                                "uncompressed-sha256": "6db872386efa22a21298d0be8cc9ce6b22739bb1d0d94e5b11cb15dbe3bde150"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "434b80b05d9453f3bc280be467ce5bf042e7ecf62402ce2bdc9ea8585d2e5b5c",
+                                "uncompressed-sha256": "60653f402fd95b850d6f05a1b65ea979cf25c450e63a0c969c27e80b808b0707"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "52d55b3f7dfa65a6e875ae58ca3ef249c6809c68023152f18576c514454452cc",
-                                "uncompressed-sha256": "03b6a29009e325d7c6b95958f05fd41f7ba3bc411dbeba4929306bdb9c0470bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "73098af1ccb9084c4b7302c3027c12e966cccc8858c87e0fa1495c93601fced4",
+                                "uncompressed-sha256": "623705d596a8e1d674b0455d46325dd57430da3ea61643f56f0ac3a1a4d5641c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "d20224f1df05b3a12cb9a401a5b692a59210da85d3ad35b41a5914c725ca06b8",
-                                "uncompressed-sha256": "b6ccc4c10cdf2dcfeb729f095b4a3dbd212b6c948e5cf59c82ce8eddd013338d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "acf73e9b43ded167a16552ea5e377202bcbafdd9d18471e9f48225bfb94c5fc0",
+                                "uncompressed-sha256": "07763b4af45f4eadfdf463bacaf25fa3fe06f0bfbafcf5abb51206a48859b3b4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9cb91fe762952464d670127264cc8e73ec69540f0b6fe064ceb2d1fee83d0850",
-                                "uncompressed-sha256": "195f5babfa97bec631b453af9aed59a461b51d67156283f61f73cb7a35d3f3c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "080f7020faba0a4b11906d01336a291701753a76f29eb157b6f2829acca194dd",
+                                "uncompressed-sha256": "7b949c41c6c509dbc9a61d98849a5ef436ab6ae9a4faf809f593a9ab9e12b50f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e45af0578c63f095cb8d2b3c9246c94e32aa0ebb2746f69ec249f3dfdd24a0f1",
-                                "uncompressed-sha256": "caacc4603c6d0d90d7b0ba89f6938ca719d43dafca43ec70286de494a9a76c95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "61e8155249f6375f2b2966510b3e4ede4a0e6d6af906a750a3efd7666c4a43dc",
+                                "uncompressed-sha256": "7d81e9ef48012750218fc22e685b8359ff061f46558c90ee7edad3a3da543244"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "85a0893667ec9dba59874c49f10e6368df1ebf8e4ac56c73c477d3c027eb8081",
-                                "uncompressed-sha256": "0ccf3fa71ddb5d78b39c14c8e70b140e69bc31900d55ff2855b27dbd618d5c3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "09b196e2d2e42fc4539c508f6dc905a220aa30d01f0dd12893ff03bcb958bd6d",
+                                "uncompressed-sha256": "188c36523e4bd73059a7661eecdc0d3708669f05bb25d89e698e8c178fa73352"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b2b40b70cc1959f52e3b61a822a39d49ff887800c0413c9753e32f91af55f137"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ed71da62d4ce8d5b962efef2cd7d65dcaa16b07376e1d9db441392b4439324f8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "91d39e0161aa23877a7cff3304447daf97a8b91207ec1b1dfec31bb104c2e1c1",
-                                "uncompressed-sha256": "62611e0a86d8bc28994a436af6a598bdf6f112e0ddd49d7ce17764b376e1297b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0bfc1e3fe216aa088d82d897c6efb0669c88535b48fc207ab7c84f4c91366a3f",
+                                "uncompressed-sha256": "f4f8ca0baedccf1656f366c0f135b2e959cac597f1789198fdb524fe7e0418b3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live.x86_64.iso.sig",
-                                "sha256": "46bc10a249243029648578f4430db27e105d623cab750034bb263822a8b41c0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live.x86_64.iso.sig",
+                                "sha256": "0107e06cb79d598e29ece905b7832c046ed5e5835b3763bfef135f1f09ebb47c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-kernel-x86_64.sig",
-                                "sha256": "65e863770c2e40c9221b8e55623dc12372ffc1c01784a9b8103122e9f19556ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-kernel-x86_64.sig",
+                                "sha256": "042f96248c38a74bc086105a6535205c34aa4f878178370ffba3974c23dd482e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7267ce9527a98a8468742f0e6cc46e10b96c62dfa138dcfeaad4ab8b52e612b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "431542034ea8f2995ca6d76b3916b43f1e8b1a5fde070e4d04867d772024134a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "bb758e7483f1a4b7e13c0488790b544fef81e9044e12ff403e62bb633aaaab64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e8c39b189043f37ba00ec881e73ceae3c0052b22b3f18f96b1c141971218012d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1d4a1b235b0d15f966fcc1ac54e054918a0ede3cc3f6d454c64d03c737c9128b",
-                                "uncompressed-sha256": "18e10ab619d0fee57859c009612e44810ab9937c3a102b1f4e9b8c5702ed742e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "006bae002547481e4b164212a5f776ad5e5c35ef3eedadc10ab20a888d50b41d",
+                                "uncompressed-sha256": "4005f8cbc815e188e24f7797414daaab7d1098cefcffc429742826b319917180"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c6d5a07abb7d3ee3ad6178ece8b014d9b995a8bb32f550b09f894c6256c2f8f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "784e8ffd2297d0a56f532f4e987530f781b3bacea75a5520b995c949cac80f60"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "03256c8da86b69dd81595b0dcc2af58371d8dfa6439647a889c8a0a9143659ea",
-                                "uncompressed-sha256": "a651f9e809ef8f78d9ed66ca3bf534258bddf88372662a620cf2b6fdfce1801a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e495f9cf5e3004336d9fb29588173359fdbbff5e9d1b035650272a1cfb5d4947",
+                                "uncompressed-sha256": "2d22f035a48173bce725ad8ab5a61ea2439d9cffcd67e5878cb3cd5507ae9ea5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "13e695334fba5fabdb77da4990eca6aa5b34be1f39bca2be404bcb6b8914f4a5",
-                                "uncompressed-sha256": "4b1ca880f78f54a987b4346e69d7d70e1f91459146d2ce9e4dbbded39f7adf17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5cb3a30402ab0b502fcbb402501389ba781926df7bd68d4aeb45e55fe6855e97",
+                                "uncompressed-sha256": "b3475b09074f5cec44b307e57354ced1ae5dc6907b7763d4398988eea40c93a0"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "66a363a8343eeea9fa56b625b52ca204072e45c8ee4d00863ebb1396065030ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "118bf16de697671a73f92c9cca9b492514a4a3558edd6bbfd7a51ee9cfcda7db"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "fe71225df3bb2a90b00a3bd72538bf831e9f647a9bee1da6637efcee207e407c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "bddf863e30e9c5d1725978b043e6a7e344aa21d46250e956b7763fa70f815baf"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241109.1.0/x86_64/fedora-coreos-41.20241109.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "22b5886f6f9f4aca56a2211d1ec6ed4721fb080fa209e208eb2acbf537da412b",
-                                "uncompressed-sha256": "278fd3754e3be103d2d422f9ddc9d0c265b3d4d2a79540ac822b138347e30199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1e4e588a9c0a38a6cc11f13708ded5414b0dea830b2cf69bbb29d37aeeb0e76e",
+                                "uncompressed-sha256": "44a50cae52f9522ab45ac07c3ad4586fe541d5fe85c74077f5402670f736c02f"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-04f28162a1fbf9473"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0e78cbda144eb059b"
                         },
                         "ap-east-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0a6d887945ece7c56"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0827c88002e1095a4"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0d3f8c07364d4d8b4"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-098d4eefbbc8e9e1e"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0ce35f2ce0095b808"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0f60629aead842c10"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-05deaf1d684d6df2e"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-08781ba4018669c4a"
                         },
                         "ap-south-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0ac7a8375bd4a486b"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-048baa73f8174cccd"
                         },
                         "ap-south-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-038b4134c0b44016f"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0b4c8e7cf8e383e9f"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0636c8961eff4830b"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0cfbf02b2ab4c50ec"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0e3f9176d4b0a5503"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-049ee05b767e1148b"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0c3df8231bbd41406"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0031eb980d0eba1db"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0835b21dbcd528011"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0617278b9702a2f16"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0947a4a8734bcbbbb"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0c33e09f2e259cfcc"
                         },
                         "ca-central-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-02f8d7b4ff7b49eff"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-05e820c30b3b39e8f"
                         },
                         "ca-west-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-01a5cd49a33e076f4"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0b0440db63968b409"
                         },
                         "eu-central-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-091a7078abbd79226"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0ea67dbe971ab6b5d"
                         },
                         "eu-central-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0e3d6607740624268"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0e320bf78bd29f005"
                         },
                         "eu-north-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-07b88834171e83655"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0f34f1b8fa0e0b8e3"
                         },
                         "eu-south-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0dff3e5025975447d"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-09573455fd440e7e3"
                         },
                         "eu-south-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-004906f21427973ae"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0bfec5584e16b218f"
                         },
                         "eu-west-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-089625db614db5eea"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-037bc845010e21593"
                         },
                         "eu-west-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0c4e89497b2457269"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0945831c4e3d8055f"
                         },
                         "eu-west-3": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0bebf025b51cbd512"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0c4fd662151807028"
                         },
                         "il-central-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0ab64dcea6bfa65b2"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0bfbb0209e1e1e0e6"
                         },
                         "me-central-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0e2bd5e79779290e8"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-05461892cda16118b"
                         },
                         "me-south-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-086c1e294b30a128f"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-01d5d6952c28443a7"
                         },
                         "sa-east-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0dffc9e64f76f07a1"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0ac067705483349d6"
                         },
                         "us-east-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0879cbb5532f58251"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0b259c6773df76310"
                         },
                         "us-east-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-03ce0938e3df96957"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0cadc03512ff1d56c"
                         },
                         "us-west-1": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-0795144c21c1ae0e8"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-009eb28904f1717b8"
                         },
                         "us-west-2": {
-                            "release": "41.20241109.1.0",
-                            "image": "ami-07e1bd65512c94dcc"
+                            "release": "41.20241122.1.0",
+                            "image": "ami-0f51a10f85a290758"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20241109-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241122-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241109.1.0",
+                    "release": "41.20241122.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:97fcdbd301c5cdce0e0f83f4ab208d09db9f05ceabd7a0d61ee41fc66381f177"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:63e67ca8d764f5a60be57c803048218f8da15525dd6ce64e04b0e3b273e6ff9f"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-11-12T20:28:55Z",
+        "last-modified": "2024-11-25T18:17:16Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "9c1373e7d046de4f3028e5a74f437a79ed02fa5d18a5afaac466149ef1bbc948",
-                                "uncompressed-sha256": "0f4fbd9d114af6d2b8c3c22877348c195b0857b6202176f5a26028483613dea6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "0b0146ff049cbad69a524b201fd899e4d1dbd62e2fc4ce929e96cf3367bfccfc",
+                                "uncompressed-sha256": "a9d71caa0b9c1441fc34b44602c01cec6908a36fbf8e08a4ccff3f6bbc58e6b9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ed7a7a5d7b7083e5e0dfb82d75488c99b2d2c68698dbc3ce411b1a5ac7758606",
-                                "uncompressed-sha256": "b24f5a180ae2f56a5d7006caddcc929832553829a4a944edc619be1caeea0cad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "df479ba5bdb885553fb882b97b5f91bf303facf36ac688a2b5b2982bac2e83ff",
+                                "uncompressed-sha256": "7d54174b0c98221d40c482b885ff573f43ab1d1235d26f90cdab2dc4e9a05eb5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "9341aeca7dda296094955319a6a5991b41db2ba6e7ee984e8489c23f199c60d9",
-                                "uncompressed-sha256": "2d964c83c6d31a17869bb884fb23a2f2183c23955f6a2c1684a0b059ea8a883b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "62e55bda4f7293b30fcfa178a2e4e9ae1a13989c08bc7db6313ddb60839e0e2f",
+                                "uncompressed-sha256": "e147cd2132a045195b0829a3b3a4f55fc83c7550bb5aecc6653bb00e456d6b33"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "e49e8890f38fe20f734e4934e87c4f591f7db69819c2e0355bb4f653633a6697",
-                                "uncompressed-sha256": "581b2c39c615e9561695d6bc49020487b3af8d66cdee625ddf7b6224c7ba8ca8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "5d3cbdfa4ad7b7473f8c19934bbed01d1f4bf0ec9413cfa96f6a4df5b7ecf1bc",
+                                "uncompressed-sha256": "66f099f48bbbe456771a88096f058899749ba7132b207a4f1516dd3601bd3339"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "0d6f356f1464b4b16f8dc2de89e18bbf73dee66b4549823cd7a93347c37ddf1e",
-                                "uncompressed-sha256": "ae4ff8bcad59b93900b83e5794fd0eabc285a8db36c5ba180a285cc93789daa0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "3cd6510f67662a50c724ff7b23b2962a0d7fc6451cbd0f5b9c01a817654a1f4b",
+                                "uncompressed-sha256": "269e81b70730d4c67e878b27042dabb35ff4865c88a18151563933b1a4d07315"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "1eb69380c1fca9157f3338fdfeb83c5a5ceb3a2689c54a186f82fad28bbe93ea",
-                                "uncompressed-sha256": "c797905af619c6f510145556a69f5a42a29d37146e805a16a59b7f3250a4ee3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "3ea8afba89bea0047123ad566f2a22439949eb673c20f3195282c6d33742449f",
+                                "uncompressed-sha256": "aa52378dc4f592d98ce47f01d4f8a3da12cdee528dd4aefec1fee2e0d1f26166"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live.aarch64.iso.sig",
-                                "sha256": "f90a2c252eeb61695b751f31865dc662222fc53966f0016d982e4cb8c9273fb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live.aarch64.iso.sig",
+                                "sha256": "404cde0f08764614118d55a903d2b5f484722ae717a2f0eda73f251fbe59c5c4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-kernel-aarch64.sig",
-                                "sha256": "b7593504d57829cb34817c4bca93d6ae8feb923a46518fea4e6ea02d91e89c5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-kernel-aarch64.sig",
+                                "sha256": "9bbc0c304cdc2bbbe539c6ab63d3f7b173ae92a18c880f8b5d840ce5d36298a9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "066823fab2a06f55191d999db1357c8d5043231ee65f7cd633493354ae354c34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "3c09ebf6a38593e09ce97648567011e1cf4387d7fd3912bff307fdf50d2dfa75"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "15ef82582d35540cec9e2ecb19874ac6d91e06f69c5a879dd7948de6941ba938"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "03faea73b5436bed6e232d129f2c1383f4eff212f5aacb56239941901cc154a5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "4bd703dd49b8aeeffddeb957d19c86bd2528733cf9a3f4799b22fde06f7009af",
-                                "uncompressed-sha256": "42fc3c169e4ba9fae07b6bf43105ce1df85d9aaecee1ec37b8735d473e9f2922"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "be42fcbe76843875ccc97b2e6423e60632ba17a3eac177ff3cfe1d1ad5760aaa",
+                                "uncompressed-sha256": "6a0d53495055c7212c1c9dc4f2da0d170d174b837de78893ef37d1752eeea7c7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f32b9ad724932f17385374a4ded1c46b60c1a2e6159a6e0aebc58b82d75f4202",
-                                "uncompressed-sha256": "da86bcec921652cfd49a192936480fd550843ccc6d988715e08a381857da1e0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "da845d85e74ad1b3dcd1129b5a4651be85575f427b014995ef2c0be3bc8a3c77",
+                                "uncompressed-sha256": "18502c20a9eac77c2291245523501a1cbb2392c1f1dc1320665675822b9864ed"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/aarch64/fedora-coreos-41.20241027.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6c1d137d06bfcbc829f08647f444d4a0847f902779983945c5280b829ee044ca",
-                                "uncompressed-sha256": "3147e88c3f0f9c0e829e5eea85dbf8353225bfacd7618d53f6943154d3a6c945"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "48331bc49d4e5717982aa669f032288d6de5d3867bf6958a04b1e4598476d950",
+                                "uncompressed-sha256": "3b42ced994f707d76ba45a50d7daef7bc8454eb106f1101a3cb72298a41b67df"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0d8684ee8b9ef02a1"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-05339bb9419f79a88"
                         },
                         "ap-east-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0e6c88c82632f2396"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-029af3e0118434f20"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0eeb0566ecbfb009e"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0e54704055a5ed880"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-069c313c5f0c585fb"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-00904ba769f6f2c0a"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-066f294dd8690156b"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-07f85d200fab73f3d"
                         },
                         "ap-south-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0d470451187bef771"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-09d170004e040df07"
                         },
                         "ap-south-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-00924226fd603c114"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-00cf038abdc0bf1f1"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0a8257b03a4726fd1"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-049580f5c1fc663a1"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0c28728089e75a4f0"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0e8a076e05bcb4b67"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-015cb5015d6f66e97"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0be0eb540bda13bdf"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0d776f99dddbad5ce"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0f181365a39c7531e"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0fef4f723cd026312"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-01d465968f10af583"
                         },
                         "ca-central-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0cc61c1e9dfdaf4fe"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0c4c83b9a6f42bbeb"
                         },
                         "ca-west-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-09bc74cd1806f5bac"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-00cd5c35bc12eb3d9"
                         },
                         "eu-central-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0ceefd6010d12f8ea"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0f31f1fdb1044d0e7"
                         },
                         "eu-central-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0c401c3d5b4159389"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0fc793625eec89da0"
                         },
                         "eu-north-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0effc13a7c9defceb"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0781d91101261b207"
                         },
                         "eu-south-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0dd5fc44ba7be89e4"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0707d6562bbf5a80c"
                         },
                         "eu-south-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0a4120b5478c0c344"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0a82e6625ca29e39c"
                         },
                         "eu-west-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-09a82458e40ffde07"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-000d0bdbe63084a4c"
                         },
                         "eu-west-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-01f99deee18de1d0d"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0547462cabaeb06cb"
                         },
                         "eu-west-3": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-048470b13121f9043"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0e6f54350607efdba"
                         },
                         "il-central-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-055e5803d2dfd903a"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0570690b457a6f880"
                         },
                         "me-central-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-04975baeb8daf1e44"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-082e7fe0fb0a595bc"
                         },
                         "me-south-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-016905336acbb249d"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-065066351e43a6c24"
                         },
                         "sa-east-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0a3f789251d67002a"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0480a640e76e9db31"
                         },
                         "us-east-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0e37f372c54b69f34"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-08ea0700f133d11c3"
                         },
                         "us-east-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-03488d76e1a8a8389"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0be62107193b9fab3"
                         },
                         "us-west-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-052ae089ed932cb28"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-03d7bde92d6e0222e"
                         },
                         "us-west-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0b6cfbf5b1b41a005"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-04249309a05d1b9fd"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20241027-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241109-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6c4fc1cb199fd5dece367d72c0d558d879767a0ad19801ebc90bf18615a61bc1",
-                                "uncompressed-sha256": "4fe092f342d3610e44da46911a7a11569e31acc2640d1e8c687ce490ff75d136"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6db75cc4bff556a75c5705b90e1bb0806b14d77686a08c8aed39c2bbe1e0b6c4",
+                                "uncompressed-sha256": "c8dc508a88357899fb203ace4d99bcf8af1de5c108ee9f33efa0b763d3005660"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live.ppc64le.iso.sig",
-                                "sha256": "1a19ecce5c9ad0a91c154ba96312fc2503fbbc6d6962e74adfa08d8e586d6ab7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live.ppc64le.iso.sig",
+                                "sha256": "0e48ff4970631318660004db97523ea9fd56fa5ff39e251a324dc525bbe86637"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "5c3a59742a992e2778dd5f06757cb90f5e616525b56f2e1ea07ce2831cb56b5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "be45daaec2933f2ec16ec24fd6a6f5b367def5039cd68587c463ca84c5e631ab"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "a371d6927a77d7eb77a15ef5bcbf25a2a0f1f7afba000fcc88c32a2c0d999dc4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "181e712d1ab32944e7a3155732d5692f350eaf0aa181ae00da015418af615c92"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "5aabdf4060a863070bceaa8286944638ae6ae03cf08308a96e3dea17ea08c001"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "32685534c40170a3df2683011b7bb24bbb5549d13160668d76e1d5dc528f8e26"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "eb1bee3543725a59d5d2c64583b1350dc295107126fea58a4a0c8e5ceffed9f8",
-                                "uncompressed-sha256": "eedf744ed0e65591bdf524181107e0a3d2ec1b8f271482411d78f5b2597f2927"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "788e11719c9b2e80df8411bfc4a144c210af85367bdf6bdf5d5ec1993347538b",
+                                "uncompressed-sha256": "454532a0acce1db2bcfb09eafbe258afbbb268724d3d58ccbc36f98b8024bff3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "02e4c65ca75610f775c5cf81bac7a5ad2f9419d3f5046e5e01d803b928d0a66f",
-                                "uncompressed-sha256": "84c7f10f81e1915784f80fb1887f4fca572920c9ee8374d5121eb98c4a771f90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "333a2332b22a4e2549bf7a856c78508007da0d182e413a25cb4c4f092c8af5d9",
+                                "uncompressed-sha256": "7f8fa7fd0391debe700825da2bd13e5781fd033f930314e6164d6ac7da0babe7"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "65447f83acfe58ce58cec2b0fc2f360a45d158dc18fb9aef0ff6144c5230a38b",
-                                "uncompressed-sha256": "616b386579121f50eb3cef4437c3ea0092ccda526f0d4e4f1dc7067d86846eca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "dd69295f79d26c6260998ed15f5713d1b43e7df4d797be6121900a5fd5a621b4",
+                                "uncompressed-sha256": "100b4db0b1fc9900fa074733d58a20f8e9acaac533736e23f5867d1e77a5813d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/ppc64le/fedora-coreos-41.20241027.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "a614be6b27ccdd1b8bec9d8a991ecf84070efee7e879c0d498e6147fce1d9242",
-                                "uncompressed-sha256": "46a34e064f3fb53c2dbbcc3d5daa08aa72e278bcfe6f3857896835485065d65e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "82e0e03b6a86b0b7b51fb7884b7c57d22d2fb54ee0036cdca2f1f6e51a72b7f4",
+                                "uncompressed-sha256": "74e32e3c52afdd1857452802068b918ceb1d90d2b647cf1d9a140a7957db2b13"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "2855eb9858c9703fc3798c8755293a23f28d06587bfdaf8a5eb7406d5ec2ce07",
-                                "uncompressed-sha256": "d5799842fe3519fe18bc9d36d2d8924eac82a16d831f62288d96716f81f4b17d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9a3a5718bd5f3b3c224bff56e6ea042cf85c2d71131e9318ec9656c4cbb46422",
+                                "uncompressed-sha256": "9ab25063d6aeef0a8a34db2e05b0b62c1b5bd67e600d75091cde38e853c4b38e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "fe5bad2da9947b653682c66233e68eb141b2c7f969ae8e2d1fe4e6afb8fe8ae6",
-                                "uncompressed-sha256": "481a5efc499588ec93cdc2120e3d04a5fe563a2166c95daec49a6c0eed7825dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e567781d709ec5f7b67967c22fc62f59f50bf38b5b72a326711c4ad7555356f4",
+                                "uncompressed-sha256": "46b1601703ecc6edc8c137439a22e0b8a41820d158ef25ed60f61efa3b3ce286"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live.s390x.iso.sig",
-                                "sha256": "ac58b46bc662c7e3cbb006d5c6142f96d75201c32d126c263137e6e20eff7e02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live.s390x.iso.sig",
+                                "sha256": "09fd635a5359e8fcf1f866d912c18f141f055b220bd5f022a01acf96dc15f5fa"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-kernel-s390x.sig",
-                                "sha256": "e470d5ee058c8bc9439d44e3338f569b76012d7f588b31e5fe5073bb9ad3b770"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-kernel-s390x.sig",
+                                "sha256": "8e1100819d5840b74d59cf37e4e2fa3679ba8a5b733ea15b63d43f98604703df"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "66a432775eefef6d6b896806fef94238c5c96aa4ba0535f1ca8f4b55bc15a237"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "95f26e02542d77851a52518b1228abe9a8531dac1cc893c3d0fa694b06b06a50"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "5711c04c8da10de1e20e1d5075b03ac97a542c31522b540dabd0c7ccefa1cfe2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f101ea277374178f72f466018571a7b198937c33f922a75347884c158a66910c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "bbe6a458e61971bcb20067324f8960e0d2af6679d95af06258de821588378089",
-                                "uncompressed-sha256": "fa731344d690baae057e45cc03f0121a0b1552095f8a1bd4dd31b304db48e62a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "48f7755890fd94ed90b402806adeb043297f449d233498492e00f7ed3a8f9f72",
+                                "uncompressed-sha256": "68e46267cfc8480e66e7d036f86a56eb37a7c2a3363582c7578e3e3e626c7b7c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c58d718c9d02e7e0180ce5260d56a0e5ad5eb6d81e59841d15d023b885113cb3",
-                                "uncompressed-sha256": "f6b2040ec9be8c2a4856cb91d275ecec52e23f31e0d8b2a797ccf279e9af8d2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "549b117f225107c119fb60619b41a67d53c78cacb04db80ba776d68f913091eb",
+                                "uncompressed-sha256": "c18025a7fee196610cfd522ef6418198a0735db8e3d9886484a8761831ea3de3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/s390x/fedora-coreos-41.20241027.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d78efc23a77c6da96a4d93217944b51654ba787743c7fc4fedab6ef82566000a",
-                                "uncompressed-sha256": "03d29426d849e59f45877507adf9257ae36ec0a381d5b237e4538e35d80a935c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "004e6cc55c94efa36f916a2b185d2d696a1dc68e87da1f9b4c271400102a8252",
+                                "uncompressed-sha256": "55641e5045c8891b866ef5044ded31c5de6f2c61e478ff49a7d33f4ae6dba574"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "74d117c28e95952f101ea66cdec906d0399bf8ef158a00935b2483f1c5317ae5",
-                                "uncompressed-sha256": "557b340e70696bb56b5211a9181d1be66c9783e455efd57520b6d31ebd0270aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ce8c3d396be0ce94e24950ee31b61521eb167492957274809eb7e8a10165a0e4",
+                                "uncompressed-sha256": "ddb7e6afdb89719667c9420717a8aae2e87572ad35a9088a353b839d5932bf23"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "3cc0ecd71667cc2d3c84f919aee690eb71f4a57e036c8c8eb141b082bdcd7567",
-                                "uncompressed-sha256": "cf8fb15d100335306386aa2d598b231d7d490dcec2245eada4ffbc9818190f5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "8489e59c904a9234dd992daf0cd2c94db14f21bc124556444cc0b01c35d807aa",
+                                "uncompressed-sha256": "f457bb3109df72908ed575eb23dcab93b4dda95301eff0b2c42d6f33a7fdef1b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "70507ca0393e2d8d7374ff3d9a1c763057d62edd35a02a9790908741d7e59f8a",
-                                "uncompressed-sha256": "8ffd94842af6b96411ebd06ac9fe5edf3bb253dbd797dced9fba08c1aafd0992"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d06ebf4d90ed58a0710cab0641436a44addb83c489069acedcb72fdfbcc9b531",
+                                "uncompressed-sha256": "8812ee21cb5bbfacfa8cc45c67372914b105b1d7a57646118bf0917f29b03634"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e8f5ecbe0a8c236a6198a4e85195cf5eb9e9f01ccf6994bf0e38a922392db5e1",
-                                "uncompressed-sha256": "3b411d977c9444a04ebe031cbb140407edaef0dd32dbcea40ed3a1a00136d829"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "83614ab0c33759db70a5e80de9c4bd1da4064a5d41568cddf2ca2f00e67d4a0b",
+                                "uncompressed-sha256": "d4e506e40cdb8834007cdfc6f4dfc321ac4673b6e016cf9684a664283c996fd3"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "972cf4a288e456bf96424e99cc4a3afde700b390a86c4057b2dcc59587318101",
-                                "uncompressed-sha256": "cf082c26322ddbe646bd6c5d738d3c77429a9d3a577460df2c716e9cc1a49d9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "387558d3c8c67be27bd15e90afd08a196948d40456315ccef0ad9564c2950be9",
+                                "uncompressed-sha256": "dc2160501b7a53b107ec713387f72221fa21ba2394edcb956589ab8d1503da89"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c06084ede43852eee5b9b1356d6d98b6538400bfe322b1995096201653cd38e9",
-                                "uncompressed-sha256": "fafd966f3fc443031da6a1faa70e7bca3c53ef4ea211c55bc019791390024a84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d53e5519017ea5e0da555ff4331843d6f33e98c520f87011d5093f9f597d67f8",
+                                "uncompressed-sha256": "0ecc738187adf9d104915df102d2e7dc71596c51748adf2497a1a982970ae8df"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1d82760546d8b6642299fcf1cb539fae1a26d7ae6c0676e59646a1f81ab43f4c",
-                                "uncompressed-sha256": "123d35426685c1fbdea0c1a5276ff557c9a13494a376220ebdbef7b277b4cf6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d1471636f80259754d20af2f1c17f64ec25e9c57a1773a0e5c5c88ba20154bb9",
+                                "uncompressed-sha256": "a7631ca187879c2856fc3ca24e6b411642f59408f065bed86fa471413e586905"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f38df19b6c609a6b358d32935d8d4b2f7d0fd4ff920f1a012bba36b28e1ed6c9",
-                                "uncompressed-sha256": "1e4e79b82823c7c5846bfa50a7f422744f43b3843dae5f9feb7711ecc4e383a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "69715919fff558cc078ceff4b33dece997f4af843d2603f9358568791b3f36f6",
+                                "uncompressed-sha256": "14801e1564a6d098eb96275266a8282f1334b6cdc3b8667eb39335bc853bf9a5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "1227d7bad30721e9360d18426cb569a6fce9035c02874e5b56ec9fa81517fdf6",
-                                "uncompressed-sha256": "47005a6fb9ef3f48cd96f9d929e604852fa6809d3516042c3968d9cb15fa2237"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "4c79b0347376b84c33c35a24cf351d4acc16e5f5a96200e0c9d9fc8a16fffc56",
+                                "uncompressed-sha256": "351255c3a85418f97cb5d6e05232e741ac83df53d9a8fbeb535f7358d5a46074"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "92cb09afe970d7467e5d6b821bb05333d7989d13e3846ffc42ca39b5e53a3d70",
-                                "uncompressed-sha256": "b9f2dbb47632d959b061bb62c7b13e9e5cbb84626a15b2ed1fe52fab5b31845e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9b6fb16165a05797fd3480cd784a27d373309dc694e670a43ccdf85dcb159eb7",
+                                "uncompressed-sha256": "45fa210cdbb5dabf5416f8cb65ac12acbdee789a668388ed6a2dfc29ad9d419b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "af4fa7c98f04eb31fd19ab1b5c7fc41aeb2c6b921be059d16d2c40cee0df951b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c5ff3dd48be0539ec4692cf268550cb0a8eca7a15a26bec09dc655d932d92513"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a435695737035340c205bd88b5583acc93131ccb8464da7d7e7cf08988444d2d",
-                                "uncompressed-sha256": "e0ed55291f575d7ab7447456665cc0883337aab4961ae1b309b03a79027bbca2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "86ea01b2af1f568fff299e2132e219fcea3f85fff99432d37c93a934b678ce99",
+                                "uncompressed-sha256": "4228c4197a0bd171f609096e8848f6bfe1e347c49cd1e2984e1ea319a0bad13f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live.x86_64.iso.sig",
-                                "sha256": "fcb99dd0ab593ee5f56c9ab62d8a03b40f527e5291ac195721d3b69a6fb86e02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live.x86_64.iso.sig",
+                                "sha256": "52923840ea43b246a1824e9c4a5179065e50359f515d7538574bdf9afb60a52b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-kernel-x86_64.sig",
-                                "sha256": "4a8f189eb2dddfca6495f5e951a0099882e1453e9f6629ad4d961f99428e12c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-kernel-x86_64.sig",
+                                "sha256": "65e863770c2e40c9221b8e55623dc12372ffc1c01784a9b8103122e9f19556ac"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e762701e21a0142143a6b70d9108b5918c6e49aefc6fadca131d14b64b67a10a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "8a798fca54e395fd9b270dfb56d41c5f3a358a6716ecbcce264578cfb4149d9b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3593d5f55cdcf9150459401f23ff3e66f22b2505b659b7a7b46c2accec811fe2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "16f3a649f3757838d0eadf25f73a609787e523fffebdcbfa6a96dea676633521"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "786058fe79911bad9ea40b71034433cd01aff3c131dbee01d23fdd503e2f2d05",
-                                "uncompressed-sha256": "6e8d506bf6b7da44bd926e5f45363acdda2f4c7c49767a242e7ff892f22d6ed0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a62ab5d766dafa1031950729b3c899f45e0e969d5ba93898de04581b7fe4af7a",
+                                "uncompressed-sha256": "e9ffdc97cf405dbb39977417aac8c14aadf46dfb52a956f10f7c23f9eac950b7"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e20d22c68f4085bca60512bd86311e66be9bd6b9683d734857ffac862e6898a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0871d61386a1caa3fe6faaad65f219bfe41a791ca560cecb4faacc935ea998e2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7f43c2c2a47f5e0fff7b78eaf728bffaaef253225de607c3a14858893f08370f",
-                                "uncompressed-sha256": "36f9761e8da3c2fb52987381171109411316ee2be45154c47d65fc9158100ca5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "d00c634e19148cb9d684916b5e695582b5eaf7d8ff1810b56fd9f8c5063ea5ed",
+                                "uncompressed-sha256": "c097289fb685e9ebc5fd112c619a0ff554fbb3aab9bce63f8de9b6aa9bf8118d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "923df6c83d8ed6dfe39f41ba4c6e32a7baa0f796b2061398feefa02f7a900dbf",
-                                "uncompressed-sha256": "d6dc471906e994ddc6c7a54f477f893bfbf719a86d0602d0b3be5cca8fd51dc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3e92734f04ff702979acbd54bda59e18a79f5bcb199e1ebbd0201aab07ad3da4",
+                                "uncompressed-sha256": "784e279c39c3da1c245457b0d6f17cf3f03e9ca3da444b5bee77b3300ffc8601"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "4cc8fb39d1c7044bff09d62cc9e57363addd92e13b7547a13bdbdfec02c24580"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f55c8af8790edaf77553ece4061c25a77900b144294ae44e3c1370154db4973e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "088f4aecbd50a44afb59cf0a1b89f73d424c61be2e60393b4a10eef63b7fd217"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "9c7067eda3d11312452ab0754a81d718533ccaed14ae8a1366e6cc03ec0046a3"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241027.3.0/x86_64/fedora-coreos-41.20241027.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4b61f54398ecb2d31cbf6de8c3c0109a20e779ffad2abfb592f5eb764fc07e5b",
-                                "uncompressed-sha256": "5b89a0b13cae1d7dd2be24ad5f1345537e96afac17289b57944f8aea34b5d4c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "54582793f2ba76bf238d4b1503092f36c37643aa3b02d83cce2572748420ffdf",
+                                "uncompressed-sha256": "7c30d46f257d92b11034312125e4ccf3935f616a9061c68ba7e70e5635761660"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0b9140fdb33145e65"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-069c535ca10cef4d5"
                         },
                         "ap-east-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0db022ac97aa6cc07"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-078ce40d3206a3ccd"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-061147b37cdf17e65"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0e8b32386179be0b8"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-09a8ec1954ee5cef0"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0e1bd1bba8cbe0570"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0e70764df9b922a15"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-035144b1c3be4ce72"
                         },
                         "ap-south-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-00faa5e85acb049d9"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-09ce370251db039e4"
                         },
                         "ap-south-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-030b42a61179d10c6"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-07801019949cfbef9"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-04ec3a51efef04c94"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0054d9a4d1b39a52a"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0e713c707d94e43b2"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-02d56220d4625dc5f"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-08f8053e425e0212e"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0989e5a2ea6c7a0ca"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-04799313d341eb188"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0d6fcc53ff3eb58fe"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-01a387521733f7a4a"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0c06a979d5049c8d8"
                         },
                         "ca-central-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-05d20ff45cecb0108"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-00a4223260a607a04"
                         },
                         "ca-west-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0ad6027e712338056"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0aeb43f4b820c8070"
                         },
                         "eu-central-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0eebc7dccf64fa6d6"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0bbb085d664b47387"
                         },
                         "eu-central-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0deac50f9951fe1f3"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-08d020953527ecd4d"
                         },
                         "eu-north-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0b2ba1e66305c1ee1"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-011931490025934ea"
                         },
                         "eu-south-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-001ace1f9f4950dd1"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-04ecde5ab49df41c2"
                         },
                         "eu-south-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-05919804fc1fc7e32"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-07f112f1cba9c16a0"
                         },
                         "eu-west-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-07b533dbd76716e85"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-03e338cdae1a3d813"
                         },
                         "eu-west-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-085426defd2933a48"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0db26c28edc5b0487"
                         },
                         "eu-west-3": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0283978425f898620"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-04e2475694b3dc899"
                         },
                         "il-central-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-04d032ebd4a7fe334"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-07f029198adca1cbd"
                         },
                         "me-central-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0bc3b26ca81e48d13"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-004beb94132888fec"
                         },
                         "me-south-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-02bec4c89eef7dc25"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-086bca0b3ca1690ae"
                         },
                         "sa-east-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-03a4d540923a0ebfb"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-022f3b6c423c0c2b2"
                         },
                         "us-east-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-038bd0e6543e58caa"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-0f1955c35d05f87b2"
                         },
                         "us-east-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-08237145c1888110f"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-07d84428127f205b9"
                         },
                         "us-west-1": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0ea4fe9019600cb4b"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-09fe72436cc97d5bb"
                         },
                         "us-west-2": {
-                            "release": "41.20241027.3.0",
-                            "image": "ami-0423221dbf56a3d4e"
+                            "release": "41.20241109.3.0",
+                            "image": "ami-03734b0484e249f7a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20241027-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241109-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241027.3.0",
+                    "release": "41.20241109.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d44ec678bc1a1259e98fe2eed9743871d814f9ca5efa5833a619b0abbbfacf0e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:28d171e9d0f29031884d58849843974f9a0d1a93494b36918f85a39aa606ae76"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-11-12T20:28:57Z",
+        "last-modified": "2024-11-25T18:17:17Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "2a75365b645388b147f9c584eee43dc783dd43da292d0e348714dcef855ab7a4",
-                                "uncompressed-sha256": "1aeddf72214545969eb30fceb8bea4f759610aaef39523061321499de6145b1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "6e97ff0a751acb3088da21584d185f28cc9223fc11d4aa4bfe6f1a131179cff3",
+                                "uncompressed-sha256": "ebe5778403bed4529567c4e6b8b07cd22747ef1a929d6aeef5a6c1107e03d272"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "88111cf70ef074ffb49cf3aff6ae495ca6bc2aeccfcbbd7adb08af4b1f6166e8",
-                                "uncompressed-sha256": "f2aac515df59b33bc278aa97ca06d5e293451fe2d55fc8e75f9a0f2d3115e351"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2394a6d745fc5add80500cd0ec737b0e710389edb7f68f92e21136a924a99d8f",
+                                "uncompressed-sha256": "47b41807ed48401872a286e441b9d6d63b6acccfa6dd423a3b9dcb7c39cbb9f8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "35b6c488d9c096312005fdda46fab505b657dd6043fd8e761440731cf4cc7c58",
-                                "uncompressed-sha256": "160b54ad87db0b8e67ab8b0e87753128c0a205fef79b3d290347d094c944a297"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "f3d386958cef05024c81b6d51bec11d4f8219bc9fb70d92649aace231e2af1e9",
+                                "uncompressed-sha256": "9a5fa830652c16e30cbf9beb43013a10b48348a37f9949987b18c36bd779216b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "f10bb5cb20481d386d2473dd95dce5c0a18ad020d2c6e36fcf3645a48670fd19",
-                                "uncompressed-sha256": "9460d64a9fc5a9720a870865977ffcf3ecba7e4ac5574bce97d700ef5fb2547b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "740062b55ee62b55a43ad0df22d60e4972486d220457eae1e888f02e6dd15f62",
+                                "uncompressed-sha256": "29fc5a6c2e73795c088e890dbd86f94a6fa5be49ae4afd161cd094850fcd1e56"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "cd07646ed7b3fd6dab5ca4d5c2aa33dc13977d40921068b0fa8ab72372c1f223",
-                                "uncompressed-sha256": "216bcb2223ffb9878a8270e713088b052e02bcc3826338e848d604718b43944b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "8bdda404ea5c0f1bc8f9578388dbdee8bd9f9b4d2bbdf7de565903d6f9c93ea3",
+                                "uncompressed-sha256": "3d9f5ee5c03f8d864cec9537862d805d08f81a46ef144e102fbb429054233a04"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c427f2f3bcaa34debdbc0567da03517f1afcf0a47abbe95f3d7df623fc222c6d",
-                                "uncompressed-sha256": "61fc795a936e49eff50ee96bb5fa10ccd65628791cf16bbd2c3add9ab4b22025"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2431376be45636884ef9a716367de1f6dd51e650fed703a566a3b056ba8eaa28",
+                                "uncompressed-sha256": "9c0871875b5f40554aba22cb4286408cabb80ee14cc21523d901806229444ca6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live.aarch64.iso.sig",
-                                "sha256": "9ebac68f11c441d07429de2d41f2ba94c1e0d9364b08566c8bb4d5f5fc9f395f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live.aarch64.iso.sig",
+                                "sha256": "cba924b9856a5c2cefcbfb14cda921407274cec32b8d0d957dd0a296d53ecca9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-kernel-aarch64.sig",
-                                "sha256": "9bbc0c304cdc2bbbe539c6ab63d3f7b173ae92a18c880f8b5d840ce5d36298a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-kernel-aarch64.sig",
+                                "sha256": "2528f9394bc537b9e2a0d5631b3aa751ec3ec4ba4dc04461a9f27282a24d9a66"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "0de86d029e85ee31a0dd5bb848c3ba788f52c974382fe7bf83fe0125bfd1740a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "668c5199c57f3abe932f90e69c2f03fbc3d5f3a9261feedda7619c216812dec9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "b0a1c80bea1190632ced1907d14e9a2ae6ca0cc702e700396c9a719e0b92eb44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "ffe82c9c8ccfdfd5c9306c4076c392faa1d3329bd48907f9bb5eb86163b4aa7c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "75376181a8a39eda8329710a83a7f8fbac1b63903bb8a40cd3c4c58ecdacdcdd",
-                                "uncompressed-sha256": "99956bb43b0ea0ddadbc046ca716d63221647febadd4a345693d173a672ad8c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7f6b6e679ffdc9158bfbe3c19dcfbfbebd1632aed15225a3f520c3868063044d",
+                                "uncompressed-sha256": "0237fcfb9cbfd4190c1fe109484706dbe88b35035713237a35734ce4103c8bc8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "74699c38de18dedffff4d04e2f9591157d30ae5537757d74fc38eb0c2724bc67",
-                                "uncompressed-sha256": "dbe1dcfbc1de497b149e50d6b1315d37ca468d80f29a4c1bb7188f8c8af22030"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2557fda488b9e3b4e983171a8335d7fff86f479b07f764ad520a1ccafab59e59",
+                                "uncompressed-sha256": "79438e34be7aa93c74eb6a3c51be3670f7e1858032c73a52495d1864a66735e2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/aarch64/fedora-coreos-41.20241109.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "3c0d658db3a1a34b21d3f826ee962c1777a12c5547684cd4d19bdd1911e6bf15",
-                                "uncompressed-sha256": "2dd0d1cf047b641e4bc0646703eaa27025efda524a3813a483400121bd52fb59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "4a6a3eb8ed9bd14ec9fc3f14f5a7cee3762242db7828698117708cf2840e2d69",
+                                "uncompressed-sha256": "479f315c0a551ceaa3bc3b00d6cbbe70fc34b3912a27e9dbbf55ba678d9e06be"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0495f871858894a28"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-010d18c74841931f6"
                         },
                         "ap-east-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-01465e938d9601b80"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0ae431418fb2a5be5"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-07e22a9912ca8a599"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0b69919dd97393418"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-09e7c67637c81f603"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-08332a6f4a2aaa079"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-01e773e40a7de1d45"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-087db97bd6b2903a2"
                         },
                         "ap-south-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-071418c8537586c11"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-07dfb7d8b883fc703"
                         },
                         "ap-south-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0948e344d2e226a21"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-006e94b8ea1194df9"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-032e51d19d4ff1beb"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0ee32e260df53927e"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-02e46c303860e1a57"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0ac8f16210e8bc790"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-05efd37a4e71cf051"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-00871cef2ba248e17"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-012f72749e3693c05"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0aa53da2aa2f0a93f"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-02325924bca6e4d2a"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-00ed8859bff94abbb"
                         },
                         "ca-central-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-08baba569aa42174e"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0a1f1c37b91d35ef4"
                         },
                         "ca-west-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0a292b82bd82d3fca"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0b2d27e92a7a5405f"
                         },
                         "eu-central-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-082a0bec1f3d74e6a"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0df0268598f92d518"
                         },
                         "eu-central-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-01f6c24c26626ee3a"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0f55beee000f4b976"
                         },
                         "eu-north-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-09a2799444b2102b3"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0402815a03b33a943"
                         },
                         "eu-south-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0d34ebacaa5e76551"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-01b4d1030a059f5cd"
                         },
                         "eu-south-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-08127adf1b962c3c4"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0f7d7a12cc2b256bb"
                         },
                         "eu-west-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-087e63a56abc88966"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-05957fa6ca0872d4f"
                         },
                         "eu-west-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-077df2abfdd8b969c"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0b523c2c2db508640"
                         },
                         "eu-west-3": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-07733b359f49562e4"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0ef1b2af71a2f9e9e"
                         },
                         "il-central-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0c0d3913f8c2c1825"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0274a68ffd4d51823"
                         },
                         "me-central-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0c41761554904d9a6"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0f8db1fec835d8418"
                         },
                         "me-south-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-048d2c4c41e49ddc4"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0c5b180b2df3d2500"
                         },
                         "sa-east-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0af89d6762e3ff1f3"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0d1d8ded597266c73"
                         },
                         "us-east-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-09eae17cf5ab21b1b"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-01769cf784f49a654"
                         },
                         "us-east-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0c489420efba9a77c"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0486a40c64e5623c1"
                         },
                         "us-west-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0025480cb472a54a0"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0003c6fc6a5ee1900"
                         },
                         "us-west-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0e41b7bbc18807037"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0ba64cccec2e99729"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20241109-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241122-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "03146ce2616aadf30c23dd97dc6de8ca1df9d1d556c7ea7323ad0b72e46573c3",
-                                "uncompressed-sha256": "edc0dfbc28b08904fbe85898657fcf16bd68f88515412396d17921c5fff31159"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f975c34f5698ec5ee02c43e7567cc9a9b044a94ed6ac190db1d98ba4ef989595",
+                                "uncompressed-sha256": "a6e3bde0a32914e3a6993cc8771b32ddba70f4c77d89c83a1d82f9475b0f9c5b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live.ppc64le.iso.sig",
-                                "sha256": "1aee8d49985a7f65656b225c68319fa50026e9d0c5df1a387fd93fe0baf3c9ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live.ppc64le.iso.sig",
+                                "sha256": "cfebd4ff9113dc1aea5a6bb92f12cd00f859cea19cc898e0edb6284a07e10ee2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "be45daaec2933f2ec16ec24fd6a6f5b367def5039cd68587c463ca84c5e631ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "65a7d7c8d37c79132477d06f3cae97bf6fd90593022d36b71550c21e2bb49eba"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "730f3eb2e885da5216a2a5bc0bcf4c472f9dfff0cd50cbba21625d3cbec47d0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "3a6199fb8c49577d5ec4899026a26852eeb4671f9ebb67359156fcafcb1c37e9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "63d234db85ee5d797ec1a5f1850a0a806e7b27ebf343a4801dfd504be6efe6bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "21efc34f6455299a46d7b18119d16740c86ccfca7c64dc579222fddfbba4cf5b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "f51e06a396062bc33480dc66060b4705dd1987ef50617a7d12a1f531204c0e53",
-                                "uncompressed-sha256": "04c424352d6afd9bcf106c684d63e902b18498c17cacc477a6a2305463d7c7cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "b2354e60bec1064b67886f03114e43f1f6e365bda25999695b19be8cab4377fa",
+                                "uncompressed-sha256": "fb51f0941f2237686620a70704d696d8ee34bfdcd11c55116280929bc1d249d1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "989df43f15747ef890bb81d865e012284879e273d1e48e4cbfa53a5880c96e8e",
-                                "uncompressed-sha256": "c28ac250596f159da40a3306cb8163213b22cc32a15b7e6659a55bbac4c3e6cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "5330ff27b29598b82d374e40de032370f99177cda921d6e3c636f235ce8f789d",
+                                "uncompressed-sha256": "ce92ef3a6054c709f3834b91550a19f4ac7fdbc7f6ff19eaf1ed0d1a92fd7918"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "25d1842b8cef3f462df455c7a7aaf6ed06de65a620dfd9286cea77fbf6be021f",
-                                "uncompressed-sha256": "e7b9306d3902e738487b9ad9135ec00cade2bac8cbf7fe1a3c36b76e652fea71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "b4303d2d888eb73d9ed358dbef4b4fa688367942bd96171e40d19ef238b9da64",
+                                "uncompressed-sha256": "779949c86e8e5b53016e9773632c612681e652eb9ea1f9bb6046f05c2c014793"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/ppc64le/fedora-coreos-41.20241109.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "cbf3584b23d3a1cd09f0544e62aecde094744c6f17ace99d499439c513bd0faa",
-                                "uncompressed-sha256": "15aaaa466ed8b71bc132b611ff1b50884b2c417ae39828f99f644c37df99fa62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "dc7b05d391ce144e018bb85a74a46a8281216ae0ebbff18df0c38a7ba76ad51f",
+                                "uncompressed-sha256": "28f94b3cf0ab790e329ec3a9c39f5df03f4538e3858526795d1ff2044ff6e723"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4e6efd97b2ae0540e5ecb89a312adf397e8057180823b3d967fd1ee241374d97",
-                                "uncompressed-sha256": "c1a7d754fc82de3e13cd7cffc8e97fc91032e8b5e8eb9279ce47a29e7ebbbbde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e9d8a70318b6d8b69f102d7f82fd1d487483bff2515d28237a105a9062ee0a04",
+                                "uncompressed-sha256": "5ec5bf6c1b59d431809fb8effc89d5c41752882de96daa84fd3b0fdda2e3a3da"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "a74a8f5f5be8a058bf179f93c39d3f0d2b83e452ea2aa4c13d2e612e50b1d6c3",
-                                "uncompressed-sha256": "fdf6e783f4b1c4050c2c5bb350f9279fca1fec817959f5efb86bc7981a9b2b6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e8c573a4cf2c1df1c2fe8233a06642b0745b885ba17cf2d16b63fcfa1227cd51",
+                                "uncompressed-sha256": "d8b939bca41f12577fe31f9c43f0cef44b4b75d7a43cd0116f203dff8b4112aa"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live.s390x.iso.sig",
-                                "sha256": "570192d928057834cdb381e7cd2a132f7fed672fd033efd446599f0e74341e35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live.s390x.iso.sig",
+                                "sha256": "c8c0e40cbe4173504c4e7c14b651a3884e519fa9f84749a802d515a15474b163"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-kernel-s390x.sig",
-                                "sha256": "8e1100819d5840b74d59cf37e4e2fa3679ba8a5b733ea15b63d43f98604703df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-kernel-s390x.sig",
+                                "sha256": "8bb336e20b321ac5a7ba733d3e29e339893f1e1c3bc5bba40b26f75a18b8250a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "805aa86c4e71e912c56b374a5897ad247e6b709da5d9aa11c5a68d76da82f390"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "a248cd9d784d3ef8ee14adf5435700485d934d9be98a69687e8a371367b9c57a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "7955529f0fe7f12dffabd99050068b00931828f3eb3a84c3ff5dea0046a34b8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f20dc938754de154e1e8246d77425f18291ac7553ff7e914fc97b8dcc870bb11"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "34648e360de702e4c292f6ad7544071bd7b4ae46bc1ef9c238a332ed34388acf",
-                                "uncompressed-sha256": "72c119ff95c131c5eaecb158b1ad95955eb16ac305d175860e2372782e91f190"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "550da78a11ff0e2f4a82319daf035b2def775ba72db6dbcbc4b4ab417b96f4c1",
+                                "uncompressed-sha256": "79050115f867af1d3b6f8644a6f9f0bec34a06fb1610aa1cd5c4b574bc55c68e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b3a2fff9062856d5acffb375a812e570fb8ffa3548c720b711e19cfe82ebe93f",
-                                "uncompressed-sha256": "e2effd2810af2e2356872d80ce017e7d0dab2f8ae59069a3d0c644c4b5634816"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c0abe27c0af1db589fd1dc175bf5fc0c4665a2ca67dd6e7b4452c1fe23d306bb",
+                                "uncompressed-sha256": "0423c17ac7a325816695b8b6aa524e986c15b37a7a0f2b06a60cea52dd0204f1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/s390x/fedora-coreos-41.20241109.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "b65e19b66d76e6d6093063e077b67b373136e45884ac5e9df83a12a4ac4fbe67",
-                                "uncompressed-sha256": "784a9a2abaab1603583946d1e58a2b2407f80959bd84c5ffda651e72f3e5a18f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "1b9d09643d7e44ce7f96cc7a8ccb7b8c302c12c55b302a5734bfead5c1dbc274",
+                                "uncompressed-sha256": "27d87562ec2e72beeed84db615a8f4508ebb4876e5c8b3193001fa5c9dc0ffd2"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "34b33aee9e04c195719c268b1fb05d431e1c7461ac729da88ad3e764376865a1",
-                                "uncompressed-sha256": "486014409b6f8b632462c46b40feaa501665899b3bd63bdd793d7a1a20bc52ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "02b0b22725273ea5f62d35eeef8bbbf053cc7b7a52f9aa81f125118f77dee2f8",
+                                "uncompressed-sha256": "2df6050d942630b21e435d5852024673b81fa133f5664c73a3d1c4fcb787bd08"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "027a6157fa34da80fc698af88393bc911b6523b8f91e9032b427c360a7119807",
-                                "uncompressed-sha256": "d1fe10e100c9a69e78f1d537a7817a218b97830122b36ed07a63a6026f2b28bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "6fd9ba6af23c692cf5c393ac8055cb00662841ca0ed946c68f11996210bd8abd",
+                                "uncompressed-sha256": "88a55bce23940fd3e2ccdaa41350cc6e2710e7be341d8e5bfeaf9d1ffd5e9ca9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e549c11b45733ef55ad07b90f3954eb9240e3e5b6f7dc44acec0ecf47692eead",
-                                "uncompressed-sha256": "5d0f233c8866c326be4469b25006f5d961b078cbdd1bd72a3e0edb028fd15620"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "5817d108d7ea929e2af7e0316e0ab60e818d240ff96792b394ca1b2cb1a9f605",
+                                "uncompressed-sha256": "b2d996ecaf210c2dbbc77196a7f27f3b051b7e8a7ceca9717c59f7090c4fa373"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8b339b1320c8499c4348b17a58d76f0ac90f0b250231af1f9c873e501aa0b142",
-                                "uncompressed-sha256": "c7a5a3f02b6acfdb3fc6506ec09bbcb5d9323690e63bcafe17c164e791270d04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5663639d1dc9a91f263fd0bd497e18b0149b01534cc9956025b8495f55ae9193",
+                                "uncompressed-sha256": "c3689f73b491dff4060d43a12323cb66ac31f7a4d7277fbd0d6649c3e7b76f6e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "fdfbabfcd9e528d4adf9106d2478cbaf400795a8878ae71c987a4ab49aa514ca",
-                                "uncompressed-sha256": "6258e32f2a69f08e27f05b66272437d22a59527abc1809437e637b1014e31f02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "242c927c53880ceca887e3cee64cf911e25c3d5f64cb773df00d71e5acf4c16e",
+                                "uncompressed-sha256": "de87494c28194c43a2e80940618aafd44c8da48c74dd56074e17d43fca4d4c06"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4ba9e94526e70e7be0968eec681790fbb7f33b327580a00b5efd4a33b6f934c7",
-                                "uncompressed-sha256": "a83418715085f9e4b312ffcf0d32f0484216e206fd76d3c8b20051479f4c97e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9ec8b47dcc53bcd93721a0b854596fdf711d5dae6bd19ef3a606ce5a61477068",
+                                "uncompressed-sha256": "c548dffea417e0e5822c4af435fd6be976aa1eb1214a44bb81a21800aced9777"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e3ff4de22e087beca8ee960b6781518b7d596e5b2dc67d30df95debf4f563cc5",
-                                "uncompressed-sha256": "8d7e9666055e695d8785f00016b88be762778f8b81a4809da300d75af1ca8d4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7182d9dab8f93205bfe06853980a0a4b462b334b9b0c6cc6e191511eeeaba086",
+                                "uncompressed-sha256": "edad811974673cb4502d7760466db57f6e9f9d2fc0b0d15c88e03dddbcd305e4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2f71a1593716d39347ca96e6c6246489888b5fe0f84ecc638add443010ee9cc2",
-                                "uncompressed-sha256": "91a681474c95c8ac4158e233aaa5b57bccc848dff70e7372b9adc4979e9c2cee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "0c0165ba948bebd75095d640cdd7c3a22b6788b47763632cd4dff088f32cee01",
+                                "uncompressed-sha256": "8027eb45e6c5968983801f7b8008b66e51dfb12f10424be6f92911ab507872cb"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "28bda853d6bf8c6021aaf892a772e1e3b02a858bd01e44ea600d1cee68924242",
-                                "uncompressed-sha256": "69f30140a15414a9eac5810654be4d34006e7c449209f82965d0f16343aace0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "cb66e758e27422f66724e0d36bad90db91ce70dd3a7de4d401b771b665584b36",
+                                "uncompressed-sha256": "728b2e82a9d60d338230dfd2e327df6f7691443d2b333a81b20b705a8d13abd3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "bf9aad8e38bdc58033a5231a6578d540028f72cd0c686f4d6f1af2372584c271",
-                                "uncompressed-sha256": "5057422b0057d73b244e921a8dd8f72da464ad17ffaa8ef7cb83db7c556cb428"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b19452d923b07ed548c74f735edf30f21e97a01235efc74c4fb51d891deb23ff",
+                                "uncompressed-sha256": "2e754f4a6cd95da80dab62b9dac91e657b4c0ac9c6384e38db1e74af3a1bf7f8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "159a3223be0afa8cfd87a07b7cf356713833009fb597bdbb9f75ffc5eb21ac1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d787f29c6908783fba40fbbb7209c198090d10bd9911a563f16c6eca5414c10d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f0cf6e9fcbc9285d461cb38a8c13e2f7802a115e3a8870fe4a99c5ac61694900",
-                                "uncompressed-sha256": "82f2f8346b3ce2ded9ac0b58ef38757a7dc5f3d3c1525413e083c7abcdb59931"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2aca32313692e3fa31f55a60e5f59a173e6fc819c6ff71f88ce0c0b67549b857",
+                                "uncompressed-sha256": "6f82ce2bb24b75e78675129d03fa55dcb0d804895c84254ae61cee0468e48acb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live.x86_64.iso.sig",
-                                "sha256": "3b8ef678e5930ad4db33960779851e13e42d9193b0529cbf68f1c18bb8b00028"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live.x86_64.iso.sig",
+                                "sha256": "f25217c6b2e2801dbb2156b98fbb81ecba0982d9d1796295c936bb231c575030"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-kernel-x86_64.sig",
-                                "sha256": "65e863770c2e40c9221b8e55623dc12372ffc1c01784a9b8103122e9f19556ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-kernel-x86_64.sig",
+                                "sha256": "042f96248c38a74bc086105a6535205c34aa4f878178370ffba3974c23dd482e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e97f46a17f7e5d600fddae5dcae4fb2d70b60e36c3f601a80d0ec085076f182c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1f6340cdd09bd21ea054234d1e6dad8d4010013e18d0e7de237209e722ca4ec8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "8a5a22d26fc9f312cfaf321440963a287b5ca63ee17bf58a500e3f4a81ab4cab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "21c996930ffc463a94a02a469e41be45b685afaa31380f2f7065c952a7f898cb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3b65391bf705d49bdd3db8110d288fa01deba9958d55d40469f3afeb6f88b7fb",
-                                "uncompressed-sha256": "c8b9f90c759d9182ca2fc52c264b541c22334c7988cf9a3ec92643f89707e80e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e81f821ee61d4074f039e21295acd8f07b975a311381612794af24ba437c6d39",
+                                "uncompressed-sha256": "0a50e8ebefe1bd0d8f1329d010c0d0103b4a476f23668116f85964d10accf6b2"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e6668377db6a3253fb47493231e437d1b28ab1f7bb43887b2d2fe2c796bee579"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c592fb824d05bcd5ea6e024d119b005268c1205a80eb65d101911cc2ec6eac15"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "139dda291e88437ad4f861fa93b01704e19c75b0b2a81d063acfb7762976b8d7",
-                                "uncompressed-sha256": "7ea2f0f3082d43f12a14a5118b4c98cee4a5f775d5cd5ed49eaf0b0ed48a2a30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "42c5c92247a44951807950f1773d614a120c24f6903544c255a916b0e289478d",
+                                "uncompressed-sha256": "3b64b6e445c52bbbda94f95abfc94e5912a6bf91462235c4e26a812feb1a0d56"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "fac83a205c3e7caf468a079cde0dd7af299cdfc00cb17fc84d70fb3dd6c7feea",
-                                "uncompressed-sha256": "1c639fdc7b96304a53ccf53ac7be1b0e64d338a0be98c7e03297e8609bd784df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "74e7cc2d9339625fcc2400317048bef94ec1c972026c43ef7217f7964a48a859",
+                                "uncompressed-sha256": "b0b491992670e6d5b53cf48feda10aed2cd4938fd477259eff1e442c6257323d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "8eef1f83dd4d5458d7f4fe4568dd2393a6a542a2150427f1db076d8dc3c67545"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c11665af26e27083a1d807acb55f769dc825dc17f3de675c540e2d10956c7b75"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "99b2019b0152b8a0edaf2d7bce5222da4788a9e36bcf9fd480c349c4b64b3ec8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "de0c4cf9faafa73d38fc5f71cb36c80efbf21b2cb98348f860d20ea39aaff68d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241109.2.0/x86_64/fedora-coreos-41.20241109.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d6fc3605f775aa2320465f4c52b50f827093c173e7444e1ed462f19ee4092c00",
-                                "uncompressed-sha256": "05c886271e9bc3723eedce76285684be53b307b85c12c4c02f35144beda6dfb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6decc2f8312b7e178d09317acf6ccab31418cac5b24f4b674cec0542e7dbadb0",
+                                "uncompressed-sha256": "52d2b8370e4e3d0260e8b9a4417cc1c5ea99a823e83cfea617a97dabb3e401b6"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-04d2e7013a1c8300e"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-09253447fd00a9f9e"
                         },
                         "ap-east-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-02638b148691839b9"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0714c7f7d99d175c1"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0711658794e557932"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0d380a4d3e293227b"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0f797ea202477273c"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0a463fbc6caa9a4c6"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0fa7f3ac1024cd407"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-03b3230490aa5bd52"
                         },
                         "ap-south-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0b88d811a1b16a882"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0c8fbcbabd2bc4697"
                         },
                         "ap-south-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0d51ceb9ad2af192c"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-08259747d747c3d82"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0abf5bd66b1b739a9"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0de03742a51f6877d"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0fe8eb3ec7fb95f90"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-074f37e6068cf8ee3"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-06b8f09ce5d117044"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-01d97cecd616e5ddf"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0c926727ab035ef83"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-033ee9cd4ecbeac57"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-03f1a1d13afe70cea"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0f3abfb401267626f"
                         },
                         "ca-central-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-08caace5fb21f5393"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-003aa2a8e78d2c88f"
                         },
                         "ca-west-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-08b7e883d2e8f57a8"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-028737460eab67d64"
                         },
                         "eu-central-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0221ec0a767c77d19"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-07ba0d611b0b22337"
                         },
                         "eu-central-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-05c04375c4da1d1e6"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-097eaa4816f90a7f3"
                         },
                         "eu-north-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-01d4b70d821bd0d5c"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-069af73db24fe8eeb"
                         },
                         "eu-south-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0a5200d1c970a60e4"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0b189b1f644bcc340"
                         },
                         "eu-south-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-075f58f51593ab400"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-03296a211233918e2"
                         },
                         "eu-west-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-00cb1359ad17b7c58"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-06ae55077d53c2718"
                         },
                         "eu-west-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-08f231dbf7cf71fc1"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-047cd3b69687cf636"
                         },
                         "eu-west-3": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-036f70e13796ba2e4"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0ed8bf80a8d5f4dd5"
                         },
                         "il-central-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0f5189ac003082cf1"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0feb8c2f9585a7c24"
                         },
                         "me-central-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0409ef8333273c0fb"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0c6ab0351028fe777"
                         },
                         "me-south-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0649b325f6e244074"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0b8742d1884e7a955"
                         },
                         "sa-east-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-086147c59f1d216cf"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0ea3aacf4372ec4b1"
                         },
                         "us-east-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-00f74224bc1a5e4f2"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-083f53a14231338dc"
                         },
                         "us-east-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-00e18af14638ae570"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0d78521186ac8fa71"
                         },
                         "us-west-1": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0a2c9a9a615aca30f"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0ad2462ec4076e2e5"
                         },
                         "us-west-2": {
-                            "release": "41.20241109.2.0",
-                            "image": "ami-0ee45d48c06fa6be6"
+                            "release": "41.20241122.2.0",
+                            "image": "ami-0d0840b3f2ed38fc8"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20241109-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241122-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241109.2.0",
+                    "release": "41.20241122.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6a2cb345b2373adc1f1cf140a626bdfabcc57ff1468fc324ff42aefdb49a2249"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5193292ed8aad4dcc74ad10765e0908464b51e0ea1329e7a45a9051df28c6719"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-11-12T20:29:00Z"
+    "last-modified": "2024-11-25T18:17:18Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20241027.1.0",
+      "version": "41.20241109.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20241109.1.0",
+      "version": "41.20241122.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1731502800,
+          "duration_minutes": 2160,
+          "start_epoch": 1732564800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-11-12T20:28:57Z"
+    "last-modified": "2024-11-25T18:17:17Z"
   },
   "releases": [
     {
@@ -111,9 +111,6 @@
     {
       "version": "40.20241019.3.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -123,8 +120,16 @@
       "version": "41.20241027.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1731502800,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "41.20241109.3.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2160,
+          "start_epoch": 1732564800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-11-12T20:28:58Z"
+    "last-modified": "2024-11-25T18:17:18Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20241027.2.0",
+      "version": "41.20241109.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20241109.2.0",
+      "version": "41.20241122.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1731502800,
+          "duration_minutes": 2160,
+          "start_epoch": 1732564800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).