### PR TITLE
Roll out stable 41.20241215.3.0, testing 41.20250105.2.0, next 41.20250105.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2024-12-17T17:26:24Z",
+        "last-modified": "2025-01-07T16:36:43Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "83029562f2dd8d705aaa78a6bb363a752c15948ec783880e1e14f56c1d3f9edd",
-                                "uncompressed-sha256": "51a2f7af62c263c1855f64c03807afefaa762082d7d2df96f9ad0c87c83d92a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "422f6adc06654a0488ac61c42946614161fbf98b327bd264de9e43ef8d1f3e89",
+                                "uncompressed-sha256": "391b1b895ad956891806c88050e4c28d0ee9e7d164ac7b5dc268685253de5826"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "245e6fa970290fa5f69f146d259a7f430aadad390bee16db29ce8df400d09d58",
-                                "uncompressed-sha256": "23d734eab64117762cc3fe41f90a6b7d928bb0b4d8311f959dc5de00c42f4251"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2d0d27610f265e7138cd49b8b17298d1ebb399c44d9c26609a3c4077fa70f4e6",
+                                "uncompressed-sha256": "84051c9489f76d573422707114cb8147176c6b5f8b9215498254d1db7ec4f8be"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "50d36538899980ea5010ec3fa8370fc5f4ceda1c040fbf1aa28588c8dd51bc9c",
-                                "uncompressed-sha256": "03c5c1a96e0723cfcc57cf2242f5d925471256b88bf7086588472b8a69e84a77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "21868300c29eeb3c94458a62d741f59d71b15cc0a6c8f75e7c7f1625b68e0b9b",
+                                "uncompressed-sha256": "31b53a3dce4de0c655ef251578f4c71d658d6b6cf0f7fc300e0bada95303ec61"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "5168753048e05bdc007b737ee8cc6569cc6d09356893216ba4ac1150772e562d",
-                                "uncompressed-sha256": "dd400a6c6d96163d60c92dbdc01b5c2c828555768d41d6af95b28b9877149479"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a1fb383d5aa9d864f452a72b23ff29f7044b76f14cd3260a3827d7731adb2296",
+                                "uncompressed-sha256": "5cf9684ee0e5f854888d316f5717fc5a5b030c340ac8f70e1266adde47f387c9"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "0d925c487300c3815742c44b6941c2228ca8e340fa3e9f7be3230dcd63a66b66",
-                                "uncompressed-sha256": "e6813062eaf1c658fcb8b11a2b804df79640f013b426432f9f40debe3ee6f1bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "bb067168c7f8ce641633d7f01b0d448ad53764088dd4da846a9d0bb638b71564",
+                                "uncompressed-sha256": "3278140851dbf593482264ad0cb467529f3fe6b6b9720675fcfd337542588199"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ede5098023d1d66c0559e10eff76cb9b4d4d8c2fe4b69030d624f6c524b219f7",
-                                "uncompressed-sha256": "202f0c025beb2cee180d201c1e5aa874ff792923cb186820373f9531047c9baa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "1438e498d12d6b98a4ac0044c2c3f439bc02077cc80e22a58badb52abee5d3db",
+                                "uncompressed-sha256": "0d0413c4793ce7700f752a51b69ca191487a256737b9fe6645e607469182123e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live.aarch64.iso.sig",
-                                "sha256": "81f0893d55b55b012cf97e8b71e3f4b1ab8b80b62aad724d95546d2a6180da3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live.aarch64.iso.sig",
+                                "sha256": "49369bd6b5489a658d6a48bdbc0cd0898abff5d41561d67289d7029c0d3add12"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-kernel-aarch64.sig",
-                                "sha256": "8c3d727cfcba05687c73b5ebfd72fdf85fe34ebfe6d21d1535be36bf8b1e122a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-kernel-aarch64.sig",
+                                "sha256": "65836d747fe845b87ccc7facd3ba98a1129acd89aae9a8f4f583b728044ffd64"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "ad8178502b710e543f01fdefa288d9f1116eea746fb842c146c6bf29fe61fe9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "d74e399513d6e1bb25dc50bac200a8aa39c0cb7f36e17c07a4893b2d0e3363c5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d877da7986c7f57cfb8d046ceb137b7ee8db52f945f6fb34794bc213fd70297e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "dfd9dff537f7cbabda6c09534a28b1db2ca2c8fced940f9882466bf216bf9336"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "64a357d37c0be90f220f219101b79c80f36cc14a255336a5540a33434be2156c",
-                                "uncompressed-sha256": "842454518efaa7eb8761636fc7ba1468f6d80e1f8169fdafc63841cb44cd69ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "8bbb93579d7fed85c482711d2e233b107f6bef1ad719e03516a44b0bebc97674",
+                                "uncompressed-sha256": "fc469a837e59b3eb7af7e808a460d7770b33292217befb74923d75a9afc57816"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "eccace11e125da8425dc4f48f362faf5435afd3d9552581b152349d6c42a6acb",
-                                "uncompressed-sha256": "72ecbc7feb2d73b18457eac391bb4e3a38af7e023e4e65e050c5f4401402bdbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3daf766cdcb693348c7b9b1a16c938c140a84136ecbf07f6405a58109e849193",
+                                "uncompressed-sha256": "b60e06860e3e447e21c30957237bb47ba864d40c4d32c86be9b40da52c132ea8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/aarch64/fedora-coreos-41.20241215.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "bc3fd47c9575806c945bd95e56743669adad4623fd6e8d00a01544c11701a2d0",
-                                "uncompressed-sha256": "2369f628e40ef08b03bf038b64842d6a608a09a01629cfaa62083eb6592e317b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "4421b85483973e1403e429934a0cf21873494e101e6e4e74c858cc101a419eff",
+                                "uncompressed-sha256": "307c88c53da56430c839724b2ccf2380c65ca70d9b752d738372089ebb7a3236"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0657c14f74aa12c84"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-062a1c31a93c16b46"
                         },
                         "ap-east-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0366463be5df13596"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0abc79c3d478b1ef1"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0057a46eff909aef4"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0f1a6b89071fa61a6"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0e010c98af648309f"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-03f7f95db0f268641"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0ccde6a5e334e2339"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-04ab8fe6cd4681ba5"
                         },
                         "ap-south-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0cb0d62a064423013"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-077a5903e4e146f66"
                         },
                         "ap-south-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-07e1a20eb7150bbe7"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-03cff9a50e0199263"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-02be67b70c12bf2b0"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-054ed1fbd2283751d"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0b8588375a3f44935"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-051134f80ee547269"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-00ff4d013b9b21424"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-08609568bb927e60b"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0acd76b77ae08acf0"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-035a0d4242923d58c"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0a8f9f195ac77c251"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0b8c24da80792d13a"
                         },
                         "ca-central-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0b370e58403382559"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0a87586c05e8ef6f0"
                         },
                         "ca-west-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0cc265eeb20fb032c"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-00712ba9b99631083"
                         },
                         "eu-central-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-05218cf73e5385cc3"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0dfd8f1a8279ed0e7"
                         },
                         "eu-central-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0556af134e47b3dd3"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-061b78eb47aa7ad3b"
                         },
                         "eu-north-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-018b4709b15e7431f"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-066892abfb5cb264f"
                         },
                         "eu-south-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0e86411ae518df76e"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-08648b5bb42cb7864"
                         },
                         "eu-south-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0f0677568929b7c6e"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0c78666e7690f0f66"
                         },
                         "eu-west-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-04d3ef52deddf6546"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-07fbd7b2e04dfc3b7"
                         },
                         "eu-west-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0d7339f38ed068a5d"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0c24afa43f765dd76"
                         },
                         "eu-west-3": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-09b6aa7fcf24d1104"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-008e330ceb418502d"
                         },
                         "il-central-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0a3c75e48419f969b"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0e129ef088c1bd92a"
                         },
                         "me-central-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-03c1adcf2b03682e6"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0c815756231375782"
                         },
                         "me-south-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0f609e30526332bbb"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0bd3242f352d7c7d0"
                         },
                         "sa-east-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0d1687ad0852571d1"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-07d74623a3545b98e"
                         },
                         "us-east-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0899d915bb1409b65"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0d5b162289a780dd6"
                         },
                         "us-east-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-06355b19217dc53f1"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-037c99a548a554c70"
                         },
                         "us-west-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-06a45f03c14fd22aa"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0f10b665170cda2ed"
                         },
                         "us-west-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-02a25e402e379a627"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-082dc95a9b77b6bcb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20241215-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250105-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "972e2df1304cb54c93ebe9d22eb8bbc2e409cc4face0ccdcf70523d26a1327ce",
