### PR TITLE
Roll out stable 41.20250105.3.0, testing 41.20250117.2.0, next 41.20250117.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-01-07T16:36:43Z",
+        "last-modified": "2025-01-21T22:49:15Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "422f6adc06654a0488ac61c42946614161fbf98b327bd264de9e43ef8d1f3e89",
-                                "uncompressed-sha256": "391b1b895ad956891806c88050e4c28d0ee9e7d164ac7b5dc268685253de5826"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "d21940be7dab503c3ff9a0b47e27af815c5a886aa37a191437efb80c3ad2d00b",
+                                "uncompressed-sha256": "668dce5c374ba3bf10c3a825801c117279f6656ad9ea3c0c16284f42ce4e68fb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2d0d27610f265e7138cd49b8b17298d1ebb399c44d9c26609a3c4077fa70f4e6",
-                                "uncompressed-sha256": "84051c9489f76d573422707114cb8147176c6b5f8b9215498254d1db7ec4f8be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fd539530f5614a33a180399c5fe121a2781eb9917325a19e036eec139e3850e1",
+                                "uncompressed-sha256": "8d697097dcba39d538e90d869d9c69782d58ea22aaad8a0639953ac9e9190fcf"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "21868300c29eeb3c94458a62d741f59d71b15cc0a6c8f75e7c7f1625b68e0b9b",
-                                "uncompressed-sha256": "31b53a3dce4de0c655ef251578f4c71d658d6b6cf0f7fc300e0bada95303ec61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1b89b8b3fc2f5056a99f7c862e88f1b85b20873782322c6621df60a461b7fb2b",
+                                "uncompressed-sha256": "27d1e4b3865a5ced01c24aa55ee34401a3cbd916e20f9e7bef0c3814a058fa13"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a1fb383d5aa9d864f452a72b23ff29f7044b76f14cd3260a3827d7731adb2296",
-                                "uncompressed-sha256": "5cf9684ee0e5f854888d316f5717fc5a5b030c340ac8f70e1266adde47f387c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "d2d50f5ee9656db0d6e61f9ced74eaa05ad273712f61519cd047a4210f9b599b",
+                                "uncompressed-sha256": "6c17121ddfc46620c1faa53031c1c23a39d03941ee13921ba82f62e4cd8c1932"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "bb067168c7f8ce641633d7f01b0d448ad53764088dd4da846a9d0bb638b71564",
-                                "uncompressed-sha256": "3278140851dbf593482264ad0cb467529f3fe6b6b9720675fcfd337542588199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "7b258776851faedd1d2fa4f02631590105eb0ef9d4969aedeba38883489d5ac8",
+                                "uncompressed-sha256": "19fa816f7ad0734cda5c1020b94c470beda13fc171b0a1bc89f33ec62ffac067"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "1438e498d12d6b98a4ac0044c2c3f439bc02077cc80e22a58badb52abee5d3db",
-                                "uncompressed-sha256": "0d0413c4793ce7700f752a51b69ca191487a256737b9fe6645e607469182123e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "382e2c10890faf7c796709407f7844542b45a5bd28fbea66ce494be4ac38d9f2",
+                                "uncompressed-sha256": "89e38413f58183134dae8894a7ff93b7cb01fe6f31642c1f7047806afcfda7b8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live.aarch64.iso.sig",
-                                "sha256": "49369bd6b5489a658d6a48bdbc0cd0898abff5d41561d67289d7029c0d3add12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live.aarch64.iso.sig",
+                                "sha256": "6b22135d89c457eec16350042a7c6c26f275fa31cd567f508ef15d6e1fb63928"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-kernel-aarch64.sig",
-                                "sha256": "65836d747fe845b87ccc7facd3ba98a1129acd89aae9a8f4f583b728044ffd64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-kernel-aarch64.sig",
+                                "sha256": "b6b69d9b21a4e68e6778c76cbdc77d8b3f4a9b30b0e8581378c885dee605cc20"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "d74e399513d6e1bb25dc50bac200a8aa39c0cb7f36e17c07a4893b2d0e3363c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "206d62fd9381060beb63ecd2ba122e7ab2d1292dd04186b9032bffc3f692293f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "dfd9dff537f7cbabda6c09534a28b1db2ca2c8fced940f9882466bf216bf9336"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "ffc938cbc231a3abbd12825746a5ec04b6035df49bf6beb3fc19a1877f74c389"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "8bbb93579d7fed85c482711d2e233b107f6bef1ad719e03516a44b0bebc97674",
-                                "uncompressed-sha256": "fc469a837e59b3eb7af7e808a460d7770b33292217befb74923d75a9afc57816"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "6bd920da9555e860deacbe90edb5647d19236986fa6c0a642a5b7b5043d776c3",
+                                "uncompressed-sha256": "76b7c6eff97c059324dd5fc68d8f0fa67facf93dfbabb0ffab95daafb83db8e8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3daf766cdcb693348c7b9b1a16c938c140a84136ecbf07f6405a58109e849193",
-                                "uncompressed-sha256": "b60e06860e3e447e21c30957237bb47ba864d40c4d32c86be9b40da52c132ea8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7d0a003db9157a1f76e718a429a4dff4322b7963705187ea4f7b9ab63c2f72fe",
+                                "uncompressed-sha256": "56f8ea711a82a66b47f1b09f312a1e8c26b379f81338b1cf2e48957c0dbf9006"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/aarch64/fedora-coreos-41.20250105.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "4421b85483973e1403e429934a0cf21873494e101e6e4e74c858cc101a419eff",
-                                "uncompressed-sha256": "307c88c53da56430c839724b2ccf2380c65ca70d9b752d738372089ebb7a3236"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c2334a60722d68b5ffbe9779066b2737af43d03a6c859eac44efc8868716b83e",
+                                "uncompressed-sha256": "2442fb7b98171eab61647544d8b2f34c0df45c36657cbb7b9fbf869add55380c"
                             }
                         }
                     }
@@ -148,217 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-062a1c31a93c16b46"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0047992380b3c7f14"
                         },
                         "ap-east-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0abc79c3d478b1ef1"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0e68d9d4c47ec83e2"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0f1a6b89071fa61a6"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-055f20e7b73a0a4a4"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-03f7f95db0f268641"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0af482c7322721e3c"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-04ab8fe6cd4681ba5"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0d61be785a555ea09"
                         },
                         "ap-south-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-077a5903e4e146f66"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-04122bf04380b82fa"
                         },
                         "ap-south-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-03cff9a50e0199263"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0dd664246f5711054"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-054ed1fbd2283751d"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-044469a640b07ee73"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-051134f80ee547269"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0e24441d8509f4f15"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-08609568bb927e60b"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0b70ae586263e32e5"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-035a0d4242923d58c"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-08b37292e8d38cdbc"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0b8c24da80792d13a"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-00ae3439ce7aee5ac"
+                        },
+                        "ap-southeast-7": {
+                            "release": "41.20250117.1.0",
+                            "image": "ami-01d2e3f40f47677f4"
                         },
                         "ca-central-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0a87586c05e8ef6f0"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-030bd641487b1f2a4"
                         },
                         "ca-west-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-00712ba9b99631083"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0601e65fa44491649"
                         },
                         "eu-central-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0dfd8f1a8279ed0e7"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0390e11f5946e6f73"
                         },
                         "eu-central-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-061b78eb47aa7ad3b"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0be2a65c30246e2fc"
                         },
                         "eu-north-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-066892abfb5cb264f"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0a0a2f26e72f8fa9a"
                         },
                         "eu-south-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-08648b5bb42cb7864"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-09031cdd82434c97e"
                         },
                         "eu-south-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0c78666e7690f0f66"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0be3ab3672aad2d94"
                         },
                         "eu-west-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-07fbd7b2e04dfc3b7"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-07991b799d9259287"
                         },
                         "eu-west-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0c24afa43f765dd76"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0e7ca292560a7551d"
                         },
                         "eu-west-3": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-008e330ceb418502d"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-08970adeac7ca1ba0"
                         },
                         "il-central-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0e129ef088c1bd92a"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-018b68dab89002dcd"
                         },
                         "me-central-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0c815756231375782"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-01c6d6524dc2d09fb"
                         },
                         "me-south-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0bd3242f352d7c7d0"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-097111c332d877b8d"
+                        },
+                        "mx-central-1": {
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0e1bf8c211db499e3"
                         },
                         "sa-east-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-07d74623a3545b98e"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0b99cbfcf6ae90885"
                         },
                         "us-east-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0d5b162289a780dd6"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-05b4ca747d181e8b7"
                         },
                         "us-east-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-037c99a548a554c70"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0317c501503d22b62"
                         },
                         "us-west-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0f10b665170cda2ed"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0444ed23f6bfe5cde"
                         },
                         "us-west-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-082dc95a9b77b6bcb"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0299d971a47289bbc"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20250105-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250117-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "5fe316b4efa677f37438342578723cf63657ba4e00dca810261d3ceb4f28d0be",
-                                "uncompressed-sha256": "4fefea4fdfaf462d783ff68a73ce487a12ed0e83e4e40370cfca249bd6f421f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "7fced780fd2b57c1fac4b65db04281fe0087feb30d25b4e7ec368c3b5d8bfa15",
+                                "uncompressed-sha256": "018a3f8aca5a3b2debdb057fa9b254bb046bcafc1a05cb2705b8401ff7ffc6b6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live.ppc64le.iso.sig",
-                                "sha256": "8aac34dbec9c9ed95eff6d0e5547075d6f9c59eab1da0a366d7c2dcf6023ff73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live.ppc64le.iso.sig",
+                                "sha256": "4556e4e3500276e14ecc072c280ccdaf2cc920d09e48ff96659a1974dadc6bd1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-kernel-ppc64le.sig",
-                                "sha256": "3d9793518dae060b9ca6185012b3e533e1442b51676e77cfbd89100a3b278c98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "bedf2b9b1f4d7897a093680bce908bf7fe43e59b76fe2b2d96ee28d74d5ac6c1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "7c55b256977a58c8bb30f43804902b2353564b2c6b4ebfd4127576689177f66d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e0fa41c8932011d4140470aa24aa0ffc55658750048f8a8ccf8d33a1334e4d8d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "1e0795f3efcd7273f9f25cdfe3d22a85a505c430d999351c7054837bc9039926"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "4feb190c3ff520de5c452b6d71d01b643799a83cb9c211ad66668e4015a00e49"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "3dcc564362ca8e4f7a71cba960b5c1952e64dc64b4374628ff25189b982993ca",
-                                "uncompressed-sha256": "24807ced848d4e9d686cb4fd7978570f15bdac36a7941185c956e6d07f7fc78c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "73fac5290eb69dc3925bde2c209b9f7f44d20ca77ad0f6c726ad860597e32c57",
+                                "uncompressed-sha256": "a1b0ea7b6b9e63421f050390cb56a93d86f489eaf4328e584cadd84b06e96d4a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "1e3682c5aef82a97e1213e3be7e8725c59e58d1120d1ac818584997dcc288b40",
-                                "uncompressed-sha256": "27c8efde81e0ae77c150447fd72ea42cfeb0c498e70b1f0ca919d78af0590276"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "26d77e31b6d2e6f93feffc1bd3b2adf27608c15440dc64acda71a1491c37c1a0",
+                                "uncompressed-sha256": "28ef2649df353bec00cee80ef3a5773d34e1c9947b7c351c601107ac4eb889df"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "0e28da58cfda2f771696335f7277c8fe45860328146c76259681a5e65952ef7e",
-                                "uncompressed-sha256": "16e583b77f5cf836834aa7202d3040b18982f11d043674508e776590e14f89b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "be84aaad14dc65a77e3f6c074ccccf51053523b9bc12b11603cc05ae1933512c",
+                                "uncompressed-sha256": "25a782d291c54a7a2b834e71a0a41ac70304e08b9fac7f35d725e151f6e37cc7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/ppc64le/fedora-coreos-41.20250105.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "4ff408560d2d2257da9bad3d062ba479dcaa8468febd8a0cf09321f4ef8b1bc6",
-                                "uncompressed-sha256": "a50fe212c945ad9e5b1afb5c9fc28ed9e770d3c55d348a462359d40680b50af5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "260fd72e987ac5038df5232f184fd02f7ac1063ea69c05cc5a3a9c58bd0384c8",
+                                "uncompressed-sha256": "bac14dac4da7d6fc0407789f114992680c988e54ae842c2c7c599cf492419483"
                             }
                         }
                     }
