### PR TITLE
Roll out stable 41.20241122.3.0, testing 41.20241215.2.0, next 41.20241215.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-11-25T18:17:18Z",
+        "last-modified": "2024-12-17T17:26:24Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "700dba36890b3a11ea5e8c6e35d241129ff3d4430c1bcaef8b65826e56354866",
-                                "uncompressed-sha256": "5028add057c8735362b64241e7cb751d5b7cae3d4ec856e0b7dbf3da54736757"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "83029562f2dd8d705aaa78a6bb363a752c15948ec783880e1e14f56c1d3f9edd",
+                                "uncompressed-sha256": "51a2f7af62c263c1855f64c03807afefaa762082d7d2df96f9ad0c87c83d92a6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a140510eee22098ac16e8f770d5ea80e9f582ee48702c57d8d69a1d7cb1516f0",
-                                "uncompressed-sha256": "18a6a223b5821f5cd19c7845ebc9995f3ef4e5a4a3b8d874f456e416b008c823"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "245e6fa970290fa5f69f146d259a7f430aadad390bee16db29ce8df400d09d58",
+                                "uncompressed-sha256": "23d734eab64117762cc3fe41f90a6b7d928bb0b4d8311f959dc5de00c42f4251"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "db037e2a82b770f8b84821a6fefad84288d2f6d1018aefb9fad5cef75bb4cbf0",
-                                "uncompressed-sha256": "9a433f13c018a6656bf071d8773ea151935e05790baf36069b16eab3b6175629"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "50d36538899980ea5010ec3fa8370fc5f4ceda1c040fbf1aa28588c8dd51bc9c",
+                                "uncompressed-sha256": "03c5c1a96e0723cfcc57cf2242f5d925471256b88bf7086588472b8a69e84a77"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "143a89569c4eac0efdb50239210aca769bc12ca447cabdea1e0a534ec13f2316",
-                                "uncompressed-sha256": "e65b857fbc152db5bf8d798c79bc7c911b8b7ca472e062f7a3a5ff83eef90973"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "5168753048e05bdc007b737ee8cc6569cc6d09356893216ba4ac1150772e562d",
+                                "uncompressed-sha256": "dd400a6c6d96163d60c92dbdc01b5c2c828555768d41d6af95b28b9877149479"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "4abe625fc1a49d0801dad827b88bf732bd865ddd4ca644c6bb3a68bbf347cc4f",
-                                "uncompressed-sha256": "39bd58000e11d6c4bf896fa9f58d267cc068c1e418b6b692199526b0841eb19e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "0d925c487300c3815742c44b6941c2228ca8e340fa3e9f7be3230dcd63a66b66",
+                                "uncompressed-sha256": "e6813062eaf1c658fcb8b11a2b804df79640f013b426432f9f40debe3ee6f1bd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "60590b2915a45a54fb121d813cbdeab070041875225d38c8e7d308c8df7af8d1",
-                                "uncompressed-sha256": "3f0d5deb30ec6e97fc25f8d6e8bd531dd22a1373282465f7f1ffa169dd6c9f30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ede5098023d1d66c0559e10eff76cb9b4d4d8c2fe4b69030d624f6c524b219f7",
+                                "uncompressed-sha256": "202f0c025beb2cee180d201c1e5aa874ff792923cb186820373f9531047c9baa"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live.aarch64.iso.sig",
-                                "sha256": "996138910e19745f8857af22c56aeaf3ae3c3a2a9699502d26fcf21e90afe791"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live.aarch64.iso.sig",
+                                "sha256": "81f0893d55b55b012cf97e8b71e3f4b1ab8b80b62aad724d95546d2a6180da3b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-kernel-aarch64.sig",
-                                "sha256": "2528f9394bc537b9e2a0d5631b3aa751ec3ec4ba4dc04461a9f27282a24d9a66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-kernel-aarch64.sig",
+                                "sha256": "8c3d727cfcba05687c73b5ebfd72fdf85fe34ebfe6d21d1535be36bf8b1e122a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "c9548664d3fad16c9059a48adea7234133c4df561a12ef7c74eb873dcdee705a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ad8178502b710e543f01fdefa288d9f1116eea746fb842c146c6bf29fe61fe9f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "16d269fd6f5434176e679954dd4642840959106ec619a424a2366cca7419f2ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d877da7986c7f57cfb8d046ceb137b7ee8db52f945f6fb34794bc213fd70297e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "6af85a11751d5fb79939cd779cf54c96a71f2bef88c93963911c7c30a1b38cb1",
-                                "uncompressed-sha256": "8c0e99e47157a09ac744bad47f75eab2a9f8b492a53b8894b190098b70799ee6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "64a357d37c0be90f220f219101b79c80f36cc14a255336a5540a33434be2156c",
+                                "uncompressed-sha256": "842454518efaa7eb8761636fc7ba1468f6d80e1f8169fdafc63841cb44cd69ff"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3e6e3082ba32aa9e9e0d5c4e6f2f207213b8fed9988e9609b24824ce1e316aa0",
-                                "uncompressed-sha256": "336f7d657da15470b8c467508b886936ecb13f95d2772ba86885bb48f993f0d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "eccace11e125da8425dc4f48f362faf5435afd3d9552581b152349d6c42a6acb",
+                                "uncompressed-sha256": "72ecbc7feb2d73b18457eac391bb4e3a38af7e023e4e65e050c5f4401402bdbc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/aarch64/fedora-coreos-41.20241122.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "3f9ef4cd5eb197f223b480307c5a6cb4b2dd5be998964adac65a9f37e6836105",
-                                "uncompressed-sha256": "d7dab8659124ef269044bcd8503391ddf25fd0e17d18b1a2fd5dc75ad8cd23d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "bc3fd47c9575806c945bd95e56743669adad4623fd6e8d00a01544c11701a2d0",
+                                "uncompressed-sha256": "2369f628e40ef08b03bf038b64842d6a608a09a01629cfaa62083eb6592e317b"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0f26094d67ea065ba"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0657c14f74aa12c84"
                         },
                         "ap-east-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-003b13363e2a66294"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0366463be5df13596"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-08ecf74efa431ca6e"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0057a46eff909aef4"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-05109bc5a267bba22"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0e010c98af648309f"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-093c4e8bf5385f97f"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0ccde6a5e334e2339"
                         },
                         "ap-south-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-07855b56eed73a3d7"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0cb0d62a064423013"
                         },
                         "ap-south-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-02f68678b2872a81d"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-07e1a20eb7150bbe7"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0729978dce756907d"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-02be67b70c12bf2b0"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0cbebab2efe64a0ea"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0b8588375a3f44935"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-034d036e496f43966"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-00ff4d013b9b21424"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0305f0f24ee6ca6d4"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0acd76b77ae08acf0"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0e9dacf160e6e6445"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0a8f9f195ac77c251"
                         },
                         "ca-central-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0233fd3bae7574a61"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0b370e58403382559"
                         },
                         "ca-west-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0e75a0e6794f5a34d"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0cc265eeb20fb032c"
                         },
                         "eu-central-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-07f9751e3e9733dc3"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-05218cf73e5385cc3"
                         },
                         "eu-central-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-07eb0c8c5fba246fd"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0556af134e47b3dd3"
                         },
                         "eu-north-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-09e3b8c47840e2f4f"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-018b4709b15e7431f"
                         },
                         "eu-south-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0c2611e99d59fac6c"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0e86411ae518df76e"
                         },
                         "eu-south-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0a186369f6b6239f6"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0f0677568929b7c6e"
                         },
                         "eu-west-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-037b3eb42fac3afea"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-04d3ef52deddf6546"
                         },
                         "eu-west-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0d23f86e12f136e2b"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0d7339f38ed068a5d"
                         },
                         "eu-west-3": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-09df49dcef4702689"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-09b6aa7fcf24d1104"
                         },
                         "il-central-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-02176abca79d02f22"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0a3c75e48419f969b"
                         },
                         "me-central-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-042bad3ca16b30484"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-03c1adcf2b03682e6"
                         },
                         "me-south-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0b5886dd0e8bdc8e4"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0f609e30526332bbb"
                         },
                         "sa-east-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0d0c451b96446c6c8"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0d1687ad0852571d1"
                         },
                         "us-east-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0d373818310ed2140"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0899d915bb1409b65"
                         },
                         "us-east-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0fb6478ad5274ec03"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-06355b19217dc53f1"
                         },
                         "us-west-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-027a5a17fa6334b96"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-06a45f03c14fd22aa"
                         },
                         "us-west-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0c22c550987875878"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-02a25e402e379a627"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20241122-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241215-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "e301a8f5912f834cb3e96b3a234b1c26619ec50358aee721e0ecf0c80a1d553d",
