### PR TITLE
workflows/promote-config: use Fedora instead of Ubuntu

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -13,7 +13,10 @@ jobs:
     name: Open promotion pull request
     if: ${{ github.event.label.name == 'ok-to-promote' }}
     runs-on: ubuntu-latest
+    container: quay.io/fedora/fedora:latest
     steps:
+      - name: Install dependencies
+        run: dnf install -y git
       - name: Extract stream name
         run: |
           set -euo pipefail


### PR DESCRIPTION
Currently, `ubuntu-latest` is still 22.04 which has git v2.34. Let's use
`fedora:latest` instead, which gives us much newer git (v2.47.1).

I suspect this should fix submodule-related issues we're seeing with
promotion:

https://github.com/coreos/fedora-coreos-config/pull/3302#issuecomment-2545817324