@@ -369,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "1eaf576610b3bb754b49c8eddc752e22013a897b389a7e18c3abb4d186ed7439",
-                                "uncompressed-sha256": "85299fe69ef01d16db70292aeed6fc276210b118aecf683b1181cf014b7655e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "2caaef02c2b4c8b504fa4c61146d5899220e989c70433f314752e7ef98afb212",
+                                "uncompressed-sha256": "e251a7f296b254d8ac9ac6dd4c123cfa2671c92cb5c72b1c157c3b13d76a06a5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "6ef6c00e2ac1eaa20dc4f1f3bbbd1d35e9ebe86ed1aab8ebdfd2d0d10aaf2fee",
-                                "uncompressed-sha256": "8bbd7b90ef70baecfde0edf9e241d024a3078d4915fbe1ba23da549a0ff42615"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "6f2110d0e7e629eec76f6bdf7b7674441847a2481e5b213e6c47540d1a1b8f23",
+                                "uncompressed-sha256": "8a1fce1f607d8e21caf1a7575bbcc1a7d597a12a5591f17bbb6fda5c8e93d774"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live.s390x.iso.sig",
-                                "sha256": "0277830e86bdbeae6bd6458b1d8d70e3fccf2d4e1ed2230ca61d526a76f29888"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live.s390x.iso.sig",
+                                "sha256": "e3f6a7bd07a3e43b2625fbbfb9b5d8220a798273ef5a40283a708d408871d628"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-kernel-s390x.sig",
-                                "sha256": "2969a1ddce9913888882d563131d29640c7a5909aad0eccb8debf4256a691261"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-kernel-s390x.sig",
+                                "sha256": "00d59a35fe27244bcf89afbad1844536659c2f26f0f483310a625bb3cd0b04bc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "6fdeaf7504b69abcaf3365b8e451d48ac0c18a9ec1297e3fae546e2ad582008b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "e4f3023665ce062f29e29164ee18cf63a6611f52b1b722a9beba9c39cb0d5d94"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "d1566df30b54099dcd8a68035b341bac5e4de836e301cde7520887110031f3d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "eddade62db2d8fbaa62d29346186a070541cb62a3c704bbf9dc0db2a20510ee6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "ad295d19d93c982cdc936227688253432c4ab9ca651d9276a26d53313d4f1a51",
-                                "uncompressed-sha256": "6ab10dc65d61336b781bc2570276a13c80c55ceb322a87d1888137c49c4aa111"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "fb5c1819adc12106a463b1a91d1a1590a7af6dfb25df8578968db06309ba77fc",
+                                "uncompressed-sha256": "5729b7f0c567f7cd939fc3f0582cd90866544f2ee85a4cd265642a9e65f66e9e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "3c21cbc92729335fb01cd986b2c8bb6aaef21d7a68967312c053216b5c54d843",
-                                "uncompressed-sha256": "77932ef421e448039932480cf7e8822df1ed8a8f3c8b277155ee503f786d71a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9f7ce3fa514ad00da3fb6d23ed85f171854cc6c5fe364e1b2aba94bf8993186d",
+                                "uncompressed-sha256": "1d1e58dcc1121b77e95072ee2a64510d6290ffc184c515a17d42b56ab0b2659c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/s390x/fedora-coreos-41.20250105.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "85a3257d438811cd48fdde40d0778f626c41857230262815ac003ca69947b8dd",
-                                "uncompressed-sha256": "0c3b60b3bcb9b6357c6940edd5b2627e55419bfa989522224994e59a399c1c54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "672263d0f7ea76f9d7195e1ea57358583c48a4fda9407366cd2dc2cc482d4a74",
+                                "uncompressed-sha256": "a5c00a241f76fddcd69b22b0f88c6faf50e19a2726f160e7d0fc6015a57d10ab"
                             }
                         }
                     }
@@ -458,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "91f6fdfe0a97d7022d79ad1788fa51ff5995a7d0b329046df8ab337c6f19f791",
-                                "uncompressed-sha256": "865c1ad3faac508abddcb4f95317c9a719be5eac1e26d00d8800846d673bff95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8cf839467f01e07d068d3d17ef83580fbe96715dbe9a6dcdd96423b05f399b9a",
+                                "uncompressed-sha256": "1934d453f008cf57295d1a8b6fd4320379989650850b742a210652b659267a84"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "45f8de68a4eee522d1b798e3a2b08f2355764b09d16a076b11e509624e7be6ea",
-                                "uncompressed-sha256": "f05c17097483b761dcd3fa2d727bdbcdfb53e9489c2af84609f8c5fb8dfd2d17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ecd3968e11429684a36e05b5ddf49e6bf2b1aa6392a028621173e2fff0e569b2",
+                                "uncompressed-sha256": "d20e44a2dff27e0a7c481bffe3c03354988103c1364dbb97325372476acda4b7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "5e69f3dfd12c4181b6ed11d6a70723e22cbe97909d04bf6030498d1907afaacb",
-                                "uncompressed-sha256": "0ef50717f5fe6604f1929fa98c8f95c7282bff5f19dc5e668f17ca044d78d5d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a65660535b4e223b0f00a693bbbb69399bed981d6de4c0653927da9c9cdbced7",
+                                "uncompressed-sha256": "e302e6715108d842b56820daed947395b6824db69021193337e3599574e7bd2a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3b30f16c7eea5843d5d99f89b29615457b161737911e4810e9181e6bce634220",
-                                "uncompressed-sha256": "2c22230a41a20e7def85dbc7747be8e5aca76cf90c2a25d4dd491b6df8d4d2fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3548163581c0aa829c05bf9b128dcc86dad1dc63e526e8657730d685adb15923",
+                                "uncompressed-sha256": "4f5d13a6cf74ca68232eef01728ecb3b13fefbc6a786aca11932b2144544afe7"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "40d9d0a596ee06c0e52ac4f7b8343030a284ed5e389ea0e6f480a733c54b889f",
-                                "uncompressed-sha256": "589301fd2bb9616d0f9c855805aeb813eba4b96a3f455531bd27371895041d97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b1309b14576b136162d4024c85c884660944a73f50d89eeb2e4d7bc7b80a1716",
+                                "uncompressed-sha256": "db27158f76c230390e3569460ddda01debd8515cc23e4b22f62e24b9196ba0fe"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e8c951ebaacd2708e1e468e180ec5dd85ec49136a160dde07d4e1c4f5d374b6e",
-                                "uncompressed-sha256": "80fe04ea69fd9fed04244069487998c77eadf74b035aa114c10a4bccd27675de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7c666c70ccc9f921370fd5105115ce569ce0707a1b1d11c1af35cbfc752aa900",
+                                "uncompressed-sha256": "7b93508125777e9b2878d41fab288b96334a6da8a78b8c0da74fe47a5566635a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ade8197bb1358ff54041bdb7f93cf1b939d4f3ef0a2a30f357f55cb9c7d6712b",
-                                "uncompressed-sha256": "9e49b491a8de7ae51baad820ee04089324d6fddbb84bf6ac0d687691c12abd8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "de8c5d4c7ff124db934a70d3c28bd34aae27a6b653fca67c574bd22ea64f2fdc",
+                                "uncompressed-sha256": "25ecefb0d942aca5e50baf9009ab730f442f9188a9cfc999c220e36e362ef827"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b9a0271858edf9b2bb4d75dd6961336bd53538b5fea7942f5e44674d18e2fb5a",
-                                "uncompressed-sha256": "8c7a154436d0417fb8df4fecf48ebc12200dbec39e5ce4a84de6620c9be926ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9428cb951742b8a873d4454094313acb518a5a11da8e6a407aefbbc2d0f444d8",
+                                "uncompressed-sha256": "71cdd0653f3f41fc3b15ef22acf9e0ee55a6c3a89ce52d2c4c9192da271f3c04"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "b326c0383553f6b6443e72d4df67014e2a829b4474a36bea9a9d4853b02a8067",
-                                "uncompressed-sha256": "7f99e47a477336fc475ed64637c838c949eb2e0dc42c4074eea71ccba21bda37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "46690c99dd2187a27695f050d04cb0c7ef12bbdcc9530bb7a89d963994fd10c5",
+                                "uncompressed-sha256": "8b16b0a4f721cd245f0413439d117505066386fee1dbc9b2d21b579a7ec945be"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "15af5e0b5f940ecde892ed3980926d25f17eecfb281804ca15faf7481d56f519",
-                                "uncompressed-sha256": "1ff466d6e5d64dadbc0e374491450ed230f00bfeadf6fada33b554fcaf1ce325"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "bba8d2d4c1aabd912511560f03413341b9f558ea933dfda37a5fe36c2d27104f",
+                                "uncompressed-sha256": "0c4bfb5a87ad6a7c4a6d93782eb435bd1fcff9abeb5402a903b9a77360b10f87"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "31993f5901ade0898cb9576f4fdbac0ddab7424059ad172e58a2ed3a41188dd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b36e6cbd0cd18b0f08dc11d17329fe8d1dca2f3b0708af0c45ee63394084c941"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "fa0d679a9092cedad64bff6277a84073fe7e1cc817483c1435f8434f366fb2c3",
-                                "uncompressed-sha256": "50599c0f28db17aed735377191ae66e55153024fd45a59eb41815d531026ad33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f57760761e4aba0f4833600ac43edbe160f7065a8c5531c8cae820e91009f4f0",
+                                "uncompressed-sha256": "67a9bfb47f1c9e0201e4a913dafd093199fdd13d07b83ad388e8c115df0d6c8f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live.x86_64.iso.sig",
-                                "sha256": "9ed040d174b60aab4ce86fbcb1980ccbc41f5a25500638325a7403a0055fa6d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live.x86_64.iso.sig",
+                                "sha256": "a713473a084d0cdafbfc920a197a6dfbf06a5c3cd8f13be9d059dcd7b8708782"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-kernel-x86_64.sig",
-                                "sha256": "5cd46b0ba12275d811470c84a8d0fbfcda364d278d40be8a9d0ade2d9f396752"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-kernel-x86_64.sig",
+                                "sha256": "4cc5bd7bdf413e0fdba2dcb986e909f69461e3d54c1714bc698043f66e7b86dd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "b0a2bcf25fd12d04ffebce2c876d397928e06d479fd6087b7c76b21ccaf8e629"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a2816274c039a397f2529995b5f3324b36078e8497b44fa6ff1056305ce5462c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "a026c8bf3e76a59794ddee1b62078c272b074aec2b55e7d87ffada64822a938d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c94f4d898d63767562244160544155d5d6dbe22c9bce308a9f471119501584b7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "191d93d05402e732ddb95da60e362baaea78e047db08423b2a3aa0ae1b1645db",
-                                "uncompressed-sha256": "a4cbf8c2333db7fddddde11b4673be33a51ab28a75d7dae5d660ed11356e6c14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "8d80e2162422aa77aa27e57a9367a9a63f9b94ceba0104c1812897d19138ca67",
+                                "uncompressed-sha256": "4e0cfe1d62b210465820c58c70532bbbe9267b2bd9937f535685fd3b9992db6a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4cd1c1f743af40a3327d1325c4da2418b7889cdb0a8ddf3cdf10770c2c8219bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "be118aa3cc8d99b82372f3344e6d211904e6872b5fc166ebde7e718733a93e9e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a81fa84eb8924e7bee9d16b8644bb8fca375663758afb858cbc63f4dc0fbe4b5",
-                                "uncompressed-sha256": "74b82dc7909541c8b47ce56c163ac4994ebed2841ddfd1c4e741d3dabdec46aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2ff0309a9b197594e91c96cdb911a43308f61597085dfe65a254a1d2bbef9805",
+                                "uncompressed-sha256": "d35bb8fab1571e4f803782d16d64867b6b9e6527149f4d6a2e6f65cd2704095d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9aa4e577cf549762327f27d13cfa6cc6816fc53e7bf3caa6d08c0e2b77350ed6",
-                                "uncompressed-sha256": "c5c2014a14d7173184c6579163f1ec1ce14f46a83d4c3152d13d0b941a669468"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1330fd0e8162b7f3a59df3560e9e5696091e4df361296009440b26625a37bec8",
+                                "uncompressed-sha256": "41da9b4d806617679ee7753ece7179e973550ac4e1c0d2513462b0351497dce9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "0290ac8b5463aaba6ddcf804c687f7406728abdc95fb56cb58c095abe81ba0d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "f400c4bcbcbbdd4173aea7269e81f63f1b6ac9bae1736a212b2f4d30c97a0d16"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "4f48ec5006a7c741693e9ba4db47c4122605fa9231a84825ed10719726a89cb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "8d00c47e1061a3a29f8bd078492f536099a15f667c35f5953f469bd87dd5b100"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250105.1.1/x86_64/fedora-coreos-41.20250105.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "1f347e6b21a27aab53f7cbd106757d7fc7d613e16c5af7042efafc250f0ffc68",
-                                "uncompressed-sha256": "7d1e22e62d5d73a2ef9fa6ad887b1554ab611554eb3cf9c582821ebf1a904078"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "f479bda319c522122ea1d70fdb91aaaec608047806736f21c210e144ffb00c5c",
+                                "uncompressed-sha256": "e9a24c1b6876107fc4a7dd37047875dbc17652587fca570b65255924524c0246"
                             }
                         }
                     }