-                                "uncompressed-sha256": "e625a5f361f0506e5ac0116dfa250920c20efa90d455e266a2170eb5a8dc8f3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "972e2df1304cb54c93ebe9d22eb8bbc2e409cc4face0ccdcf70523d26a1327ce",
+                                "uncompressed-sha256": "ac617785e93ede0aae9ed0325e11efb0e20bb17e3a1824d7829b63b3a8ae4514"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live.ppc64le.iso.sig",
-                                "sha256": "d051932c3cf8fae4a7272668056951b0b0158ce64035345d75472e297ffc572e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live.ppc64le.iso.sig",
+                                "sha256": "9be55960dfaf4eceb0d13313776fa0349a1d1a375914af8e8a371cbffb8a0304"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "65a7d7c8d37c79132477d06f3cae97bf6fd90593022d36b71550c21e2bb49eba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "583c2eed4e12c9a7d981815bad0812473a89e3bf03a38353cfa6536690c4481e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e6bf87397817ceb499f7e113eb4a141131ae1311938e096491e7855630d5210d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "f198d235215e7235a210166db6418fb193ae29b630ab84342c50ff0b5e0f6f4c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b26ec435f7e2d4e0af257ccbb7f3d7c48e47e943ca28149136fdf951290179b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "e04a50ce4c15f8044bb53ac3666b072b4696b2d33eadbb04689d2e0c17530dea"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "7c93ec8ac7c04fe916f8ebfbd62eaa8c4ae6963843ceea87ebee2abb80fe0574",
-                                "uncompressed-sha256": "393a2cc839c3cbb0bfc30dab79b623d0d945f457527637b7560c1f6259110d8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3af4dd31f01f926309e9c8dad17738746d98d6d9ff596c86128a7df4a55fd99c",
+                                "uncompressed-sha256": "fed7b35352d15c637e67829d1d2ba9e824ffa262714cac033b791d0cc5394bad"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "87549caf110e5f1c2f99522a356ae3c52131e954b59ef2a698bdfca898dbd2cd",
-                                "uncompressed-sha256": "902805309f4e2b1c81b2b0f45526fdfe0de9c673eb9701ea456594a869377c01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2cfded08eebb9367b6a275844d6aa753af9c64e01f28c157dc6f5ead2a7f3d97",
+                                "uncompressed-sha256": "557a3a01c194c2254505a87162537f091c3d73ce72a4375f5c43f49f81c003cb"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "67d474cef8550fddfb1cf2b52ffdf73945502b044e25ed394b9c514c4a54e338",
-                                "uncompressed-sha256": "3caf3afbbd520245c5fef09cd79505f70525ef7431f039cb5fbfeaa444ad6c41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "92457f365f3e00536c53ea8069169d5cd6eaa0593448fad60eb4b923fba6b0c9",
+                                "uncompressed-sha256": "0fd86695599ee79b231861cccd3baf563f811ca7f8c88f4f38047d35903568f5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/ppc64le/fedora-coreos-41.20241122.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "f32e7db6d2f982e3eeaa50eca4907b6963b2bff9240ee07fea5ea7770df26f8d",
-                                "uncompressed-sha256": "496a834645a9b84c6b2fea894086166257829bd8b80b42f81e3a2fa772381c9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "93bfa2e11103de5b44bcc6793799c68152e060afa8ecac52cf8d4595facbe2f4",
+                                "uncompressed-sha256": "4718d7d44ab01595305ad00ffa4517faa50bcaea9b41e9b8ca922da3fd0422ac"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4feeb94b051ebd995217eed95776a7b18e23a70e5a810fda2bc123e12b9f6027",
-                                "uncompressed-sha256": "5d6c62f534dcb7e898703c939cba43da75e5ae85aa2852858f56a953730d3b88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "73b172edef441da23714ca891a76c1a088d3af46fd644c698d347034b2ce4050",
+                                "uncompressed-sha256": "a62cb98251684ceee384e3fbbce7095d0c49c856c910b9dcf76df6d4739d4d8a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b8cade87bedb950854fc08b76a7c2c605ef3a86ac06d7ca24ab0b353e842a62f",
-                                "uncompressed-sha256": "2493fb6b36dd3a3cd03b3ed890fb07fcda9fb7fee0787833008f2bdcd832d839"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3f8e65ad3ef2dee875204a2da044179093aa2a74f1f26a4cca504b54f996a208",
+                                "uncompressed-sha256": "229c7a3c2eb76a2ab2fe1eab5802d3c70acf36da3416ce066bca4d5980bde241"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live.s390x.iso.sig",
-                                "sha256": "aaa0ddd2a2301cde86642a469ba14c860c57ed4bbda944a6dfa1f998e852e540"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live.s390x.iso.sig",
+                                "sha256": "4da49fa60ef00bd0baca553ff56c355f0f776c9f8031178c3814744bc14f9489"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-kernel-s390x.sig",
-                                "sha256": "8bb336e20b321ac5a7ba733d3e29e339893f1e1c3bc5bba40b26f75a18b8250a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-kernel-s390x.sig",
+                                "sha256": "d828baa15f707cb8d187b460e1621fbd4ab32dcd32d50ed0af4fd36207c8ac0f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "28d5ef2bed660c09d9548b3f4d12439ca6518b718195e61d272c72baf4ca12c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "7f7029deb4fc6eb8022b99e073a69030b126adadfde78eb8b87847c0bb95faa9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "c0d940054bacfbc880162aba53dd00e86cea7a2c8f2da22cf265b191e7d0f4c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "5794d96f495114424ee263ffbf95e1e87e345d5a8a2b564d0905f8c2df148fae"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "f4d3c268cfe5c243135b46f97da9f15bbb298968d8fe38530d7f01f470abc379",
-                                "uncompressed-sha256": "aa97e90a73ed3463db2e9dfff961cdf192ce96c5544ff144dc48f07e2523c761"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e6ed784d411b43e940fa9a5fb4a30a9622da48b4ffc889c4b025e2a6a8f0fe25",
+                                "uncompressed-sha256": "d632bfe260999da4d9fda4ed0f5e70ebdc781cc29c503cd57bae6c2053270286"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "0fea61f9d85bad381b23af151c3d923ab3ef36b1d18e23590cc3f25b4ddd02ae",
-                                "uncompressed-sha256": "09305589db4206bd9164cc6bd7abd2481ec221d73b46975a6f9b7a94f1ff4049"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ea672668a86844c02464d20571d68eeea73c46a7d0ac04d8f44e77e04f55cfa3",
+                                "uncompressed-sha256": "004be4e1b7f7de1b48fffa1737666477814c24f8a2d3b6b826706d54c28d0e43"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/s390x/fedora-coreos-41.20241122.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6d9356a1ca20533df8df3013a938b48fd42a552de1b58f16645a3ec0accf0ce3",
-                                "uncompressed-sha256": "dcc0d25d494181cebda2930db33d8c500bf0aa7c203c8cf9162d29c65dcd9857"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5f24c7bd09551cb4694e79707820b220ab1fe3c98e3b4e4d14799e2a869778d3",
+                                "uncompressed-sha256": "4a6a5c11fffb916999faa6020cad37bc57e7aa0e660d3fbad226fb411590805f"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "dfc6e4444a462547b7c668465667875120f6a7ae5de7bf5fb020ff724cddf10f",
-                                "uncompressed-sha256": "2bd8d87e6e5a39430c1675faeff9f307dbf0287dd26eadf524d7f7d49305cb62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "39d8bd9a893be3dfb71b76228e5f53c0e3d6fdfe4d1305dd9b208011e9efd44d",
+                                "uncompressed-sha256": "6f444272e9dc85b3807a37320549cd59ec4ede6c0e9b11e3f35c8cdfb12e4239"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "07df20b9f955bcb3ad16e474e7a54f1f963fd4c8dccafd5ab43a0e084f159e4e",
-                                "uncompressed-sha256": "1422b10a414ce701725f747568240e776d3a861ca4606b31901b7494849d6256"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "5900619746a80f43ea9350371cd26fc90330741dfca633b2d357378f40f261fa",
+                                "uncompressed-sha256": "b9f8f8199ef33966d8d6780eeac7cf483a868108459105789a6a478b227de936"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "16cb3558eb4c5488df7c56f755cb6618a14177f32e168f2334183cda74273d40",
-                                "uncompressed-sha256": "def437c67d421c6312c5685082c4da519055c38bf21843d4460345f622c6fe05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "02bf87901196d974760a10c003c9a0ed9fd672169edcd4ecd5fbe00166cef2f8",
+                                "uncompressed-sha256": "a6b92fc1c2ec5e3f1804aabe7a8f88968eb01c39f942606ff5403b52a5efd9fe"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e9de2fa8f606bb642210cfa0bad5c3ed3f9cf76340a74f81b7423481da04cb0b",
-                                "uncompressed-sha256": "cefb9edb7637163ad2e10b43e085367c30302d62375cffcb9c8a26981f9d377b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "eac9063ef809709baa606f804b9490bc43425a8412e22c0a060134432084436b",
+                                "uncompressed-sha256": "f2dae6278b57bbfcecabf95c2960c0306de6f59b1b9de1d314ce9f18ab7bf58c"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "434b80b05d9453f3bc280be467ce5bf042e7ecf62402ce2bdc9ea8585d2e5b5c",
-                                "uncompressed-sha256": "60653f402fd95b850d6f05a1b65ea979cf25c450e63a0c969c27e80b808b0707"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ff5d9b6bcb409b78183146080bb38d3af976c6627c737c72376b1299f3276144",
+                                "uncompressed-sha256": "3e5a0d0ecc25cf46b2d97baddf7e0629541dfbec9f21b336eb82ad05c9b3c004"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "73098af1ccb9084c4b7302c3027c12e966cccc8858c87e0fa1495c93601fced4",
-                                "uncompressed-sha256": "623705d596a8e1d674b0455d46325dd57430da3ea61643f56f0ac3a1a4d5641c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7d0c6ae5f89425b8d8967d3023bbe6c51aa96d8520ae7141738aaf9619ccb6db",
+                                "uncompressed-sha256": "7059cca263e55780beade8a1e83b1f25e482ffb8b16cfa042afd5b8060066693"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "acf73e9b43ded167a16552ea5e377202bcbafdd9d18471e9f48225bfb94c5fc0",
-                                "uncompressed-sha256": "07763b4af45f4eadfdf463bacaf25fa3fe06f0bfbafcf5abb51206a48859b3b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "caf70425c1b30676ab45e374481aa50cf7511976860bec9260f6d3ae3bf9a35c",
+                                "uncompressed-sha256": "148aec007ebdc9a94c1b663c85a8b5e2a7e8674f59c48bd5ceefad365977904f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "080f7020faba0a4b11906d01336a291701753a76f29eb157b6f2829acca194dd",
-                                "uncompressed-sha256": "7b949c41c6c509dbc9a61d98849a5ef436ab6ae9a4faf809f593a9ab9e12b50f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "5523d95691b5d78727d914dddfc7ddfb63a97fd563157391ac61965fe8c12969",
+                                "uncompressed-sha256": "3c15be8b79e8a65ebc35a249cf5d0220b2763e1fa49c91f8c1300c9f7cfe5218"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "61e8155249f6375f2b2966510b3e4ede4a0e6d6af906a750a3efd7666c4a43dc",
-                                "uncompressed-sha256": "7d81e9ef48012750218fc22e685b8359ff061f46558c90ee7edad3a3da543244"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "273f564241db2b39ca652b2ad35dd0721c4fe2b9b06a9f1be561ed4357e7fce1",
+                                "uncompressed-sha256": "12b6dc88bfb0a9186bb105339756d74ba3584230eaf15aa9095a7a2578be323b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "09b196e2d2e42fc4539c508f6dc905a220aa30d01f0dd12893ff03bcb958bd6d",
-                                "uncompressed-sha256": "188c36523e4bd73059a7661eecdc0d3708669f05bb25d89e698e8c178fa73352"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "216e02680c961135c911a3dfa6dad91488e776732d8888b6a87f029403f5c85c",
+                                "uncompressed-sha256": "d1cfb4a620be3907f4236852138a4d69a8be3818278f55c83dda4f9cf9c4464d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ed71da62d4ce8d5b962efef2cd7d65dcaa16b07376e1d9db441392b4439324f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "41b132480a221c6e518846d2e7c3f4ec3c76954e5fad39fab53a742ef59ec60d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0bfc1e3fe216aa088d82d897c6efb0669c88535b48fc207ab7c84f4c91366a3f",
-                                "uncompressed-sha256": "f4f8ca0baedccf1656f366c0f135b2e959cac597f1789198fdb524fe7e0418b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2e6c73db9a1285316825d699936fdce336be190279793300130a7d12c213b306",
+                                "uncompressed-sha256": "0457fba6b3e2ed39f9feb21372eb6dd2f20d4e575f2fd27aa8271d592a5f7f91"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live.x86_64.iso.sig",
-                                "sha256": "0107e06cb79d598e29ece905b7832c046ed5e5835b3763bfef135f1f09ebb47c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live.x86_64.iso.sig",
+                                "sha256": "c2d16f9815652f76be4130ee405a5f4cc94f94f9827c865711525c2d696df20e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-kernel-x86_64.sig",
-                                "sha256": "042f96248c38a74bc086105a6535205c34aa4f878178370ffba3974c23dd482e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-kernel-x86_64.sig",
+                                "sha256": "d73310a5099a284cc04726234d90f8ce0873f7a26b6aa505421523ef69bebf03"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "431542034ea8f2995ca6d76b3916b43f1e8b1a5fde070e4d04867d772024134a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "042d13e21fec6d2043604c04d22da9aa32e3b69d6183b14bdbb77209412db90c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e8c39b189043f37ba00ec881e73ceae3c0052b22b3f18f96b1c141971218012d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "564c7e2866777c532475480fba5082bff1c5dc21dff83109bd080f2a8ac10676"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "006bae002547481e4b164212a5f776ad5e5c35ef3eedadc10ab20a888d50b41d",
-                                "uncompressed-sha256": "4005f8cbc815e188e24f7797414daaab7d1098cefcffc429742826b319917180"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f25b743940a16011b61a7c27087a4e153cbc76cd948848547e567c72a76275a3",
+                                "uncompressed-sha256": "d61c8db3ffb6c962b8677e9c6e675438df7c8dd276f271013e022962bc5fd467"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "784e8ffd2297d0a56f532f4e987530f781b3bacea75a5520b995c949cac80f60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e9b8f561d7c88af604c8232542fa700335359968ac46cdc758fc8c1bfbee4f61"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e495f9cf5e3004336d9fb29588173359fdbbff5e9d1b035650272a1cfb5d4947",
-                                "uncompressed-sha256": "2d22f035a48173bce725ad8ab5a61ea2439d9cffcd67e5878cb3cd5507ae9ea5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8af8660205e3f8486f03ce74d1ff51fce08a96a820482eaeae1eb8903ce0c3b0",
+                                "uncompressed-sha256": "0eca6a7f64252d5e20ceaedee55da71ef4187a25b41e510f38c908bacfc607cc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5cb3a30402ab0b502fcbb402501389ba781926df7bd68d4aeb45e55fe6855e97",
-                                "uncompressed-sha256": "b3475b09074f5cec44b307e57354ced1ae5dc6907b7763d4398988eea40c93a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5071d94b58eb6b644aaecaa8a58e482983cbd680a80ca56249a7a3abe1121dfd",
+                                "uncompressed-sha256": "4403ab6e3597a21f043bd1bd8752b5dd111e606c6fd345536c2db9de9f1292c6"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "118bf16de697671a73f92c9cca9b492514a4a3558edd6bbfd7a51ee9cfcda7db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c2f0f685ddd09ccccfd1d317c3bd1f992c571719af3020ba6d7d00028d22c9c7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "bddf863e30e9c5d1725978b043e6a7e344aa21d46250e956b7763fa70f815baf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "8476ac02e9dbb822da02c682b970584a9ded11cc5d15fc87ead098704064b1ae"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241122.1.0/x86_64/fedora-coreos-41.20241122.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1e4e588a9c0a38a6cc11f13708ded5414b0dea830b2cf69bbb29d37aeeb0e76e",
-                                "uncompressed-sha256": "44a50cae52f9522ab45ac07c3ad4586fe541d5fe85c74077f5402670f736c02f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "047459d9ad3b546a6551aa29b234d3e0134bcc2082d5995e9cd6fcdb79e435fa",
+                                "uncompressed-sha256": "f8943b5746834189b891f433dcc252d1e4a6fcd46ac984f160357f5d7d052eb0"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0e78cbda144eb059b"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0e7eb60420a4d78b0"
                         },
                         "ap-east-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0827c88002e1095a4"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0662cd2accbbd6158"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-098d4eefbbc8e9e1e"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-04e59db2a89be6c4c"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0f60629aead842c10"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0ec3243d2007de0fc"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-08781ba4018669c4a"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0bf0c73e781cca175"
                         },
                         "ap-south-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-048baa73f8174cccd"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-08037acce88e5a52a"
                         },
                         "ap-south-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0b4c8e7cf8e383e9f"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0372f29550c5f0dce"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0cfbf02b2ab4c50ec"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0823b2657c4a5936c"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-049ee05b767e1148b"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-04e33012b965c83ac"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0031eb980d0eba1db"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0a8fd1f4936d604cd"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0617278b9702a2f16"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0247fa364c8998843"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0c33e09f2e259cfcc"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0b2bb3de5d2db111b"
                         },
                         "ca-central-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-05e820c30b3b39e8f"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0504765a76a9eddff"
                         },
                         "ca-west-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0b0440db63968b409"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-075e93e2642a4a3bc"
                         },
                         "eu-central-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0ea67dbe971ab6b5d"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-085737ac2f0836b57"
                         },
                         "eu-central-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0e320bf78bd29f005"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0a5980db2d07ffeae"
                         },
                         "eu-north-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0f34f1b8fa0e0b8e3"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0e4d9373ca32fddd2"
                         },
                         "eu-south-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-09573455fd440e7e3"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0a9b2fc9afc7dc232"
                         },
                         "eu-south-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0bfec5584e16b218f"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-03f83124cdf32b6f3"
                         },
                         "eu-west-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-037bc845010e21593"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-089e7ffcda3663feb"
                         },
                         "eu-west-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0945831c4e3d8055f"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0126edd6efd394e93"
                         },
                         "eu-west-3": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0c4fd662151807028"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-066a1ddd03954e3a3"
                         },
                         "il-central-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0bfbb0209e1e1e0e6"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0f4166902f45f91a0"
                         },
                         "me-central-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-05461892cda16118b"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0fa0a2286323a98a0"
                         },
                         "me-south-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-01d5d6952c28443a7"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0db830fa8917286ee"
                         },
                         "sa-east-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0ac067705483349d6"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-05ea5844846ede0c7"
                         },
                         "us-east-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0b259c6773df76310"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0240ac0cee5fadabb"
                         },
                         "us-east-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0cadc03512ff1d56c"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0e35a9d0d7ef4628f"
                         },
                         "us-west-1": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-009eb28904f1717b8"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-04e805554ed3c3eb8"
                         },
                         "us-west-2": {
-                            "release": "41.20241122.1.0",
-                            "image": "ami-0f51a10f85a290758"
+                            "release": "41.20241215.1.0",
+                            "image": "ami-0a0dd4eee3e563211"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20241122-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241215-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241122.1.0",
+                    "release": "41.20241215.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:63e67ca8d764f5a60be57c803048218f8da15525dd6ce64e04b0e3b273e6ff9f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:23a8fa0d8dc9fb8ef6cd420acd15cc3487b092d60ba2a3b5ca49e846649d9f7f"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-11-25T18:17:16Z",
+        "last-modified": "2024-12-17T17:26:23Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "0b0146ff049cbad69a524b201fd899e4d1dbd62e2fc4ce929e96cf3367bfccfc",
-                                "uncompressed-sha256": "a9d71caa0b9c1441fc34b44602c01cec6908a36fbf8e08a4ccff3f6bbc58e6b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "ec43dcf3c48ccf11ee40e8442e9818d2879dc79b184b3bae7809b74fc5e12ef9",
+                                "uncompressed-sha256": "e90c897680d1abe44414295b6e68f6de87ddb3b8c53ba41d846c30e420ec2706"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "df479ba5bdb885553fb882b97b5f91bf303facf36ac688a2b5b2982bac2e83ff",
-                                "uncompressed-sha256": "7d54174b0c98221d40c482b885ff573f43ab1d1235d26f90cdab2dc4e9a05eb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "52323bec7a29e3c76a1b46dcc5e483ed8792f9e6513f30f3789af31cfa3e2bf2",
+                                "uncompressed-sha256": "04656ec9da7bee43b2b492526a61b03882f80c643f7d504a39de8425350294e1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "62e55bda4f7293b30fcfa178a2e4e9ae1a13989c08bc7db6313ddb60839e0e2f",
-                                "uncompressed-sha256": "e147cd2132a045195b0829a3b3a4f55fc83c7550bb5aecc6653bb00e456d6b33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a03a539b4aee89953c1a9f8aaa97de87d824ed89db6e0dbd25d6237cef2654c1",
+                                "uncompressed-sha256": "53a6cf05734f9febbe346aba6c859294cad02ee8c8efaa324dbc3ed55f86ee11"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "5d3cbdfa4ad7b7473f8c19934bbed01d1f4bf0ec9413cfa96f6a4df5b7ecf1bc",
-                                "uncompressed-sha256": "66f099f48bbbe456771a88096f058899749ba7132b207a4f1516dd3601bd3339"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a9e1975d35383c56ba51c5b6260b54caaa494378cb6068ab053ddca8269dc3e2",
+                                "uncompressed-sha256": "e29c862a52ba5baac35a634ecd6936efb829689cfc270002f9bba69818add3b7"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "3cd6510f67662a50c724ff7b23b2962a0d7fc6451cbd0f5b9c01a817654a1f4b",
-                                "uncompressed-sha256": "269e81b70730d4c67e878b27042dabb35ff4865c88a18151563933b1a4d07315"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "12f3f76fb44789458a2261240ea5141a81a23ac2adffebe12a06db0dba93fc42",
+                                "uncompressed-sha256": "cb1af1a73fe3fe98666b9c9540fd8487ac88840c686c12daf523e9706d28380d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3ea8afba89bea0047123ad566f2a22439949eb673c20f3195282c6d33742449f",
-                                "uncompressed-sha256": "aa52378dc4f592d98ce47f01d4f8a3da12cdee528dd4aefec1fee2e0d1f26166"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ad761b218447cb77d0df12806b342e5fde5e78a2fad31df2107fcb1ef8d07c1f",
+                                "uncompressed-sha256": "6e189fcd17d4ad3462ddac128b89eebf5b5915d56acc9b6aecce5fbb6dac4080"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live.aarch64.iso.sig",
-                                "sha256": "404cde0f08764614118d55a903d2b5f484722ae717a2f0eda73f251fbe59c5c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live.aarch64.iso.sig",
+                                "sha256": "d7fceeea57c82ac4c8581e83f9aef2dfbdbba0c42dfc2982c239ef4bb7eb8b34"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-kernel-aarch64.sig",
-                                "sha256": "9bbc0c304cdc2bbbe539c6ab63d3f7b173ae92a18c880f8b5d840ce5d36298a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-kernel-aarch64.sig",
+                                "sha256": "2528f9394bc537b9e2a0d5631b3aa751ec3ec4ba4dc04461a9f27282a24d9a66"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "3c09ebf6a38593e09ce97648567011e1cf4387d7fd3912bff307fdf50d2dfa75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "794cd566625fb0e7cd98e6cb0d466c84773a2b80fb34083aa93e5f387c5ef6c4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "03faea73b5436bed6e232d129f2c1383f4eff212f5aacb56239941901cc154a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "ca3b89004b3974a674e30ed4e22cc0a92b192e6d9fd1f7cbdae8c00f55ab9635"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "be42fcbe76843875ccc97b2e6423e60632ba17a3eac177ff3cfe1d1ad5760aaa",
-                                "uncompressed-sha256": "6a0d53495055c7212c1c9dc4f2da0d170d174b837de78893ef37d1752eeea7c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ecbe8dfd6081e828c8e89f816d21c8f91ab4bd1c1e717d2238ae9dd43286b5a7",
+                                "uncompressed-sha256": "911c0235ba1e31736c216ddad597a61cc4099888b1524f8f91381736327ebab4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "da845d85e74ad1b3dcd1129b5a4651be85575f427b014995ef2c0be3bc8a3c77",
-                                "uncompressed-sha256": "18502c20a9eac77c2291245523501a1cbb2392c1f1dc1320665675822b9864ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "80c08c2adb984197b4e0f67cd945ec6dfaf7d21497ffec7dbfbcaa3fb1e22566",
+                                "uncompressed-sha256": "eb9a42cdbd7c0105c813b8b0cb71b7d35c22ea8ce78e762d0ed490194b0cd845"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/aarch64/fedora-coreos-41.20241109.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "48331bc49d4e5717982aa669f032288d6de5d3867bf6958a04b1e4598476d950",
-                                "uncompressed-sha256": "3b42ced994f707d76ba45a50d7daef7bc8454eb106f1101a3cb72298a41b67df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "fefa50cb7f5d77bcd6710cd36c604959c5c9c4615347101dfcc74f0e1ffb9c9d",
+                                "uncompressed-sha256": "e58e5e94fafcdbfb5ea1e91db49d57392cb1afc6aff192ff8584cb112a806b15"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-05339bb9419f79a88"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-046e91c4cec5be145"
                         },
                         "ap-east-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-029af3e0118434f20"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0c656a057796d8652"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0e54704055a5ed880"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-03618561548347f0d"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-00904ba769f6f2c0a"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-050ea21fba8ce491c"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-07f85d200fab73f3d"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0a610fe2d4c9f83a4"
                         },
                         "ap-south-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-09d170004e040df07"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0215ab0bb8c105892"
                         },
                         "ap-south-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-00cf038abdc0bf1f1"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0901d9ac80a89585a"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-049580f5c1fc663a1"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-068ab5a755d501fe4"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0e8a076e05bcb4b67"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0109de2e291e2b8f3"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0be0eb540bda13bdf"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-085e56dd4ec4035d0"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0f181365a39c7531e"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-057718f33120dbd00"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-01d465968f10af583"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-06fb852b09c4dfc27"
                         },
                         "ca-central-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0c4c83b9a6f42bbeb"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0a7dff28fb43ef1d1"
                         },
                         "ca-west-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-00cd5c35bc12eb3d9"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0d266d7317a380478"
                         },
                         "eu-central-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0f31f1fdb1044d0e7"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0b794783134c17ddd"
                         },
                         "eu-central-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0fc793625eec89da0"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0a53bcd6632a38f32"
                         },
                         "eu-north-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0781d91101261b207"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0e79d1b12dda0a6ba"
                         },
                         "eu-south-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0707d6562bbf5a80c"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-01d441cae5ba67ba7"
                         },
                         "eu-south-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0a82e6625ca29e39c"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0a94889104d3dc03f"
                         },
                         "eu-west-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-000d0bdbe63084a4c"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-03ebc19134609bd0c"
                         },
                         "eu-west-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0547462cabaeb06cb"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-073cdb816b4d51655"
                         },
                         "eu-west-3": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0e6f54350607efdba"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-05104812eadb48df1"
                         },
                         "il-central-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0570690b457a6f880"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0df75bd41c4921c0c"
                         },
                         "me-central-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-082e7fe0fb0a595bc"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0aa310072e3c6d9d4"
                         },
                         "me-south-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-065066351e43a6c24"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-02257cd1bdc9dc718"
                         },
                         "sa-east-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0480a640e76e9db31"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-03a2396838fc380fc"
                         },
                         "us-east-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-08ea0700f133d11c3"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0459ddd3d9a07b425"
                         },
                         "us-east-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0be62107193b9fab3"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-065c49d3c30604a26"
                         },
                         "us-west-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-03d7bde92d6e0222e"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0f3198206d23126b6"
                         },
                         "us-west-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-04249309a05d1b9fd"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-07c31a337cc2a0cc4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20241109-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241122-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6db75cc4bff556a75c5705b90e1bb0806b14d77686a08c8aed39c2bbe1e0b6c4",