-                                "uncompressed-sha256": "ac617785e93ede0aae9ed0325e11efb0e20bb17e3a1824d7829b63b3a8ae4514"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "5fe316b4efa677f37438342578723cf63657ba4e00dca810261d3ceb4f28d0be",
+                                "uncompressed-sha256": "4fefea4fdfaf462d783ff68a73ce487a12ed0e83e4e40370cfca249bd6f421f7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live.ppc64le.iso.sig",
-                                "sha256": "9be55960dfaf4eceb0d13313776fa0349a1d1a375914af8e8a371cbffb8a0304"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live.ppc64le.iso.sig",
+                                "sha256": "8aac34dbec9c9ed95eff6d0e5547075d6f9c59eab1da0a366d7c2dcf6023ff73"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "583c2eed4e12c9a7d981815bad0812473a89e3bf03a38353cfa6536690c4481e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-kernel-ppc64le.sig",
+                                "sha256": "3d9793518dae060b9ca6185012b3e533e1442b51676e77cfbd89100a3b278c98"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f198d235215e7235a210166db6418fb193ae29b630ab84342c50ff0b5e0f6f4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "7c55b256977a58c8bb30f43804902b2353564b2c6b4ebfd4127576689177f66d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "e04a50ce4c15f8044bb53ac3666b072b4696b2d33eadbb04689d2e0c17530dea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "1e0795f3efcd7273f9f25cdfe3d22a85a505c430d999351c7054837bc9039926"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "3af4dd31f01f926309e9c8dad17738746d98d6d9ff596c86128a7df4a55fd99c",
-                                "uncompressed-sha256": "fed7b35352d15c637e67829d1d2ba9e824ffa262714cac033b791d0cc5394bad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3dcc564362ca8e4f7a71cba960b5c1952e64dc64b4374628ff25189b982993ca",
+                                "uncompressed-sha256": "24807ced848d4e9d686cb4fd7978570f15bdac36a7941185c956e6d07f7fc78c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "2cfded08eebb9367b6a275844d6aa753af9c64e01f28c157dc6f5ead2a7f3d97",
-                                "uncompressed-sha256": "557a3a01c194c2254505a87162537f091c3d73ce72a4375f5c43f49f81c003cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "1e3682c5aef82a97e1213e3be7e8725c59e58d1120d1ac818584997dcc288b40",
+                                "uncompressed-sha256": "27c8efde81e0ae77c150447fd72ea42cfeb0c498e70b1f0ca919d78af0590276"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "92457f365f3e00536c53ea8069169d5cd6eaa0593448fad60eb4b923fba6b0c9",
-                                "uncompressed-sha256": "0fd86695599ee79b231861cccd3baf563f811ca7f8c88f4f38047d35903568f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "0e28da58cfda2f771696335f7277c8fe45860328146c76259681a5e65952ef7e",
+                                "uncompressed-sha256": "16e583b77f5cf836834aa7202d3040b18982f11d043674508e776590e14f89b6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/ppc64le/fedora-coreos-41.20241215.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "93bfa2e11103de5b44bcc6793799c68152e060afa8ecac52cf8d4595facbe2f4",
-                                "uncompressed-sha256": "4718d7d44ab01595305ad00ffa4517faa50bcaea9b41e9b8ca922da3fd0422ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4ff408560d2d2257da9bad3d062ba479dcaa8468febd8a0cf09321f4ef8b1bc6",
+                                "uncompressed-sha256": "a50fe212c945ad9e5b1afb5c9fc28ed9e770d3c55d348a462359d40680b50af5"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "73b172edef441da23714ca891a76c1a088d3af46fd644c698d347034b2ce4050",
-                                "uncompressed-sha256": "a62cb98251684ceee384e3fbbce7095d0c49c856c910b9dcf76df6d4739d4d8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "1eaf576610b3bb754b49c8eddc752e22013a897b389a7e18c3abb4d186ed7439",
+                                "uncompressed-sha256": "85299fe69ef01d16db70292aeed6fc276210b118aecf683b1181cf014b7655e8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3f8e65ad3ef2dee875204a2da044179093aa2a74f1f26a4cca504b54f996a208",
-                                "uncompressed-sha256": "229c7a3c2eb76a2ab2fe1eab5802d3c70acf36da3416ce066bca4d5980bde241"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "6ef6c00e2ac1eaa20dc4f1f3bbbd1d35e9ebe86ed1aab8ebdfd2d0d10aaf2fee",
+                                "uncompressed-sha256": "8bbd7b90ef70baecfde0edf9e241d024a3078d4915fbe1ba23da549a0ff42615"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live.s390x.iso.sig",
-                                "sha256": "4da49fa60ef00bd0baca553ff56c355f0f776c9f8031178c3814744bc14f9489"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live.s390x.iso.sig",
+                                "sha256": "0277830e86bdbeae6bd6458b1d8d70e3fccf2d4e1ed2230ca61d526a76f29888"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-kernel-s390x.sig",
-                                "sha256": "d828baa15f707cb8d187b460e1621fbd4ab32dcd32d50ed0af4fd36207c8ac0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-kernel-s390x.sig",
+                                "sha256": "2969a1ddce9913888882d563131d29640c7a5909aad0eccb8debf4256a691261"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "7f7029deb4fc6eb8022b99e073a69030b126adadfde78eb8b87847c0bb95faa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "6fdeaf7504b69abcaf3365b8e451d48ac0c18a9ec1297e3fae546e2ad582008b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "5794d96f495114424ee263ffbf95e1e87e345d5a8a2b564d0905f8c2df148fae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "d1566df30b54099dcd8a68035b341bac5e4de836e301cde7520887110031f3d2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e6ed784d411b43e940fa9a5fb4a30a9622da48b4ffc889c4b025e2a6a8f0fe25",
-                                "uncompressed-sha256": "d632bfe260999da4d9fda4ed0f5e70ebdc781cc29c503cd57bae6c2053270286"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "ad295d19d93c982cdc936227688253432c4ab9ca651d9276a26d53313d4f1a51",
+                                "uncompressed-sha256": "6ab10dc65d61336b781bc2570276a13c80c55ceb322a87d1888137c49c4aa111"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ea672668a86844c02464d20571d68eeea73c46a7d0ac04d8f44e77e04f55cfa3",
-                                "uncompressed-sha256": "004be4e1b7f7de1b48fffa1737666477814c24f8a2d3b6b826706d54c28d0e43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "3c21cbc92729335fb01cd986b2c8bb6aaef21d7a68967312c053216b5c54d843",
+                                "uncompressed-sha256": "77932ef421e448039932480cf7e8822df1ed8a8f3c8b277155ee503f786d71a2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/s390x/fedora-coreos-41.20241215.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5f24c7bd09551cb4694e79707820b220ab1fe3c98e3b4e4d14799e2a869778d3",
-                                "uncompressed-sha256": "4a6a5c11fffb916999faa6020cad37bc57e7aa0e660d3fbad226fb411590805f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "85a3257d438811cd48fdde40d0778f626c41857230262815ac003ca69947b8dd",
+                                "uncompressed-sha256": "0c3b60b3bcb9b6357c6940edd5b2627e55419bfa989522224994e59a399c1c54"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "39d8bd9a893be3dfb71b76228e5f53c0e3d6fdfe4d1305dd9b208011e9efd44d",
-                                "uncompressed-sha256": "6f444272e9dc85b3807a37320549cd59ec4ede6c0e9b11e3f35c8cdfb12e4239"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "91f6fdfe0a97d7022d79ad1788fa51ff5995a7d0b329046df8ab337c6f19f791",
+                                "uncompressed-sha256": "865c1ad3faac508abddcb4f95317c9a719be5eac1e26d00d8800846d673bff95"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "5900619746a80f43ea9350371cd26fc90330741dfca633b2d357378f40f261fa",
-                                "uncompressed-sha256": "b9f8f8199ef33966d8d6780eeac7cf483a868108459105789a6a478b227de936"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "45f8de68a4eee522d1b798e3a2b08f2355764b09d16a076b11e509624e7be6ea",
+                                "uncompressed-sha256": "f05c17097483b761dcd3fa2d727bdbcdfb53e9489c2af84609f8c5fb8dfd2d17"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "02bf87901196d974760a10c003c9a0ed9fd672169edcd4ecd5fbe00166cef2f8",
-                                "uncompressed-sha256": "a6b92fc1c2ec5e3f1804aabe7a8f88968eb01c39f942606ff5403b52a5efd9fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "5e69f3dfd12c4181b6ed11d6a70723e22cbe97909d04bf6030498d1907afaacb",
+                                "uncompressed-sha256": "0ef50717f5fe6604f1929fa98c8f95c7282bff5f19dc5e668f17ca044d78d5d9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "eac9063ef809709baa606f804b9490bc43425a8412e22c0a060134432084436b",
-                                "uncompressed-sha256": "f2dae6278b57bbfcecabf95c2960c0306de6f59b1b9de1d314ce9f18ab7bf58c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3b30f16c7eea5843d5d99f89b29615457b161737911e4810e9181e6bce634220",
+                                "uncompressed-sha256": "2c22230a41a20e7def85dbc7747be8e5aca76cf90c2a25d4dd491b6df8d4d2fd"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ff5d9b6bcb409b78183146080bb38d3af976c6627c737c72376b1299f3276144",
-                                "uncompressed-sha256": "3e5a0d0ecc25cf46b2d97baddf7e0629541dfbec9f21b336eb82ad05c9b3c004"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "40d9d0a596ee06c0e52ac4f7b8343030a284ed5e389ea0e6f480a733c54b889f",
+                                "uncompressed-sha256": "589301fd2bb9616d0f9c855805aeb813eba4b96a3f455531bd27371895041d97"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7d0c6ae5f89425b8d8967d3023bbe6c51aa96d8520ae7141738aaf9619ccb6db",
-                                "uncompressed-sha256": "7059cca263e55780beade8a1e83b1f25e482ffb8b16cfa042afd5b8060066693"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e8c951ebaacd2708e1e468e180ec5dd85ec49136a160dde07d4e1c4f5d374b6e",
+                                "uncompressed-sha256": "80fe04ea69fd9fed04244069487998c77eadf74b035aa114c10a4bccd27675de"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "caf70425c1b30676ab45e374481aa50cf7511976860bec9260f6d3ae3bf9a35c",
-                                "uncompressed-sha256": "148aec007ebdc9a94c1b663c85a8b5e2a7e8674f59c48bd5ceefad365977904f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ade8197bb1358ff54041bdb7f93cf1b939d4f3ef0a2a30f357f55cb9c7d6712b",
+                                "uncompressed-sha256": "9e49b491a8de7ae51baad820ee04089324d6fddbb84bf6ac0d687691c12abd8e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "5523d95691b5d78727d914dddfc7ddfb63a97fd563157391ac61965fe8c12969",
-                                "uncompressed-sha256": "3c15be8b79e8a65ebc35a249cf5d0220b2763e1fa49c91f8c1300c9f7cfe5218"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b9a0271858edf9b2bb4d75dd6961336bd53538b5fea7942f5e44674d18e2fb5a",
+                                "uncompressed-sha256": "8c7a154436d0417fb8df4fecf48ebc12200dbec39e5ce4a84de6620c9be926ba"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "273f564241db2b39ca652b2ad35dd0721c4fe2b9b06a9f1be561ed4357e7fce1",
-                                "uncompressed-sha256": "12b6dc88bfb0a9186bb105339756d74ba3584230eaf15aa9095a7a2578be323b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "b326c0383553f6b6443e72d4df67014e2a829b4474a36bea9a9d4853b02a8067",
+                                "uncompressed-sha256": "7f99e47a477336fc475ed64637c838c949eb2e0dc42c4074eea71ccba21bda37"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "216e02680c961135c911a3dfa6dad91488e776732d8888b6a87f029403f5c85c",
-                                "uncompressed-sha256": "d1cfb4a620be3907f4236852138a4d69a8be3818278f55c83dda4f9cf9c4464d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "15af5e0b5f940ecde892ed3980926d25f17eecfb281804ca15faf7481d56f519",
+                                "uncompressed-sha256": "1ff466d6e5d64dadbc0e374491450ed230f00bfeadf6fada33b554fcaf1ce325"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "41b132480a221c6e518846d2e7c3f4ec3c76954e5fad39fab53a742ef59ec60d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "31993f5901ade0898cb9576f4fdbac0ddab7424059ad172e58a2ed3a41188dd0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2e6c73db9a1285316825d699936fdce336be190279793300130a7d12c213b306",
-                                "uncompressed-sha256": "0457fba6b3e2ed39f9feb21372eb6dd2f20d4e575f2fd27aa8271d592a5f7f91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "fa0d679a9092cedad64bff6277a84073fe7e1cc817483c1435f8434f366fb2c3",
+                                "uncompressed-sha256": "50599c0f28db17aed735377191ae66e55153024fd45a59eb41815d531026ad33"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live.x86_64.iso.sig",
-                                "sha256": "c2d16f9815652f76be4130ee405a5f4cc94f94f9827c865711525c2d696df20e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live.x86_64.iso.sig",
+                                "sha256": "9ed040d174b60aab4ce86fbcb1980ccbc41f5a25500638325a7403a0055fa6d4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-kernel-x86_64.sig",
-                                "sha256": "d73310a5099a284cc04726234d90f8ce0873f7a26b6aa505421523ef69bebf03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-kernel-x86_64.sig",
+                                "sha256": "5cd46b0ba12275d811470c84a8d0fbfcda364d278d40be8a9d0ade2d9f396752"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "042d13e21fec6d2043604c04d22da9aa32e3b69d6183b14bdbb77209412db90c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "b0a2bcf25fd12d04ffebce2c876d397928e06d479fd6087b7c76b21ccaf8e629"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "564c7e2866777c532475480fba5082bff1c5dc21dff83109bd080f2a8ac10676"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "a026c8bf3e76a59794ddee1b62078c272b074aec2b55e7d87ffada64822a938d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f25b743940a16011b61a7c27087a4e153cbc76cd948848547e567c72a76275a3",
-                                "uncompressed-sha256": "d61c8db3ffb6c962b8677e9c6e675438df7c8dd276f271013e022962bc5fd467"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "191d93d05402e732ddb95da60e362baaea78e047db08423b2a3aa0ae1b1645db",
+                                "uncompressed-sha256": "a4cbf8c2333db7fddddde11b4673be33a51ab28a75d7dae5d660ed11356e6c14"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e9b8f561d7c88af604c8232542fa700335359968ac46cdc758fc8c1bfbee4f61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4cd1c1f743af40a3327d1325c4da2418b7889cdb0a8ddf3cdf10770c2c8219bb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8af8660205e3f8486f03ce74d1ff51fce08a96a820482eaeae1eb8903ce0c3b0",
-                                "uncompressed-sha256": "0eca6a7f64252d5e20ceaedee55da71ef4187a25b41e510f38c908bacfc607cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a81fa84eb8924e7bee9d16b8644bb8fca375663758afb858cbc63f4dc0fbe4b5",
+                                "uncompressed-sha256": "74b82dc7909541c8b47ce56c163ac4994ebed2841ddfd1c4e741d3dabdec46aa"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5071d94b58eb6b644aaecaa8a58e482983cbd680a80ca56249a7a3abe1121dfd",
-                                "uncompressed-sha256": "4403ab6e3597a21f043bd1bd8752b5dd111e606c6fd345536c2db9de9f1292c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9aa4e577cf549762327f27d13cfa6cc6816fc53e7bf3caa6d08c0e2b77350ed6",
+                                "uncompressed-sha256": "c5c2014a14d7173184c6579163f1ec1ce14f46a83d4c3152d13d0b941a669468"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c2f0f685ddd09ccccfd1d317c3bd1f992c571719af3020ba6d7d00028d22c9c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "0290ac8b5463aaba6ddcf804c687f7406728abdc95fb56cb58c095abe81ba0d8"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "8476ac02e9dbb822da02c682b970584a9ded11cc5d15fc87ead098704064b1ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "4f48ec5006a7c741693e9ba4db47c4122605fa9231a84825ed10719726a89cb0"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20241215.1.0/x86_64/fedora-coreos-41.20241215.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "047459d9ad3b546a6551aa29b234d3e0134bcc2082d5995e9cd6fcdb79e435fa",
-                                "uncompressed-sha256": "f8943b5746834189b891f433dcc252d1e4a6fcd46ac984f160357f5d7d052eb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1f347e6b21a27aab53f7cbd106757d7fc7d613e16c5af7042efafc250f0ffc68",
+                                "uncompressed-sha256": "7d1e22e62d5d73a2ef9fa6ad887b1554ab611554eb3cf9c582821ebf1a904078"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0e7eb60420a4d78b0"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0c2539f7b6aa797af"
                         },
                         "ap-east-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0662cd2accbbd6158"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0beb779dfe2fb8021"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-04e59db2a89be6c4c"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-009ed5b90ad152ac1"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0ec3243d2007de0fc"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-05c6fdf6fe713acf0"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0bf0c73e781cca175"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0e86bd90330b93415"
                         },
                         "ap-south-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-08037acce88e5a52a"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-009af9f51f064e031"
                         },
                         "ap-south-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0372f29550c5f0dce"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0a87cb1a6f233fc40"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0823b2657c4a5936c"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-09aaacbd78e46ee0e"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-04e33012b965c83ac"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0c763068db028272a"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0a8fd1f4936d604cd"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0beb18eec462db7c0"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0247fa364c8998843"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0f11dc065691642d5"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0b2bb3de5d2db111b"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-042adde32199601c3"
                         },
                         "ca-central-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0504765a76a9eddff"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-016ea2ed950efa76e"
                         },
                         "ca-west-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-075e93e2642a4a3bc"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0cf3c75c54c3561d8"
                         },
                         "eu-central-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-085737ac2f0836b57"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-04daf03bf2908ba92"
                         },
                         "eu-central-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0a5980db2d07ffeae"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-081e5579c199106d1"
                         },
                         "eu-north-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0e4d9373ca32fddd2"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0a79fedc065b047fe"
                         },
                         "eu-south-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0a9b2fc9afc7dc232"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0981508a97dbc8d8e"
                         },
                         "eu-south-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-03f83124cdf32b6f3"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0d69b775e377c2500"
                         },
                         "eu-west-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-089e7ffcda3663feb"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-08738477e3dcd4b29"
                         },
                         "eu-west-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0126edd6efd394e93"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0e4b284fe27376d76"
                         },
                         "eu-west-3": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-066a1ddd03954e3a3"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-00e9b9d3a0d849b7a"
                         },
                         "il-central-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0f4166902f45f91a0"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0f5c0e4d22ff3ec79"
                         },
                         "me-central-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0fa0a2286323a98a0"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0140254402f7b71a1"
                         },
                         "me-south-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0db830fa8917286ee"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0b1e9e13774082ebf"
                         },
                         "sa-east-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-05ea5844846ede0c7"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0216329edfce9235c"
                         },
                         "us-east-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0240ac0cee5fadabb"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0d673cb72b1b4b842"
                         },
                         "us-east-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0e35a9d0d7ef4628f"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-00930c81cca832a43"
                         },
                         "us-west-1": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-04e805554ed3c3eb8"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-04ddcfb2195b41c80"
                         },
                         "us-west-2": {
-                            "release": "41.20241215.1.0",
-                            "image": "ami-0a0dd4eee3e563211"
+                            "release": "41.20250105.1.1",
+                            "image": "ami-0d7b886457a835d59"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20241215-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250105-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241215.1.0",
+                    "release": "41.20250105.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:23a8fa0d8dc9fb8ef6cd420acd15cc3487b092d60ba2a3b5ca49e846649d9f7f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f92a3bef49897db65bf59c7d947fc18cc965d8a1dcfa7207e50c90a4cb15f3cb"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2024-12-17T17:26:23Z",
+        "last-modified": "2025-01-07T16:36:41Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ec43dcf3c48ccf11ee40e8442e9818d2879dc79b184b3bae7809b74fc5e12ef9",
-                                "uncompressed-sha256": "e90c897680d1abe44414295b6e68f6de87ddb3b8c53ba41d846c30e420ec2706"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "517928c1dcd64d1bb737fecc0a7d7cbef832c26964dfcf37c81eddca673f6f99",
+                                "uncompressed-sha256": "c7aa9d84af9a356551829e4065d86c7bea84474acaf2db88ff51db7181170404"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "52323bec7a29e3c76a1b46dcc5e483ed8792f9e6513f30f3789af31cfa3e2bf2",
-                                "uncompressed-sha256": "04656ec9da7bee43b2b492526a61b03882f80c643f7d504a39de8425350294e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "1a9aa4924c0d61499accaed299619b13c02df8f7c77978999ed3b8eb37f24903",
+                                "uncompressed-sha256": "529208ef411bd37b3deb1f5e87ac39518183c117b50e5ccc0c269717fd37db3e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a03a539b4aee89953c1a9f8aaa97de87d824ed89db6e0dbd25d6237cef2654c1",
-                                "uncompressed-sha256": "53a6cf05734f9febbe346aba6c859294cad02ee8c8efaa324dbc3ed55f86ee11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1434b6b7d2b9da0f8fabae3bd59196eb493f575fbd764afa71633dae3fa720ef",
+                                "uncompressed-sha256": "2995c4a4ed26a6c69bb043153fd408b68d64994fbe458dbbb7edc7ab7d15123c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a9e1975d35383c56ba51c5b6260b54caaa494378cb6068ab053ddca8269dc3e2",
-                                "uncompressed-sha256": "e29c862a52ba5baac35a634ecd6936efb829689cfc270002f9bba69818add3b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "f4108002ffd643900ef2deee1bc49e2cd1f2d7878e8f160a1ca9c7dead76f172",
+                                "uncompressed-sha256": "34db446d38b46f50a99f3a309f69fac22526482e8b8e0928b199f45ab57bace9"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "12f3f76fb44789458a2261240ea5141a81a23ac2adffebe12a06db0dba93fc42",
-                                "uncompressed-sha256": "cb1af1a73fe3fe98666b9c9540fd8487ac88840c686c12daf523e9706d28380d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "a5a8f86fc5a18cb77f30c1acf8cf5b001348a2518e7ee416213387637fa1b9e4",
+                                "uncompressed-sha256": "ca664497b9156d0983e907ece31e0421d6b1fb8f12fb882f1c86b6e9c84abf05"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ad761b218447cb77d0df12806b342e5fde5e78a2fad31df2107fcb1ef8d07c1f",
-                                "uncompressed-sha256": "6e189fcd17d4ad3462ddac128b89eebf5b5915d56acc9b6aecce5fbb6dac4080"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "027375936dace7cd74d7cf7279ab1a3d488048aa1e5908cbb0aaadbedb74cb37",
+                                "uncompressed-sha256": "3cb3ba413154aa0560c32a01c85ac823bc6bcca58272f43bd8615a7481d97ef6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live.aarch64.iso.sig",
-                                "sha256": "d7fceeea57c82ac4c8581e83f9aef2dfbdbba0c42dfc2982c239ef4bb7eb8b34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live.aarch64.iso.sig",
+                                "sha256": "a43374f656e44bd59deb95bb68c62ebbdc91b21a5fc23314adffb95c5fc6918d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-kernel-aarch64.sig",
-                                "sha256": "2528f9394bc537b9e2a0d5631b3aa751ec3ec4ba4dc04461a9f27282a24d9a66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-kernel-aarch64.sig",
+                                "sha256": "8c3d727cfcba05687c73b5ebfd72fdf85fe34ebfe6d21d1535be36bf8b1e122a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "794cd566625fb0e7cd98e6cb0d466c84773a2b80fb34083aa93e5f387c5ef6c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d010ceea9b84953e53b621d5a092824f66a4766d27c3fd600557f588af4d7f2f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ca3b89004b3974a674e30ed4e22cc0a92b192e6d9fd1f7cbdae8c00f55ab9635"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "87b314ba20aa49760067f9af19f61c24f8fa85cf43582563810043bd7ba90c7d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ecbe8dfd6081e828c8e89f816d21c8f91ab4bd1c1e717d2238ae9dd43286b5a7",
-                                "uncompressed-sha256": "911c0235ba1e31736c216ddad597a61cc4099888b1524f8f91381736327ebab4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "9370fa95551ed06f3c0650c2948b2c7c93bb12fc4b53ef5cfee69b7196348087",
+                                "uncompressed-sha256": "22c228d2e24b2076f78416d6704cbc6453272956446c9b43142d884e5f3c8dd5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "80c08c2adb984197b4e0f67cd945ec6dfaf7d21497ffec7dbfbcaa3fb1e22566",
-                                "uncompressed-sha256": "eb9a42cdbd7c0105c813b8b0cb71b7d35c22ea8ce78e762d0ed490194b0cd845"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "af7fe6242088a619f4fa43db88e7076ffea550e9d70aaf4dbadec13554a08b6e",
+                                "uncompressed-sha256": "b67a30bfce8159e9d58085ede7be559167d75d5720a77b677891689e155b5095"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/aarch64/fedora-coreos-41.20241122.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "fefa50cb7f5d77bcd6710cd36c604959c5c9c4615347101dfcc74f0e1ffb9c9d",
-                                "uncompressed-sha256": "e58e5e94fafcdbfb5ea1e91db49d57392cb1afc6aff192ff8584cb112a806b15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "cf8089219569c0911cc51e8a0c0db47607d763c7b9e3656e8159e9ae17f73cfa",
+                                "uncompressed-sha256": "8551fdddd1d0613daed42f38f31a2944d536da7f6b7a559f42e2cc9163dd4ea2"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-046e91c4cec5be145"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0b411c34081d8b99e"
                         },
                         "ap-east-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0c656a057796d8652"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0e337edd38d71ea10"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-03618561548347f0d"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-07abae7cf2c2a53a0"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-050ea21fba8ce491c"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-095ffe33b6adb3957"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0a610fe2d4c9f83a4"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0c0704bf9de0a9930"
                         },
                         "ap-south-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0215ab0bb8c105892"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0dcc5bb6f146e774e"
                         },
                         "ap-south-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0901d9ac80a89585a"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0cf7f741bc7c1f8e5"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-068ab5a755d501fe4"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-060b1447590442bfd"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0109de2e291e2b8f3"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-03c829b6ef4581b99"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-085e56dd4ec4035d0"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-06f6298eaff66f182"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-057718f33120dbd00"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-061c8252f76c74bb0"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-06fb852b09c4dfc27"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-023d4224243e6d574"
                         },
                         "ca-central-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0a7dff28fb43ef1d1"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0d8b61efce11ae0fc"
                         },
                         "ca-west-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0d266d7317a380478"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0a80a76db130f9c5c"
                         },
                         "eu-central-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0b794783134c17ddd"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-054be3cfa82315d56"
                         },
                         "eu-central-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0a53bcd6632a38f32"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0a9cb7194f4766079"
                         },
                         "eu-north-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0e79d1b12dda0a6ba"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-05be7f7366f8bffc1"
                         },
                         "eu-south-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-01d441cae5ba67ba7"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-006e56807397462b8"
                         },
                         "eu-south-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0a94889104d3dc03f"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-08bd0bb8c2e428d76"
                         },
                         "eu-west-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-03ebc19134609bd0c"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-01393d18559787f43"
                         },
                         "eu-west-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-073cdb816b4d51655"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0a547a759260bb9c8"
                         },
                         "eu-west-3": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-05104812eadb48df1"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0e77145bc4912ec0e"
                         },
                         "il-central-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0df75bd41c4921c0c"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-086368c52729338c1"
                         },
                         "me-central-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0aa310072e3c6d9d4"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-07b7b6ab1ce4974a3"
                         },
                         "me-south-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-02257cd1bdc9dc718"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0c824052f4ae5eec0"
                         },
                         "sa-east-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-03a2396838fc380fc"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0f1156cb3411782a5"
                         },
                         "us-east-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0459ddd3d9a07b425"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0ccef191a0d102455"
                         },
                         "us-east-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-065c49d3c30604a26"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0010254a6969c8998"
                         },
                         "us-west-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0f3198206d23126b6"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0b43f8242685de362"
                         },
                         "us-west-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-07c31a337cc2a0cc4"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0a1b2cd8635d29117"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20241122-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20241215-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "7f27c1b6b53e345b445e3dd171357c0261845c561a683cad8786f43d89f02fbe",