@@ -724,137 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0c2539f7b6aa797af"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-09ba1219d7635aa96"
                         },
                         "ap-east-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0beb779dfe2fb8021"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-053e0b8bf3058683c"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-009ed5b90ad152ac1"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0df91834b2c813929"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-05c6fdf6fe713acf0"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0620cf694b5c96e0a"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0e86bd90330b93415"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-03e5e6a69293014fa"
                         },
                         "ap-south-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-009af9f51f064e031"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0e6b8795ac1abbe11"
                         },
                         "ap-south-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0a87cb1a6f233fc40"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-05b54bb9565d0ce48"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-09aaacbd78e46ee0e"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0893e637f37ba7864"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0c763068db028272a"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0407233d4b7c7f732"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0beb18eec462db7c0"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-091ef62da85e35178"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0f11dc065691642d5"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0dfef7cb6bde3fed2"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-042adde32199601c3"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0c601793347ed0be9"
+                        },
+                        "ap-southeast-7": {
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0bfe9360d172fd89d"
                         },
                         "ca-central-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-016ea2ed950efa76e"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0320dd5642778f4b7"
                         },
                         "ca-west-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0cf3c75c54c3561d8"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0421a63e9ad70d7a3"
                         },
                         "eu-central-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-04daf03bf2908ba92"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-041c6530415e3bc2d"
                         },
                         "eu-central-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-081e5579c199106d1"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0f83e8fc905a0283d"
                         },
                         "eu-north-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0a79fedc065b047fe"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-06765447aa4a8adf7"
                         },
                         "eu-south-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0981508a97dbc8d8e"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-02e1a08ee4cba3343"
                         },
                         "eu-south-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0d69b775e377c2500"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-091bcefa082768a33"
                         },
                         "eu-west-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-08738477e3dcd4b29"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-06c5ab95947426cc4"
                         },
                         "eu-west-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0e4b284fe27376d76"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-030f59ea46bd66fb9"
                         },
                         "eu-west-3": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-00e9b9d3a0d849b7a"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-08ba7dbcd4eded6f5"
                         },
                         "il-central-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0f5c0e4d22ff3ec79"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0a3ae5b2a4a14e22f"
                         },
                         "me-central-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0140254402f7b71a1"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0dd131d4493bcfb16"
                         },
                         "me-south-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0b1e9e13774082ebf"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-025220b7c86653175"
+                        },
+                        "mx-central-1": {
+                            "release": "41.20250117.1.0",
+                            "image": "ami-00a64869b06649f2f"
                         },
                         "sa-east-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0216329edfce9235c"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0e14b301f90605bdd"
                         },
                         "us-east-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0d673cb72b1b4b842"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-033d451c66f5107e8"
                         },
                         "us-east-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-00930c81cca832a43"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-06acd4ce9bc977584"
                         },
                         "us-west-1": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-04ddcfb2195b41c80"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-016edb4e5d76740d4"
                         },
                         "us-west-2": {
-                            "release": "41.20250105.1.1",
-                            "image": "ami-0d7b886457a835d59"
+                            "release": "41.20250117.1.0",
+                            "image": "ami-0e928b8ee7dac96c8"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20250105-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250117-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250105.1.1",
+                    "release": "41.20250117.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f92a3bef49897db65bf59c7d947fc18cc965d8a1dcfa7207e50c90a4cb15f3cb"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b09fe31a58617491067853603ab556c0d6289be9fdda3e1a47b972e4b0ff0a80"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-01-07T16:36:41Z",
+        "last-modified": "2025-01-21T22:49:13Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "517928c1dcd64d1bb737fecc0a7d7cbef832c26964dfcf37c81eddca673f6f99",
-                                "uncompressed-sha256": "c7aa9d84af9a356551829e4065d86c7bea84474acaf2db88ff51db7181170404"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "8fe3cd4ec5d90ed870219b99e51b5032f2385177c0355ae8ba56c2f5a4c4cb35",
+                                "uncompressed-sha256": "8ebfc1fb49889cd28388a58678e01f13ba5bb27dbd41b3ca2f6be57d520263da"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "1a9aa4924c0d61499accaed299619b13c02df8f7c77978999ed3b8eb37f24903",
-                                "uncompressed-sha256": "529208ef411bd37b3deb1f5e87ac39518183c117b50e5ccc0c269717fd37db3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2b7ee598b9623e6bba6416c7ada88346cad93b0b919a67d5ffb1485e88126179",
+                                "uncompressed-sha256": "2e7acb476fda384071c877d157c5244cba45353360ab980692c215fe857beeef"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "1434b6b7d2b9da0f8fabae3bd59196eb493f575fbd764afa71633dae3fa720ef",
-                                "uncompressed-sha256": "2995c4a4ed26a6c69bb043153fd408b68d64994fbe458dbbb7edc7ab7d15123c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "6723852068fe6f217efb4f29e4a28cd929d0b9c2a2cca44aa675d4893dfc1370",
+                                "uncompressed-sha256": "fd7f2424233475f5119bebb79425bb8e405e984fe1befd80867e81a5cbd50061"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "f4108002ffd643900ef2deee1bc49e2cd1f2d7878e8f160a1ca9c7dead76f172",
-                                "uncompressed-sha256": "34db446d38b46f50a99f3a309f69fac22526482e8b8e0928b199f45ab57bace9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "2f00380ce5c87b3351e84394c19eb9697d59ca6649245de25665298887036dfb",
+                                "uncompressed-sha256": "86f7677a7c67287cc57eafc0fb95fbc1dbb1e8f1e5eef2ec5c3916ae897f8d51"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "a5a8f86fc5a18cb77f30c1acf8cf5b001348a2518e7ee416213387637fa1b9e4",
-                                "uncompressed-sha256": "ca664497b9156d0983e907ece31e0421d6b1fb8f12fb882f1c86b6e9c84abf05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "b044ab760624784c88ce24a3afdfab371d610aef23e6958937cf418253e13b81",
+                                "uncompressed-sha256": "baa0a65ccd83ca7682da812e784b96e480d84b96a5de76e2300ec4b43ee3bb06"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "027375936dace7cd74d7cf7279ab1a3d488048aa1e5908cbb0aaadbedb74cb37",
-                                "uncompressed-sha256": "3cb3ba413154aa0560c32a01c85ac823bc6bcca58272f43bd8615a7481d97ef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2cee40b78dea154a04256bf74e68b477f41194434ec0c7ad6ad3241c67e89813",
+                                "uncompressed-sha256": "9b5a352de87593373a27a2837c288b845d96a549b004a96889ef54d9d3bce347"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live.aarch64.iso.sig",
-                                "sha256": "a43374f656e44bd59deb95bb68c62ebbdc91b21a5fc23314adffb95c5fc6918d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live.aarch64.iso.sig",
+                                "sha256": "387f643b0bab7c05d46de6b5c9829d64cfcdb2a44abe33fc02c02fd27f05b78b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-kernel-aarch64.sig",
-                                "sha256": "8c3d727cfcba05687c73b5ebfd72fdf85fe34ebfe6d21d1535be36bf8b1e122a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-kernel-aarch64.sig",
+                                "sha256": "65836d747fe845b87ccc7facd3ba98a1129acd89aae9a8f4f583b728044ffd64"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d010ceea9b84953e53b621d5a092824f66a4766d27c3fd600557f588af4d7f2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "8de44beb140fa8c6e118a1851a87e0369e1413343625247176ab0a3a306c1730"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "87b314ba20aa49760067f9af19f61c24f8fa85cf43582563810043bd7ba90c7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "8b22eb8ae3ae886b8f891917e8c0f6c08f3e0ace1ef6512d543f73de466f3d99"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "9370fa95551ed06f3c0650c2948b2c7c93bb12fc4b53ef5cfee69b7196348087",
-                                "uncompressed-sha256": "22c228d2e24b2076f78416d6704cbc6453272956446c9b43142d884e5f3c8dd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "cb851349c1689921763882df57378740616e09fc8fb0ab79aa7dd61d0f6bb43b",
+                                "uncompressed-sha256": "875213c5ea2334d8fe097935783793e034684c472c755e7e1a81ff76c45496ce"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "af7fe6242088a619f4fa43db88e7076ffea550e9d70aaf4dbadec13554a08b6e",
-                                "uncompressed-sha256": "b67a30bfce8159e9d58085ede7be559167d75d5720a77b677891689e155b5095"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "664454d88245bdee9d9c41af63c4d17bd0f72aa89daf4bb868ad3a49db7cde75",
+                                "uncompressed-sha256": "edbe49d1822bcf25760eadb3a37d3fb029c0cf45782946c646661463811881ce"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/aarch64/fedora-coreos-41.20241215.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "cf8089219569c0911cc51e8a0c0db47607d763c7b9e3656e8159e9ae17f73cfa",
-                                "uncompressed-sha256": "8551fdddd1d0613daed42f38f31a2944d536da7f6b7a559f42e2cc9163dd4ea2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "709441d670af63455409b65d02f23cd966212dad775aabea1658f0d671aa7d56",
+                                "uncompressed-sha256": "3953fd3bcc4d86c36c3f4a9e73588151abcbb8fb437f2cd42d59b0373ac5efd0"
                             }
                         }
                     }