-                                "uncompressed-sha256": "c8dc508a88357899fb203ace4d99bcf8af1de5c108ee9f33efa0b763d3005660"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "7f27c1b6b53e345b445e3dd171357c0261845c561a683cad8786f43d89f02fbe",
+                                "uncompressed-sha256": "096b063fafb26d6dcb69a68ddc0aa2f1824e9eaccfcdb7b60e83a02b4066a09a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live.ppc64le.iso.sig",
-                                "sha256": "0e48ff4970631318660004db97523ea9fd56fa5ff39e251a324dc525bbe86637"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live.ppc64le.iso.sig",
+                                "sha256": "a43dee0ccc56c5ea52a572f1499f67aeec7ff1f8eeddc1063d6e1c477ab529c3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "be45daaec2933f2ec16ec24fd6a6f5b367def5039cd68587c463ca84c5e631ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "65a7d7c8d37c79132477d06f3cae97bf6fd90593022d36b71550c21e2bb49eba"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "181e712d1ab32944e7a3155732d5692f350eaf0aa181ae00da015418af615c92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b52f93465a1da4f45393c094081c43c55f9e5bfff48e47fdeb1086b65beb1647"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "32685534c40170a3df2683011b7bb24bbb5549d13160668d76e1d5dc528f8e26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "9ab8e1397433cc190404d95d0943a5c8a101739fa05cb659b073fae2cfea7c8f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "788e11719c9b2e80df8411bfc4a144c210af85367bdf6bdf5d5ec1993347538b",
-                                "uncompressed-sha256": "454532a0acce1db2bcfb09eafbe258afbbb268724d3d58ccbc36f98b8024bff3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "017b1745c8f53fd6d09a67228357c353bf98eb2bd1fc68d0f5a9c023dfc6cd71",
+                                "uncompressed-sha256": "afe272ee0aa288563d635da3f6c2032f77dccc25cf216b7a6190237082b78e34"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "333a2332b22a4e2549bf7a856c78508007da0d182e413a25cb4c4f092c8af5d9",
-                                "uncompressed-sha256": "7f8fa7fd0391debe700825da2bd13e5781fd033f930314e6164d6ac7da0babe7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "c30ad273d6c635cc14bfe919ea4a1c6cf8601b8ec74af1d90ecc83cf08a91e7f",
+                                "uncompressed-sha256": "dc37230437819b01b36c370db1ecfc86c929ba7de583715081cde891b4ebfbd7"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "dd69295f79d26c6260998ed15f5713d1b43e7df4d797be6121900a5fd5a621b4",
-                                "uncompressed-sha256": "100b4db0b1fc9900fa074733d58a20f8e9acaac533736e23f5867d1e77a5813d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "fa57f2f6d9a8fb00b323e305513d129d89abdb059a9698c5807eed9f4fc2f4b9",
+                                "uncompressed-sha256": "0202074f1985b491e1394267a39ad1852b2836fbc9bef32e7556d8ad59d3c2dd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/ppc64le/fedora-coreos-41.20241109.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "82e0e03b6a86b0b7b51fb7884b7c57d22d2fb54ee0036cdca2f1f6e51a72b7f4",
-                                "uncompressed-sha256": "74e32e3c52afdd1857452802068b918ceb1d90d2b647cf1d9a140a7957db2b13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "871d13b0a3b1ab027ef43bd3756abbf58cd4227f6be0e7930d7519aa5936b2da",
+                                "uncompressed-sha256": "0dab128d9b4d2388edc5927d053a8ac0a614018fbd2b752f9cface15ece8c92e"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9a3a5718bd5f3b3c224bff56e6ea042cf85c2d71131e9318ec9656c4cbb46422",
-                                "uncompressed-sha256": "9ab25063d6aeef0a8a34db2e05b0b62c1b5bd67e600d75091cde38e853c4b38e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "3144da03e25021d727e078770c16f5fb0d32c76143b01bf904b950cd6b3b6654",
+                                "uncompressed-sha256": "c819293d8326cb3dcc5de35cd7ad06069d0e50d3d03006b4e6bf40b69f0d6ee1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e567781d709ec5f7b67967c22fc62f59f50bf38b5b72a326711c4ad7555356f4",
-                                "uncompressed-sha256": "46b1601703ecc6edc8c137439a22e0b8a41820d158ef25ed60f61efa3b3ce286"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "10ed8f9e3de394f43fafa3f7c6bc81e823701570ccfc129b0cf5b1854a1ff7a0",
+                                "uncompressed-sha256": "120fb28e186390801864f614a53dd520d2e2fdbe275f36cd7dea6c590aa595e2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live.s390x.iso.sig",
-                                "sha256": "09fd635a5359e8fcf1f866d912c18f141f055b220bd5f022a01acf96dc15f5fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live.s390x.iso.sig",
+                                "sha256": "a87b53dc138866df801715700e848e32c897f1cce427c426ecc3ad08e14257f7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-kernel-s390x.sig",
-                                "sha256": "8e1100819d5840b74d59cf37e4e2fa3679ba8a5b733ea15b63d43f98604703df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-kernel-s390x.sig",
+                                "sha256": "8bb336e20b321ac5a7ba733d3e29e339893f1e1c3bc5bba40b26f75a18b8250a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "95f26e02542d77851a52518b1228abe9a8531dac1cc893c3d0fa694b06b06a50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "2fab32de0337b4715cb2e71d7d8a02572ab155b738d0a2f1a49450dd6ecb37b0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "f101ea277374178f72f466018571a7b198937c33f922a75347884c158a66910c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "6839af73f25273193ee4d9b07fc1d357be60427b7781bcaea2b8878c8674b8ce"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "48f7755890fd94ed90b402806adeb043297f449d233498492e00f7ed3a8f9f72",
-                                "uncompressed-sha256": "68e46267cfc8480e66e7d036f86a56eb37a7c2a3363582c7578e3e3e626c7b7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "0341cebd7e4189ed43fccc7d70ce6a16670e8237259a09ea45c58fc975240c1f",
+                                "uncompressed-sha256": "d6efcdecae8cb15cee4f3ca556b8160965c46700f6404d3cf9dd8d7d429af6d1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "549b117f225107c119fb60619b41a67d53c78cacb04db80ba776d68f913091eb",
-                                "uncompressed-sha256": "c18025a7fee196610cfd522ef6418198a0735db8e3d9886484a8761831ea3de3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5f40578d11fd131e7a3f4a8d090e569d9498a41b7f29771a63b21ffc7be19c82",
+                                "uncompressed-sha256": "6fec6e4c18ae8483148ec786bd7eb4aecabf8a68c169e9345734e2462e92ad95"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/s390x/fedora-coreos-41.20241109.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "004e6cc55c94efa36f916a2b185d2d696a1dc68e87da1f9b4c271400102a8252",
-                                "uncompressed-sha256": "55641e5045c8891b866ef5044ded31c5de6f2c61e478ff49a7d33f4ae6dba574"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "b08be976cbb60d4cd1698a635730edeb237001541db07a157b33d39934757bd5",
+                                "uncompressed-sha256": "214aca9114ffeaf426a247784bd8c3dd324fb3432a83590c7cd44bebdc4aa629"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ce8c3d396be0ce94e24950ee31b61521eb167492957274809eb7e8a10165a0e4",
-                                "uncompressed-sha256": "ddb7e6afdb89719667c9420717a8aae2e87572ad35a9088a353b839d5932bf23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a10d97d40edf7af11f6381a4fe00c1a9f9c8a60eab1b7796e3608a4811d111f0",
+                                "uncompressed-sha256": "226b77c810596b9efec1de8f961f1dd7e7fff0baa7fe8358b07048399e9305c6"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "8489e59c904a9234dd992daf0cd2c94db14f21bc124556444cc0b01c35d807aa",
-                                "uncompressed-sha256": "f457bb3109df72908ed575eb23dcab93b4dda95301eff0b2c42d6f33a7fdef1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "419e41cdbe2dcb9a55e83c668efbacce50553787c4b6ee441e646b15ca578330",
+                                "uncompressed-sha256": "7077343a5f69e6668b5290129ec5cd4d7d39a7355de94ad85556aed820e23b3f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d06ebf4d90ed58a0710cab0641436a44addb83c489069acedcb72fdfbcc9b531",
-                                "uncompressed-sha256": "8812ee21cb5bbfacfa8cc45c67372914b105b1d7a57646118bf0917f29b03634"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0a32adfcfab4324b2c33180e17bb0d6a7e7956e13d7e60f88552d913c237dd54",
+                                "uncompressed-sha256": "28b67918f5530e2ea36402a9f3aacd3192d9248060192eab119076c068b36d27"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "83614ab0c33759db70a5e80de9c4bd1da4064a5d41568cddf2ca2f00e67d4a0b",
-                                "uncompressed-sha256": "d4e506e40cdb8834007cdfc6f4dfc321ac4673b6e016cf9684a664283c996fd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "67e5eda3abd61f890a78fe0883d25b579062e83f32f691310f7f8e29e5c77e76",
+                                "uncompressed-sha256": "ce08d619ef80a246c4ed289a68983c6bca960daf9c217cbce0d20fdcde9012f5"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "387558d3c8c67be27bd15e90afd08a196948d40456315ccef0ad9564c2950be9",
-                                "uncompressed-sha256": "dc2160501b7a53b107ec713387f72221fa21ba2394edcb956589ab8d1503da89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "728ddcd08865484735ccd8ca756a5e02ade8162c9610d5d4c750d2dbfb5a377f",
+                                "uncompressed-sha256": "8f03ad53b89fd06fe00d6e1c89555bddbce0f296706397024480624d9571d9e5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d53e5519017ea5e0da555ff4331843d6f33e98c520f87011d5093f9f597d67f8",
-                                "uncompressed-sha256": "0ecc738187adf9d104915df102d2e7dc71596c51748adf2497a1a982970ae8df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "045d62a6f8aa74ff9224ab63ffcbc66041e683dfa1a6db1e1300ca2948909adc",
+                                "uncompressed-sha256": "47194ecaf6f037180dee4e5ffc687095f55852d99886ee50623618d1196c7965"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "d1471636f80259754d20af2f1c17f64ec25e9c57a1773a0e5c5c88ba20154bb9",
-                                "uncompressed-sha256": "a7631ca187879c2856fc3ca24e6b411642f59408f065bed86fa471413e586905"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "54077a7d9b5aafcc39c9e7f29a89ee5a8ff1eaf1eca824f11c662fedad0bfac5",
+                                "uncompressed-sha256": "a5b8fd174f35edd40c0a6cbb5586bb8347f6daf116b51345cd52f6c1cc3a3a4a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "69715919fff558cc078ceff4b33dece997f4af843d2603f9358568791b3f36f6",
-                                "uncompressed-sha256": "14801e1564a6d098eb96275266a8282f1334b6cdc3b8667eb39335bc853bf9a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f0391e6d39832dab1b6c946427a015cca3b0c999bdf699ae8dc4dfa10d5280ab",
+                                "uncompressed-sha256": "f6a9111615b8cdb7d2ce3f4fa3816d044a8a96014e27f1f598f80e282ef96837"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "4c79b0347376b84c33c35a24cf351d4acc16e5f5a96200e0c9d9fc8a16fffc56",
-                                "uncompressed-sha256": "351255c3a85418f97cb5d6e05232e741ac83df53d9a8fbeb535f7358d5a46074"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "aa0f3cfe8c95a014bb4c2b755ce0a03206bc3bd9b88ca1d6508c03e6a8cd0129",
+                                "uncompressed-sha256": "6f64c73f95913f77ecc55f13f8bfbe39691f7920602ec6fc4377033b95a61822"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9b6fb16165a05797fd3480cd784a27d373309dc694e670a43ccdf85dcb159eb7",
-                                "uncompressed-sha256": "45fa210cdbb5dabf5416f8cb65ac12acbdee789a668388ed6a2dfc29ad9d419b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "347f671b600d5cd336b314336813e39983f52d3be536ff352094805c7042eee3",
+                                "uncompressed-sha256": "563205a421382e309dcc2d10ee592f04e54d5659816530d4f05933809ada5f07"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c5ff3dd48be0539ec4692cf268550cb0a8eca7a15a26bec09dc655d932d92513"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "1c6d389facb3d5b6a5090513c051aa0d312f5c6df7bfd19ed3624ca84043095c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "86ea01b2af1f568fff299e2132e219fcea3f85fff99432d37c93a934b678ce99",
-                                "uncompressed-sha256": "4228c4197a0bd171f609096e8848f6bfe1e347c49cd1e2984e1ea319a0bad13f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6b315a2522153124529e978cf6258efc3f1b024ed8026efe8de833375adb808c",
+                                "uncompressed-sha256": "bae32a9781a6e3391895cdd8a955e105c48bbb83ab48ce41226b945be25bd490"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live.x86_64.iso.sig",
-                                "sha256": "52923840ea43b246a1824e9c4a5179065e50359f515d7538574bdf9afb60a52b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live.x86_64.iso.sig",
+                                "sha256": "65ee2eee9ac844ad115631dcbbaa6662e5824ccb21f0365e9e0c336748479ab6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-kernel-x86_64.sig",
-                                "sha256": "65e863770c2e40c9221b8e55623dc12372ffc1c01784a9b8103122e9f19556ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-kernel-x86_64.sig",
+                                "sha256": "042f96248c38a74bc086105a6535205c34aa4f878178370ffba3974c23dd482e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8a798fca54e395fd9b270dfb56d41c5f3a358a6716ecbcce264578cfb4149d9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "11cd9db2f94dbc4c8170f15c0d3f59dbcc0f64832e80ccb13c9a5ee48e1e5793"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "16f3a649f3757838d0eadf25f73a609787e523fffebdcbfa6a96dea676633521"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "68dcd4b03e58e25546b3b1bd55400996548500a230c3d3a99f724b0c71418ef7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a62ab5d766dafa1031950729b3c899f45e0e969d5ba93898de04581b7fe4af7a",
-                                "uncompressed-sha256": "e9ffdc97cf405dbb39977417aac8c14aadf46dfb52a956f10f7c23f9eac950b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a0ca4edb6850c0d04c36eb5832abadbd611e2a2466c6def9058c761f4602b49e",
+                                "uncompressed-sha256": "84cbc91d806f0d0606fed3acb8ad99aefdb6b0213b1796ac188dde0502acf222"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0871d61386a1caa3fe6faaad65f219bfe41a791ca560cecb4faacc935ea998e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b908a6dd8115bc2698ce8e0bfd3ad90c928e6ae0ac831af408e2ea50cc624dd9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "d00c634e19148cb9d684916b5e695582b5eaf7d8ff1810b56fd9f8c5063ea5ed",
-                                "uncompressed-sha256": "c097289fb685e9ebc5fd112c619a0ff554fbb3aab9bce63f8de9b6aa9bf8118d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "6630c3706ef0ecd4908893cb837b89324f59c64d81eab53cf1c2900154840605",
+                                "uncompressed-sha256": "cdaeb1f25ec1878d765fc547801e5638194dc3d597f86e6ff3b0f2459b030289"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3e92734f04ff702979acbd54bda59e18a79f5bcb199e1ebbd0201aab07ad3da4",
-                                "uncompressed-sha256": "784e279c39c3da1c245457b0d6f17cf3f03e9ca3da444b5bee77b3300ffc8601"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1350484fe0e054b24c928c3e9c597d70f601b0fe2dc7c4b00c8123d4b23d2078",
+                                "uncompressed-sha256": "bcf60dc8fe4306ae66d6837304858a0bf1219cc0d5fc7362d0aab0caa5aedced"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f55c8af8790edaf77553ece4061c25a77900b144294ae44e3c1370154db4973e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "ab7c520dcffdcab23fbb36a2e3b19b432f65b3ebe5e8f3722d5b8e5f16850a97"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "9c7067eda3d11312452ab0754a81d718533ccaed14ae8a1366e6cc03ec0046a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "a3225f845f55a8eb7343cced7eb196d7b4adbdc94694da20c33af9c983f11e6b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241109.3.0/x86_64/fedora-coreos-41.20241109.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "54582793f2ba76bf238d4b1503092f36c37643aa3b02d83cce2572748420ffdf",
-                                "uncompressed-sha256": "7c30d46f257d92b11034312125e4ccf3935f616a9061c68ba7e70e5635761660"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "18a832fd46568f076357acb11eb3ca97339bf2cc1fbd302620b4c02bde241505",
+                                "uncompressed-sha256": "368841df5b055741669d54e9b5f78059c800f072d95e14b83be6de76c90c8677"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-069c535ca10cef4d5"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0feeaa1699dd4e20e"
                         },
                         "ap-east-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-078ce40d3206a3ccd"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-097144713c6ae3959"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0e8b32386179be0b8"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0343fd37481e9d178"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0e1bd1bba8cbe0570"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0b28f6015be6020e0"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-035144b1c3be4ce72"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0b2ddb4613455f383"
                         },
                         "ap-south-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-09ce370251db039e4"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-09c3f040a806baa37"
                         },
                         "ap-south-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-07801019949cfbef9"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-00b75c6eed87af506"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0054d9a4d1b39a52a"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-07531da4a7eeff849"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-02d56220d4625dc5f"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0d18aadf6865a30ff"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0989e5a2ea6c7a0ca"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-00897d95237962bd5"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0d6fcc53ff3eb58fe"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-02848b828c4f34192"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0c06a979d5049c8d8"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-01eb4892efe35b8b6"
                         },
                         "ca-central-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-00a4223260a607a04"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0900eb7c700ef815a"
                         },
                         "ca-west-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0aeb43f4b820c8070"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0c6bc81073ca8baaa"
                         },
                         "eu-central-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0bbb085d664b47387"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0b7d65a0017218bc7"
                         },
                         "eu-central-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-08d020953527ecd4d"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-04c4f0899591df73e"
                         },
                         "eu-north-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-011931490025934ea"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0be49a9a062511c96"
                         },
                         "eu-south-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-04ecde5ab49df41c2"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-01b1e91431f59205c"
                         },
                         "eu-south-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-07f112f1cba9c16a0"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-01883633ce51a371e"
                         },
                         "eu-west-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-03e338cdae1a3d813"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0c3f1942fd365fbb9"
                         },
                         "eu-west-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0db26c28edc5b0487"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-06758f85deae9e6bc"
                         },
                         "eu-west-3": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-04e2475694b3dc899"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-010ed6e7ac657d3e4"
                         },
                         "il-central-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-07f029198adca1cbd"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0bb78ddd161a9de81"
                         },
                         "me-central-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-004beb94132888fec"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-0cd1ac2b0cef92004"
                         },
                         "me-south-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-086bca0b3ca1690ae"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-06342feb6daaa775f"
                         },
                         "sa-east-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-022f3b6c423c0c2b2"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-06d6857a302ca5e6e"
                         },
                         "us-east-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-0f1955c35d05f87b2"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-04631d2c883552c84"
                         },
                         "us-east-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-07d84428127f205b9"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-07e374bfb84baad7e"
                         },
                         "us-west-1": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-09fe72436cc97d5bb"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-00680ea249f4f328b"
                         },
                         "us-west-2": {
-                            "release": "41.20241109.3.0",
-                            "image": "ami-03734b0484e249f7a"
+                            "release": "41.20241122.3.0",
+                            "image": "ami-03e47b15fc5d9e603"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20241109-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241122-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241109.3.0",
+                    "release": "41.20241122.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:28d171e9d0f29031884d58849843974f9a0d1a93494b36918f85a39aa606ae76"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4bb7599f2e0737ea0a20572c27a5efeb4b0d84a30a7d7de0080ad67fa1fd7d51"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-11-25T18:17:17Z",
+        "last-modified": "2024-12-17T17:26:23Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "6e97ff0a751acb3088da21584d185f28cc9223fc11d4aa4bfe6f1a131179cff3",
-                                "uncompressed-sha256": "ebe5778403bed4529567c4e6b8b07cd22747ef1a929d6aeef5a6c1107e03d272"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "7dddcdd55e86aa7582aa48e209c93518f40507415293eee6b7f9cd8d8197a702",
+                                "uncompressed-sha256": "57998dfdcb5d593be64f1516f201eb7df0abdb779bc2d8ac7953e5ae13202786"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2394a6d745fc5add80500cd0ec737b0e710389edb7f68f92e21136a924a99d8f",
-                                "uncompressed-sha256": "47b41807ed48401872a286e441b9d6d63b6acccfa6dd423a3b9dcb7c39cbb9f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "cf97daccb60e544f88438fb963f5f1ccca9da80d669ba4b11a015fa6924ce2f7",
+                                "uncompressed-sha256": "e8f5aa1f1705b4f4ac85e3dd51fcff30884c5be12289f861f1ad4d74d6822bf7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "f3d386958cef05024c81b6d51bec11d4f8219bc9fb70d92649aace231e2af1e9",
-                                "uncompressed-sha256": "9a5fa830652c16e30cbf9beb43013a10b48348a37f9949987b18c36bd779216b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "fbe1a580a52bbfacbc0356467dda2bb01f27b89d1bdb77e6d9c74bae3a372019",
+                                "uncompressed-sha256": "b087df679b16dd09bccfcc21d6db5cb4789fc747abc82333e6afee6fa704b72c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "740062b55ee62b55a43ad0df22d60e4972486d220457eae1e888f02e6dd15f62",
-                                "uncompressed-sha256": "29fc5a6c2e73795c088e890dbd86f94a6fa5be49ae4afd161cd094850fcd1e56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "f038bba7f1eb979b2089fd9e0aa7e137ec8f8b97a7daf03afbf45f889a658c23",
+                                "uncompressed-sha256": "912746b9463574151d298c810840b3f6e5f61386db11a5c64cce99cb5d37caec"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "8bdda404ea5c0f1bc8f9578388dbdee8bd9f9b4d2bbdf7de565903d6f9c93ea3",
-                                "uncompressed-sha256": "3d9f5ee5c03f8d864cec9537862d805d08f81a46ef144e102fbb429054233a04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "ba6ace0752d3a94bbf6e0e0c06c02065da1562d11afd77a7055dc50fd8636006",
+                                "uncompressed-sha256": "1a3769b492d6182526e8e5c4883b0b24a914035232da5d3009def046432c68d7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2431376be45636884ef9a716367de1f6dd51e650fed703a566a3b056ba8eaa28",
-                                "uncompressed-sha256": "9c0871875b5f40554aba22cb4286408cabb80ee14cc21523d901806229444ca6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "740701f8fedacf64da86a0c4de60ba54e9f311430ca0aaed8d3ef7c3d68c554d",
+                                "uncompressed-sha256": "b1cefec9054bb26821d73f31564b1f93fe7ed71f4f6ebfb440ac8c60b00402c5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live.aarch64.iso.sig",
-                                "sha256": "cba924b9856a5c2cefcbfb14cda921407274cec32b8d0d957dd0a296d53ecca9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live.aarch64.iso.sig",
+                                "sha256": "f310949364f6e8e731fb1f35061263d34fccdca9aa484ef3644b897524b39662"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-kernel-aarch64.sig",
-                                "sha256": "2528f9394bc537b9e2a0d5631b3aa751ec3ec4ba4dc04461a9f27282a24d9a66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-kernel-aarch64.sig",
+                                "sha256": "8c3d727cfcba05687c73b5ebfd72fdf85fe34ebfe6d21d1535be36bf8b1e122a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "668c5199c57f3abe932f90e69c2f03fbc3d5f3a9261feedda7619c216812dec9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "2e3b914aa776854ad87468eda3e0a104b8bc5b47a86889f70e406f1be6d89208"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ffe82c9c8ccfdfd5c9306c4076c392faa1d3329bd48907f9bb5eb86163b4aa7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "664034449cedf80a292d15f7c446e00873143fab58e93948eb384e24cfec751c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "7f6b6e679ffdc9158bfbe3c19dcfbfbebd1632aed15225a3f520c3868063044d",
-                                "uncompressed-sha256": "0237fcfb9cbfd4190c1fe109484706dbe88b35035713237a35734ce4103c8bc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "a4431e2c72ff17822740c64a611f204d0a4fade668f546c3670f9806e074b85e",
+                                "uncompressed-sha256": "0749b27891c96461acb28e7cef41ab211a554cb30c307757349fc2fe7e9aab3b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2557fda488b9e3b4e983171a8335d7fff86f479b07f764ad520a1ccafab59e59",
-                                "uncompressed-sha256": "79438e34be7aa93c74eb6a3c51be3670f7e1858032c73a52495d1864a66735e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e30cb554a7be66c963ebad96d8ffb6f3745f3e86df3e79910794bb0206b20d55",
+                                "uncompressed-sha256": "a0b3381ab2788fb049ec5bcbf1bbbf521bdd9df845138df96339a9e650a60d5c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/aarch64/fedora-coreos-41.20241122.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "4a6a3eb8ed9bd14ec9fc3f14f5a7cee3762242db7828698117708cf2840e2d69",
-                                "uncompressed-sha256": "479f315c0a551ceaa3bc3b00d6cbbe70fc34b3912a27e9dbbf55ba678d9e06be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "2aed9747a6f59157ff01a47f0543d8bb05eff321db3e48c0d338e706bae4a762",
+                                "uncompressed-sha256": "6c994592e0a8f09524f07910255cff5281b72b5a799c6bc61bd589cf8cacae00"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-010d18c74841931f6"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0726760bcb3b19e75"
                         },
                         "ap-east-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0ae431418fb2a5be5"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0e4ea8e47928e6627"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0b69919dd97393418"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-07ddd07cb322672d7"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-08332a6f4a2aaa079"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-076d10e4393ab3e8f"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-087db97bd6b2903a2"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-000b700f818b5dac8"
                         },
                         "ap-south-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-07dfb7d8b883fc703"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0b9227688ee44fa35"
                         },
                         "ap-south-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-006e94b8ea1194df9"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0355822ef394f3322"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0ee32e260df53927e"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0088a18eaacd4738f"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0ac8f16210e8bc790"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-05721bdddba0ff74d"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-00871cef2ba248e17"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0a0160001b009338f"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0aa53da2aa2f0a93f"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-064bf96e2b7a87664"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-00ed8859bff94abbb"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-01eee27b2bc36407c"
                         },
                         "ca-central-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0a1f1c37b91d35ef4"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-08647d64e8f4ee727"
                         },
                         "ca-west-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0b2d27e92a7a5405f"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-08ba21a81ec895334"
                         },
                         "eu-central-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0df0268598f92d518"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0db704a0af561cd9b"
                         },
                         "eu-central-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0f55beee000f4b976"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-02f04aaec7892a904"
                         },
                         "eu-north-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0402815a03b33a943"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0f8d549e7cba140a6"
                         },
                         "eu-south-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-01b4d1030a059f5cd"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-07faf61369faaeec8"
                         },
                         "eu-south-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0f7d7a12cc2b256bb"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-05345f8783b9c3a2c"
                         },
                         "eu-west-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-05957fa6ca0872d4f"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0eea6bed7676887f7"
                         },
                         "eu-west-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0b523c2c2db508640"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-06f58275421b9a843"
                         },
                         "eu-west-3": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0ef1b2af71a2f9e9e"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0fe65f357313c77e3"
                         },
                         "il-central-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0274a68ffd4d51823"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-05977c97a42041f31"
                         },
                         "me-central-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0f8db1fec835d8418"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-016c93123b1b4198b"
                         },
                         "me-south-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0c5b180b2df3d2500"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0bbde9c49fbfc3104"
                         },
                         "sa-east-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0d1d8ded597266c73"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-011ad88c2bac692e5"
                         },
                         "us-east-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-01769cf784f49a654"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-04ad931abd91d56f1"
                         },
                         "us-east-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0486a40c64e5623c1"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-05edc347c62039d45"
                         },
                         "us-west-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0003c6fc6a5ee1900"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0dae2b35030966e1a"
                         },
                         "us-west-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0ba64cccec2e99729"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0bd8d700a664876d5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20241122-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241215-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f975c34f5698ec5ee02c43e7567cc9a9b044a94ed6ac190db1d98ba4ef989595",