-                                "uncompressed-sha256": "096b063fafb26d6dcb69a68ddc0aa2f1824e9eaccfcdb7b60e83a02b4066a09a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "86ad5096f0985718f00850aa3155ab4014656d91c5e5e496ed0ffc15191eb231",
+                                "uncompressed-sha256": "0d615b949b525724afb1a7a838a5a38a7cfaeed6ef59b4ee450f5753ca530984"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live.ppc64le.iso.sig",
-                                "sha256": "a43dee0ccc56c5ea52a572f1499f67aeec7ff1f8eeddc1063d6e1c477ab529c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live.ppc64le.iso.sig",
+                                "sha256": "c046ebf46e9ef2ad4366f37a8241a79196553cbb7ae60390bd59ccba81e41448"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "65a7d7c8d37c79132477d06f3cae97bf6fd90593022d36b71550c21e2bb49eba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "583c2eed4e12c9a7d981815bad0812473a89e3bf03a38353cfa6536690c4481e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b52f93465a1da4f45393c094081c43c55f9e5bfff48e47fdeb1086b65beb1647"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "cf1dbd65703027f53b910ec34a35a92c531c18d23d0e874ba7b88ba7936f72e6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "9ab8e1397433cc190404d95d0943a5c8a101739fa05cb659b073fae2cfea7c8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "7bee6257ca48252fef590f016f806873c963d13c75e8cc7f4e9279bd8e1d1c8c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "017b1745c8f53fd6d09a67228357c353bf98eb2bd1fc68d0f5a9c023dfc6cd71",
-                                "uncompressed-sha256": "afe272ee0aa288563d635da3f6c2032f77dccc25cf216b7a6190237082b78e34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "319858fd291338185bd66e1dcdbaf5b96af06bbd75821415b1c65faf2ce2511b",
+                                "uncompressed-sha256": "e60d93fb6ae41c3b75d3657918bbb655a21df18045ef817a8c9122f9f6921a53"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "c30ad273d6c635cc14bfe919ea4a1c6cf8601b8ec74af1d90ecc83cf08a91e7f",
-                                "uncompressed-sha256": "dc37230437819b01b36c370db1ecfc86c929ba7de583715081cde891b4ebfbd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "ab8f9641d1a7e2b027cf73ded305edc2477ebd3a29285ce1d0f3e7907e6edf11",
+                                "uncompressed-sha256": "8d4606aa17906669ba45b7d6eb4cd4c7e728809336c67a2f5dee49b6973d4a9e"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "fa57f2f6d9a8fb00b323e305513d129d89abdb059a9698c5807eed9f4fc2f4b9",
-                                "uncompressed-sha256": "0202074f1985b491e1394267a39ad1852b2836fbc9bef32e7556d8ad59d3c2dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "84beaca3d9a28f7851d72bdb839c79daf389680d6da4f6615237311658c004bd",
+                                "uncompressed-sha256": "3a5250150ab69f90ae2128661bd7098bb8767fe769ac3077dbd05d5ec30d55e7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/ppc64le/fedora-coreos-41.20241122.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "871d13b0a3b1ab027ef43bd3756abbf58cd4227f6be0e7930d7519aa5936b2da",
-                                "uncompressed-sha256": "0dab128d9b4d2388edc5927d053a8ac0a614018fbd2b752f9cface15ece8c92e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "3acba98a7795a3e5c88086f607ed41dbd2332e8ae408cdb16733dd90b992f410",
+                                "uncompressed-sha256": "81442cd1a384488663f178411cbee6bb4382fed0a1d73f8d9180ad7fe13c0281"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "3144da03e25021d727e078770c16f5fb0d32c76143b01bf904b950cd6b3b6654",
-                                "uncompressed-sha256": "c819293d8326cb3dcc5de35cd7ad06069d0e50d3d03006b4e6bf40b69f0d6ee1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "835301c56bb947a63ffcb9c28a6595bc3e2f6a8393dd9121c1da7ddeeabde057",
+                                "uncompressed-sha256": "dd9e8debec3a30a5779e6fcd90d5e9af76ae68633cb188069d9e0b690a5a0376"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "10ed8f9e3de394f43fafa3f7c6bc81e823701570ccfc129b0cf5b1854a1ff7a0",
-                                "uncompressed-sha256": "120fb28e186390801864f614a53dd520d2e2fdbe275f36cd7dea6c590aa595e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "7374489aa6f51848f5e99adce20f26ac32ea0146093bf51fd1da84c703961ad2",
+                                "uncompressed-sha256": "9bf742c34a5b0f9ce5f8421ccc75ffd5b9726a352b6e80222a76d4e4d9a4974c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live.s390x.iso.sig",
-                                "sha256": "a87b53dc138866df801715700e848e32c897f1cce427c426ecc3ad08e14257f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live.s390x.iso.sig",
+                                "sha256": "05f9c2e9634fdf31078bf19d6ebd06312031574186b8d68d49017fc3f3913105"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-kernel-s390x.sig",
-                                "sha256": "8bb336e20b321ac5a7ba733d3e29e339893f1e1c3bc5bba40b26f75a18b8250a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-kernel-s390x.sig",
+                                "sha256": "d828baa15f707cb8d187b460e1621fbd4ab32dcd32d50ed0af4fd36207c8ac0f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "2fab32de0337b4715cb2e71d7d8a02572ab155b738d0a2f1a49450dd6ecb37b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "5512dd98c416f6d4f02d49f03292b68ebbf48d1cef31e3bc06236cd7ba7287f0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "6839af73f25273193ee4d9b07fc1d357be60427b7781bcaea2b8878c8674b8ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "fe95f16125cd27cf88a639a2bf9bc5b33fceb497d4addcce982ca9f828144d5b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "0341cebd7e4189ed43fccc7d70ce6a16670e8237259a09ea45c58fc975240c1f",
-                                "uncompressed-sha256": "d6efcdecae8cb15cee4f3ca556b8160965c46700f6404d3cf9dd8d7d429af6d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "bb43d9aaec84407e4a019ba56e1d475b4a78025c23b101ccbf3b62682e06a3f7",
+                                "uncompressed-sha256": "305caf77bd50b355798a290ad49e2c2b76b3d3000d717173cc8c14096e19b7cb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5f40578d11fd131e7a3f4a8d090e569d9498a41b7f29771a63b21ffc7be19c82",
-                                "uncompressed-sha256": "6fec6e4c18ae8483148ec786bd7eb4aecabf8a68c169e9345734e2462e92ad95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "48ccd611a4647cec96b610f43135d6673d1d1a564158b21c537d0e414ed7d863",
+                                "uncompressed-sha256": "031359f2361b92e48d09165280262a0c7670f3e4ef512518bb2de0b922e7591c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/s390x/fedora-coreos-41.20241122.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "b08be976cbb60d4cd1698a635730edeb237001541db07a157b33d39934757bd5",
-                                "uncompressed-sha256": "214aca9114ffeaf426a247784bd8c3dd324fb3432a83590c7cd44bebdc4aa629"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ce45c58007c29dad368dd6ec707220dd83fc09d11d99a6af3f9846ab5569cabe",
+                                "uncompressed-sha256": "6029235628cfb59a4ce77a2c06092b08d9a4cb5d1d436bcbe1e38ab94b01a9ef"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a10d97d40edf7af11f6381a4fe00c1a9f9c8a60eab1b7796e3608a4811d111f0",
-                                "uncompressed-sha256": "226b77c810596b9efec1de8f961f1dd7e7fff0baa7fe8358b07048399e9305c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3597d6ee27a9f33f8e244b46636d97c1e556e50875b85208750ea89f3cb5646d",
+                                "uncompressed-sha256": "649f3ad15735fe7dc66b23db5ad6ec392c6792efef9224ed11da28054d0d696f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "419e41cdbe2dcb9a55e83c668efbacce50553787c4b6ee441e646b15ca578330",
-                                "uncompressed-sha256": "7077343a5f69e6668b5290129ec5cd4d7d39a7355de94ad85556aed820e23b3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "2a704daae865b2817748e485af1711ca06852ecd511e0d5602957143169b5d01",
+                                "uncompressed-sha256": "2b33f501b0fd1f5a9eeaf1df77c46d61086eb2fd43ed6d698102bef8b12edce6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0a32adfcfab4324b2c33180e17bb0d6a7e7956e13d7e60f88552d913c237dd54",
-                                "uncompressed-sha256": "28b67918f5530e2ea36402a9f3aacd3192d9248060192eab119076c068b36d27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "f58e7f8532ee207232fa3d9634cd3f2b084400047812ba6e769df4b485a0b053",
+                                "uncompressed-sha256": "67bae3f7162664e1f9eda1f95a0de79cd3f3cd9de0195a0359a0b20e3de0b7d2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "67e5eda3abd61f890a78fe0883d25b579062e83f32f691310f7f8e29e5c77e76",
-                                "uncompressed-sha256": "ce08d619ef80a246c4ed289a68983c6bca960daf9c217cbce0d20fdcde9012f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "22067c52d2d9ed7005414473aed97ef9a002e496a335cb6190e673c8bee5365b",
+                                "uncompressed-sha256": "e0c86ebeb6b4d63619390417b5b1c975ff64951d05cb2788d8dbe3dabd99fe6d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "728ddcd08865484735ccd8ca756a5e02ade8162c9610d5d4c750d2dbfb5a377f",
-                                "uncompressed-sha256": "8f03ad53b89fd06fe00d6e1c89555bddbce0f296706397024480624d9571d9e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ef77867525d23c64f776fb49aab7140b36bc0bc0317403fe2afb625d1a62344e",
+                                "uncompressed-sha256": "c8fb6ad5fac6a02d79476d8c90b6f44affcf931ff5edf6cb3ffa8f1e11378e35"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "045d62a6f8aa74ff9224ab63ffcbc66041e683dfa1a6db1e1300ca2948909adc",
-                                "uncompressed-sha256": "47194ecaf6f037180dee4e5ffc687095f55852d99886ee50623618d1196c7965"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "179460a1c45c2f6fbe969ef40c2ee50af732a066c1e6b3c07648e725216946b6",
+                                "uncompressed-sha256": "2a260f24114a6efd96a0739e05ad5c4a78b542f4b936aca621d1ffc45dac719c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "54077a7d9b5aafcc39c9e7f29a89ee5a8ff1eaf1eca824f11c662fedad0bfac5",
-                                "uncompressed-sha256": "a5b8fd174f35edd40c0a6cbb5586bb8347f6daf116b51345cd52f6c1cc3a3a4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ef7f91821f6f613054d5d268f81db33257a92027ba963d41451c0da07b1b886e",
+                                "uncompressed-sha256": "d56e95508605aecbd2179c125bd4964ea69b019a686d396bf35f1a29e36fb758"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f0391e6d39832dab1b6c946427a015cca3b0c999bdf699ae8dc4dfa10d5280ab",
-                                "uncompressed-sha256": "f6a9111615b8cdb7d2ce3f4fa3816d044a8a96014e27f1f598f80e282ef96837"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "76684140e6a56a5b5f84eb457e98b5fdf522626a7f0eae1d1c645a9b2777e0ec",
+                                "uncompressed-sha256": "61924abf7a1628e3c028c90524ed8e6712e190129bd3ad2a32ed704bb02eaef5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "aa0f3cfe8c95a014bb4c2b755ce0a03206bc3bd9b88ca1d6508c03e6a8cd0129",
-                                "uncompressed-sha256": "6f64c73f95913f77ecc55f13f8bfbe39691f7920602ec6fc4377033b95a61822"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "7ff5eb275603554a48a4e5bce90418a95c1814b62cf8be317e0c2ec0c0035b0d",
+                                "uncompressed-sha256": "43e0ab54b4f6df6abb672b411deaeac23da9de7804adffe5ddb83bf5170a83f7"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "347f671b600d5cd336b314336813e39983f52d3be536ff352094805c7042eee3",
-                                "uncompressed-sha256": "563205a421382e309dcc2d10ee592f04e54d5659816530d4f05933809ada5f07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "677cb8e6d0563fd1c1e31d1d337e7f24b70ead7650c470f81a73d0b581617329",
+                                "uncompressed-sha256": "61fba1e40556792cf100f833c77a4212b4285f9202cdf0c0724bd1ac530a1a8c"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "1c6d389facb3d5b6a5090513c051aa0d312f5c6df7bfd19ed3624ca84043095c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "42b62b1581c8c67682965db27192367a4d8ac3b17d3c1124b96e3d55eff0c8fa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6b315a2522153124529e978cf6258efc3f1b024ed8026efe8de833375adb808c",
-                                "uncompressed-sha256": "bae32a9781a6e3391895cdd8a955e105c48bbb83ab48ce41226b945be25bd490"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "cbf66c0464913102be94553c6de3e0b01f038a5cd037629b72a225e3561794e9",
+                                "uncompressed-sha256": "2a1eb5ff5a4ad45078b4bb7fb3b66c24d0e2c03bbc54d06046f6aba7d6850f87"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live.x86_64.iso.sig",
-                                "sha256": "65ee2eee9ac844ad115631dcbbaa6662e5824ccb21f0365e9e0c336748479ab6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live.x86_64.iso.sig",
+                                "sha256": "b38e6286daf7df1ebee5d53db16a23064b71cf9fbd9c1667ea06251a0269b6b8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-kernel-x86_64.sig",
-                                "sha256": "042f96248c38a74bc086105a6535205c34aa4f878178370ffba3974c23dd482e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-kernel-x86_64.sig",
+                                "sha256": "d73310a5099a284cc04726234d90f8ce0873f7a26b6aa505421523ef69bebf03"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "11cd9db2f94dbc4c8170f15c0d3f59dbcc0f64832e80ccb13c9a5ee48e1e5793"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e258876c18a23fd27b0db3bcd208e52bed0673c0185cda7520317d26f51f4e58"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "68dcd4b03e58e25546b3b1bd55400996548500a230c3d3a99f724b0c71418ef7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "801f1df8d20e35cce0e10afef50487776ec3cc9adb8ef001b08fc00e97800d77"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "a0ca4edb6850c0d04c36eb5832abadbd611e2a2466c6def9058c761f4602b49e",
-                                "uncompressed-sha256": "84cbc91d806f0d0606fed3acb8ad99aefdb6b0213b1796ac188dde0502acf222"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e5ff2e004deab3c6d241c2c5766f7259c15df8a44c366477d23fdff7300b41ae",
+                                "uncompressed-sha256": "9c358b8fc8f3f0b6c2deda5f4782d92a5df89ffde6caf45ebda33c56eb8f6ab6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b908a6dd8115bc2698ce8e0bfd3ad90c928e6ae0ac831af408e2ea50cc624dd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4cf290880346015a2a871d32432cbb2f366d247fcd161b87a3d934074166e4e4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "6630c3706ef0ecd4908893cb837b89324f59c64d81eab53cf1c2900154840605",
-                                "uncompressed-sha256": "cdaeb1f25ec1878d765fc547801e5638194dc3d597f86e6ff3b0f2459b030289"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0c32bc0e418afcee875608aca44d6b1efc820270ab6ef8621ffcbc83c9856a4d",
+                                "uncompressed-sha256": "5965c002ad2261e8a6093e84ce43d5a1019de9dfa38a32f9ac976c7d3450488d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1350484fe0e054b24c928c3e9c597d70f601b0fe2dc7c4b00c8123d4b23d2078",
-                                "uncompressed-sha256": "bcf60dc8fe4306ae66d6837304858a0bf1219cc0d5fc7362d0aab0caa5aedced"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8cfa066333c0ed987b8b2b6178d35f94514ab3f3db2194de03a9dd79e3f40d18",
+                                "uncompressed-sha256": "04b5fd816f7658e48469cf3441b0b0d2ca20c5e560f17bcd2c3c52404ae20f41"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "ab7c520dcffdcab23fbb36a2e3b19b432f65b3ebe5e8f3722d5b8e5f16850a97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "745b16fdbbd3780750165f750907acb0199f9b5d0f772127c65c76ae12f6c0d0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "a3225f845f55a8eb7343cced7eb196d7b4adbdc94694da20c33af9c983f11e6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "e0826867d09b24c5c61a4e65cf8ab18b0cb063942a44f7f2bceb3e36849c63ea"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241122.3.0/x86_64/fedora-coreos-41.20241122.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "18a832fd46568f076357acb11eb3ca97339bf2cc1fbd302620b4c02bde241505",
-                                "uncompressed-sha256": "368841df5b055741669d54e9b5f78059c800f072d95e14b83be6de76c90c8677"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8c9c1245b40f843fa49f30df36cef09d6bfe9b31b0a336f55379bd1f7860887e",
+                                "uncompressed-sha256": "2f1d4e10bf66c4169224ab194adf396e8dd1dd58e46f0afe3ffd1d63eb357d35"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0feeaa1699dd4e20e"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0376c8aa84ea55da3"
                         },
                         "ap-east-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-097144713c6ae3959"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-027944d5be1ff7eb8"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0343fd37481e9d178"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0c7470242896c917e"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0b28f6015be6020e0"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-043dba9042553b614"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0b2ddb4613455f383"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-094ca77669f7b8fa1"
                         },
                         "ap-south-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-09c3f040a806baa37"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-059c4550baac5fe07"
                         },
                         "ap-south-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-00b75c6eed87af506"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-04c4d07fed18a6ee2"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-07531da4a7eeff849"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-021a08503db1a25b1"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0d18aadf6865a30ff"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-02a328a080b6d0758"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-00897d95237962bd5"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-05aa37ae884719ca2"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-02848b828c4f34192"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-020a3c0cc54cb71c7"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-01eb4892efe35b8b6"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-05fedd78d57f455ba"
                         },
                         "ca-central-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0900eb7c700ef815a"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-07bd660b891185a6f"
                         },
                         "ca-west-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0c6bc81073ca8baaa"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0778ce522a4e36659"
                         },
                         "eu-central-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0b7d65a0017218bc7"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0b5ab33036b59a6ae"
                         },
                         "eu-central-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-04c4f0899591df73e"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-08639d8b650d262c0"
                         },
                         "eu-north-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0be49a9a062511c96"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-011f863b26b1c1511"
                         },
                         "eu-south-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-01b1e91431f59205c"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0a140d7de04e865f6"
                         },
                         "eu-south-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-01883633ce51a371e"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0317129ccf0600d1c"
                         },
                         "eu-west-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0c3f1942fd365fbb9"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-014f51b69c9bd4d12"
                         },
                         "eu-west-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-06758f85deae9e6bc"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-04c17e2673258c060"
                         },
                         "eu-west-3": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-010ed6e7ac657d3e4"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0daafc67fc771af45"
                         },
                         "il-central-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0bb78ddd161a9de81"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0c169f420cafb13d2"
                         },
                         "me-central-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-0cd1ac2b0cef92004"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0f8c9fed7282e3035"
                         },
                         "me-south-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-06342feb6daaa775f"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-07812479804f2219d"
                         },
                         "sa-east-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-06d6857a302ca5e6e"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-092b88d84201b98e0"
                         },
                         "us-east-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-04631d2c883552c84"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-014f25064b32fbec5"
                         },
                         "us-east-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-07e374bfb84baad7e"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-06f286180fec53913"
                         },
                         "us-west-1": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-00680ea249f4f328b"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-0c1050ba0b34cd8a4"
                         },
                         "us-west-2": {
-                            "release": "41.20241122.3.0",
-                            "image": "ami-03e47b15fc5d9e603"
+                            "release": "41.20241215.3.0",
+                            "image": "ami-06fd716a2a27d700a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20241122-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20241215-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241122.3.0",
+                    "release": "41.20241215.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4bb7599f2e0737ea0a20572c27a5efeb4b0d84a30a7d7de0080ad67fa1fd7d51"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0eabc0fb26345669834dfbca40ad6985437e2158d98fa0cc17ac6c27a2b44397"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2024-12-17T17:26:23Z",
+        "last-modified": "2025-01-07T16:36:42Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "7dddcdd55e86aa7582aa48e209c93518f40507415293eee6b7f9cd8d8197a702",
-                                "uncompressed-sha256": "57998dfdcb5d593be64f1516f201eb7df0abdb779bc2d8ac7953e5ae13202786"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "74f5e02590b63bfc71ea22db2642754f1ec7b418c14882449354269cd6a34bbe",
+                                "uncompressed-sha256": "6c795f1c7682172c77407ac736296337ba816162909b6f084688ed0cfbdb00fa"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "cf97daccb60e544f88438fb963f5f1ccca9da80d669ba4b11a015fa6924ce2f7",
-                                "uncompressed-sha256": "e8f5aa1f1705b4f4ac85e3dd51fcff30884c5be12289f861f1ad4d74d6822bf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "92ea2bdd219e0f2daf053d458daa4dcd5b57deee2fd4e86c727f67b208c2d65f",
+                                "uncompressed-sha256": "3ab968487a4c884f02cec12ea9795b8db9fdc6473b8dba1befa4792436650fbf"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "fbe1a580a52bbfacbc0356467dda2bb01f27b89d1bdb77e6d9c74bae3a372019",
-                                "uncompressed-sha256": "b087df679b16dd09bccfcc21d6db5cb4789fc747abc82333e6afee6fa704b72c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "caa14285a6c5f6910d069bc79ab0a7b63c11b5b3d078dbfca3e68cb6fd215d15",
+                                "uncompressed-sha256": "63f3c38b272a061394e15d6c4dbf0c88dfbd8ebbba3852cae3b33d7448a76fe8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "f038bba7f1eb979b2089fd9e0aa7e137ec8f8b97a7daf03afbf45f889a658c23",
-                                "uncompressed-sha256": "912746b9463574151d298c810840b3f6e5f61386db11a5c64cce99cb5d37caec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "330a99f62893048ae786461d3a1f6923ceb6ff5068be21a545816334617fe4cb",
+                                "uncompressed-sha256": "bf7a4ae190122aa25d7d5ad818c4edc0f709382c5ec867512f663d77095d17b1"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "ba6ace0752d3a94bbf6e0e0c06c02065da1562d11afd77a7055dc50fd8636006",
-                                "uncompressed-sha256": "1a3769b492d6182526e8e5c4883b0b24a914035232da5d3009def046432c68d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "fb9047bc8222646189de809ca4849ff12bc1399a685d07526094ad1ccffe74fd",
+                                "uncompressed-sha256": "86dff89248ee5edfbe3694275f506f4dafb8785f6533380e3c10c2bff95931d9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "740701f8fedacf64da86a0c4de60ba54e9f311430ca0aaed8d3ef7c3d68c554d",
-                                "uncompressed-sha256": "b1cefec9054bb26821d73f31564b1f93fe7ed71f4f6ebfb440ac8c60b00402c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "372dbc62ed95b52a0dbd3f7a44dbc0a09af6c3fc2382bd42030ce169950f2ccd",
+                                "uncompressed-sha256": "fbbd982e891956f22eda30a8e9bdc6a05d17ae0acd13416f34775bf14ab5413b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live.aarch64.iso.sig",
-                                "sha256": "f310949364f6e8e731fb1f35061263d34fccdca9aa484ef3644b897524b39662"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live.aarch64.iso.sig",
+                                "sha256": "fb6eb1a9bdcf25ace1375fb5ecb96bf4af994c7c6f93f134cb316cced99406fe"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-kernel-aarch64.sig",
-                                "sha256": "8c3d727cfcba05687c73b5ebfd72fdf85fe34ebfe6d21d1535be36bf8b1e122a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-kernel-aarch64.sig",
+                                "sha256": "65836d747fe845b87ccc7facd3ba98a1129acd89aae9a8f4f583b728044ffd64"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "2e3b914aa776854ad87468eda3e0a104b8bc5b47a86889f70e406f1be6d89208"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a37ee4ee006921492205081c58e37b41f8da2accef09a8afe1a485f2751b35e2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "664034449cedf80a292d15f7c446e00873143fab58e93948eb384e24cfec751c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "7b1940fad96e8144adf49474cb72fcdabd1b639c97ff042584a8351b3596cef4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "a4431e2c72ff17822740c64a611f204d0a4fade668f546c3670f9806e074b85e",
-                                "uncompressed-sha256": "0749b27891c96461acb28e7cef41ab211a554cb30c307757349fc2fe7e9aab3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c7660e9b5c12ea052ed8c4186bcc154877ab22b17be65dd5f3f32d2bf3f29459",
+                                "uncompressed-sha256": "b1be8aeeb78051f0b81c62dec01fede12ad46dde2944dfbd06ac72a104870158"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e30cb554a7be66c963ebad96d8ffb6f3745f3e86df3e79910794bb0206b20d55",
-                                "uncompressed-sha256": "a0b3381ab2788fb049ec5bcbf1bbbf521bdd9df845138df96339a9e650a60d5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "ffdc2447ca696a8cb3b05cdad1263216619dcf90c5b389f3820af9df4df7cc71",
+                                "uncompressed-sha256": "8bef81aafa7845bb00778f312f7f0d985a7f061bc2de8eb0d1289ac6ffc9dbad"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/aarch64/fedora-coreos-41.20241215.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "2aed9747a6f59157ff01a47f0543d8bb05eff321db3e48c0d338e706bae4a762",
-                                "uncompressed-sha256": "6c994592e0a8f09524f07910255cff5281b72b5a799c6bc61bd589cf8cacae00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "cf57f70017950beb9d6de8a6e209d47cf4621150ef5723cca2fbf62b6f3d3064",
+                                "uncompressed-sha256": "7b41fdb1ddd4025ba7c5959fad094007a3c710676b74f6e13d29d5cf7b4dde0e"
                             }
                         }
                     }