@@ -148,217 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0b411c34081d8b99e"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-09c741b70d93182a9"
                         },
                         "ap-east-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0e337edd38d71ea10"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0dcbb22a1a2791b5f"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-07abae7cf2c2a53a0"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0f5efc5005e0dc9f4"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-095ffe33b6adb3957"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-08cbc8bb7afd5518b"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0c0704bf9de0a9930"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0cb167ded14f65b67"
                         },
                         "ap-south-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0dcc5bb6f146e774e"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-04c2ed4294916943b"
                         },
                         "ap-south-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0cf7f741bc7c1f8e5"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0a216d20b73a0bd38"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-060b1447590442bfd"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-029573c56a9dac2b4"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-03c829b6ef4581b99"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-03cd3e689496088bd"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-06f6298eaff66f182"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-051f80c6e6a7d1b1a"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-061c8252f76c74bb0"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-02e5291d04ed7a755"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-023d4224243e6d574"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-06330a0589d004298"
+                        },
+                        "ap-southeast-7": {
+                            "release": "41.20250105.3.0",
+                            "image": "ami-06ae8f1ebc163d331"
                         },
                         "ca-central-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0d8b61efce11ae0fc"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0ae2d204ee8272982"
                         },
                         "ca-west-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0a80a76db130f9c5c"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-025cbcd4f24d548ae"
                         },
                         "eu-central-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-054be3cfa82315d56"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-06de8cbff26b09b30"
                         },
                         "eu-central-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0a9cb7194f4766079"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0f42d8959eeb20f23"
                         },
                         "eu-north-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-05be7f7366f8bffc1"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0fcbb51d4e965f7fa"
                         },
                         "eu-south-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-006e56807397462b8"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-048d361d29c8b9eed"
                         },
                         "eu-south-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-08bd0bb8c2e428d76"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0e20f869b69a1e3d2"
                         },
                         "eu-west-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-01393d18559787f43"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-03c48151c4173de99"
                         },
                         "eu-west-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0a547a759260bb9c8"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0a1f84439c747e018"
                         },
                         "eu-west-3": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0e77145bc4912ec0e"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-03bf2db0fb1b15365"
                         },
                         "il-central-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-086368c52729338c1"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-00640fe4d2e63a901"
                         },
                         "me-central-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-07b7b6ab1ce4974a3"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-002376fc08a816e24"
                         },
                         "me-south-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0c824052f4ae5eec0"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-011f7ad10b66c35ee"
+                        },
+                        "mx-central-1": {
+                            "release": "41.20250105.3.0",
+                            "image": "ami-09e5f3be5e0891417"
                         },
                         "sa-east-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0f1156cb3411782a5"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-025f191ceaae7096d"
                         },
                         "us-east-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0ccef191a0d102455"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-07b58a50f4e1c32c8"
                         },
                         "us-east-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0010254a6969c8998"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-00470e6a8a80e4691"
                         },
                         "us-west-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0b43f8242685de362"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0f99c86bacaaf260a"
                         },
                         "us-west-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0a1b2cd8635d29117"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-054add26fc685414d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20241215-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250105-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "86ad5096f0985718f00850aa3155ab4014656d91c5e5e496ed0ffc15191eb231",
-                                "uncompressed-sha256": "0d615b949b525724afb1a7a838a5a38a7cfaeed6ef59b4ee450f5753ca530984"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "29fbcca9ed186256f61e6940e277bf019a7d87c26fc37ea059d1cd1155f5b834",
+                                "uncompressed-sha256": "6ff9708c21c6c56442b5c6d15311c0ee62442d349ccf3c975aa9988d383bb3fb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live.ppc64le.iso.sig",
-                                "sha256": "c046ebf46e9ef2ad4366f37a8241a79196553cbb7ae60390bd59ccba81e41448"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live.ppc64le.iso.sig",
+                                "sha256": "c55e6c3b99ac6d5e24be531f363ffe8ef788642b05523b3b89cc67a56fd048bb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "583c2eed4e12c9a7d981815bad0812473a89e3bf03a38353cfa6536690c4481e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "3d9793518dae060b9ca6185012b3e533e1442b51676e77cfbd89100a3b278c98"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "cf1dbd65703027f53b910ec34a35a92c531c18d23d0e874ba7b88ba7936f72e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "450e0b33e3f0e95acf30e717c9296e1ff02fe2a5cbef11e7b66367f1a2b8d8d7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "7bee6257ca48252fef590f016f806873c963d13c75e8cc7f4e9279bd8e1d1c8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "90b6cbc4971cef26fd46521e14f37ac0f74429a789dafd6ac5c1597b2dfe2df0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "319858fd291338185bd66e1dcdbaf5b96af06bbd75821415b1c65faf2ce2511b",
-                                "uncompressed-sha256": "e60d93fb6ae41c3b75d3657918bbb655a21df18045ef817a8c9122f9f6921a53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "169eb7b847568bad549649e5f6cacdb5b502e13fd4290e3530102de9427c0698",
+                                "uncompressed-sha256": "4465ca8c747424fd5807ecba95b7d402543e917ab9de4076119a9c762089fddc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "ab8f9641d1a7e2b027cf73ded305edc2477ebd3a29285ce1d0f3e7907e6edf11",
-                                "uncompressed-sha256": "8d4606aa17906669ba45b7d6eb4cd4c7e728809336c67a2f5dee49b6973d4a9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "d5f3dafca3d0096a78165eadef89e040fa8725cba4ce2b0cc490eba2dec27a7b",
+                                "uncompressed-sha256": "e6710f2d984ef803897328fa7729523a17a4b699075fc78aca0bce5ac620bc2d"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "84beaca3d9a28f7851d72bdb839c79daf389680d6da4f6615237311658c004bd",
-                                "uncompressed-sha256": "3a5250150ab69f90ae2128661bd7098bb8767fe769ac3077dbd05d5ec30d55e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "4e06a448ec3642c5ee3f1e5826ffbc2bb180375cd3fdf4d539a64948ed0f5f94",
+                                "uncompressed-sha256": "652da8f3cb2e891daf292a285181fc384f2f2ef2cd4f92e507acf4114abf45c7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/ppc64le/fedora-coreos-41.20241215.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "3acba98a7795a3e5c88086f607ed41dbd2332e8ae408cdb16733dd90b992f410",
-                                "uncompressed-sha256": "81442cd1a384488663f178411cbee6bb4382fed0a1d73f8d9180ad7fe13c0281"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "0cb9d38081d42630797ff75ff38ec76495836ae14742a0435d0d2d3468632291",
+                                "uncompressed-sha256": "4249ff9aca9563aa9a86e715b055e0996005aec9490ecdd0e69ce7208d9db418"
                             }
                         }
                     }
@@ -369,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "835301c56bb947a63ffcb9c28a6595bc3e2f6a8393dd9121c1da7ddeeabde057",
-                                "uncompressed-sha256": "dd9e8debec3a30a5779e6fcd90d5e9af76ae68633cb188069d9e0b690a5a0376"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "887af4f068b19a5cedfb756bb16a739f11b96d001a2e3b47a5fafbcd82c12303",
+                                "uncompressed-sha256": "1b019c39751050a9b8efcc74ee7cec734935e1fd352f59df2d9f981c2d15a83d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "7374489aa6f51848f5e99adce20f26ac32ea0146093bf51fd1da84c703961ad2",
-                                "uncompressed-sha256": "9bf742c34a5b0f9ce5f8421ccc75ffd5b9726a352b6e80222a76d4e4d9a4974c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "931239c0ddcb713980bbdb4fa63850a85fa5d3ef2f2c3629bd2da2c45b6d65a2",
+                                "uncompressed-sha256": "be64d772c0bb5a54e249872e7d9229fbe235b798ede6fad4f59be2d9031bbc4e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live.s390x.iso.sig",
-                                "sha256": "05f9c2e9634fdf31078bf19d6ebd06312031574186b8d68d49017fc3f3913105"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live.s390x.iso.sig",
+                                "sha256": "e4198bce5b7b822a34adbedb9514a6f6efb56597ba8c6f21b375312f5d5a6d2f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-kernel-s390x.sig",
-                                "sha256": "d828baa15f707cb8d187b460e1621fbd4ab32dcd32d50ed0af4fd36207c8ac0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-kernel-s390x.sig",
+                                "sha256": "2969a1ddce9913888882d563131d29640c7a5909aad0eccb8debf4256a691261"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "5512dd98c416f6d4f02d49f03292b68ebbf48d1cef31e3bc06236cd7ba7287f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "c9caed57c38a7bbaf4cf3833223d2e8bc4a6edf402b6ea2015abf65530a99850"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "fe95f16125cd27cf88a639a2bf9bc5b33fceb497d4addcce982ca9f828144d5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "a07e343c5db180fbfe7abbae960614e21ff16fb7166617be5acdc1a0b682d2c6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "bb43d9aaec84407e4a019ba56e1d475b4a78025c23b101ccbf3b62682e06a3f7",
-                                "uncompressed-sha256": "305caf77bd50b355798a290ad49e2c2b76b3d3000d717173cc8c14096e19b7cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "78cb41c0156b2f5812f059f9f19c88b89bcab4d31a373a88ac0b67184cbe59fe",
+                                "uncompressed-sha256": "e237481927a59d7eb7d9ddac88ce93de57c8b518f21bb5a727f374fef1912eab"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "48ccd611a4647cec96b610f43135d6673d1d1a564158b21c537d0e414ed7d863",
-                                "uncompressed-sha256": "031359f2361b92e48d09165280262a0c7670f3e4ef512518bb2de0b922e7591c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "a69748fce627d01cbf1896d5fb0067f8ee32df3c82b015fcd243372364eb70fa",
+                                "uncompressed-sha256": "6daba308210cbb7a2a47de5a648fbe12358df32aaa2dcda1fe6df326790d7f17"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/s390x/fedora-coreos-41.20241215.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ce45c58007c29dad368dd6ec707220dd83fc09d11d99a6af3f9846ab5569cabe",
-                                "uncompressed-sha256": "6029235628cfb59a4ce77a2c06092b08d9a4cb5d1d436bcbe1e38ab94b01a9ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "1b69f71f4c7c5a885d5e82cde01f4052b67d22c0af923852ee8a68af23fce6c9",
+                                "uncompressed-sha256": "767bf4d8982ce16f43edb5179ecd372dc39818291b3be5346b3b2a2a0af2e1ae"
                             }
                         }
                     }
