### PR TITLE
workflows/promote-config: clone fedora-coreos-config with submodules

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -53,6 +53,7 @@ jobs:
           ref: ${{ env.target_stream }}
           path: fcos
           token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
+          submodules: true
       - name: Checkout fedora-coreos-releng-automation
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
To promote submodule content, we need to also make sure we clone the repo with git submodules in the first place.