@@ -148,217 +148,217 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0726760bcb3b19e75"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-022581e53ad63895c"
                         },
                         "ap-east-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0e4ea8e47928e6627"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0811c4f81c9f363d1"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-07ddd07cb322672d7"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0b40adaf51682b4f0"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-076d10e4393ab3e8f"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-00b5414bb54795077"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-000b700f818b5dac8"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0823097631b3c5b6e"
                         },
                         "ap-south-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0b9227688ee44fa35"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-01e57ff685042b584"
                         },
                         "ap-south-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0355822ef394f3322"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0700dbd8d8ac925b0"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0088a18eaacd4738f"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0eee178cab98c5f10"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-05721bdddba0ff74d"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0c92fe7b737c529b6"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0a0160001b009338f"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0b6608df6777d8988"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-064bf96e2b7a87664"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0fc4af351d448116d"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-01eee27b2bc36407c"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0c3aab687fd078729"
                         },
                         "ca-central-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-08647d64e8f4ee727"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0fadece54e709bce6"
                         },
                         "ca-west-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-08ba21a81ec895334"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-020502230b8f37df5"
                         },
                         "eu-central-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0db704a0af561cd9b"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-08d9fa2da97097514"
                         },
                         "eu-central-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-02f04aaec7892a904"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-010418538e627c886"
                         },
                         "eu-north-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0f8d549e7cba140a6"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0eb4c494e85435ff2"
                         },
                         "eu-south-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-07faf61369faaeec8"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-085dfeddbfbd212ff"
                         },
                         "eu-south-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-05345f8783b9c3a2c"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-001e1bd4a6cfeb150"
                         },
                         "eu-west-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0eea6bed7676887f7"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-06bad0216ea223aec"
                         },
                         "eu-west-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-06f58275421b9a843"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-05b15cd8e0c3a16cd"
                         },
                         "eu-west-3": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0fe65f357313c77e3"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0bc403bfeefc4dc9f"
                         },
                         "il-central-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-05977c97a42041f31"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0f4008a4b77d217a4"
                         },
                         "me-central-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-016c93123b1b4198b"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-00be971a492000479"
                         },
                         "me-south-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0bbde9c49fbfc3104"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-00bd54fba5a4c3671"
                         },
                         "sa-east-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-011ad88c2bac692e5"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-04b06f7e93554e80f"
                         },
                         "us-east-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-04ad931abd91d56f1"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0b660552c5bbf1eb0"
                         },
                         "us-east-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-05edc347c62039d45"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-08f696fcc0bd9818a"
                         },
                         "us-west-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0dae2b35030966e1a"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-001cdf2b63e7b01cf"
                         },
                         "us-west-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0bd8d700a664876d5"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0fff0fccd096abfe1"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20241215-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250105-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6e3a4e0275e53d36fb67aba03cdc9cd3a0ebc140140d0a22400626f3993e414d",