@@ -458,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3597d6ee27a9f33f8e244b46636d97c1e556e50875b85208750ea89f3cb5646d",
-                                "uncompressed-sha256": "649f3ad15735fe7dc66b23db5ad6ec392c6792efef9224ed11da28054d0d696f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c51f44d43a0fa839003441b7d496e78a0a37a759cbb9fe8f1b25ebee894d385b",
+                                "uncompressed-sha256": "8aca75198e2bd5b46284450fb1ac33307cfdcffbb6a1912e95f1a51a21ca768a"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "2a704daae865b2817748e485af1711ca06852ecd511e0d5602957143169b5d01",
-                                "uncompressed-sha256": "2b33f501b0fd1f5a9eeaf1df77c46d61086eb2fd43ed6d698102bef8b12edce6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "f78cba2103e55fcbb6923ceb29020eefa92332ffa119b4751e4c48213ab916ff",
+                                "uncompressed-sha256": "d3fdcb3c70c35e6bedb62d86a85a6cf1c99013fbe107a07e10c8f87d2703c4f0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "f58e7f8532ee207232fa3d9634cd3f2b084400047812ba6e769df4b485a0b053",
-                                "uncompressed-sha256": "67bae3f7162664e1f9eda1f95a0de79cd3f3cd9de0195a0359a0b20e3de0b7d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "351fee3a4152b15c7309359cb8422c0994853587e591dc58b426529d704ba118",
+                                "uncompressed-sha256": "4370e790d04580c37bda830d2c930fd2ffc396b4afbb7ec3e36316761e00f032"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "22067c52d2d9ed7005414473aed97ef9a002e496a335cb6190e673c8bee5365b",
-                                "uncompressed-sha256": "e0c86ebeb6b4d63619390417b5b1c975ff64951d05cb2788d8dbe3dabd99fe6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f7ba7f943098629172fd583e744b854a7814459648a38fd6993fa67b8e2ff8b7",
+                                "uncompressed-sha256": "695bdb88d3fd5da6d14c1fc0af0a04a10670b6ac75258ecf8346419173e88ced"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ef77867525d23c64f776fb49aab7140b36bc0bc0317403fe2afb625d1a62344e",
-                                "uncompressed-sha256": "c8fb6ad5fac6a02d79476d8c90b6f44affcf931ff5edf6cb3ffa8f1e11378e35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7ae2415f5f9575a973bd667df2478eeae5871053451177900cf850e90d1bc161",
+                                "uncompressed-sha256": "4e3f39c6121e29019ba83bf947d4b7f7003634eea3b1c2ef4a25367c169edf0d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "179460a1c45c2f6fbe969ef40c2ee50af732a066c1e6b3c07648e725216946b6",
-                                "uncompressed-sha256": "2a260f24114a6efd96a0739e05ad5c4a78b542f4b936aca621d1ffc45dac719c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "05748ca44280ce5cd1799b26117e9789296e12546366cad5e966fd758561ae20",
+                                "uncompressed-sha256": "f2c5e75028cbb4fc22ad2695b9abc75d23158b311364b4bee5bedceed8a26039"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ef7f91821f6f613054d5d268f81db33257a92027ba963d41451c0da07b1b886e",
-                                "uncompressed-sha256": "d56e95508605aecbd2179c125bd4964ea69b019a686d396bf35f1a29e36fb758"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "92cc9ec5cafb5898b517746eb35b5f847ba3b2834c5b51fad3190184953aa609",
+                                "uncompressed-sha256": "725e1fefad458a5fd5134ae716f3ef3a60bb3cff1300e8aad2517d7363f5aeed"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "76684140e6a56a5b5f84eb457e98b5fdf522626a7f0eae1d1c645a9b2777e0ec",
-                                "uncompressed-sha256": "61924abf7a1628e3c028c90524ed8e6712e190129bd3ad2a32ed704bb02eaef5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "30ead392509b73cbb21a6fbce8a50810e0806b90e9e05b7e0d318ec1a4fbba48",
+                                "uncompressed-sha256": "086b32bee571a0ccb8ed9e5183fc40726bfd07d8cd5ce5b802819fe816c117bf"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "7ff5eb275603554a48a4e5bce90418a95c1814b62cf8be317e0c2ec0c0035b0d",
-                                "uncompressed-sha256": "43e0ab54b4f6df6abb672b411deaeac23da9de7804adffe5ddb83bf5170a83f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "ddaf017b1b84ee6356c22835d432e1d6f49a054af61649efb23ab2807605624e",
+                                "uncompressed-sha256": "a56dd0682f4319f9a30548f0c38db48e53f5c4bb0182a87445a62b8b008d9ab2"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "677cb8e6d0563fd1c1e31d1d337e7f24b70ead7650c470f81a73d0b581617329",
-                                "uncompressed-sha256": "61fba1e40556792cf100f833c77a4212b4285f9202cdf0c0724bd1ac530a1a8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a11e1146646e1d58e58aa3c948a0cfcd40f16da1e8ce5255e90a3983e6f2af02",
+                                "uncompressed-sha256": "d0cdd7e932fb934845eaa0f8df186349e3a38e08e5e91da6943821fdd309c442"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "42b62b1581c8c67682965db27192367a4d8ac3b17d3c1124b96e3d55eff0c8fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "3d428e2079320f7761d8938cde05c305f4800245ffffb2da5be41954aed50b76"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "cbf66c0464913102be94553c6de3e0b01f038a5cd037629b72a225e3561794e9",
-                                "uncompressed-sha256": "2a1eb5ff5a4ad45078b4bb7fb3b66c24d0e2c03bbc54d06046f6aba7d6850f87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7e8491817a530ea568a5422f6c0b831beb273dea79b9d738041061cc8684ebb4",
+                                "uncompressed-sha256": "ecde2828f2cbb171c8fc32f86b470a8cf7b6867b4208a2e3bad896a8de3cb1e1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live.x86_64.iso.sig",
-                                "sha256": "b38e6286daf7df1ebee5d53db16a23064b71cf9fbd9c1667ea06251a0269b6b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live.x86_64.iso.sig",
+                                "sha256": "ee7df8824fb4237bb37588d4e3d42f660a2051b32dd33ee64fb84debd866bb0c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-kernel-x86_64.sig",
-                                "sha256": "d73310a5099a284cc04726234d90f8ce0873f7a26b6aa505421523ef69bebf03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-kernel-x86_64.sig",
+                                "sha256": "5cd46b0ba12275d811470c84a8d0fbfcda364d278d40be8a9d0ade2d9f396752"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e258876c18a23fd27b0db3bcd208e52bed0673c0185cda7520317d26f51f4e58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1d82de704c11deca651416fe55340e70e6ec0c9aa5e5e73c04dcccf7bc05402e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "801f1df8d20e35cce0e10afef50487776ec3cc9adb8ef001b08fc00e97800d77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3055cbe01c33fb7e841ae6023f6fd50f131a195ac66d814cfe4b34d314c410fa"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e5ff2e004deab3c6d241c2c5766f7259c15df8a44c366477d23fdff7300b41ae",
-                                "uncompressed-sha256": "9c358b8fc8f3f0b6c2deda5f4782d92a5df89ffde6caf45ebda33c56eb8f6ab6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e4f950daa716566886b859547220029730fc4d28fa228e4404f71dbe5b6fff52",
+                                "uncompressed-sha256": "dec1d976bb1d1582d32a3f07a667717bf5311fcf9a152311191b73df750384bc"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4cf290880346015a2a871d32432cbb2f366d247fcd161b87a3d934074166e4e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9efa83aafeaa562ecf8f28e415ee542e4e73febdc13c8047caf4f0a377a2c68b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0c32bc0e418afcee875608aca44d6b1efc820270ab6ef8621ffcbc83c9856a4d",
-                                "uncompressed-sha256": "5965c002ad2261e8a6093e84ce43d5a1019de9dfa38a32f9ac976c7d3450488d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "65be06a1392208ea23186e60f310f204b55a91036a274e5f3ee9f9382df383a8",
+                                "uncompressed-sha256": "3ddaafd49fdb33208150a224fc1f29a86764dd22a6850d294b32991cddd7225d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8cfa066333c0ed987b8b2b6178d35f94514ab3f3db2194de03a9dd79e3f40d18",
-                                "uncompressed-sha256": "04b5fd816f7658e48469cf3441b0b0d2ca20c5e560f17bcd2c3c52404ae20f41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e24905da112fdeb66a79df6ef818e039d4ba80204d6346157eef85cb53c7457f",
+                                "uncompressed-sha256": "85332b051426606d9fa12406bb42353ce1d641c2d7a8da08416d8bbbcc752527"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "745b16fdbbd3780750165f750907acb0199f9b5d0f772127c65c76ae12f6c0d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "d2ec4644e8fb4e84e8b24d9d7c2dd8075a9835818738021d605008587ca4154b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "e0826867d09b24c5c61a4e65cf8ab18b0cb063942a44f7f2bceb3e36849c63ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "5a8ad3e654c85952cacb01ef89ad56bd268c6405539ab53aa2fd6d172e7408fe"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20241215.3.0/x86_64/fedora-coreos-41.20241215.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8c9c1245b40f843fa49f30df36cef09d6bfe9b31b0a336f55379bd1f7860887e",
-                                "uncompressed-sha256": "2f1d4e10bf66c4169224ab194adf396e8dd1dd58e46f0afe3ffd1d63eb357d35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3ccb5701853edb1c9076e2e1d81779f93bfc56e406553c05d3f6309ed8196c82",
+                                "uncompressed-sha256": "e928354af4e0d665a444189cadfeaaf0d17438374009c35965b88b98b5e69ce3"
                             }
                         }
                     }