-                                "uncompressed-sha256": "a6e3bde0a32914e3a6993cc8771b32ddba70f4c77d89c83a1d82f9475b0f9c5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6e3a4e0275e53d36fb67aba03cdc9cd3a0ebc140140d0a22400626f3993e414d",
+                                "uncompressed-sha256": "b6da68a9cbc3eb2810dbbc0c833f1592c93e9fda1c6d5ab1ced86e8a36a30802"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live.ppc64le.iso.sig",
-                                "sha256": "cfebd4ff9113dc1aea5a6bb92f12cd00f859cea19cc898e0edb6284a07e10ee2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live.ppc64le.iso.sig",
+                                "sha256": "2a408e7bafaf52fe77def42b189156a760a70f012b9ffc377187f09ac36fdf48"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "65a7d7c8d37c79132477d06f3cae97bf6fd90593022d36b71550c21e2bb49eba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "583c2eed4e12c9a7d981815bad0812473a89e3bf03a38353cfa6536690c4481e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "3a6199fb8c49577d5ec4899026a26852eeb4671f9ebb67359156fcafcb1c37e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "93549db75abba1bb6932593ff764079341e4ff0e1ef9be956a997cac9ca71f90"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "21efc34f6455299a46d7b18119d16740c86ccfca7c64dc579222fddfbba4cf5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "21baf6cd13d2368ae981a7538a88f7cfc5e56b2a38a304c6d989bf1e735c5e3a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "b2354e60bec1064b67886f03114e43f1f6e365bda25999695b19be8cab4377fa",
-                                "uncompressed-sha256": "fb51f0941f2237686620a70704d696d8ee34bfdcd11c55116280929bc1d249d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "6aee2af0e466888220c6591751f60b6ae1704d000a6020209d5f73b111f6cb82",
+                                "uncompressed-sha256": "1b510ac54cae4dd0518730517a51b6fff97076b23af10ed86eb86fd60863dfdc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "5330ff27b29598b82d374e40de032370f99177cda921d6e3c636f235ce8f789d",
-                                "uncompressed-sha256": "ce92ef3a6054c709f3834b91550a19f4ac7fdbc7f6ff19eaf1ed0d1a92fd7918"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "130ccd57acdcf1344f742b25c6a3127dff6335c3acf07441d810da8f868f4c82",
+                                "uncompressed-sha256": "dfe5dd3e4ac824f6540bcececd015b9b0510c58e9ba76cc4118d74bc46422386"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b4303d2d888eb73d9ed358dbef4b4fa688367942bd96171e40d19ef238b9da64",
-                                "uncompressed-sha256": "779949c86e8e5b53016e9773632c612681e652eb9ea1f9bb6046f05c2c014793"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "1d4156e4ad613c15c960109f8176802769600a9c2c6e125a637adb1056ad3fe2",
+                                "uncompressed-sha256": "f97cc363d1ccf901dd72130fab073b33b4127a887889d60c6ea22b8cee945cd0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/ppc64le/fedora-coreos-41.20241122.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "dc7b05d391ce144e018bb85a74a46a8281216ae0ebbff18df0c38a7ba76ad51f",
-                                "uncompressed-sha256": "28f94b3cf0ab790e329ec3a9c39f5df03f4538e3858526795d1ff2044ff6e723"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2c7cd5c29d55c08ff647544eb003e5c40308a3f4ed07487c13e1502d598257ff",
+                                "uncompressed-sha256": "0d35b6053f0b7f26c6693524f98ddfb58b4cc8ecb0e3d35707ec3b22f5ecdf50"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e9d8a70318b6d8b69f102d7f82fd1d487483bff2515d28237a105a9062ee0a04",
-                                "uncompressed-sha256": "5ec5bf6c1b59d431809fb8effc89d5c41752882de96daa84fd3b0fdda2e3a3da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a67a2efc4ad39516d01d223e933692a972951f9e1bad08e0de7f386e5fcbba91",
+                                "uncompressed-sha256": "17804d54e8aed87798fdda5af1ceebb6d88dadc62297c16eb085c30eae601793"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e8c573a4cf2c1df1c2fe8233a06642b0745b885ba17cf2d16b63fcfa1227cd51",
-                                "uncompressed-sha256": "d8b939bca41f12577fe31f9c43f0cef44b4b75d7a43cd0116f203dff8b4112aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e79010e013839f611264c2126fed8727869d0c6c4779bc95ef06b10e22739baa",
+                                "uncompressed-sha256": "cde83e5711196282f8624d058183c5ea65a8b79b661975d6799a862014f434e2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live.s390x.iso.sig",
-                                "sha256": "c8c0e40cbe4173504c4e7c14b651a3884e519fa9f84749a802d515a15474b163"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live.s390x.iso.sig",
+                                "sha256": "720d1a44865aab882fc50efc515c89bff08ad7010954109c7f7d7344c6effaa0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-kernel-s390x.sig",
-                                "sha256": "8bb336e20b321ac5a7ba733d3e29e339893f1e1c3bc5bba40b26f75a18b8250a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-kernel-s390x.sig",
+                                "sha256": "d828baa15f707cb8d187b460e1621fbd4ab32dcd32d50ed0af4fd36207c8ac0f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "a248cd9d784d3ef8ee14adf5435700485d934d9be98a69687e8a371367b9c57a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "4b02554ad3a96d810bcadd60e441143bcf92b16299be2341fecd976c4e2d01f8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "f20dc938754de154e1e8246d77425f18291ac7553ff7e914fc97b8dcc870bb11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "166204da08e010251eb5eae651ddaa633716b73cb729ad6b4b45995c0135d061"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "550da78a11ff0e2f4a82319daf035b2def775ba72db6dbcbc4b4ab417b96f4c1",
-                                "uncompressed-sha256": "79050115f867af1d3b6f8644a6f9f0bec34a06fb1610aa1cd5c4b574bc55c68e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "42ff0636915b67a4168f886fc6f995fed5f3905fef3d7b515d5f6229bda996cf",
+                                "uncompressed-sha256": "6d340bfdb4dbf9b1bc86dc1b24561e530cbd05b6ea5a12d38fbef3586541b807"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c0abe27c0af1db589fd1dc175bf5fc0c4665a2ca67dd6e7b4452c1fe23d306bb",
-                                "uncompressed-sha256": "0423c17ac7a325816695b8b6aa524e986c15b37a7a0f2b06a60cea52dd0204f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b1053de24ec25910eb354647c4eefdac78fcdaccc340b1534705c55afa7c6373",
+                                "uncompressed-sha256": "7a554c3ff1f2378e3ecae40f9ed25a16a77bb6e0bd8c223845af0e761e69c274"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/s390x/fedora-coreos-41.20241122.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "1b9d09643d7e44ce7f96cc7a8ccb7b8c302c12c55b302a5734bfead5c1dbc274",
-                                "uncompressed-sha256": "27d87562ec2e72beeed84db615a8f4508ebb4876e5c8b3193001fa5c9dc0ffd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d648ae75dd861d487ef6a7c6dc6da3223d202b4c45ff29ddf0e67cb7bd2c0dbd",
+                                "uncompressed-sha256": "f8be7079aff1e95e938657c011c90c9c1778c235a973aa90f057925c168b8362"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "02b0b22725273ea5f62d35eeef8bbbf053cc7b7a52f9aa81f125118f77dee2f8",
-                                "uncompressed-sha256": "2df6050d942630b21e435d5852024673b81fa133f5664c73a3d1c4fcb787bd08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "60831133097179c196dcdfbdcfa524f523a8aa1ce6f289ec181326ded74b2f16",
+                                "uncompressed-sha256": "9838e3da4bb3d8a3f2bceb4dc62761204f925fb11c89b938df303d109659b76d"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "6fd9ba6af23c692cf5c393ac8055cb00662841ca0ed946c68f11996210bd8abd",
-                                "uncompressed-sha256": "88a55bce23940fd3e2ccdaa41350cc6e2710e7be341d8e5bfeaf9d1ffd5e9ca9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "e33e898c84fccce09519d32d557091af5314e6118ada92746696133e52851ef1",
+                                "uncompressed-sha256": "b22a740c2a6d37949ab6b589d90ef0a562c7c1ff27787fdaf6f9698866b554fb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "5817d108d7ea929e2af7e0316e0ab60e818d240ff96792b394ca1b2cb1a9f605",
-                                "uncompressed-sha256": "b2d996ecaf210c2dbbc77196a7f27f3b051b7e8a7ceca9717c59f7090c4fa373"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9ba0f5635cd18f63c4441f9b1fb193db38d02ee813aba1f1efea2a9cd1b2ebc2",
+                                "uncompressed-sha256": "f6b99b9a301367d44645318709f15ee58b7210fb04d1d288dfbc97cab070c9c1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "5663639d1dc9a91f263fd0bd497e18b0149b01534cc9956025b8495f55ae9193",
-                                "uncompressed-sha256": "c3689f73b491dff4060d43a12323cb66ac31f7a4d7277fbd0d6649c3e7b76f6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6e7b1f806c9f29d37f7213a384ac454d442b4531d07d1db12a73884b760a42c0",
+                                "uncompressed-sha256": "63a5dbbae725d5174e35f1be1a93db4282941efd33fbd23bd1192ae1eadb038b"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "242c927c53880ceca887e3cee64cf911e25c3d5f64cb773df00d71e5acf4c16e",
-                                "uncompressed-sha256": "de87494c28194c43a2e80940618aafd44c8da48c74dd56074e17d43fca4d4c06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5cc86bae2db6893f3e7b48fc6a5007f698d4366110192a8fc98316ca97954b91",
+                                "uncompressed-sha256": "296adbefaf548756af5be361cd8157cc7677fabb6a1431c3910c9d80bf11387a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9ec8b47dcc53bcd93721a0b854596fdf711d5dae6bd19ef3a606ce5a61477068",
-                                "uncompressed-sha256": "c548dffea417e0e5822c4af435fd6be976aa1eb1214a44bb81a21800aced9777"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "73ae20ae34360ae9f7ec3b5f0114ff3209489678a69c20a8bc1c121b0c9234d6",
+                                "uncompressed-sha256": "bc4be3ea82b23148657da8f2e8a45be8b61259a0bb898a69c53dd5d15bee7371"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7182d9dab8f93205bfe06853980a0a4b462b334b9b0c6cc6e191511eeeaba086",
-                                "uncompressed-sha256": "edad811974673cb4502d7760466db57f6e9f9d2fc0b0d15c88e03dddbcd305e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "5b6d8ce5ccd7929c558513f607b7db61c85ad55f696245a103662855f2974a5d",
+                                "uncompressed-sha256": "29e54e4ea8dbc1a69085a58062e2bda8ca4e89868269796a65010ba602d6d711"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0c0165ba948bebd75095d640cdd7c3a22b6788b47763632cd4dff088f32cee01",
-                                "uncompressed-sha256": "8027eb45e6c5968983801f7b8008b66e51dfb12f10424be6f92911ab507872cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "45d50ebbaf2f14af9dfd17d5e8ef9329af6dbac0448d678cb2fd9689af51fb3c",
+                                "uncompressed-sha256": "07d88d8e99c97bd7201441382126f6182adba867092cee8e187d03b06517132b"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "cb66e758e27422f66724e0d36bad90db91ce70dd3a7de4d401b771b665584b36",
-                                "uncompressed-sha256": "728b2e82a9d60d338230dfd2e327df6f7691443d2b333a81b20b705a8d13abd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "d946448e0953cc8f3bd35126d28371518da3f431ef7a8439265393ad8a9b03b2",
+                                "uncompressed-sha256": "cdb3863eddd4ad82202f3101c969f2efac401a4b049d3034bf8ea9509d729ed3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b19452d923b07ed548c74f735edf30f21e97a01235efc74c4fb51d891deb23ff",
-                                "uncompressed-sha256": "2e754f4a6cd95da80dab62b9dac91e657b4c0ac9c6384e38db1e74af3a1bf7f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "89bc9aeb8e8a47862f390bbbac20c2a7a40513128c1643eede23c5fdf31442b2",
+                                "uncompressed-sha256": "cb1cd681b5ab08ff98370e9aeba548cd63006e92c1f246d6c326924383d74689"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d787f29c6908783fba40fbbb7209c198090d10bd9911a563f16c6eca5414c10d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "7bdfa88718953636faa5aa76d784c601859c3af50088ca5229960db7bc6a049f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2aca32313692e3fa31f55a60e5f59a173e6fc819c6ff71f88ce0c0b67549b857",
-                                "uncompressed-sha256": "6f82ce2bb24b75e78675129d03fa55dcb0d804895c84254ae61cee0468e48acb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cb7c3332023d5d6a3d349a2d844cd672d3ed93d527169286a0616c5098744c7e",
+                                "uncompressed-sha256": "ba5ddf7c460d40dbde60d45fd96fe5e43873b948a67608d4fb26e6b8536544ec"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live.x86_64.iso.sig",
-                                "sha256": "f25217c6b2e2801dbb2156b98fbb81ecba0982d9d1796295c936bb231c575030"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live.x86_64.iso.sig",
+                                "sha256": "3eb61320a8212f7f22d3310d6c6cf19251211fe12f7bf2147b073c1ccce58413"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-kernel-x86_64.sig",
-                                "sha256": "042f96248c38a74bc086105a6535205c34aa4f878178370ffba3974c23dd482e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-kernel-x86_64.sig",
+                                "sha256": "d73310a5099a284cc04726234d90f8ce0873f7a26b6aa505421523ef69bebf03"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1f6340cdd09bd21ea054234d1e6dad8d4010013e18d0e7de237209e722ca4ec8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "813ae59b4ffb6ec7d5a861567009bb2490597e14a5730e2ca19a811cb4c36582"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "21c996930ffc463a94a02a469e41be45b685afaa31380f2f7065c952a7f898cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "fce92004fd911c82bca3cfe474c07a2a16defcd253042822f74a5e484cb8178e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e81f821ee61d4074f039e21295acd8f07b975a311381612794af24ba437c6d39",
-                                "uncompressed-sha256": "0a50e8ebefe1bd0d8f1329d010c0d0103b4a476f23668116f85964d10accf6b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "64506b378961bc0f3a65d998c86c5a66a5fd555075f522cd0215d766206388eb",
+                                "uncompressed-sha256": "e39fbc79bad760d6de37483363b452226d56663db7b0c9ef95a0f60477d0836e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c592fb824d05bcd5ea6e024d119b005268c1205a80eb65d101911cc2ec6eac15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c94f04d30dcc2279effda20ff563d8196d2e45c656bded0aad66ce7d7255e3e9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "42c5c92247a44951807950f1773d614a120c24f6903544c255a916b0e289478d",
-                                "uncompressed-sha256": "3b64b6e445c52bbbda94f95abfc94e5912a6bf91462235c4e26a812feb1a0d56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "cfcca61c377be0fda5eaf04191a44ed52012d7f78f458186f72333ad88b19ae1",
+                                "uncompressed-sha256": "ea49f78b1a2e15de87f4d79f60df22a9e0f901e78d3d73fc3ca88f7b77bff808"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "74e7cc2d9339625fcc2400317048bef94ec1c972026c43ef7217f7964a48a859",
-                                "uncompressed-sha256": "b0b491992670e6d5b53cf48feda10aed2cd4938fd477259eff1e442c6257323d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9e84dac08afbbba123eeaf8e2417d4d0845f55169fced302aaf7c602a5e7aa72",
+                                "uncompressed-sha256": "635a960d660a3ae4e3b9031909b9c13f97c403e1e42244e7a657daa9ed2677cb"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c11665af26e27083a1d807acb55f769dc825dc17f3de675c540e2d10956c7b75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "8668c9479f743655a5b5194bae8ab5cd2600bb5de364e60aafa66b5babce4a95"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "de0c4cf9faafa73d38fc5f71cb36c80efbf21b2cb98348f860d20ea39aaff68d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "6ba4c575fd142ecb7d060d634cf413123a15e18c45abfe5dbad6e41aa71e158a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241122.2.0/x86_64/fedora-coreos-41.20241122.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6decc2f8312b7e178d09317acf6ccab31418cac5b24f4b674cec0542e7dbadb0",
-                                "uncompressed-sha256": "52d2b8370e4e3d0260e8b9a4417cc1c5ea99a823e83cfea617a97dabb3e401b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "31368d544f68ae93759c7a372f085dc3721ae1ff096e720c4c6ce8900f4ba750",
+                                "uncompressed-sha256": "132b957bc97a625617a25bdaa3de78487aa5de714de96cc453d17b683b674297"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-09253447fd00a9f9e"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0f342ba7bae817f8c"
                         },
                         "ap-east-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0714c7f7d99d175c1"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-032b829230887fc65"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0d380a4d3e293227b"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0d1db00b79bc979de"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0a463fbc6caa9a4c6"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-008db21649db8b43c"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-03b3230490aa5bd52"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0543d54939b3e7e4f"
                         },
                         "ap-south-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0c8fbcbabd2bc4697"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-079e139d9e0534e54"
                         },
                         "ap-south-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-08259747d747c3d82"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0a9dfe237c3135dae"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0de03742a51f6877d"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0de5fc6388575d27a"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-074f37e6068cf8ee3"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-06db6fbbd4c5541ce"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-01d97cecd616e5ddf"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0c689e3d98fb692af"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-033ee9cd4ecbeac57"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0391ef5c0f3954174"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0f3abfb401267626f"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-05f53942045a5849c"
                         },
                         "ca-central-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-003aa2a8e78d2c88f"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0f1a0e66de8447800"
                         },
                         "ca-west-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-028737460eab67d64"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-097e9aa9ed1222738"
                         },
                         "eu-central-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-07ba0d611b0b22337"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0e98cadf9fca55adc"
                         },
                         "eu-central-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-097eaa4816f90a7f3"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0e0da7917ae6615ad"
                         },
                         "eu-north-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-069af73db24fe8eeb"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-081fee2904f575217"
                         },
                         "eu-south-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0b189b1f644bcc340"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0c54f72f69a0153ad"
                         },
                         "eu-south-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-03296a211233918e2"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0622bbfff1e5733ca"
                         },
                         "eu-west-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-06ae55077d53c2718"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-098724aac30a3796d"
                         },
                         "eu-west-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-047cd3b69687cf636"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-095246175a5decd18"
                         },
                         "eu-west-3": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0ed8bf80a8d5f4dd5"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-062730fbc652df885"
                         },
                         "il-central-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0feb8c2f9585a7c24"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0cfee70f3a03a8fcf"
                         },
                         "me-central-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0c6ab0351028fe777"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-05eb2facc91e14ad0"
                         },
                         "me-south-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0b8742d1884e7a955"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-02debefc849a42b59"
                         },
                         "sa-east-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0ea3aacf4372ec4b1"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-071cfd1df29acfa0b"
                         },
                         "us-east-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-083f53a14231338dc"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0d63dde6337150265"
                         },
                         "us-east-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0d78521186ac8fa71"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0a2f8409dc572fb3a"
                         },
                         "us-west-1": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0ad2462ec4076e2e5"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-0af791b4ce7d5b384"
                         },
                         "us-west-2": {
-                            "release": "41.20241122.2.0",
-                            "image": "ami-0d0840b3f2ed38fc8"
+                            "release": "41.20241215.2.0",
+                            "image": "ami-05c1716975233839e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20241122-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241215-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241122.2.0",
+                    "release": "41.20241215.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5193292ed8aad4dcc74ad10765e0908464b51e0ea1329e7a45a9051df28c6719"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:78803c3aa01934ee85fc8f297a90ef308c83c85aa354af01d3776e44e3bbf77f"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-11-25T18:17:18Z"
+    "last-modified": "2024-12-17T17:26:25Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20241109.1.0",
+      "version": "41.20241122.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20241122.1.0",
+      "version": "41.20241215.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1732564800,
+          "duration_minutes": 2880,
+          "start_epoch": 1734458400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-11-25T18:17:17Z"
+    "last-modified": "2024-12-17T17:26:23Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "41.20241027.3.0",
+      "version": "41.20241109.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "41.20241109.3.0",
+      "version": "41.20241122.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1732564800,
+          "duration_minutes": 2880,
+          "start_epoch": 1734458400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-11-25T18:17:18Z"
+    "last-modified": "2024-12-17T17:26:24Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20241109.2.0",
+      "version": "41.20241122.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20241122.2.0",
+      "version": "41.20241215.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1732564800,
+          "duration_minutes": 2880,
+          "start_epoch": 1734458400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).