-                                "uncompressed-sha256": "b6da68a9cbc3eb2810dbbc0c833f1592c93e9fda1c6d5ab1ced86e8a36a30802"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "90ec0a90708adabbae0b4c69f44f762c373bb867a974d8790a09c6c207d32174",
+                                "uncompressed-sha256": "f1370f2472e5dc22eb2452ce384a0f4367b2b9d4122167de438765cd256e6034"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live.ppc64le.iso.sig",
-                                "sha256": "2a408e7bafaf52fe77def42b189156a760a70f012b9ffc377187f09ac36fdf48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live.ppc64le.iso.sig",
+                                "sha256": "42aafc81b784e275c1fad2ef5d96b83252de6e9ee06ff7a742cfb9e4993acaab"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "583c2eed4e12c9a7d981815bad0812473a89e3bf03a38353cfa6536690c4481e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "3d9793518dae060b9ca6185012b3e533e1442b51676e77cfbd89100a3b278c98"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "93549db75abba1bb6932593ff764079341e4ff0e1ef9be956a997cac9ca71f90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "bfabf4cfd8b355877b9c5b124fa847978fa1525d72cde2f0cd9173ecdac3809b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "21baf6cd13d2368ae981a7538a88f7cfc5e56b2a38a304c6d989bf1e735c5e3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "4c4ea61aea8c1f08f0fb18758bd497a69e43981930206423cc6209a053fdaaa3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6aee2af0e466888220c6591751f60b6ae1704d000a6020209d5f73b111f6cb82",
-                                "uncompressed-sha256": "1b510ac54cae4dd0518730517a51b6fff97076b23af10ed86eb86fd60863dfdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "4f0cfe7ac07689dc18ec44a7afd31990f35bb9e2082767e0857da28fc5bb1e5a",
+                                "uncompressed-sha256": "fc0f0092a2290e8176822726261c3a2d55df2d94a7618fb1b5773fe3500e3279"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "130ccd57acdcf1344f742b25c6a3127dff6335c3acf07441d810da8f868f4c82",
-                                "uncompressed-sha256": "dfe5dd3e4ac824f6540bcececd015b9b0510c58e9ba76cc4118d74bc46422386"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "b9808b412382fa4214af4c675d6f6b66b8401fac8de9678b133ee0d4b768242e",
+                                "uncompressed-sha256": "e2d137cf3e0da0cd18f09df71f833bee793debd6dbb7fb0a1bb4d6e662155144"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "1d4156e4ad613c15c960109f8176802769600a9c2c6e125a637adb1056ad3fe2",
-                                "uncompressed-sha256": "f97cc363d1ccf901dd72130fab073b33b4127a887889d60c6ea22b8cee945cd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "b8a4478dfdbf30c0645c8fd88fb6f7e9708ce2eb9d1e19b0f3902950d3f35c79",
+                                "uncompressed-sha256": "83b7818cc674c414cbdd23b4ff42130bf0fbb8c73e700615c3b49a34ed8de9a8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/ppc64le/fedora-coreos-41.20241215.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "2c7cd5c29d55c08ff647544eb003e5c40308a3f4ed07487c13e1502d598257ff",
-                                "uncompressed-sha256": "0d35b6053f0b7f26c6693524f98ddfb58b4cc8ecb0e3d35707ec3b22f5ecdf50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "7cdad4e65f6da7c47cc8a93233566d40a64ecff120d7305e4b8f257f092c95ab",
+                                "uncompressed-sha256": "fca29f5337d5f7e92aa8345a3f9fa460fc12f12107043a505ebd8e155c1b5196"
                             }
                         }
                     }