@@ -724,137 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0376c8aa84ea55da3"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-00e43ce07c637ee4a"
                         },
                         "ap-east-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-027944d5be1ff7eb8"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-037c1df6de1c75c0d"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0c7470242896c917e"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-032ed209805effc6b"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-043dba9042553b614"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-00fd2a0a450d6fa35"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-094ca77669f7b8fa1"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-08a1bb2b2dc809c98"
                         },
                         "ap-south-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-059c4550baac5fe07"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0c2461f64a795e8f6"
                         },
                         "ap-south-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-04c4d07fed18a6ee2"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0f0a6dc561b0bb3a0"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-021a08503db1a25b1"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0798c25e247173dc7"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-02a328a080b6d0758"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0b1f317cc7afd8a72"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-05aa37ae884719ca2"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-022842621770bc20c"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-020a3c0cc54cb71c7"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0d041fc2661c7596b"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-05fedd78d57f455ba"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0942fe5e3f9383e8c"
+                        },
+                        "ap-southeast-7": {
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0af4d523c7fbf5cd8"
                         },
                         "ca-central-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-07bd660b891185a6f"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0f7559f091bff7c3c"
                         },
                         "ca-west-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0778ce522a4e36659"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-00b208ef687ce50aa"
                         },
                         "eu-central-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0b5ab33036b59a6ae"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-03008ea46b291d685"
                         },
                         "eu-central-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-08639d8b650d262c0"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0d64f333572f9aa09"
                         },
                         "eu-north-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-011f863b26b1c1511"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-05b05310787334b3a"
                         },
                         "eu-south-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0a140d7de04e865f6"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-05edf74a1104b24b9"
                         },
                         "eu-south-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0317129ccf0600d1c"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0a442b9e0f7125dfe"
                         },
                         "eu-west-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-014f51b69c9bd4d12"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0ee39973a43286ec9"
                         },
                         "eu-west-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-04c17e2673258c060"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0eb7e96c4041ad83f"
                         },
                         "eu-west-3": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0daafc67fc771af45"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-08da4f9caeabd054f"
                         },
                         "il-central-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0c169f420cafb13d2"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-007f2e314cbc88d08"
                         },
                         "me-central-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0f8c9fed7282e3035"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0b4c1d1a9378700e1"
                         },
                         "me-south-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-07812479804f2219d"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-03ad3b630db4da4be"
+                        },
+                        "mx-central-1": {
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0a84f654b751d4103"
                         },
                         "sa-east-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-092b88d84201b98e0"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-02885cd7dca41412f"
                         },
                         "us-east-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-014f25064b32fbec5"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-062e91802cc9291d2"
                         },
                         "us-east-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-06f286180fec53913"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-076e026b65a6d77d6"
                         },
                         "us-west-1": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-0c1050ba0b34cd8a4"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-0af3ec5b2e70e9c71"
                         },
                         "us-west-2": {
-                            "release": "41.20241215.3.0",
-                            "image": "ami-06fd716a2a27d700a"
+                            "release": "41.20250105.3.0",
+                            "image": "ami-00e470f951ae957ec"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20241215-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250105-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20241215.3.0",
+                    "release": "41.20250105.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0eabc0fb26345669834dfbca40ad6985437e2158d98fa0cc17ac6c27a2b44397"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:cdc12b5a9066da6cfe98048ca2ae3e8ee1f4ef086e5e6f08a16e47d97502fd54"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-01-07T16:36:42Z",
+        "last-modified": "2025-01-21T22:49:15Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "74f5e02590b63bfc71ea22db2642754f1ec7b418c14882449354269cd6a34bbe",
-                                "uncompressed-sha256": "6c795f1c7682172c77407ac736296337ba816162909b6f084688ed0cfbdb00fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "25f4b9c8218ebaf852eb71d672161971044177f2c6d2e0452f30c3763730b434",
+                                "uncompressed-sha256": "8e289fec6174c5a1508021751b46869630a46079fd6158040e5efe15b0a65e92"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "92ea2bdd219e0f2daf053d458daa4dcd5b57deee2fd4e86c727f67b208c2d65f",
-                                "uncompressed-sha256": "3ab968487a4c884f02cec12ea9795b8db9fdc6473b8dba1befa4792436650fbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "7aa90805e51f1682dca30bf815c703971b314707079d8a1b9e3d7e93f6c9ca9e",
+                                "uncompressed-sha256": "70f652d9939e293514ad2c8ffcfd052cf6f99dc34c004d4f7ea6e2894ef8d086"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "caa14285a6c5f6910d069bc79ab0a7b63c11b5b3d078dbfca3e68cb6fd215d15",
-                                "uncompressed-sha256": "63f3c38b272a061394e15d6c4dbf0c88dfbd8ebbba3852cae3b33d7448a76fe8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "aa8f6a0d541d2cb2020c8847f1a82d58cc929574c728052acf5e55aa69e4d85f",
+                                "uncompressed-sha256": "e2329e4f785ec67a8994e99daaa8128b0d1ba6b2baa04a2c7f15f778bd85e7dc"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "330a99f62893048ae786461d3a1f6923ceb6ff5068be21a545816334617fe4cb",
-                                "uncompressed-sha256": "bf7a4ae190122aa25d7d5ad818c4edc0f709382c5ec867512f663d77095d17b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "8eb2a52467a649a48f8f75a91a96c51d372f1b217cd8924658757026b25ac1ff",
+                                "uncompressed-sha256": "81332886f6d115ffed1c0ca27868eaa3da6ec5fbfd9eb67a9b72ca713f115194"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "fb9047bc8222646189de809ca4849ff12bc1399a685d07526094ad1ccffe74fd",
-                                "uncompressed-sha256": "86dff89248ee5edfbe3694275f506f4dafb8785f6533380e3c10c2bff95931d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "965ca2bf314de235ab26a8a6155299102cdcad544e557c7aef256f75233e14d4",
+                                "uncompressed-sha256": "f5bb30c5aaa85480671c680724ba7d8110c7ff79fb609db7e5c9b552323023a2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "372dbc62ed95b52a0dbd3f7a44dbc0a09af6c3fc2382bd42030ce169950f2ccd",
-                                "uncompressed-sha256": "fbbd982e891956f22eda30a8e9bdc6a05d17ae0acd13416f34775bf14ab5413b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5d2497616e88b765c27c1ea7b9158555d4fc473a2b5bda1dfac87fa8ad7450d2",
+                                "uncompressed-sha256": "a095b6bd5c9a3411c48406b9e1efc34ee61978e69d7a3af8e909c614472c4a13"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live.aarch64.iso.sig",
-                                "sha256": "fb6eb1a9bdcf25ace1375fb5ecb96bf4af994c7c6f93f134cb316cced99406fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live.aarch64.iso.sig",
+                                "sha256": "3cb9128ff047c2ea60a78d80953fb64cbc90d511e0fe1531aaf71168aa5836b8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-kernel-aarch64.sig",
-                                "sha256": "65836d747fe845b87ccc7facd3ba98a1129acd89aae9a8f4f583b728044ffd64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-kernel-aarch64.sig",
+                                "sha256": "b6b69d9b21a4e68e6778c76cbdc77d8b3f4a9b30b0e8581378c885dee605cc20"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a37ee4ee006921492205081c58e37b41f8da2accef09a8afe1a485f2751b35e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "dc23b19c90cfc67655aae001b43b30c124c9c0741585a64e7b06e1bd0274d86c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "7b1940fad96e8144adf49474cb72fcdabd1b639c97ff042584a8351b3596cef4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "9332053d6e087e19ecc233199ff7f0efcb4067ebe3f05f9b4a8ba3b9676f791c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c7660e9b5c12ea052ed8c4186bcc154877ab22b17be65dd5f3f32d2bf3f29459",
-                                "uncompressed-sha256": "b1be8aeeb78051f0b81c62dec01fede12ad46dde2944dfbd06ac72a104870158"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "a10c7ef7204fdae476ed295237ee8fab44c0c0aa4ad7c99f4219b51f386a2d88",
+                                "uncompressed-sha256": "a2f1eaa472d34f267357edf5cd9bf6907707447842ad6be358ac1a12cf59b0e2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "ffdc2447ca696a8cb3b05cdad1263216619dcf90c5b389f3820af9df4df7cc71",
-                                "uncompressed-sha256": "8bef81aafa7845bb00778f312f7f0d985a7f061bc2de8eb0d1289ac6ffc9dbad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "1ad018081b90ac05584f4884a0db380a68fa4d5b06b2f9b2443620cdf310ddec",
+                                "uncompressed-sha256": "982710d9c5d7b68657d018d8060c6ee452982598d68f6195fd6f3a7e7d24debc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/aarch64/fedora-coreos-41.20250105.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "cf57f70017950beb9d6de8a6e209d47cf4621150ef5723cca2fbf62b6f3d3064",
-                                "uncompressed-sha256": "7b41fdb1ddd4025ba7c5959fad094007a3c710676b74f6e13d29d5cf7b4dde0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8114cc24ec7db4e67ed8b970864ae1c154d926e4dc1723eeb2d62fc51043d26e",
+                                "uncompressed-sha256": "e7026280affaa90c140e84b6eb7474d80dc05ade7d54895bb8658342f83bdd98"
                             }
                         }
                     }
@@ -148,217 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-022581e53ad63895c"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0867952d70773645d"
                         },
                         "ap-east-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0811c4f81c9f363d1"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-068cef5860f0adac0"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0b40adaf51682b4f0"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0b531022690c53174"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-00b5414bb54795077"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0a1ff2939840c0e96"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0823097631b3c5b6e"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-09a1e830b9e907d12"
                         },
                         "ap-south-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-01e57ff685042b584"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-094b314e5854e3707"
                         },
                         "ap-south-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0700dbd8d8ac925b0"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-04d3ce092c33381d2"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0eee178cab98c5f10"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-050c91b3313278b98"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0c92fe7b737c529b6"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-03ccc12437267e037"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0b6608df6777d8988"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-079240aae7dcb9ffe"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0fc4af351d448116d"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0d80120f06279d57c"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0c3aab687fd078729"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-017e4ee865dafeed2"
+                        },
+                        "ap-southeast-7": {
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0ba134f59a43824dd"
                         },
                         "ca-central-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0fadece54e709bce6"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0a722076e4833485e"
                         },
                         "ca-west-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-020502230b8f37df5"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0d047a0ce9d3d8b07"
                         },
                         "eu-central-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-08d9fa2da97097514"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0a218f8ed08b6b596"
                         },
                         "eu-central-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-010418538e627c886"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0d5fb03d578ffe5de"
                         },
                         "eu-north-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0eb4c494e85435ff2"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-04040c28923af0bdd"
                         },
                         "eu-south-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-085dfeddbfbd212ff"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0f66b36226357bcee"
                         },
                         "eu-south-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-001e1bd4a6cfeb150"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0b9aeabcf5db87c53"
                         },
                         "eu-west-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-06bad0216ea223aec"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-01aff12adb15014e3"
                         },
                         "eu-west-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-05b15cd8e0c3a16cd"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-05916b72084e2fbaa"
                         },
                         "eu-west-3": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0bc403bfeefc4dc9f"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-071ccc16c18018b04"
                         },
                         "il-central-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0f4008a4b77d217a4"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-08b36c7e7301669ad"
                         },
                         "me-central-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-00be971a492000479"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0a5f9d6c263349d75"
                         },
                         "me-south-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-00bd54fba5a4c3671"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0a3e31fafb02f7556"
