### PR TITLE
workflows/promote-config: add jq

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -16,7 +16,7 @@ jobs:
     container: quay.io/fedora/fedora:latest
     steps:
       - name: Install dependencies
-        run: dnf install -y git
+        run: dnf install -y git jq
       - name: Extract stream name
         run: |
           set -euo pipefail


### PR DESCRIPTION
Needed by workflow.

Fixes ac64d24 ("workflows/promote-config: use Fedora instead of Ubuntu").