@@ -369,85 +369,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a67a2efc4ad39516d01d223e933692a972951f9e1bad08e0de7f386e5fcbba91",
-                                "uncompressed-sha256": "17804d54e8aed87798fdda5af1ceebb6d88dadc62297c16eb085c30eae601793"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e7236e486da305330d04991cd7eeb56a523a2c876225ec0997ff6f4553dfe695",
+                                "uncompressed-sha256": "dab776676408d9c0c3518b6c64f8a05bbe6605f42e90108b2640751d870d6992"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e79010e013839f611264c2126fed8727869d0c6c4779bc95ef06b10e22739baa",
-                                "uncompressed-sha256": "cde83e5711196282f8624d058183c5ea65a8b79b661975d6799a862014f434e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "257a38504e6647e2d827c28278861b550dab79259969ab50db6613c96417b009",
+                                "uncompressed-sha256": "5f9149dc88b84234ebda5870a0853eae88ad6852bc1172e1db26919a4c9e14ae"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live.s390x.iso.sig",
-                                "sha256": "720d1a44865aab882fc50efc515c89bff08ad7010954109c7f7d7344c6effaa0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live.s390x.iso.sig",
+                                "sha256": "e5adb2635616efb58e8900ae2f6e5b1137874695e848f95604ad488a03009bee"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-kernel-s390x.sig",
-                                "sha256": "d828baa15f707cb8d187b460e1621fbd4ab32dcd32d50ed0af4fd36207c8ac0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-kernel-s390x.sig",
+                                "sha256": "2969a1ddce9913888882d563131d29640c7a5909aad0eccb8debf4256a691261"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "4b02554ad3a96d810bcadd60e441143bcf92b16299be2341fecd976c4e2d01f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "606c2ae6fdf9bd28df7c81e614cb01d03e8ab9019880eeaf066ad4e9be8274ad"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "166204da08e010251eb5eae651ddaa633716b73cb729ad6b4b45995c0135d061"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "a653c98264445f03972937a0d2401781a294f2b1756c37a7a2575d23fa87b33b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "42ff0636915b67a4168f886fc6f995fed5f3905fef3d7b515d5f6229bda996cf",
-                                "uncompressed-sha256": "6d340bfdb4dbf9b1bc86dc1b24561e530cbd05b6ea5a12d38fbef3586541b807"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "5c344156514a6e2c613f0139083161c50c101b7d720acd8180d428af442d75a8",
+                                "uncompressed-sha256": "95350e7f083be0f75495a22fbb48a445b990b17df95d617728426e01a2f08564"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b1053de24ec25910eb354647c4eefdac78fcdaccc340b1534705c55afa7c6373",
-                                "uncompressed-sha256": "7a554c3ff1f2378e3ecae40f9ed25a16a77bb6e0bd8c223845af0e761e69c274"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "83dee693b6f512599a745e92f7237e73c3889416421bd501c3c9c4ee9229ff79",
+                                "uncompressed-sha256": "49d285774b62913070423f5bd0ad0c02d44a944b456deffa76c56dc60bcd324b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/s390x/fedora-coreos-41.20241215.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d648ae75dd861d487ef6a7c6dc6da3223d202b4c45ff29ddf0e67cb7bd2c0dbd",
-                                "uncompressed-sha256": "f8be7079aff1e95e938657c011c90c9c1778c235a973aa90f057925c168b8362"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c40069a87e140f56bf41f18476197db9ea9fe7b2cbbe2a1ac3b9a25a8130da5d",
+                                "uncompressed-sha256": "cccbb997a193056be5e8277409e8487d21810fa9d23b8683504d3cbfc2b128c1"
                             }
                         }
                     }