+                        },
+                        "mx-central-1": {
+                            "release": "41.20250117.2.0",
+                            "image": "ami-04ac48eb6ad41a170"
                         },
                         "sa-east-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-04b06f7e93554e80f"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0daafbced1df68a2d"
                         },
                         "us-east-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0b660552c5bbf1eb0"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-001832301beeafb22"
                         },
                         "us-east-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-08f696fcc0bd9818a"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0b5b82b9f7f750e9f"
                         },
                         "us-west-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-001cdf2b63e7b01cf"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0c76f4968bb316f8b"
                         },
                         "us-west-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0fff0fccd096abfe1"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0d6cf4e4f67d19a74"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20250105-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250117-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "90ec0a90708adabbae0b4c69f44f762c373bb867a974d8790a09c6c207d32174",
-                                "uncompressed-sha256": "f1370f2472e5dc22eb2452ce384a0f4367b2b9d4122167de438765cd256e6034"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "ff46d5438aad9efe392259f9cefc6f81544759fc212ac37a146dfc37ea779083",
+                                "uncompressed-sha256": "ceffe6fe2b7f8984d702d0d216af5f026c6e3309c043ebcbdad06d7e04f312fe"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live.ppc64le.iso.sig",
-                                "sha256": "42aafc81b784e275c1fad2ef5d96b83252de6e9ee06ff7a742cfb9e4993acaab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live.ppc64le.iso.sig",
+                                "sha256": "fa4cb99b6879ac5734b87e5a93f40b108b938870bf17716aec267250141bda62"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "3d9793518dae060b9ca6185012b3e533e1442b51676e77cfbd89100a3b278c98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "bedf2b9b1f4d7897a093680bce908bf7fe43e59b76fe2b2d96ee28d74d5ac6c1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "bfabf4cfd8b355877b9c5b124fa847978fa1525d72cde2f0cd9173ecdac3809b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "d9356264e72c5e1641ec63765be7e9970667307fc63e98bf5a89657a6876caff"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "4c4ea61aea8c1f08f0fb18758bd497a69e43981930206423cc6209a053fdaaa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "ca956e0e64fa1214131b761ab20e658bc8ee79fc83baa10e9ba083a2a00646dc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "4f0cfe7ac07689dc18ec44a7afd31990f35bb9e2082767e0857da28fc5bb1e5a",
-                                "uncompressed-sha256": "fc0f0092a2290e8176822726261c3a2d55df2d94a7618fb1b5773fe3500e3279"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "507fc2027a7c32286f11f0762448eab1b5f489875157c69be66996892e634b56",
+                                "uncompressed-sha256": "5bb13a4a17ae25237a933356a3086b8e85b6681cac4c321fea59383e911a5c79"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "b9808b412382fa4214af4c675d6f6b66b8401fac8de9678b133ee0d4b768242e",
-                                "uncompressed-sha256": "e2d137cf3e0da0cd18f09df71f833bee793debd6dbb7fb0a1bb4d6e662155144"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "c4a0364b381cbda72b2f329c4443ce3e602b1670c445d9acb9eaabcd4f646657",
+                                "uncompressed-sha256": "6b31e41c767f21659cffe0893ef1f4627fe3f5172bd434f65f0f7b16cf4c72d3"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b8a4478dfdbf30c0645c8fd88fb6f7e9708ce2eb9d1e19b0f3902950d3f35c79",
-                                "uncompressed-sha256": "83b7818cc674c414cbdd23b4ff42130bf0fbb8c73e700615c3b49a34ed8de9a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "abf233cc7dd113f3af10b220c3c90b4ab3a4f454fbb767ce7e6a8e9aed1c1a22",
+                                "uncompressed-sha256": "c873f50029bb9819c58c7757b8f2cbb509c4ac61f02f3a7f458c2a3268ef190e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/ppc64le/fedora-coreos-41.20250105.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "7cdad4e65f6da7c47cc8a93233566d40a64ecff120d7305e4b8f257f092c95ab",
-                                "uncompressed-sha256": "fca29f5337d5f7e92aa8345a3f9fa460fc12f12107043a505ebd8e155c1b5196"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "9538fa59d147c35ad52a1c44ce1780e33a2a98007f99b8327a6f03145afd7a28",
+                                "uncompressed-sha256": "aac59c40d32c5356d7e858c51a5148805c7286b3641dd09ba782dae3df2200b7"
                             }
                         }
                     }
@@ -369,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e7236e486da305330d04991cd7eeb56a523a2c876225ec0997ff6f4553dfe695",
-                                "uncompressed-sha256": "dab776676408d9c0c3518b6c64f8a05bbe6605f42e90108b2640751d870d6992"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "0d0cd36371ba5390f76afce83278a484a9887a437e43409958fd72e7f328336f",
+                                "uncompressed-sha256": "8f9c2564389d70e40c9ba3deb86fd1548bf1b60555be262042a376472c20205a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "257a38504e6647e2d827c28278861b550dab79259969ab50db6613c96417b009",
-                                "uncompressed-sha256": "5f9149dc88b84234ebda5870a0853eae88ad6852bc1172e1db26919a4c9e14ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b4a58abea41f92d33213827e90a965b4d0e08d24e6f51ddd7cb16097a6a2c83d",
+                                "uncompressed-sha256": "3fac56c1590febfa0b167a06656abb28058a0ab20bb39df94839e435ae6f80b3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live.s390x.iso.sig",
-                                "sha256": "e5adb2635616efb58e8900ae2f6e5b1137874695e848f95604ad488a03009bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live.s390x.iso.sig",
+                                "sha256": "5190e5fbedc82f6b12501ebe8f7ad799d4fa398ad412aa12a7b005176267e5ab"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-kernel-s390x.sig",
-                                "sha256": "2969a1ddce9913888882d563131d29640c7a5909aad0eccb8debf4256a691261"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-kernel-s390x.sig",
+                                "sha256": "00d59a35fe27244bcf89afbad1844536659c2f26f0f483310a625bb3cd0b04bc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "606c2ae6fdf9bd28df7c81e614cb01d03e8ab9019880eeaf066ad4e9be8274ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ceb7ed1b9f9285fc1f172b397cd55b53821fe2508becbad06c1487d564604fc2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "a653c98264445f03972937a0d2401781a294f2b1756c37a7a2575d23fa87b33b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "cd7af7d8bf70255d7ceada163d64fb12122e69eddbe9f1501ec043599960f4aa"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "5c344156514a6e2c613f0139083161c50c101b7d720acd8180d428af442d75a8",
-                                "uncompressed-sha256": "95350e7f083be0f75495a22fbb48a445b990b17df95d617728426e01a2f08564"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "43a8479e749ff19e9e17053d9043f75e271f87246ee5a0f4ca934a3a94db5f55",
+                                "uncompressed-sha256": "8b376d6e01c6c8fc979dcaaa7103923243e07d871a97bc17320e017fbd22585e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "83dee693b6f512599a745e92f7237e73c3889416421bd501c3c9c4ee9229ff79",
-                                "uncompressed-sha256": "49d285774b62913070423f5bd0ad0c02d44a944b456deffa76c56dc60bcd324b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "483e82c5f34442901d89828320cedb5f6c47c633ea25c924e580ef101ac50af9",
+                                "uncompressed-sha256": "91a8be5468ae38d0a751b17e7678a954efbfdf9cae831b4a65c8e6b94c4cadcf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/s390x/fedora-coreos-41.20250105.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "c40069a87e140f56bf41f18476197db9ea9fe7b2cbbe2a1ac3b9a25a8130da5d",
-                                "uncompressed-sha256": "cccbb997a193056be5e8277409e8487d21810fa9d23b8683504d3cbfc2b128c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "a3a7f1587ffac29a8836d0070d9bb74ea842e328b9eeb852e0162d790859505b",
+                                "uncompressed-sha256": "1c1e51a0d3a6ccb05d301b534bde163590f11b23305ea6ddb1058f8d4e98c693"
                             }
                         }
                     }