@@ -458,263 +458,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "60831133097179c196dcdfbdcfa524f523a8aa1ce6f289ec181326ded74b2f16",
-                                "uncompressed-sha256": "9838e3da4bb3d8a3f2bceb4dc62761204f925fb11c89b938df303d109659b76d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4e3d18e76e381edb08ef656b97715b4e7f1c7f9b7748142c865596d959fecee0",
+                                "uncompressed-sha256": "a1d2addc12c2d3aa1848479bdff63e09d36290aed2b51f643da39804b257c262"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "e33e898c84fccce09519d32d557091af5314e6118ada92746696133e52851ef1",
-                                "uncompressed-sha256": "b22a740c2a6d37949ab6b589d90ef0a562c7c1ff27787fdaf6f9698866b554fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "cb15e014773f1fd4aef460dfbea32564dae28307705b443cd16110973e140495",
+                                "uncompressed-sha256": "a64da5087ffa91932926372a74bbfdde8ebaee3ca551a09b563519ec3256edab"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9ba0f5635cd18f63c4441f9b1fb193db38d02ee813aba1f1efea2a9cd1b2ebc2",
-                                "uncompressed-sha256": "f6b99b9a301367d44645318709f15ee58b7210fb04d1d288dfbc97cab070c9c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "82f3ac102a02485583455a8bfa672c9d2ac6c89a971cf06f30ffb6cec7b3059f",
+                                "uncompressed-sha256": "e39afcf0b07d21817fd5cb24635a2c2d4140268065bbbf5976a07deb7510a671"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6e7b1f806c9f29d37f7213a384ac454d442b4531d07d1db12a73884b760a42c0",
-                                "uncompressed-sha256": "63a5dbbae725d5174e35f1be1a93db4282941efd33fbd23bd1192ae1eadb038b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7445b5604c761d6ed1581024466206593e54b3a1938194c4416eea6a9b27489f",
+                                "uncompressed-sha256": "0440256b83f20cefb5c37f0f24f66c55991e61a140acae7232f2f9aa1fd11f84"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "5cc86bae2db6893f3e7b48fc6a5007f698d4366110192a8fc98316ca97954b91",
-                                "uncompressed-sha256": "296adbefaf548756af5be361cd8157cc7677fabb6a1431c3910c9d80bf11387a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "861eda06fe83e9c39f26b962afa5fc3a2965cbd1530e0fe485e6b6c4b5a46a97",
+                                "uncompressed-sha256": "e94dcaf810378750954c5df4bf10750474fa14563f4bfc66f92e28bed767257a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "73ae20ae34360ae9f7ec3b5f0114ff3209489678a69c20a8bc1c121b0c9234d6",
-                                "uncompressed-sha256": "bc4be3ea82b23148657da8f2e8a45be8b61259a0bb898a69c53dd5d15bee7371"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1cdd1af9206a3c3e65df4f3333eb686e9e199306439146030dd58a32bc9725bd",
+                                "uncompressed-sha256": "f060f2b1dcf2c1be2828f19c8046e075d0b06b7b8380aae5a7c898cdd1070d10"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "5b6d8ce5ccd7929c558513f607b7db61c85ad55f696245a103662855f2974a5d",
-                                "uncompressed-sha256": "29e54e4ea8dbc1a69085a58062e2bda8ca4e89868269796a65010ba602d6d711"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "da5c617d838dc671dc069100e18e98ea19c21f19fbc8e44d17bad8cbc52626ff",
+                                "uncompressed-sha256": "d4a780aa705f426371d978bb312102aabda5aca82e6372f9a8fa6fb3fa49e2d3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "45d50ebbaf2f14af9dfd17d5e8ef9329af6dbac0448d678cb2fd9689af51fb3c",
-                                "uncompressed-sha256": "07d88d8e99c97bd7201441382126f6182adba867092cee8e187d03b06517132b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "298b4392b99baa2a2700529abd7754047533ea93f95703ce04744ae7ec7b4fcd",
+                                "uncompressed-sha256": "213ba2937e201652f34a582132447aeed878ffdd8553170ad03459842bf9b275"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "d946448e0953cc8f3bd35126d28371518da3f431ef7a8439265393ad8a9b03b2",
-                                "uncompressed-sha256": "cdb3863eddd4ad82202f3101c969f2efac401a4b049d3034bf8ea9509d729ed3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "b18df2bff48b5a8d6b37e785d283f1c40062aa487f89c0006b769fa6a1e5bf95",
+                                "uncompressed-sha256": "4cdbf1ce0b8b7919c2520ed121529633b23d6d769900ecaccd1130394df01a2d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "89bc9aeb8e8a47862f390bbbac20c2a7a40513128c1643eede23c5fdf31442b2",
-                                "uncompressed-sha256": "cb1cd681b5ab08ff98370e9aeba548cd63006e92c1f246d6c326924383d74689"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b7f74e127121f7193a7351adc8ca47a3e28803df2497a333ebdcb1b8b63bdb75",
+                                "uncompressed-sha256": "ca505d2053f0d57b9a5d12a7b44b4baa3a7106829ce5e58752ba052e4f90ed9e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "7bdfa88718953636faa5aa76d784c601859c3af50088ca5229960db7bc6a049f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d3c82c582efb10688f5307da5e0f42af137eae55f6778fa1c8f78ae6508b9f13"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cb7c3332023d5d6a3d349a2d844cd672d3ed93d527169286a0616c5098744c7e",
-                                "uncompressed-sha256": "ba5ddf7c460d40dbde60d45fd96fe5e43873b948a67608d4fb26e6b8536544ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "984975f1e4d24ae38bacb883d7757b5017ba65afb4874e3963522aa2b44ea7e7",
+                                "uncompressed-sha256": "6ba7a4acfd1d46e5ea77889bc41ae404330de5e7c65fe22b5f8de5691ddbf17c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live.x86_64.iso.sig",
-                                "sha256": "3eb61320a8212f7f22d3310d6c6cf19251211fe12f7bf2147b073c1ccce58413"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live.x86_64.iso.sig",
+                                "sha256": "a62d2651b5994e02d6f33732becabc97f29c3127c2bc141fe7427545920ec2b3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-kernel-x86_64.sig",
-                                "sha256": "d73310a5099a284cc04726234d90f8ce0873f7a26b6aa505421523ef69bebf03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-kernel-x86_64.sig",
+                                "sha256": "5cd46b0ba12275d811470c84a8d0fbfcda364d278d40be8a9d0ade2d9f396752"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "813ae59b4ffb6ec7d5a861567009bb2490597e14a5730e2ca19a811cb4c36582"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "20ef453305ee91bf2ed25b172729afacbdd70d72ddf1ab044dd68fabe9bd8a60"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "fce92004fd911c82bca3cfe474c07a2a16defcd253042822f74a5e484cb8178e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "5375846be5d5ad5b6d6751f46cdf6330e941cb33ed56d791ab061e5342dd364e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "64506b378961bc0f3a65d998c86c5a66a5fd555075f522cd0215d766206388eb",
-                                "uncompressed-sha256": "e39fbc79bad760d6de37483363b452226d56663db7b0c9ef95a0f60477d0836e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "5cef87755fb0e04fa45041605671d31452e20d93ed8f23387bf1c3873e66aae0",
+                                "uncompressed-sha256": "80e52b8fc809d14045ff362803ebcf2a70d4492d205f4931751911e8fdf55928"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c94f04d30dcc2279effda20ff563d8196d2e45c656bded0aad66ce7d7255e3e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "faa8727f2097b1bb04af4472275f452222220ff5a18eb636d52b7569f31cf383"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "cfcca61c377be0fda5eaf04191a44ed52012d7f78f458186f72333ad88b19ae1",
-                                "uncompressed-sha256": "ea49f78b1a2e15de87f4d79f60df22a9e0f901e78d3d73fc3ca88f7b77bff808"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "3a3cca78e5ce7336d9ba40064097210d0cda4ab8115b8123e8ee9748d01d5246",
+                                "uncompressed-sha256": "8686de9afbef055017e0b5d216aa95a7bb4e44635ecb6a826ece7130fe190abb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9e84dac08afbbba123eeaf8e2417d4d0845f55169fced302aaf7c602a5e7aa72",
-                                "uncompressed-sha256": "635a960d660a3ae4e3b9031909b9c13f97c403e1e42244e7a657daa9ed2677cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "12017ebd9baea5a83c2c47d8f778562bab0d0b9c3c0c4f8dc574e5023cc9f5ed",
+                                "uncompressed-sha256": "28e30069a07af84441eab7193f49a318254208568d6c32f87b93a7e9e7aa5943"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "8668c9479f743655a5b5194bae8ab5cd2600bb5de364e60aafa66b5babce4a95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "85890746bcf44eb193746cd2172de5bb560ab87c14b9f95274bb270f43eeb43f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "6ba4c575fd142ecb7d060d634cf413123a15e18c45abfe5dbad6e41aa71e158a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "05236d0500a69e1319a443b0e009299de2b89a38422e0feea0c57f9fe54e80ce"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20241215.2.0/x86_64/fedora-coreos-41.20241215.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "31368d544f68ae93759c7a372f085dc3721ae1ff096e720c4c6ce8900f4ba750",
-                                "uncompressed-sha256": "132b957bc97a625617a25bdaa3de78487aa5de714de96cc453d17b683b674297"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "f48ec1df39d342e444052079b8a1d1a43da94f545a9cc4fa4c303e823a159331",
+                                "uncompressed-sha256": "e1c900468f0f2ee1e45309965593e5642ac79f52285ab46327461a85771bc51f"
                             }
                         }
                     }
@@ -724,137 +724,137 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0f342ba7bae817f8c"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-086a80205d9164091"
                         },
                         "ap-east-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-032b829230887fc65"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-031da7228f24d9c6d"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0d1db00b79bc979de"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-049ea0a589b7489a7"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-008db21649db8b43c"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0f17f316bf0ac25de"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0543d54939b3e7e4f"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-010b6241e3550568e"
                         },
                         "ap-south-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-079e139d9e0534e54"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0cba14034b14893a5"
                         },
                         "ap-south-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0a9dfe237c3135dae"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-02f648c57c3d1e579"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0de5fc6388575d27a"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-063d7e702a115e44c"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-06db6fbbd4c5541ce"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0d94b5665d897c09d"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0c689e3d98fb692af"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0b34ffed8caa7726d"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0391ef5c0f3954174"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0b153a6f4d3035d15"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-05f53942045a5849c"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0d721b9b7ea0467ea"
                         },
                         "ca-central-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0f1a0e66de8447800"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0f881793364563d9a"
                         },
                         "ca-west-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-097e9aa9ed1222738"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0a64fdda3870e816f"
                         },
                         "eu-central-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0e98cadf9fca55adc"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-079d5a0dc3812c0df"
                         },
                         "eu-central-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0e0da7917ae6615ad"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0d0b37dbacdd6f325"
                         },
                         "eu-north-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-081fee2904f575217"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-04777b9565f87f1d2"
                         },
                         "eu-south-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0c54f72f69a0153ad"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-094125d75ea8ead0f"
                         },
                         "eu-south-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0622bbfff1e5733ca"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-03617b9b3bc0f20d3"
                         },
                         "eu-west-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-098724aac30a3796d"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-01292c736fca89499"
                         },
                         "eu-west-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-095246175a5decd18"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0a0c964ee298ba06c"
                         },
                         "eu-west-3": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-062730fbc652df885"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-066e6c817b00973d1"
                         },
                         "il-central-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0cfee70f3a03a8fcf"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-02f5b9adcbb5ec38d"
                         },
                         "me-central-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-05eb2facc91e14ad0"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0ba4b11cc275f1eac"
                         },
                         "me-south-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-02debefc849a42b59"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-02154db73d4dd9a5f"
                         },
                         "sa-east-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-071cfd1df29acfa0b"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0b4ed87a5ea195d99"
                         },
                         "us-east-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0d63dde6337150265"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0faf6363dcbd4f5ea"
                         },
                         "us-east-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0a2f8409dc572fb3a"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-00ab5b8f4fe7a09ea"
                         },
                         "us-west-1": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-0af791b4ce7d5b384"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-0c66174882bb4f185"
                         },
                         "us-west-2": {
-                            "release": "41.20241215.2.0",
-                            "image": "ami-05c1716975233839e"
+                            "release": "41.20250105.2.0",
+                            "image": "ami-025d88cd7d45211ac"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20241215-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250105-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241215.2.0",
+                    "release": "41.20250105.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:78803c3aa01934ee85fc8f297a90ef308c83c85aa354af01d3776e44e3bbf77f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:356c74886ce6f950b3bb8aa3f9af8f83648dc4b7f99c4ae63acb37ace2b59498"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2024-12-17T17:26:25Z"
+    "last-modified": "2025-01-07T16:36:43Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20241122.1.0",
+      "version": "41.20241215.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20241215.1.0",
+      "version": "41.20250105.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1734458400,
+          "start_epoch": 1736344800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2024-12-17T17:26:23Z"
+    "last-modified": "2025-01-07T16:36:42Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "41.20241109.3.0",
+      "version": "41.20241122.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "41.20241122.3.0",
+      "version": "41.20241215.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1734458400,
+          "start_epoch": 1736344800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2024-12-17T17:26:24Z"
+    "last-modified": "2025-01-07T16:36:43Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20241122.2.0",
+      "version": "41.20241215.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20241215.2.0",
+      "version": "41.20250105.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1734458400,
+          "start_epoch": 1736344800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).