@@ -458,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4e3d18e76e381edb08ef656b97715b4e7f1c7f9b7748142c865596d959fecee0",
-                                "uncompressed-sha256": "a1d2addc12c2d3aa1848479bdff63e09d36290aed2b51f643da39804b257c262"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f9120e9053bd407f93b2908a3a432b12f08a54f0c0bfa747936021836c54c344",
+                                "uncompressed-sha256": "dc892ff9ed9745c6d979a689eaf23d7fb81b819ccb80ff7b3353dce84f9d8e29"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "cb15e014773f1fd4aef460dfbea32564dae28307705b443cd16110973e140495",
-                                "uncompressed-sha256": "a64da5087ffa91932926372a74bbfdde8ebaee3ca551a09b563519ec3256edab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "288fec2433a1835d13c5edefa9766a1f12984248400a3c01c6c0f4d2838e53c0",
+                                "uncompressed-sha256": "005d4cc7d12eb09ed9cc00558975b3f0d6fc48618c6e692b12fc086732fd14e1"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "82f3ac102a02485583455a8bfa672c9d2ac6c89a971cf06f30ffb6cec7b3059f",
-                                "uncompressed-sha256": "e39afcf0b07d21817fd5cb24635a2c2d4140268065bbbf5976a07deb7510a671"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c0cda090bc73c22a3115f55c83ce7b0cba265e3b1396aa808701e7f69761174c",
+                                "uncompressed-sha256": "92549e2cf40a05675f6bde4608d0be167e97ff7e498ae97062df2020101b39de"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7445b5604c761d6ed1581024466206593e54b3a1938194c4416eea6a9b27489f",
-                                "uncompressed-sha256": "0440256b83f20cefb5c37f0f24f66c55991e61a140acae7232f2f9aa1fd11f84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9cb5b2e67fc2ad0a64b8bfe1d271157f7ef989f75477a752a5b9fcd43cee55c0",
+                                "uncompressed-sha256": "847c90aeee45f7af02d3066f94f06f75f223e4b69069dc73b170afec8f8a96c2"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "861eda06fe83e9c39f26b962afa5fc3a2965cbd1530e0fe485e6b6c4b5a46a97",
-                                "uncompressed-sha256": "e94dcaf810378750954c5df4bf10750474fa14563f4bfc66f92e28bed767257a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "331977cde483f94e192b61d0d0b3fc0cdab96b406d7dc7af00e32998c902058e",
+                                "uncompressed-sha256": "4b0105b03110209ce7d5de3b6ae9aebdf98f6ba2ec9e470af15b58a507c9a92b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1cdd1af9206a3c3e65df4f3333eb686e9e199306439146030dd58a32bc9725bd",
-                                "uncompressed-sha256": "f060f2b1dcf2c1be2828f19c8046e075d0b06b7b8380aae5a7c898cdd1070d10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "921735f468122ce07eb881e2888fc398f84c1f68a9c603ae79e05fae0b710d43",
+                                "uncompressed-sha256": "8ddc4cd8f0902dc5eeeb8d767b683a3bb57307a3b387f1091a1680fddcab9239"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "da5c617d838dc671dc069100e18e98ea19c21f19fbc8e44d17bad8cbc52626ff",
-                                "uncompressed-sha256": "d4a780aa705f426371d978bb312102aabda5aca82e6372f9a8fa6fb3fa49e2d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3e66e188b9b6bec4fc6329e503d9acc8549dbe79c81d8a9b957fc2b44774dff2",
+                                "uncompressed-sha256": "eae79edea4fc099a6912c799505de670ad5127c43707d3e0bc0749d8614e40b4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "298b4392b99baa2a2700529abd7754047533ea93f95703ce04744ae7ec7b4fcd",
-                                "uncompressed-sha256": "213ba2937e201652f34a582132447aeed878ffdd8553170ad03459842bf9b275"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "608e0d700ab3dddca1f3653d3a061a3b54e81380a536b7c2f83e64b09972f6dd",
+                                "uncompressed-sha256": "dce3ef43306a88420d7650db697625ab43f674f601e7747deb2b297767ba9df2"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "b18df2bff48b5a8d6b37e785d283f1c40062aa487f89c0006b769fa6a1e5bf95",
-                                "uncompressed-sha256": "4cdbf1ce0b8b7919c2520ed121529633b23d6d769900ecaccd1130394df01a2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "4452906a1b175f5f3baa83aa83980e6e367e062bc449b4176746235b6229b6d8",
+                                "uncompressed-sha256": "5df2c83c515147d808380058aa83311353a3a5c86fc956fba2318a9e434a9d33"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b7f74e127121f7193a7351adc8ca47a3e28803df2497a333ebdcb1b8b63bdb75",
-                                "uncompressed-sha256": "ca505d2053f0d57b9a5d12a7b44b4baa3a7106829ce5e58752ba052e4f90ed9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "578aa95469b24c6f2c2c252626f6a52df188be6fd351356287e46773f8d16987",
+                                "uncompressed-sha256": "f4786f59c30f0419e07e6b4665dbeada3cc1761a20f6c6ff1078e0d5d3b997f8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d3c82c582efb10688f5307da5e0f42af137eae55f6778fa1c8f78ae6508b9f13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "e7b4f93d0bd4a8481b20f3a773294b32c9b568bd8a00e8417a7a13dda0d31d16"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "984975f1e4d24ae38bacb883d7757b5017ba65afb4874e3963522aa2b44ea7e7",
-                                "uncompressed-sha256": "6ba7a4acfd1d46e5ea77889bc41ae404330de5e7c65fe22b5f8de5691ddbf17c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6191cc8344a594ae44ef9800a5026b88df3896ad8effc7d3436338e219c82255",
+                                "uncompressed-sha256": "e1747a7692be60d57539140b743cc5dfbf93297a5391ec817ab8457bfe18b2d3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live.x86_64.iso.sig",
-                                "sha256": "a62d2651b5994e02d6f33732becabc97f29c3127c2bc141fe7427545920ec2b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live.x86_64.iso.sig",
+                                "sha256": "298e7d015db7eebd396724f940589ca900840650efd68cf45c0075557cddbc2f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-kernel-x86_64.sig",
-                                "sha256": "5cd46b0ba12275d811470c84a8d0fbfcda364d278d40be8a9d0ade2d9f396752"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-kernel-x86_64.sig",
+                                "sha256": "4cc5bd7bdf413e0fdba2dcb986e909f69461e3d54c1714bc698043f66e7b86dd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "20ef453305ee91bf2ed25b172729afacbdd70d72ddf1ab044dd68fabe9bd8a60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9b0d515d104d54863e5a527bfcf2e6ab8105922e73c1b8ca16e53989a4913fe3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "5375846be5d5ad5b6d6751f46cdf6330e941cb33ed56d791ab061e5342dd364e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1f6a43ed0abccf63e12e6da4393ca1a15475a715dcb13da00675812dc0e676b5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "5cef87755fb0e04fa45041605671d31452e20d93ed8f23387bf1c3873e66aae0",
-                                "uncompressed-sha256": "80e52b8fc809d14045ff362803ebcf2a70d4492d205f4931751911e8fdf55928"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "ee6f9d518bbee17cd97b6a43b8fcffe0f63fcd920059c9b5a8053c5a8317f195",
+                                "uncompressed-sha256": "435b74c8152e1c42683bd224dce17e6830252c4f61606311bf7969f872b1bf20"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "faa8727f2097b1bb04af4472275f452222220ff5a18eb636d52b7569f31cf383"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ffd957c9f9eaa9ca3856760c650cf9ded1c34c421ede14efffdede4103c62799"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3a3cca78e5ce7336d9ba40064097210d0cda4ab8115b8123e8ee9748d01d5246",
-                                "uncompressed-sha256": "8686de9afbef055017e0b5d216aa95a7bb4e44635ecb6a826ece7130fe190abb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ef2c0d93f9b6bb6f2a39dae8bec056bbf591998c36cbb9e1bdab6a1f356c645d",
+                                "uncompressed-sha256": "8079115d1fffe4de3b290f529aba0cd2a24f1b9fc5a9afc478d411aba487dd87"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "12017ebd9baea5a83c2c47d8f778562bab0d0b9c3c0c4f8dc574e5023cc9f5ed",
-                                "uncompressed-sha256": "28e30069a07af84441eab7193f49a318254208568d6c32f87b93a7e9e7aa5943"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5ed8d7b0786ec58b4c6978f2c19972acd872c4fd42f669e528d191dc7def237a",
+                                "uncompressed-sha256": "3b23600ef7f8554367ef038bf8a897e4d57bd7b7389e3233c6f33d9a01368852"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "85890746bcf44eb193746cd2172de5bb560ab87c14b9f95274bb270f43eeb43f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "1b5b7618475856d26408d54fb3cf3b7c9fe63998c2bfcf093916a88328bb8156"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "05236d0500a69e1319a443b0e009299de2b89a38422e0feea0c57f9fe54e80ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "915b8ed6a2b942ceec47320c869c686156dbd6b200091c97b1ef61bac7079584"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250105.2.0/x86_64/fedora-coreos-41.20250105.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "f48ec1df39d342e444052079b8a1d1a43da94f545a9cc4fa4c303e823a159331",
-                                "uncompressed-sha256": "e1c900468f0f2ee1e45309965593e5642ac79f52285ab46327461a85771bc51f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "e12450f1a0c7dd9081a40f25a4716ed8c245d6fe2e66a4c6ab9f04088e0e8e5c",
+                                "uncompressed-sha256": "ab42b9225a04194791d1ed4b91cdf7af2948e9ee5c1edfeb86f1c0936ff5b744"
                             }
                         }
                     }
@@ -724,137 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-086a80205d9164091"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-042998a1ab05b079c"
                         },
                         "ap-east-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-031da7228f24d9c6d"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0d4abbb883cef6f5e"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-049ea0a589b7489a7"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-05efd0c51a964937d"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0f17f316bf0ac25de"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0dc7715a507d3f99e"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-010b6241e3550568e"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-04cb192b0ab172d72"
                         },
                         "ap-south-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0cba14034b14893a5"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-09ce9c052067ac075"
                         },
                         "ap-south-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-02f648c57c3d1e579"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-019fc7ca58b74980c"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-063d7e702a115e44c"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-055129e333c314a84"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0d94b5665d897c09d"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-094fffba3cbbf29f6"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0b34ffed8caa7726d"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-09ec86022450790d1"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0b153a6f4d3035d15"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0f030d18f2a929ac7"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0d721b9b7ea0467ea"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-08bb55f7935452f0a"
+                        },
+                        "ap-southeast-7": {
+                            "release": "41.20250117.2.0",
+                            "image": "ami-06445b271bc5fa5fd"
                         },
                         "ca-central-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0f881793364563d9a"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0eb2331ace5d4f203"
                         },
                         "ca-west-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0a64fdda3870e816f"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0ab8d1de20bf37aaf"
                         },
                         "eu-central-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-079d5a0dc3812c0df"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-028c447973e0eca80"
                         },
                         "eu-central-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0d0b37dbacdd6f325"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0758ae5b448249889"
                         },
                         "eu-north-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-04777b9565f87f1d2"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0084c8a00e26d36ba"
                         },
                         "eu-south-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-094125d75ea8ead0f"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0aaff39d3688dfb46"
                         },
                         "eu-south-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-03617b9b3bc0f20d3"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0de5e9e2719cd4853"
                         },
                         "eu-west-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-01292c736fca89499"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-071d64a6af6c5c603"
                         },
                         "eu-west-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0a0c964ee298ba06c"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0019f26c9a21ad5ac"
                         },
                         "eu-west-3": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-066e6c817b00973d1"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-062c54c7111632ebe"
                         },
                         "il-central-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-02f5b9adcbb5ec38d"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0c6b4840385195ce9"
                         },
                         "me-central-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0ba4b11cc275f1eac"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0acc30872029c7765"
                         },
                         "me-south-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-02154db73d4dd9a5f"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0d135c07dfdbebcb5"
+                        },
+                        "mx-central-1": {
+                            "release": "41.20250117.2.0",
+                            "image": "ami-031c69eb236a9b35b"
                         },
                         "sa-east-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0b4ed87a5ea195d99"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0d4bc506008a1a532"
                         },
                         "us-east-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0faf6363dcbd4f5ea"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-070f6cf71956797fe"
                         },
                         "us-east-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-00ab5b8f4fe7a09ea"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-063270c97b0fc798a"
                         },
                         "us-west-1": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-0c66174882bb4f185"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0aeddc44ce21f5a95"
                         },
                         "us-west-2": {
-                            "release": "41.20250105.2.0",
-                            "image": "ami-025d88cd7d45211ac"
+                            "release": "41.20250117.2.0",
+                            "image": "ami-0b9e0ac3d32708b57"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20250105-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250117-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250105.2.0",
+                    "release": "41.20250117.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:356c74886ce6f950b3bb8aa3f9af8f83648dc4b7f99c4ae63acb37ace2b59498"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9890277dd786bc4716434055966766024e67f8209411aa45ee792f327c9fc17e"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-01-07T16:36:43Z"
+    "last-modified": "2025-01-21T22:49:16Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20241215.1.0",
+      "version": "41.20250105.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20250105.1.1",
+      "version": "41.20250117.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1736344800,
+          "duration_minutes": 2160,
+          "start_epoch": 1737554400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-01-07T16:36:42Z"
+    "last-modified": "2025-01-21T22:49:14Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "41.20241122.3.0",
+      "version": "41.20241215.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "41.20241215.3.0",
+      "version": "41.20250105.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1736344800,
+          "duration_minutes": 2160,
+          "start_epoch": 1737554400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-01-07T16:36:43Z"
+    "last-modified": "2025-01-21T22:49:15Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20241215.2.0",
+      "version": "41.20250105.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20250105.2.0",
+      "version": "41.20250117.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1736344800,
+          "duration_minutes": 2160,
+          "start_epoch": 1737554400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).