### PR TITLE
Roll out stable 41.20250117.3.0, testing 41.20250130.2.0, next 41.20250130.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-01-21T22:49:15Z",
+        "last-modified": "2025-02-04T22:27:19Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "d21940be7dab503c3ff9a0b47e27af815c5a886aa37a191437efb80c3ad2d00b",
-                                "uncompressed-sha256": "668dce5c374ba3bf10c3a825801c117279f6656ad9ea3c0c16284f42ce4e68fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "2aa342e302642247b49aebf39b29581ee5cd46eb34669900f446ca7c7b5b23f3",
+                                "uncompressed-sha256": "3a0d3d3c0d3b6f0358735f97a1815308feb1aef1a9471f0667cc5f888089fd6a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fd539530f5614a33a180399c5fe121a2781eb9917325a19e036eec139e3850e1",
-                                "uncompressed-sha256": "8d697097dcba39d538e90d869d9c69782d58ea22aaad8a0639953ac9e9190fcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8fa77ad8fd98e817837b7148866626b3f9b4beb636263013c0b4cbf8f5840f5b",
+                                "uncompressed-sha256": "70da23ddb0cfd027680d33e0f346b424cce0c3e17d27442a8335f076a9aae748"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "1b89b8b3fc2f5056a99f7c862e88f1b85b20873782322c6621df60a461b7fb2b",
-                                "uncompressed-sha256": "27d1e4b3865a5ced01c24aa55ee34401a3cbd916e20f9e7bef0c3814a058fa13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "652c78a9bb8ad0d35d46b64173c86df9d5d0aedf9ef98d0cc5882b2158c1c028",
+                                "uncompressed-sha256": "8b790aaea7499e5874fd75e574880e3551d0ba04aa3f8d937672565d8d6bbd75"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "d2d50f5ee9656db0d6e61f9ced74eaa05ad273712f61519cd047a4210f9b599b",
-                                "uncompressed-sha256": "6c17121ddfc46620c1faa53031c1c23a39d03941ee13921ba82f62e4cd8c1932"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "bee342eadb7e8eea371ec882dbecb1ce54d816411ac44e0de44009ceb6e7b46f",
+                                "uncompressed-sha256": "c15eb7e986c12c4532a6a1ac5055a3731a8c9d5f1f69ee51ff2948f3b8ff00cd"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "7b258776851faedd1d2fa4f02631590105eb0ef9d4969aedeba38883489d5ac8",
-                                "uncompressed-sha256": "19fa816f7ad0734cda5c1020b94c470beda13fc171b0a1bc89f33ec62ffac067"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "f32ff731e807953709e6399eb04a2276458e5d31ae05b5309d19c4bcf81eadc1",
+                                "uncompressed-sha256": "247f271295692a46ae08c4d783a0582cb98dfd2d93b3385b6e2a086f3c23a515"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "382e2c10890faf7c796709407f7844542b45a5bd28fbea66ce494be4ac38d9f2",
-                                "uncompressed-sha256": "89e38413f58183134dae8894a7ff93b7cb01fe6f31642c1f7047806afcfda7b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "74f4d27bd46505bb1ae12ffac10560cb724584a187aab4a30ecb3be3ab39cb5b",
+                                "uncompressed-sha256": "d4b7e9703fbc3c96b7f7780e5bdfba4291c186d07e8ebea34ca1b9b04a1c0dd7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live.aarch64.iso.sig",
-                                "sha256": "6b22135d89c457eec16350042a7c6c26f275fa31cd567f508ef15d6e1fb63928"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live.aarch64.iso.sig",
+                                "sha256": "b66132895efb27bd20de874603191985c0b9f55bd4b8e2730bf2229ab04f294e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-kernel-aarch64.sig",
-                                "sha256": "b6b69d9b21a4e68e6778c76cbdc77d8b3f4a9b30b0e8581378c885dee605cc20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-kernel-aarch64.sig",
+                                "sha256": "487e48c1483a5dce5e531699acef9740f57570f6d1cdcaa0cf7a9fa492b2fcc7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "206d62fd9381060beb63ecd2ba122e7ab2d1292dd04186b9032bffc3f692293f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "b2b0e02c7fb9e21a3285076ea62477d43d1a4189b96da9b719163914b1d2e5d1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ffc938cbc231a3abbd12825746a5ec04b6035df49bf6beb3fc19a1877f74c389"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "4c004c9fa36e0a139d0fa3dacb3860c86ec6153537f56fb305e40f77579dce9f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "6bd920da9555e860deacbe90edb5647d19236986fa6c0a642a5b7b5043d776c3",
-                                "uncompressed-sha256": "76b7c6eff97c059324dd5fc68d8f0fa67facf93dfbabb0ffab95daafb83db8e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "838134ac88b261cee291af4e4d5defd43ff50cd767987147bd60d90137c2ab21",
+                                "uncompressed-sha256": "11d179bdc94b6db7cb83e7a4c096d6677b5be0dc60f15b43d80b4d0c01cbb4c7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "7d0a003db9157a1f76e718a429a4dff4322b7963705187ea4f7b9ab63c2f72fe",
-                                "uncompressed-sha256": "56f8ea711a82a66b47f1b09f312a1e8c26b379f81338b1cf2e48957c0dbf9006"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "1c945a54d6db8686eec008c99af716388c06d1569eb7e61b11fd7119fd2c61ca",
+                                "uncompressed-sha256": "588ae6c515b5f21ba77ce79ab70321cb7b3eb22e7b573af5cacd09c926aa8ac0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/aarch64/fedora-coreos-41.20250117.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c2334a60722d68b5ffbe9779066b2737af43d03a6c859eac44efc8868716b83e",
-                                "uncompressed-sha256": "2442fb7b98171eab61647544d8b2f34c0df45c36657cbb7b9fbf869add55380c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7ab024384d64354fbc7abf0fc403b76be47c12de17bf20e1cf3823e1c8704022",
+                                "uncompressed-sha256": "4a1f6cf90b559aa0cc7ba38f3f4d69f45d6dd6801c7c1cca40ee3adaba1709de"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0047992380b3c7f14"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0346ed5f6798b39f3"
                         },
                         "ap-east-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0e68d9d4c47ec83e2"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0e3de5953b069ac47"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-055f20e7b73a0a4a4"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0dc2491341e9ecea9"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0af482c7322721e3c"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0b602fc48a99c06ea"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0d61be785a555ea09"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0a254c8ca0cecc727"
                         },
                         "ap-south-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-04122bf04380b82fa"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0e2cdaf539187c946"
                         },
                         "ap-south-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0dd664246f5711054"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0f2079194beb73e13"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-044469a640b07ee73"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0dd754cfbf7b02994"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0e24441d8509f4f15"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-02ad21868c7c55f7e"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0b70ae586263e32e5"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0eff6f14160f41886"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-08b37292e8d38cdbc"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0d497bd0ae36b63cd"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-00ae3439ce7aee5ac"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0a0ae4cd575601fff"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-01d2e3f40f47677f4"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-070a4c5f7cd1e2812"
                         },
                         "ca-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-030bd641487b1f2a4"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-087fa19c4ce8a3315"
                         },
                         "ca-west-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0601e65fa44491649"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-02326791adcec063d"
                         },
                         "eu-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0390e11f5946e6f73"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-05d31eea5d5222fd1"
                         },
                         "eu-central-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0be2a65c30246e2fc"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-03ae415b9ed5feabe"
                         },
                         "eu-north-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0a0a2f26e72f8fa9a"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0957bcbf1a68cb8e4"
                         },
                         "eu-south-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-09031cdd82434c97e"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-03e724e2e0c1169af"
                         },
                         "eu-south-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0be3ab3672aad2d94"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0b4093689e391a5ef"
                         },
                         "eu-west-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-07991b799d9259287"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0bf4a4dc2a19b8a4b"
                         },
                         "eu-west-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0e7ca292560a7551d"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-080049846d3960cd1"
                         },
                         "eu-west-3": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-08970adeac7ca1ba0"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-061bc8ab18af1972f"
                         },
                         "il-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-018b68dab89002dcd"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-011b0a7114956ca10"
                         },
                         "me-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-01c6d6524dc2d09fb"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0c4ffb6e6ba3ed470"
                         },
                         "me-south-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-097111c332d877b8d"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-03780661d366ceaa5"
                         },
                         "mx-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0e1bf8c211db499e3"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-050053cdedb639671"
                         },
                         "sa-east-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0b99cbfcf6ae90885"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0c9afda1207a1284f"
                         },
                         "us-east-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-05b4ca747d181e8b7"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-02484b031ab100ae4"
                         },
                         "us-east-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0317c501503d22b62"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-059b27fcfcdfe1be3"
                         },
                         "us-west-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0444ed23f6bfe5cde"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0c609e69362b7d8b9"
                         },
                         "us-west-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0299d971a47289bbc"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0770b84af22c42832"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20250117-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250130-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "7fced780fd2b57c1fac4b65db04281fe0087feb30d25b4e7ec368c3b5d8bfa15",
-                                "uncompressed-sha256": "018a3f8aca5a3b2debdb057fa9b254bb046bcafc1a05cb2705b8401ff7ffc6b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "bd424c4704be93d130c408b3184e5883ebd0c16c9d8722489be28b9a65d49a07",
+                                "uncompressed-sha256": "357d4602eca5f998fdc3876c8c4e8584000a10e6729a1c5cc2bddffd432cb018"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live.ppc64le.iso.sig",
-                                "sha256": "4556e4e3500276e14ecc072c280ccdaf2cc920d09e48ff96659a1974dadc6bd1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live.ppc64le.iso.sig",
+                                "sha256": "483c29ff0392e88686afed2278e88acf814897b442ff4165aa804b6d7a3b4f6e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "bedf2b9b1f4d7897a093680bce908bf7fe43e59b76fe2b2d96ee28d74d5ac6c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "686db5ecb4c80c0cac4fb9d22e79cf18a0f694abdc31c65fdfef2f6ba0776391"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e0fa41c8932011d4140470aa24aa0ffc55658750048f8a8ccf8d33a1334e4d8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "9cdc5bd276f2aae9d96b3c1113104a4aab28b150a7a7ab87c96177ac4e919638"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "4feb190c3ff520de5c452b6d71d01b643799a83cb9c211ad66668e4015a00e49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "512079b2afd8ab980323bd21b66ca5b81b1438ae618238a4fd9a5214871ca53a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "73fac5290eb69dc3925bde2c209b9f7f44d20ca77ad0f6c726ad860597e32c57",
-                                "uncompressed-sha256": "a1b0ea7b6b9e63421f050390cb56a93d86f489eaf4328e584cadd84b06e96d4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a3f3a080f077184a6abfada0191d6a8832b7b32c2ccf6a9eeb551db6263defb8",
+                                "uncompressed-sha256": "174c06e1ef6d7c00052411aae1f99e751500e254e3f3d0c31a4eac611464c7f0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "26d77e31b6d2e6f93feffc1bd3b2adf27608c15440dc64acda71a1491c37c1a0",
-                                "uncompressed-sha256": "28ef2649df353bec00cee80ef3a5773d34e1c9947b7c351c601107ac4eb889df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "ceebd60e52e068d5359b358673a3b53d993a9cb59fa15946716c1b71b2309786",
+                                "uncompressed-sha256": "7e66a0f096fb6469ab67b3c957f67ac8b9d0d927bebcc31f7ceb1994c4ca4b97"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "be84aaad14dc65a77e3f6c074ccccf51053523b9bc12b11603cc05ae1933512c",
-                                "uncompressed-sha256": "25a782d291c54a7a2b834e71a0a41ac70304e08b9fac7f35d725e151f6e37cc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "0658a23c069bb252f7bb0a2ee5f5f4ad9c961fa17e7f7626085871259b5aae11",
+                                "uncompressed-sha256": "3079e8b986f33b9211eb2f76f090d01adc958c5c6d1012ed5edd9665aa48ab08"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/ppc64le/fedora-coreos-41.20250117.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "260fd72e987ac5038df5232f184fd02f7ac1063ea69c05cc5a3a9c58bd0384c8",
-                                "uncompressed-sha256": "bac14dac4da7d6fc0407789f114992680c988e54ae842c2c7c599cf492419483"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "a283ba0b7c3c08771bce43c654d4f3ca5ea6326a0e7f82c78ad436167147d095",
+                                "uncompressed-sha256": "af084f1676a9a2b54cbb60435289e9f4711b212dda16eb8fd1f3a782b8d6f395"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "2caaef02c2b4c8b504fa4c61146d5899220e989c70433f314752e7ef98afb212",
-                                "uncompressed-sha256": "e251a7f296b254d8ac9ac6dd4c123cfa2671c92cb5c72b1c157c3b13d76a06a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4848aab1cdb891de1a40543e24e821bce6890797b64565742c2c80b679e509d4",
+                                "uncompressed-sha256": "7fe7f5707c000c198fd331d9d31dfc0ebdfe0b44a52b7010abe96bdf73a790ad"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "6f2110d0e7e629eec76f6bdf7b7674441847a2481e5b213e6c47540d1a1b8f23",
-                                "uncompressed-sha256": "8a1fce1f607d8e21caf1a7575bbcc1a7d597a12a5591f17bbb6fda5c8e93d774"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b1282f72856697a80368f524947339107e1cb3ebcc9a102cbfa2b640ff1c9888",
+                                "uncompressed-sha256": "eb74ecb883b1a78c7e7be651b5ca71138a03b215407b160eff7ff164d88b121f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live.s390x.iso.sig",
-                                "sha256": "e3f6a7bd07a3e43b2625fbbfb9b5d8220a798273ef5a40283a708d408871d628"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live.s390x.iso.sig",
+                                "sha256": "4b728fef8419f19876d1fdcc224dc50f29f7410637d9e91a60905359b94e7c7c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-kernel-s390x.sig",
-                                "sha256": "00d59a35fe27244bcf89afbad1844536659c2f26f0f483310a625bb3cd0b04bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-kernel-s390x.sig",
+                                "sha256": "ba1f9d5805906df2acffcb10f407d1acdd3d5c6c4024e13acb3a3df2d0feb3c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "e4f3023665ce062f29e29164ee18cf63a6611f52b1b722a9beba9c39cb0d5d94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "bcab5f9e16102f18de4467340243a0e877fcff0ccf1cd4ef23e61087b89b75a3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "eddade62db2d8fbaa62d29346186a070541cb62a3c704bbf9dc0db2a20510ee6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f1c714f13b135e54c4b6c87f3c4cf278523c8199248618c80a9e4920af97886e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "fb5c1819adc12106a463b1a91d1a1590a7af6dfb25df8578968db06309ba77fc",
-                                "uncompressed-sha256": "5729b7f0c567f7cd939fc3f0582cd90866544f2ee85a4cd265642a9e65f66e9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e0de1fd357fbbddf5ac95117ebcfb5119a9e05ff5c60407d329160f1cb671499",
+                                "uncompressed-sha256": "e1509354368a961babccc40a7b5e1d5064fa270e77c2caa9a83f17b4c20b8c60"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "9f7ce3fa514ad00da3fb6d23ed85f171854cc6c5fe364e1b2aba94bf8993186d",
-                                "uncompressed-sha256": "1d1e58dcc1121b77e95072ee2a64510d6290ffc184c515a17d42b56ab0b2659c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "1113194d72981c97f3eacf64384afbb1a2235450070cdfbb8c6b3c41458761d5",
+                                "uncompressed-sha256": "8755a9397114ff51007d7a2993b049ec0e12660bf2d1cab8fb838bfc9d84a17c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/s390x/fedora-coreos-41.20250117.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "672263d0f7ea76f9d7195e1ea57358583c48a4fda9407366cd2dc2cc482d4a74",
-                                "uncompressed-sha256": "a5c00a241f76fddcd69b22b0f88c6faf50e19a2726f160e7d0fc6015a57d10ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ee93d5285d1134fdb2cfe98d71970b85546a73e29e576cf3ab3ff1c2a5383b0d",
+                                "uncompressed-sha256": "3d745902314ae2abb8588bc54bdeb7e2806ace461c2a871e39c4898bd0932961"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8cf839467f01e07d068d3d17ef83580fbe96715dbe9a6dcdd96423b05f399b9a",
-                                "uncompressed-sha256": "1934d453f008cf57295d1a8b6fd4320379989650850b742a210652b659267a84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5d1d4a1d3e51553fd3df81d8e6ed476d787ac8151fe9609378277eda134bcdb3",
+                                "uncompressed-sha256": "9b4298a3d5c9dd06270e6f8049d45c9a61a395501b48537f7ea22bf132327f1d"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "ecd3968e11429684a36e05b5ddf49e6bf2b1aa6392a028621173e2fff0e569b2",
-                                "uncompressed-sha256": "d20e44a2dff27e0a7c481bffe3c03354988103c1364dbb97325372476acda4b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "3d2cea2d27d4bcc2a87ef8d239bd1e04f06b98f7a9d01337160f2be6924760be",
+                                "uncompressed-sha256": "3de51c4b71679a6c177f45ca1fca26ae084316dc325afb9c0bb3bb36c135e36b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a65660535b4e223b0f00a693bbbb69399bed981d6de4c0653927da9c9cdbced7",
-                                "uncompressed-sha256": "e302e6715108d842b56820daed947395b6824db69021193337e3599574e7bd2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "228d22bdb7f948fdf5884b7a305b0acf412af0267fafcc6cca45a3b10c9bd0b7",
+                                "uncompressed-sha256": "d4fe9d7dacd66ff91623b9957ae3b6cdf500079a923c5703649697ee07e3f2f2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3548163581c0aa829c05bf9b128dcc86dad1dc63e526e8657730d685adb15923",
-                                "uncompressed-sha256": "4f5d13a6cf74ca68232eef01728ecb3b13fefbc6a786aca11932b2144544afe7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3a96907348bd76da33d382f775a97f4b0fa53052abcd912c831d34af0b3f18ae",
+                                "uncompressed-sha256": "017a3c33e9ac06e8107f3e36e63a1f34592390724f2bbe0bb4f4372428447bf1"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b1309b14576b136162d4024c85c884660944a73f50d89eeb2e4d7bc7b80a1716",
-                                "uncompressed-sha256": "db27158f76c230390e3569460ddda01debd8515cc23e4b22f62e24b9196ba0fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "836fe3e6769ba6ee200494ab42988852044d03c68ae194e640c92be2b5f977ab",
+                                "uncompressed-sha256": "e0288c536009888d2118908bd130e527ebf8a7f3d7065e8228fa3abfacaac55f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7c666c70ccc9f921370fd5105115ce569ce0707a1b1d11c1af35cbfc752aa900",
-                                "uncompressed-sha256": "7b93508125777e9b2878d41fab288b96334a6da8a78b8c0da74fe47a5566635a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "db740c470ef78f4ccad983ed59a849bfc8ee0944afdc127bd4b722491cb977c8",
+                                "uncompressed-sha256": "8475678e3620efd853455ce53edc2b8ecc4817aec3a2cf86ab2d328736e8d451"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "de8c5d4c7ff124db934a70d3c28bd34aae27a6b653fca67c574bd22ea64f2fdc",
-                                "uncompressed-sha256": "25ecefb0d942aca5e50baf9009ab730f442f9188a9cfc999c220e36e362ef827"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "0fbf5ee9bd3c1b447d5f246ecd6b218ad7db60fb49404646bcb00e138e6d652a",
+                                "uncompressed-sha256": "6c9472fd16a7b392d07cc10029cf33ec77b113fd91c6946b192ed70f34edf30d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9428cb951742b8a873d4454094313acb518a5a11da8e6a407aefbbc2d0f444d8",
-                                "uncompressed-sha256": "71cdd0653f3f41fc3b15ef22acf9e0ee55a6c3a89ce52d2c4c9192da271f3c04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2b79b2ed58ba0e0cf9a3e9973315aa592adecafab72cc25a09122c325671106c",
+                                "uncompressed-sha256": "d9136434dc41d40fb95ee7d05baf211f852f9b0873cf139d7fbbe62ea6b78aa7"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "46690c99dd2187a27695f050d04cb0c7ef12bbdcc9530bb7a89d963994fd10c5",
-                                "uncompressed-sha256": "8b16b0a4f721cd245f0413439d117505066386fee1dbc9b2d21b579a7ec945be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0a456f3948393378e14f2ff3fd120a07065cec5b9abce6d7e487de04b9564590",
+                                "uncompressed-sha256": "821a7137e8d2c87b3b60c6cc5825a715bcedd8f0b42e4c74c8ffcfc0bf86d8a0"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "bba8d2d4c1aabd912511560f03413341b9f558ea933dfda37a5fe36c2d27104f",
-                                "uncompressed-sha256": "0c4bfb5a87ad6a7c4a6d93782eb435bd1fcff9abeb5402a903b9a77360b10f87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5618551bbec7ac96c69ea83a151f82ff284da3ba6225f7ad975ac1b8dda07508",
+                                "uncompressed-sha256": "64a839bdb1c8e98873bdde76bfe7d4bc6ebb07c064e40b09cf38a4a596885835"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b36e6cbd0cd18b0f08dc11d17329fe8d1dca2f3b0708af0c45ee63394084c941"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "f2efd9d9271cc62dda14b17ea64d532a0596682f69c8acb81eaac3dba60282a2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "f57760761e4aba0f4833600ac43edbe160f7065a8c5531c8cae820e91009f4f0",
-                                "uncompressed-sha256": "67a9bfb47f1c9e0201e4a913dafd093199fdd13d07b83ad388e8c115df0d6c8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2d6ad1f5c73aca616419cc10d01a081e4f4320af1519fa39be6aa3bfffd57fe1",
+                                "uncompressed-sha256": "19d0f5a5fd7994321d153dec920a2266fddfba74559922a5ca37ec60e1c04ead"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live.x86_64.iso.sig",
-                                "sha256": "a713473a084d0cdafbfc920a197a6dfbf06a5c3cd8f13be9d059dcd7b8708782"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live.x86_64.iso.sig",
+                                "sha256": "e49889053f75902b96e35bb3ff3a5c55ad897cb30861774eabe8244f635a4b39"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-kernel-x86_64.sig",
-                                "sha256": "4cc5bd7bdf413e0fdba2dcb986e909f69461e3d54c1714bc698043f66e7b86dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-kernel-x86_64.sig",
+                                "sha256": "c4d885839268e5943c8ebe731bbfd66e8d888db4a85497473a5bc9e91b0a2128"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a2816274c039a397f2529995b5f3324b36078e8497b44fa6ff1056305ce5462c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "8fb64821c19bc36ccefa57cf4a83aefc598af24aa61372897155887123cc51af"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "c94f4d898d63767562244160544155d5d6dbe22c9bce308a9f471119501584b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "00eeaa17d350a2e2ab80b5caae04e5797fae55e0a78fd4487dbb8a8b3da2331e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "8d80e2162422aa77aa27e57a9367a9a63f9b94ceba0104c1812897d19138ca67",
-                                "uncompressed-sha256": "4e0cfe1d62b210465820c58c70532bbbe9267b2bd9937f535685fd3b9992db6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "fbbabd0cb8a5fb729498fa5effc25aa173b7ae089e56928780e9bb15f99a1ade",
+                                "uncompressed-sha256": "c377a8d11c011275d0346f1b19ff4aaecc0107a0d562764443e2613f9d863a83"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "be118aa3cc8d99b82372f3344e6d211904e6872b5fc166ebde7e718733a93e9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "68277670bf940629167bd89fa2b435fec84664957aae2b5e71e7b098af58eef7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2ff0309a9b197594e91c96cdb911a43308f61597085dfe65a254a1d2bbef9805",
-                                "uncompressed-sha256": "d35bb8fab1571e4f803782d16d64867b6b9e6527149f4d6a2e6f65cd2704095d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0d4e7f20fd10825d2dc2824ad9e7b8fe85bbd3ae89885625e3584fc72cabec64",
+                                "uncompressed-sha256": "f6ae05016195e7d7cf6c2b01f713512588e011fba5f83a25bbeaaed9bb961de5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1330fd0e8162b7f3a59df3560e9e5696091e4df361296009440b26625a37bec8",
-                                "uncompressed-sha256": "41da9b4d806617679ee7753ece7179e973550ac4e1c0d2513462b0351497dce9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1ce31bad5580870efe7bf6bb311ab0ead4bb0f0e64f2c7d91346391afba8eaf3",
+                                "uncompressed-sha256": "fafa3416591835a3187763a61203ac3c9e31d764f4148c06eec354403c55891d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f400c4bcbcbbdd4173aea7269e81f63f1b6ac9bae1736a212b2f4d30c97a0d16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "dd8c66b0906ab35dd53244c3cba930f8a542c10dd04f0aeb5fd9ea6345ce0683"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "8d00c47e1061a3a29f8bd078492f536099a15f667c35f5953f469bd87dd5b100"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "3882378f36cf8c3cb5a62f7565680e0f72cae820eac7072cdc39ed883e12ced5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250117.1.0/x86_64/fedora-coreos-41.20250117.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "f479bda319c522122ea1d70fdb91aaaec608047806736f21c210e144ffb00c5c",
-                                "uncompressed-sha256": "e9a24c1b6876107fc4a7dd37047875dbc17652587fca570b65255924524c0246"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "09ba29215b313115965ecbf8f692804087a7cdebff75e328e36ddc43485a8595",
+                                "uncompressed-sha256": "9b336b67e5de691e1285db91bee7ebc652caf35e4ffc21a588640d428826ccab"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-09ba1219d7635aa96"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-000d6965867a8dd0f"
                         },
                         "ap-east-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-053e0b8bf3058683c"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-02565bb6c6ca85412"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0df91834b2c813929"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-05ba1baa279acd2ee"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0620cf694b5c96e0a"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-068e47e647359959b"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-03e5e6a69293014fa"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0959b79eb72032fc9"
                         },
                         "ap-south-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0e6b8795ac1abbe11"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-00a6959ed135b96aa"
                         },
                         "ap-south-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-05b54bb9565d0ce48"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-05e47e89cd9a98b0b"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0893e637f37ba7864"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-032d6143a0a126f89"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0407233d4b7c7f732"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-034e6cdd13c59d52d"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-091ef62da85e35178"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0e44d5937ffe14160"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0dfef7cb6bde3fed2"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-03ac74744137303c0"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0c601793347ed0be9"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0e88958077ee0057c"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0bfe9360d172fd89d"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0d9640811486c003b"
                         },
                         "ca-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0320dd5642778f4b7"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0b4abbc4e198a1319"
                         },
                         "ca-west-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0421a63e9ad70d7a3"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-04cad4355bac91994"
                         },
                         "eu-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-041c6530415e3bc2d"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-054f0294175c01654"
                         },
                         "eu-central-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0f83e8fc905a0283d"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-076bec48fac31e877"
                         },
                         "eu-north-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-06765447aa4a8adf7"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-048edf6182b2ff1e2"
                         },
                         "eu-south-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-02e1a08ee4cba3343"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-03ef5cb32636bfdcc"
                         },
                         "eu-south-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-091bcefa082768a33"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0b1ca9f85ad81795e"
                         },
                         "eu-west-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-06c5ab95947426cc4"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-06403376e69048f51"
                         },
                         "eu-west-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-030f59ea46bd66fb9"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-025e431dce11ed4d9"
                         },
                         "eu-west-3": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-08ba7dbcd4eded6f5"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0257c714e2d8012dc"
                         },
                         "il-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0a3ae5b2a4a14e22f"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-014b7c4e94f7a5947"
                         },
                         "me-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0dd131d4493bcfb16"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-062c2facd3c9982b7"
                         },
                         "me-south-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-025220b7c86653175"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0e73a05237eab0e8d"
                         },
                         "mx-central-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-00a64869b06649f2f"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0e7bb47d90a71b33e"
                         },
                         "sa-east-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0e14b301f90605bdd"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-02b70f959e5a05d9c"
                         },
                         "us-east-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-033d451c66f5107e8"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-02245eb0c82f5e644"
                         },
                         "us-east-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-06acd4ce9bc977584"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-013adf83204a33532"
                         },
                         "us-west-1": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-016edb4e5d76740d4"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0bccc84e36649f072"
                         },
                         "us-west-2": {
-                            "release": "41.20250117.1.0",
-                            "image": "ami-0e928b8ee7dac96c8"
+                            "release": "41.20250130.1.0",
+                            "image": "ami-0294af67595968d0f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20250117-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250130-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250117.1.0",
+                    "release": "41.20250130.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b09fe31a58617491067853603ab556c0d6289be9fdda3e1a47b972e4b0ff0a80"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:178d16b5472bda3a90cc4e6dc90a806d81a0b2f35e91937fa5775ea1118506f1"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-01-21T22:49:13Z",
+        "last-modified": "2025-02-04T22:27:18Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "8fe3cd4ec5d90ed870219b99e51b5032f2385177c0355ae8ba56c2f5a4c4cb35",
-                                "uncompressed-sha256": "8ebfc1fb49889cd28388a58678e01f13ba5bb27dbd41b3ca2f6be57d520263da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "a4f6d6912aecc412b5264fbce78b5c157123955fb88463509151b0ad8166c53d",
+                                "uncompressed-sha256": "da59897262c0b5f0a59425f74a576d3ad01d10b8295f1480c42a469f30864f7c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2b7ee598b9623e6bba6416c7ada88346cad93b0b919a67d5ffb1485e88126179",
-                                "uncompressed-sha256": "2e7acb476fda384071c877d157c5244cba45353360ab980692c215fe857beeef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d52f2795c908e8dcc60ae8900297b858d34ec296cc0590820983c06e88b48322",
+                                "uncompressed-sha256": "8040ecf9bf42295f77282951c72fd518af351d53080f88f01aa1610711d71f5c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "6723852068fe6f217efb4f29e4a28cd929d0b9c2a2cca44aa675d4893dfc1370",
-                                "uncompressed-sha256": "fd7f2424233475f5119bebb79425bb8e405e984fe1befd80867e81a5cbd50061"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7226050bf1a1508061b0d1dfc3260a56af4a85e7786f9ee151c3bef385ff3202",
+                                "uncompressed-sha256": "61127871ef5ca0b40072239b1e5b595b4c8b3ce504a88d4ef2aa468acd29f28e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "2f00380ce5c87b3351e84394c19eb9697d59ca6649245de25665298887036dfb",
-                                "uncompressed-sha256": "86f7677a7c67287cc57eafc0fb95fbc1dbb1e8f1e5eef2ec5c3916ae897f8d51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "8106dbcc027f6282bf5f22bc5a781a92643f552ff9c912929833b007da706f58",
+                                "uncompressed-sha256": "514465c949a197d657bad6b07ee2be77646d4bdd05e4001bdb3cd68fc0c9dcf4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "b044ab760624784c88ce24a3afdfab371d610aef23e6958937cf418253e13b81",
-                                "uncompressed-sha256": "baa0a65ccd83ca7682da812e784b96e480d84b96a5de76e2300ec4b43ee3bb06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "b05ecea29d3584cbd7145d803870dfbdf27f3177fe23fd5727c315689c17b882",
+                                "uncompressed-sha256": "7beffc24082dca00d8ae9ed88c5153832e139936ca67282f4bb0ec0ae1fe2a57"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2cee40b78dea154a04256bf74e68b477f41194434ec0c7ad6ad3241c67e89813",
-                                "uncompressed-sha256": "9b5a352de87593373a27a2837c288b845d96a549b004a96889ef54d9d3bce347"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "86523487d3b59598405218497b0a224b3bcd87777275e9c803eb4d9207d4a296",
+                                "uncompressed-sha256": "c560454201afe45999ad0314bfe6d5b55498adbd1ca6c5831692dc68f65477e7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live.aarch64.iso.sig",
-                                "sha256": "387f643b0bab7c05d46de6b5c9829d64cfcdb2a44abe33fc02c02fd27f05b78b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live.aarch64.iso.sig",
+                                "sha256": "70c9285e718c1b35d6db7fb0d5d40af06ad5ddef8e3a34b4649768a4de37dca3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-kernel-aarch64.sig",
-                                "sha256": "65836d747fe845b87ccc7facd3ba98a1129acd89aae9a8f4f583b728044ffd64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-kernel-aarch64.sig",
+                                "sha256": "b6b69d9b21a4e68e6778c76cbdc77d8b3f4a9b30b0e8581378c885dee605cc20"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8de44beb140fa8c6e118a1851a87e0369e1413343625247176ab0a3a306c1730"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "b8e17a9f75b5ba582c96eb1a9db50a031bf890d1eba12b42d44c078879ece4f2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "8b22eb8ae3ae886b8f891917e8c0f6c08f3e0ace1ef6512d543f73de466f3d99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "46f83845b42147f9c4ed90bff15a212491989ceb9d662cc17fa220849055c41f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "cb851349c1689921763882df57378740616e09fc8fb0ab79aa7dd61d0f6bb43b",
-                                "uncompressed-sha256": "875213c5ea2334d8fe097935783793e034684c472c755e7e1a81ff76c45496ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "cff978e9f892a8b230f83cff927d32e080825dc30dffa320cd9f472468036bfd",
+                                "uncompressed-sha256": "65263c14bb56e26c7fdf6ad50d5199528fef9d5467ffeec3bc15a2c7e8311b5a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "664454d88245bdee9d9c41af63c4d17bd0f72aa89daf4bb868ad3a49db7cde75",
-                                "uncompressed-sha256": "edbe49d1822bcf25760eadb3a37d3fb029c0cf45782946c646661463811881ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d81c5831b1049314dee6273b0743dd1c40ecf2b2c446b726f2049ad142e72b86",
+                                "uncompressed-sha256": "9f8871390a5bbb62b99f8888d3b754c505c12707d8d1b749c6edf04963dc4d47"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/aarch64/fedora-coreos-41.20250105.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "709441d670af63455409b65d02f23cd966212dad775aabea1658f0d671aa7d56",
-                                "uncompressed-sha256": "3953fd3bcc4d86c36c3f4a9e73588151abcbb8fb437f2cd42d59b0373ac5efd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a837e3a7154849df5ab36ddc5ef0a99f8f2b3d6e472639cebe9ab6aa7be2192f",
+                                "uncompressed-sha256": "cd315f9ead5d9384b3b844443f1f6095f3b3e000fd956c5966e0324f935bf18b"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-09c741b70d93182a9"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-04daa34f1ec60b848"
                         },
                         "ap-east-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0dcbb22a1a2791b5f"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0ce32849ba180e0f4"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0f5efc5005e0dc9f4"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-03d2871f44b132541"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-08cbc8bb7afd5518b"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0878f1aa2fada0554"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0cb167ded14f65b67"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0559fd591dead4c3c"
                         },
                         "ap-south-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-04c2ed4294916943b"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-037810c6f4454eb98"
                         },
                         "ap-south-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0a216d20b73a0bd38"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0e31bfd610bd26539"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-029573c56a9dac2b4"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-04d9710f4ca40343e"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-03cd3e689496088bd"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-039f69755dac6d57c"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-051f80c6e6a7d1b1a"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0c07428e1a94c14fa"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-02e5291d04ed7a755"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-094abd940d12ec5fe"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-06330a0589d004298"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-038e2c049126bd860"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-06ae8f1ebc163d331"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0571412b8d61b3269"
                         },
                         "ca-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0ae2d204ee8272982"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0044be21dda3b87e0"
                         },
                         "ca-west-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-025cbcd4f24d548ae"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0e020ccf877bacf0a"
                         },
                         "eu-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-06de8cbff26b09b30"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-05169cda2a4491fd9"
                         },
                         "eu-central-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0f42d8959eeb20f23"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-031e833667f40f8e8"
                         },
                         "eu-north-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0fcbb51d4e965f7fa"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-08319f5c1b9052a2a"
                         },
                         "eu-south-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-048d361d29c8b9eed"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0ef1146e1be180cac"
                         },
                         "eu-south-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0e20f869b69a1e3d2"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0dcf36f774ea1d754"
                         },
                         "eu-west-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-03c48151c4173de99"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-06dcc514a5151db1b"
                         },
                         "eu-west-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0a1f84439c747e018"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0b38506274dcf7b76"
                         },
                         "eu-west-3": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-03bf2db0fb1b15365"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0305a380109eb4482"
                         },
                         "il-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-00640fe4d2e63a901"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0e3ab0f03f7cb9b3c"
                         },
                         "me-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-002376fc08a816e24"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-04ae4f0fa11c35292"
                         },
                         "me-south-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-011f7ad10b66c35ee"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0d9b8022c55bbda3d"
                         },
                         "mx-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-09e5f3be5e0891417"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0812f6044abbf6e99"
                         },
                         "sa-east-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-025f191ceaae7096d"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0de6f681925d44580"
                         },
                         "us-east-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-07b58a50f4e1c32c8"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-063f63080c849ae3b"
                         },
                         "us-east-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-00470e6a8a80e4691"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-02b27491a4d2d9a5a"
                         },
                         "us-west-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0f99c86bacaaf260a"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-082272b98fae4f02b"
                         },
                         "us-west-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-054add26fc685414d"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-016e378c0c29c1254"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20250105-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250117-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "29fbcca9ed186256f61e6940e277bf019a7d87c26fc37ea059d1cd1155f5b834",
-                                "uncompressed-sha256": "6ff9708c21c6c56442b5c6d15311c0ee62442d349ccf3c975aa9988d383bb3fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "3728b236dd2a779e98d6629379b0d07dbe16fc7ff7e312c8d1fc4ece67c140c9",
+                                "uncompressed-sha256": "9983176b6efb250039d4edfbf092c873f9ba73bc9b251bdcfcbced837062879a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live.ppc64le.iso.sig",
-                                "sha256": "c55e6c3b99ac6d5e24be531f363ffe8ef788642b05523b3b89cc67a56fd048bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live.ppc64le.iso.sig",
+                                "sha256": "eba2682196413b2e1f90a2a2c902e8639a8763e74016e91c10dfa265f854017b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "3d9793518dae060b9ca6185012b3e533e1442b51676e77cfbd89100a3b278c98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "bedf2b9b1f4d7897a093680bce908bf7fe43e59b76fe2b2d96ee28d74d5ac6c1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "450e0b33e3f0e95acf30e717c9296e1ff02fe2a5cbef11e7b66367f1a2b8d8d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "7e6c7ac5903a10c470bd08879cd66bb4c79342d35f9065d6c6394dcdc91f35e8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "90b6cbc4971cef26fd46521e14f37ac0f74429a789dafd6ac5c1597b2dfe2df0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "ed8dcd6a22d45dc1d70b8d12f3af23154fbc092ce50f825cdcffe2b86483c312"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "169eb7b847568bad549649e5f6cacdb5b502e13fd4290e3530102de9427c0698",
-                                "uncompressed-sha256": "4465ca8c747424fd5807ecba95b7d402543e917ab9de4076119a9c762089fddc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "8ca581db43ea683e2e3f4131e0eff21094f29d8c01eb34937ea6a5fccb6d8149",
+                                "uncompressed-sha256": "b634aec7411eaa5222c2ecc56dffff6bd3629c717e63486c09948183ba5fdca6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "d5f3dafca3d0096a78165eadef89e040fa8725cba4ce2b0cc490eba2dec27a7b",
-                                "uncompressed-sha256": "e6710f2d984ef803897328fa7729523a17a4b699075fc78aca0bce5ac620bc2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "0698aef78b280de69840a5af78393fbbd2ad7c8d30a0d77f13a6614f4f85e73e",
+                                "uncompressed-sha256": "25d0268b5270b6e28a5648767becc19e534c0ed0f91202f378bbcc2688e9e1d4"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "4e06a448ec3642c5ee3f1e5826ffbc2bb180375cd3fdf4d539a64948ed0f5f94",
-                                "uncompressed-sha256": "652da8f3cb2e891daf292a285181fc384f2f2ef2cd4f92e507acf4114abf45c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "37eb36317006857057359ad0104db2971f3b9cf118a14467e1b9b55babfef1a3",
+                                "uncompressed-sha256": "15738b01ea61044385060933407835a5c024dbef5fb1094526f437c25eb0138f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/ppc64le/fedora-coreos-41.20250105.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "0cb9d38081d42630797ff75ff38ec76495836ae14742a0435d0d2d3468632291",
-                                "uncompressed-sha256": "4249ff9aca9563aa9a86e715b055e0996005aec9490ecdd0e69ce7208d9db418"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "e32891e5300dd14ec8e8013eaedbb9ac2b2865a9b71727820c1d9c524ecb3c7b",
+                                "uncompressed-sha256": "2776ba1d273f0b5be3076cc7b78ea94762b51e43d26f6924cfac308526466be0"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "887af4f068b19a5cedfb756bb16a739f11b96d001a2e3b47a5fafbcd82c12303",
-                                "uncompressed-sha256": "1b019c39751050a9b8efcc74ee7cec734935e1fd352f59df2d9f981c2d15a83d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "7c163667e6cf1307d4abadd644d6b0f4d00141d5b11543127070a61db154f3e9",
+                                "uncompressed-sha256": "c5a003416ea859055dd3e94cea2faf7bdc71a9f9f0951e95ae758490bab05885"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "931239c0ddcb713980bbdb4fa63850a85fa5d3ef2f2c3629bd2da2c45b6d65a2",
-                                "uncompressed-sha256": "be64d772c0bb5a54e249872e7d9229fbe235b798ede6fad4f59be2d9031bbc4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "f233dc3aa45f6c782b7faaea9ed3e2201d9d2da2339db86737d80d3d24dc92cd",
+                                "uncompressed-sha256": "81fa6bc267f9dc89608f0a7d10ad878af21b09cc7bcb292f18639469e0736d55"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live.s390x.iso.sig",
-                                "sha256": "e4198bce5b7b822a34adbedb9514a6f6efb56597ba8c6f21b375312f5d5a6d2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live.s390x.iso.sig",
+                                "sha256": "ec5f70fa5dd3f56de0bcf6df7e35b0dfb0e614442df9b4c693c1251099edd845"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-kernel-s390x.sig",
-                                "sha256": "2969a1ddce9913888882d563131d29640c7a5909aad0eccb8debf4256a691261"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-kernel-s390x.sig",
+                                "sha256": "00d59a35fe27244bcf89afbad1844536659c2f26f0f483310a625bb3cd0b04bc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "c9caed57c38a7bbaf4cf3833223d2e8bc4a6edf402b6ea2015abf65530a99850"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b570c85d6008436cb8934fba865fd110e9d4e3ca2b316d0778c6180eaf853e62"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "a07e343c5db180fbfe7abbae960614e21ff16fb7166617be5acdc1a0b682d2c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "4c756d3c7f706fe7de8ae3f21674a9c95538098d7fc4affa9c9e3111c81dca56"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "78cb41c0156b2f5812f059f9f19c88b89bcab4d31a373a88ac0b67184cbe59fe",
-                                "uncompressed-sha256": "e237481927a59d7eb7d9ddac88ce93de57c8b518f21bb5a727f374fef1912eab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "8d87855d1fb6e358fbe61d12f08d58b7d448ba26a8fac0af93bbd652960e901b",
+                                "uncompressed-sha256": "74a0463cec344340492c77020de21d8669959d7351ad8653d43035001ff0e988"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "a69748fce627d01cbf1896d5fb0067f8ee32df3c82b015fcd243372364eb70fa",
-                                "uncompressed-sha256": "6daba308210cbb7a2a47de5a648fbe12358df32aaa2dcda1fe6df326790d7f17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "59ce9dd8803de0d9b3f03589b4f03dc16b2873f0a4128e46933a06601d1eeb95",
+                                "uncompressed-sha256": "a441d5650a7b30981bee7c0214c8ab1c1150e61103bb76f4d135d1ed069d66a8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/s390x/fedora-coreos-41.20250105.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "1b69f71f4c7c5a885d5e82cde01f4052b67d22c0af923852ee8a68af23fce6c9",
-                                "uncompressed-sha256": "767bf4d8982ce16f43edb5179ecd372dc39818291b3be5346b3b2a2a0af2e1ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "92ec64b644d6438ae72a34cf104350892e6a1d6511726e39a1f8e8b9778ad75e",
+                                "uncompressed-sha256": "075325d85b67201af8dc35af928524fcefe79bf58352d8ec1977fbcb29edc28c"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c51f44d43a0fa839003441b7d496e78a0a37a759cbb9fe8f1b25ebee894d385b",
-                                "uncompressed-sha256": "8aca75198e2bd5b46284450fb1ac33307cfdcffbb6a1912e95f1a51a21ca768a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "64c1c8daa7290d8e6a5cd1b57816dfdd2b34932707bad4da868fd71852b5d16f",
+                                "uncompressed-sha256": "a78d71d1fb1f3c049cad88513bfb2331f61cd3ca8bd041713edeacbf893f2505"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "f78cba2103e55fcbb6923ceb29020eefa92332ffa119b4751e4c48213ab916ff",
-                                "uncompressed-sha256": "d3fdcb3c70c35e6bedb62d86a85a6cf1c99013fbe107a07e10c8f87d2703c4f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "b0aaca3e632351e6a8ae33599e7b8f45ebf1aab912f040cfaa2d773d841cf069",
+                                "uncompressed-sha256": "5e9e77f7456e1fae8063f52e92756630e98f1e5b146e7e4e94c55d4547ede242"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "351fee3a4152b15c7309359cb8422c0994853587e591dc58b426529d704ba118",
-                                "uncompressed-sha256": "4370e790d04580c37bda830d2c930fd2ffc396b4afbb7ec3e36316761e00f032"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1884427f8601672fb4786ef5ae3d88f30f950ff0f98ecfb6fb6acc3a70aa9ed3",
+                                "uncompressed-sha256": "b84ae8d17d5892283702c1cc8be8d41dd7fa42b5d776fdba7bf2f313ee9fbf43"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f7ba7f943098629172fd583e744b854a7814459648a38fd6993fa67b8e2ff8b7",
-                                "uncompressed-sha256": "695bdb88d3fd5da6d14c1fc0af0a04a10670b6ac75258ecf8346419173e88ced"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1d22686510aad160b77ebc0b6c42bb626b195e06920de48122c874160743a32b",
+                                "uncompressed-sha256": "f40f567902e0b167e5abe4633aacd55c1e8d2fad6e34477c19e20b84933e8789"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7ae2415f5f9575a973bd667df2478eeae5871053451177900cf850e90d1bc161",
-                                "uncompressed-sha256": "4e3f39c6121e29019ba83bf947d4b7f7003634eea3b1c2ef4a25367c169edf0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "246d490dc64a42d8a0af0799862cc3ad2386a7df068788edc4462de0e759ed06",
+                                "uncompressed-sha256": "d558a67d1f75f17480c7249c16abd079519b5fc733778025a368d8ec60de5d7a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "05748ca44280ce5cd1799b26117e9789296e12546366cad5e966fd758561ae20",
-                                "uncompressed-sha256": "f2c5e75028cbb4fc22ad2695b9abc75d23158b311364b4bee5bedceed8a26039"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "09a54fe6f76e0fd446e62887a33d4ea2b1e353999fa2e218868cf9ead9b4c2bc",
+                                "uncompressed-sha256": "c2f787947251851baf973f40ed73429c45bb8db92282c1bd965a64d93aea606a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "92cc9ec5cafb5898b517746eb35b5f847ba3b2834c5b51fad3190184953aa609",
-                                "uncompressed-sha256": "725e1fefad458a5fd5134ae716f3ef3a60bb3cff1300e8aad2517d7363f5aeed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "739da27030a5993b5d286ccb9c9aca7e547eb6423a227505f0782c44a633797b",
+                                "uncompressed-sha256": "de77ef431f46f6a71f1aa72a5161431bbfb001191f3d0216360b00a9f9247bee"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "30ead392509b73cbb21a6fbce8a50810e0806b90e9e05b7e0d318ec1a4fbba48",
-                                "uncompressed-sha256": "086b32bee571a0ccb8ed9e5183fc40726bfd07d8cd5ce5b802819fe816c117bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e97a93ec8f9a7fc2949fefe615819138af8d7598e404064c57ebe883c22bdc2c",
+                                "uncompressed-sha256": "ff788d7fdccaf641be6ff2c8ab1c7ac0006659f8e20ed2cda760fc6dac6210f6"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "ddaf017b1b84ee6356c22835d432e1d6f49a054af61649efb23ab2807605624e",
-                                "uncompressed-sha256": "a56dd0682f4319f9a30548f0c38db48e53f5c4bb0182a87445a62b8b008d9ab2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "9bc41a42cb7411898d296b4e54a2c5af84fa142e21e3d17ad75a3b6c2995e4ec",
+                                "uncompressed-sha256": "a9c7f794dc61cec4970e949c40d788b24c62fb6a6e2854103d3b6863e1b46944"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a11e1146646e1d58e58aa3c948a0cfcd40f16da1e8ce5255e90a3983e6f2af02",
-                                "uncompressed-sha256": "d0cdd7e932fb934845eaa0f8df186349e3a38e08e5e91da6943821fdd309c442"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0a74ed531bf2a8d7bbfed15a67bdcdded1b9f78f504495a12661af14d3305dbe",
+                                "uncompressed-sha256": "be141907df051f6c4c40c69d123f4866abe36de71f472d6014b835fbf438ebca"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "3d428e2079320f7761d8938cde05c305f4800245ffffb2da5be41954aed50b76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "8e48f04d68df4dd08435243bf66f86ab2054fa25680c28d20260c2c744e39cb6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7e8491817a530ea568a5422f6c0b831beb273dea79b9d738041061cc8684ebb4",
-                                "uncompressed-sha256": "ecde2828f2cbb171c8fc32f86b470a8cf7b6867b4208a2e3bad896a8de3cb1e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c42e586044ceb372467cbf49c8b092c57b811cabc055c92d35694fae5a7e2115",
+                                "uncompressed-sha256": "db57df0d524c796c8c0736b481c1a07e5d217da65f761856b75e69e24ae4f60a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live.x86_64.iso.sig",
-                                "sha256": "ee7df8824fb4237bb37588d4e3d42f660a2051b32dd33ee64fb84debd866bb0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live.x86_64.iso.sig",
+                                "sha256": "8b784e4fd951299b43a006aeecba6acecfe68c875e55dc6778b4982c2c8e2b45"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-kernel-x86_64.sig",
-                                "sha256": "5cd46b0ba12275d811470c84a8d0fbfcda364d278d40be8a9d0ade2d9f396752"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-kernel-x86_64.sig",
+                                "sha256": "4cc5bd7bdf413e0fdba2dcb986e909f69461e3d54c1714bc698043f66e7b86dd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1d82de704c11deca651416fe55340e70e6ec0c9aa5e5e73c04dcccf7bc05402e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "8b8f28db15e4dd27b7c1b7f3e6c6f7485f0a4e578e77c1456ce8cd095ebb9cef"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3055cbe01c33fb7e841ae6023f6fd50f131a195ac66d814cfe4b34d314c410fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "52d070796ed1448315696228b3e990ff4665092eff8169d9b5bb50f27ddb4a5e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e4f950daa716566886b859547220029730fc4d28fa228e4404f71dbe5b6fff52",
-                                "uncompressed-sha256": "dec1d976bb1d1582d32a3f07a667717bf5311fcf9a152311191b73df750384bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d179af03c3b4b296bfbe2cc9918243aaedfab22875530332e23cdc0e853e9066",
+                                "uncompressed-sha256": "c67f30295285cbb58c6746400e9cb9ca31c70f1c54a67331e374756e2f3deedb"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9efa83aafeaa562ecf8f28e415ee542e4e73febdc13c8047caf4f0a377a2c68b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "457389dbd7e35144e2eaed391afa676f8139fe65e3f98b937f110e017293296b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "65be06a1392208ea23186e60f310f204b55a91036a274e5f3ee9f9382df383a8",
-                                "uncompressed-sha256": "3ddaafd49fdb33208150a224fc1f29a86764dd22a6850d294b32991cddd7225d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "399e983e58ccc59f8518a06a75d839075ab4c6d9778f3678691132a25fd98f15",
+                                "uncompressed-sha256": "bad68406bd71c676eaad867df72f685c6bbb741234b3c97b63a8bd327c353aaf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e24905da112fdeb66a79df6ef818e039d4ba80204d6346157eef85cb53c7457f",
-                                "uncompressed-sha256": "85332b051426606d9fa12406bb42353ce1d641c2d7a8da08416d8bbbcc752527"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "22bd18dd1634f347e4bffc175444d56a1b57d24567dff5097ccb8916b9b12bb2",
+                                "uncompressed-sha256": "1eddda9f86a0536a132a5b984f684fb730e33759af428cb9281c7ba3ce6be6d4"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "d2ec4644e8fb4e84e8b24d9d7c2dd8075a9835818738021d605008587ca4154b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a8db85dc03a883f480e2f34833b6637a64f68674dab8cc3f409446b22bae7ab0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "5a8ad3e654c85952cacb01ef89ad56bd268c6405539ab53aa2fd6d172e7408fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "606882401552a56ac533b2f58f8f5b9e098fbfeebc7adb3a23706ca92058bf22"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250105.3.0/x86_64/fedora-coreos-41.20250105.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3ccb5701853edb1c9076e2e1d81779f93bfc56e406553c05d3f6309ed8196c82",
-                                "uncompressed-sha256": "e928354af4e0d665a444189cadfeaaf0d17438374009c35965b88b98b5e69ce3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d7b7f4acd9a5f7c394ae44e238925c4a44f7198b9d77fbf7a9d3b40edd1981ed",
+                                "uncompressed-sha256": "be37b781b6217ac61246bc66c4d3f787a59a1c1bdccb0b1d9d097b0b7fbd796e"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-00e43ce07c637ee4a"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-008a25df042db77ea"
                         },
                         "ap-east-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-037c1df6de1c75c0d"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0c6d17cb5909f0ea6"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-032ed209805effc6b"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-03f5ef8646d6c5633"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-00fd2a0a450d6fa35"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-02d1ec39c65163ded"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-08a1bb2b2dc809c98"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0fe34e24213c43b2f"
                         },
                         "ap-south-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0c2461f64a795e8f6"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-054259f83df585431"
                         },
                         "ap-south-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0f0a6dc561b0bb3a0"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-09a11e1264497f299"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0798c25e247173dc7"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-095e3b8e727a66a97"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0b1f317cc7afd8a72"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-086c3a3ed3515149c"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-022842621770bc20c"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-044cba46d34565e24"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0d041fc2661c7596b"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-04d05d16b26e54581"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0942fe5e3f9383e8c"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-05c83fd688e82d02a"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0af4d523c7fbf5cd8"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-09ab4ada49e1eab0c"
                         },
                         "ca-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0f7559f091bff7c3c"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-03772df60637eb1af"
                         },
                         "ca-west-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-00b208ef687ce50aa"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0b12ea8b4f516d6a3"
                         },
                         "eu-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-03008ea46b291d685"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-008d51fa523dad5da"
                         },
                         "eu-central-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0d64f333572f9aa09"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-070316b80a44d207d"
                         },
                         "eu-north-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-05b05310787334b3a"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0ccb00e6d315d3ccf"
                         },
                         "eu-south-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-05edf74a1104b24b9"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-09c82b412079ecf12"
                         },
                         "eu-south-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0a442b9e0f7125dfe"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-05f8052337c616303"
                         },
                         "eu-west-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0ee39973a43286ec9"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-091f3347e51feb69c"
                         },
                         "eu-west-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0eb7e96c4041ad83f"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-046943fff0fe43812"
                         },
                         "eu-west-3": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-08da4f9caeabd054f"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0df41d1a1ee289547"
                         },
                         "il-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-007f2e314cbc88d08"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0ac38f24c9dd991c1"
                         },
                         "me-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0b4c1d1a9378700e1"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0bacc8acc89cda4a4"
                         },
                         "me-south-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-03ad3b630db4da4be"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-08363a43e4ec62ad3"
                         },
                         "mx-central-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0a84f654b751d4103"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0c33b7e5de79a2a3c"
                         },
                         "sa-east-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-02885cd7dca41412f"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-04be58cb00376d4ab"
                         },
                         "us-east-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-062e91802cc9291d2"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-021dff822684a8347"
                         },
                         "us-east-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-076e026b65a6d77d6"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-026534ac716c55c4a"
                         },
                         "us-west-1": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-0af3ec5b2e70e9c71"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-0f5893565cc743bb4"
                         },
                         "us-west-2": {
-                            "release": "41.20250105.3.0",
-                            "image": "ami-00e470f951ae957ec"
+                            "release": "41.20250117.3.0",
+                            "image": "ami-08734d76de917ea0d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20250105-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250117-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250105.3.0",
+                    "release": "41.20250117.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:cdc12b5a9066da6cfe98048ca2ae3e8ee1f4ef086e5e6f08a16e47d97502fd54"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b63ab7a17e3ff37645b88363aabe7fc24a5ed7a59169e6899d955a712bd1f902"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-01-21T22:49:15Z",
+        "last-modified": "2025-02-04T22:27:18Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "25f4b9c8218ebaf852eb71d672161971044177f2c6d2e0452f30c3763730b434",
-                                "uncompressed-sha256": "8e289fec6174c5a1508021751b46869630a46079fd6158040e5efe15b0a65e92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "98b4d0e516280ce7d86841f696c7fdbe8ce1223436d42b5d15bd20491b2acfa7",
+                                "uncompressed-sha256": "4250dde337d682be28480af9746b4ca957de0a68d1233c573c2655d601db6d4c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "7aa90805e51f1682dca30bf815c703971b314707079d8a1b9e3d7e93f6c9ca9e",
-                                "uncompressed-sha256": "70f652d9939e293514ad2c8ffcfd052cf6f99dc34c004d4f7ea6e2894ef8d086"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "070a45ae106cc5b03debe1f94c359cb1686dd963cf1f28dddabe9c8d6d217e4f",
+                                "uncompressed-sha256": "50b25aa6e267e5dc6a284a6b183e04467bc811ae4e911e617b7a82e4b6419749"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "aa8f6a0d541d2cb2020c8847f1a82d58cc929574c728052acf5e55aa69e4d85f",
-                                "uncompressed-sha256": "e2329e4f785ec67a8994e99daaa8128b0d1ba6b2baa04a2c7f15f778bd85e7dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5cdfb19e25f4e34b2789e86f02bf7b04278fdd4b3100dcf09092dd793a1dd33d",
+                                "uncompressed-sha256": "6d8b17fc4521f123bb78cd03120ea4f87dc4bdaedb755a952b2eb32a43e0d82f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "8eb2a52467a649a48f8f75a91a96c51d372f1b217cd8924658757026b25ac1ff",
-                                "uncompressed-sha256": "81332886f6d115ffed1c0ca27868eaa3da6ec5fbfd9eb67a9b72ca713f115194"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "5179dd69d0285e57970034552ff117a7c0689ecbb8d3f0547f3cec20726fea59",
+                                "uncompressed-sha256": "9dd3ebecacb3251c801fdeff2aea3d47129b768d3bed38120174cef818613af8"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "965ca2bf314de235ab26a8a6155299102cdcad544e557c7aef256f75233e14d4",
-                                "uncompressed-sha256": "f5bb30c5aaa85480671c680724ba7d8110c7ff79fb609db7e5c9b552323023a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "ab3be8dfa929789ecafbbc877799ebc2cba7d1338293b646a9c07ca4136dd3d7",
+                                "uncompressed-sha256": "712eccf6b36718c061be6318a87e7525cc41f2881b3ec0cb0e4536c12114a899"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5d2497616e88b765c27c1ea7b9158555d4fc473a2b5bda1dfac87fa8ad7450d2",
-                                "uncompressed-sha256": "a095b6bd5c9a3411c48406b9e1efc34ee61978e69d7a3af8e909c614472c4a13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5461128ff62d776b307d9c24b1d8374827c988957717adeeca067af3c709be25",
+                                "uncompressed-sha256": "a0414ab98814466485cb6ebed54055234e280333468356e31e81dc8067a89ca0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live.aarch64.iso.sig",
-                                "sha256": "3cb9128ff047c2ea60a78d80953fb64cbc90d511e0fe1531aaf71168aa5836b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live.aarch64.iso.sig",
+                                "sha256": "0a6e34773c9f7c85de980833bb6c5153a19f19644bb96b29bf8bb405fbfef815"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-kernel-aarch64.sig",
-                                "sha256": "b6b69d9b21a4e68e6778c76cbdc77d8b3f4a9b30b0e8581378c885dee605cc20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-kernel-aarch64.sig",
+                                "sha256": "487e48c1483a5dce5e531699acef9740f57570f6d1cdcaa0cf7a9fa492b2fcc7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "dc23b19c90cfc67655aae001b43b30c124c9c0741585a64e7b06e1bd0274d86c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "45947226ccb9117b528ccc3a3f988d4b2435b1fa202b77b73f504a0ee8c8a220"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "9332053d6e087e19ecc233199ff7f0efcb4067ebe3f05f9b4a8ba3b9676f791c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a565c15b85f668b75003117295e15e68bf3a0a145c2fca1785b0fb77312cbd9b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "a10c7ef7204fdae476ed295237ee8fab44c0c0aa4ad7c99f4219b51f386a2d88",
-                                "uncompressed-sha256": "a2f1eaa472d34f267357edf5cd9bf6907707447842ad6be358ac1a12cf59b0e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "2328ef21210bc22cdb10e32abd1625a23545dcf78c53ff4dfe93e1df90ca1c84",
+                                "uncompressed-sha256": "47fd24173bf610838242700b6f6d22376f1fe4d1779e629b3d81d7d974b2dcd6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1ad018081b90ac05584f4884a0db380a68fa4d5b06b2f9b2443620cdf310ddec",
-                                "uncompressed-sha256": "982710d9c5d7b68657d018d8060c6ee452982598d68f6195fd6f3a7e7d24debc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "febf966263e645bbdb73d9c703bf2c6fb23f83974f742cf5c57685830c851282",
+                                "uncompressed-sha256": "f7b4cdbee62ed5339d6bd7df10a45bf402a026f1bb7f06c9a0f1f0d3cd138acf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/aarch64/fedora-coreos-41.20250117.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8114cc24ec7db4e67ed8b970864ae1c154d926e4dc1723eeb2d62fc51043d26e",
-                                "uncompressed-sha256": "e7026280affaa90c140e84b6eb7474d80dc05ade7d54895bb8658342f83bdd98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f55a3bfc654a26656e651a31795f5239091aa4fef1ddb2797e2d1de7d4056e1c",
+                                "uncompressed-sha256": "c796ced5ccf61c9784842f0ba1d1b3f8f585ed02d99c19a20e175f6c8e3295cd"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0867952d70773645d"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-07c08ecd75d54ef2e"
                         },
                         "ap-east-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-068cef5860f0adac0"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-06e4a2791965483fe"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0b531022690c53174"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0862d67b715d7b3ac"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0a1ff2939840c0e96"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0db88b2ebb4677121"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-09a1e830b9e907d12"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-050b861fb4a4cbe9a"
                         },
                         "ap-south-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-094b314e5854e3707"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0f493a48ddf0985ca"
                         },
                         "ap-south-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-04d3ce092c33381d2"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0ffc46d0016d65fdf"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-050c91b3313278b98"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-08fa9636a4bc6feab"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-03ccc12437267e037"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-00fa194587065780d"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-079240aae7dcb9ffe"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0e3b7f9e1ec20b645"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0d80120f06279d57c"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0875bff0e0ab8d7ef"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-017e4ee865dafeed2"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0c8f43361cd385b27"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0ba134f59a43824dd"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-054101fdfd90468b9"
                         },
                         "ca-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0a722076e4833485e"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-06ddebcd02913614b"
                         },
                         "ca-west-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0d047a0ce9d3d8b07"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0eb319810e510a5dc"
                         },
                         "eu-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0a218f8ed08b6b596"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0e7dcc35e5b84a417"
                         },
                         "eu-central-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0d5fb03d578ffe5de"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-00e96403dc8d747b9"
                         },
                         "eu-north-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-04040c28923af0bdd"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-095dd9d350b269421"
                         },
                         "eu-south-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0f66b36226357bcee"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-02b86f70ca1c50042"
                         },
                         "eu-south-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0b9aeabcf5db87c53"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0c7a90dfa925aa04c"
                         },
                         "eu-west-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-01aff12adb15014e3"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-083f3029c37492f2a"
                         },
                         "eu-west-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-05916b72084e2fbaa"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-00509bd37037f82c3"
                         },
                         "eu-west-3": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-071ccc16c18018b04"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0c9ddf6eec79359ca"
                         },
                         "il-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-08b36c7e7301669ad"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0ac3478f2830b5b13"
                         },
                         "me-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0a5f9d6c263349d75"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-06546da68ad2936a3"
                         },
                         "me-south-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0a3e31fafb02f7556"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-011dbc0dc95675a30"
                         },
                         "mx-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-04ac48eb6ad41a170"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-07c517c3a4e73654a"
                         },
                         "sa-east-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0daafbced1df68a2d"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-08c219ea84f6a3e2e"
                         },
                         "us-east-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-001832301beeafb22"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-00f1b579e44ea9f79"
                         },
                         "us-east-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0b5b82b9f7f750e9f"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0d860d93b64dcd50b"
                         },
                         "us-west-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0c76f4968bb316f8b"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0a4b7353c5a1b145a"
                         },
                         "us-west-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0d6cf4e4f67d19a74"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-030bda1920f9511c2"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20250117-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250130-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "ff46d5438aad9efe392259f9cefc6f81544759fc212ac37a146dfc37ea779083",
-                                "uncompressed-sha256": "ceffe6fe2b7f8984d702d0d216af5f026c6e3309c043ebcbdad06d7e04f312fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "cb4646ec500ae329d27d2e72220908c8b7cc53a535b6856f3a69eafecaa7f376",
+                                "uncompressed-sha256": "9630dc36c502cb074706f81fb00fc81dd1194b809eb5765bc234ecb7cec82b98"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live.ppc64le.iso.sig",
-                                "sha256": "fa4cb99b6879ac5734b87e5a93f40b108b938870bf17716aec267250141bda62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live.ppc64le.iso.sig",
+                                "sha256": "947b1412eea2574f3544a194b0093bf3b777e5ae5f63f9ccff67f7b8c5471333"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "bedf2b9b1f4d7897a093680bce908bf7fe43e59b76fe2b2d96ee28d74d5ac6c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "686db5ecb4c80c0cac4fb9d22e79cf18a0f694abdc31c65fdfef2f6ba0776391"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "d9356264e72c5e1641ec63765be7e9970667307fc63e98bf5a89657a6876caff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "34d297bbcad0867c854837271f4ae9b5638ec2516e3b81aa3c9cfd3a00a79ca0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "ca956e0e64fa1214131b761ab20e658bc8ee79fc83baa10e9ba083a2a00646dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "b1e8fe9eed532b86150f68176fe334af65b367b005cca88b73904118fd8bee9f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "507fc2027a7c32286f11f0762448eab1b5f489875157c69be66996892e634b56",
-                                "uncompressed-sha256": "5bb13a4a17ae25237a933356a3086b8e85b6681cac4c321fea59383e911a5c79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "bcd608a8116899d41999ac188ad56a6d4ce4f6319dcca724c9cd9a1dfe9396d7",
+                                "uncompressed-sha256": "678eb63b9f68b9eba90ef72a4b7ac349914e61472f8f213cd241958d62540470"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "c4a0364b381cbda72b2f329c4443ce3e602b1670c445d9acb9eaabcd4f646657",
-                                "uncompressed-sha256": "6b31e41c767f21659cffe0893ef1f4627fe3f5172bd434f65f0f7b16cf4c72d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "be4da98882dc3d2290324e6b6ac6de85226b8819992cc5db651dcaa41d1b45b5",
+                                "uncompressed-sha256": "903009c6b142c406d838d5456dc8498ad1f643e7aeb583f5c37ccf2ef068b8e0"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "abf233cc7dd113f3af10b220c3c90b4ab3a4f454fbb767ce7e6a8e9aed1c1a22",
-                                "uncompressed-sha256": "c873f50029bb9819c58c7757b8f2cbb509c4ac61f02f3a7f458c2a3268ef190e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "81fbb926b96dbf336555bd615d78682c033d297b9a5254bec468aa65b0c3b481",
+                                "uncompressed-sha256": "ace982fe51dbded237f77ced52425718e636fdcfbab42792858b7ef646067a78"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/ppc64le/fedora-coreos-41.20250117.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "9538fa59d147c35ad52a1c44ce1780e33a2a98007f99b8327a6f03145afd7a28",
-                                "uncompressed-sha256": "aac59c40d32c5356d7e858c51a5148805c7286b3641dd09ba782dae3df2200b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "be956b79f0166cc5d5c717fe313779781882ff2ae22eafcedb0b6f9a9915c817",
+                                "uncompressed-sha256": "f076de5c28a67ab8ebaaf1d79d5de98a5f0a3eba8678a010a1b90846b5b412e1"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "0d0cd36371ba5390f76afce83278a484a9887a437e43409958fd72e7f328336f",
-                                "uncompressed-sha256": "8f9c2564389d70e40c9ba3deb86fd1548bf1b60555be262042a376472c20205a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "40d531bbaecd42f38790c95456b1d5e768371cbf09b37bb21a34f7b784610ba4",
+                                "uncompressed-sha256": "3310e7ef23b821014f03721a3a6ac08d90faa18dd52337eddf1059949bdf9ea1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b4a58abea41f92d33213827e90a965b4d0e08d24e6f51ddd7cb16097a6a2c83d",
-                                "uncompressed-sha256": "3fac56c1590febfa0b167a06656abb28058a0ab20bb39df94839e435ae6f80b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "42c91792e4dc1b853b606a3665fada6601169217a471457fd1309f6903250791",
+                                "uncompressed-sha256": "8d386f78abe0cdaafb46ebc8521ed6c8325fc6fdba6dc70e670cacbcce6e8917"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live.s390x.iso.sig",
-                                "sha256": "5190e5fbedc82f6b12501ebe8f7ad799d4fa398ad412aa12a7b005176267e5ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live.s390x.iso.sig",
+                                "sha256": "4d5d905fc70071ed2e610b979054e29ca4e7e979b8d00ccdf170251929556421"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-kernel-s390x.sig",
-                                "sha256": "00d59a35fe27244bcf89afbad1844536659c2f26f0f483310a625bb3cd0b04bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-kernel-s390x.sig",
+                                "sha256": "ba1f9d5805906df2acffcb10f407d1acdd3d5c6c4024e13acb3a3df2d0feb3c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ceb7ed1b9f9285fc1f172b397cd55b53821fe2508becbad06c1487d564604fc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "f5ce62fff69a4bec1a147261d7300dc78827804804077363742a653cdf5054f1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "cd7af7d8bf70255d7ceada163d64fb12122e69eddbe9f1501ec043599960f4aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "e0986d913b44a88aff4a778f4e993d5551525ebecdcf0c2be425ceeb7c20008c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "43a8479e749ff19e9e17053d9043f75e271f87246ee5a0f4ca934a3a94db5f55",
-                                "uncompressed-sha256": "8b376d6e01c6c8fc979dcaaa7103923243e07d871a97bc17320e017fbd22585e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "44c11153abb8c8161791f5ebfb67e9d3d8a9bbc91e9654d3f74a801cec5f5d37",
+                                "uncompressed-sha256": "0abdc03e7b638e35a165c5245336e10b17fb49a1c6ab255e2916e6dbb55c6533"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "483e82c5f34442901d89828320cedb5f6c47c633ea25c924e580ef101ac50af9",
-                                "uncompressed-sha256": "91a8be5468ae38d0a751b17e7678a954efbfdf9cae831b4a65c8e6b94c4cadcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c723d7f335b3d34f4deb5e438cc23fdf2be4c9bfa9ebccb3b4563a83675969d5",
+                                "uncompressed-sha256": "c88d19bf5dec73e10b22c1d9fa179a27dc259c1a314acf6e1fb5070560d04a0a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/s390x/fedora-coreos-41.20250117.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "a3a7f1587ffac29a8836d0070d9bb74ea842e328b9eeb852e0162d790859505b",
-                                "uncompressed-sha256": "1c1e51a0d3a6ccb05d301b534bde163590f11b23305ea6ddb1058f8d4e98c693"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3df1b43b3e7765789869e4a90b2e39655880b14ff59b1febf824ccdfb5af6948",
+                                "uncompressed-sha256": "c630ca2a047d48aa99fd3a28b0c8e6156560a213d969723af77060c7d1e07ad0"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f9120e9053bd407f93b2908a3a432b12f08a54f0c0bfa747936021836c54c344",
-                                "uncompressed-sha256": "dc892ff9ed9745c6d979a689eaf23d7fb81b819ccb80ff7b3353dce84f9d8e29"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8b2b903e8ffc0f1f2e21b6137a7c85de94b5d2810c045d75f39607a7e47ef721",
+                                "uncompressed-sha256": "a7380b953d1bddfae507d6fcc45cdca9554b9a3652d6d8a230a242c999d004ae"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "288fec2433a1835d13c5edefa9766a1f12984248400a3c01c6c0f4d2838e53c0",
-                                "uncompressed-sha256": "005d4cc7d12eb09ed9cc00558975b3f0d6fc48618c6e692b12fc086732fd14e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "22d903d829fea7d8a1a6cc1d97064096bc8a49571c405eba21f5c9a3d5112e49",
+                                "uncompressed-sha256": "07c7365e05a521989313df475da3cf7e6c13ea23587b34877e22fbec78101555"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c0cda090bc73c22a3115f55c83ce7b0cba265e3b1396aa808701e7f69761174c",
-                                "uncompressed-sha256": "92549e2cf40a05675f6bde4608d0be167e97ff7e498ae97062df2020101b39de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "774854ae255932a6d0218444f58d7f0f439f6f39762a7987eaa5eec440562c14",
+                                "uncompressed-sha256": "216cf8892257ada692d36b7427aa7bcb85205e965c25864b16b988159576fa08"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9cb5b2e67fc2ad0a64b8bfe1d271157f7ef989f75477a752a5b9fcd43cee55c0",
-                                "uncompressed-sha256": "847c90aeee45f7af02d3066f94f06f75f223e4b69069dc73b170afec8f8a96c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "5f43ce4c833b312ec66ced35891d4bb58ae5d4aa710d609f68c2ade0c3dcf91b",
+                                "uncompressed-sha256": "8e648ade51e8b451533405d20676d907d8a5e95475f64a30723b4aa7a3a9c391"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "331977cde483f94e192b61d0d0b3fc0cdab96b406d7dc7af00e32998c902058e",
-                                "uncompressed-sha256": "4b0105b03110209ce7d5de3b6ae9aebdf98f6ba2ec9e470af15b58a507c9a92b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3b11ad467d4b9c82aa356ec0c96f25eca9e6a044f8cdf380e3c2f5d4add2b985",
+                                "uncompressed-sha256": "169da678895487ff1b70cfe95e3966319ce6931ab7645f2530f71bf82358e6bd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "921735f468122ce07eb881e2888fc398f84c1f68a9c603ae79e05fae0b710d43",
-                                "uncompressed-sha256": "8ddc4cd8f0902dc5eeeb8d767b683a3bb57307a3b387f1091a1680fddcab9239"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "866889115a83efd10e6defbe7658f23910f0c64890fc092aea901aff775e8cb2",
+                                "uncompressed-sha256": "bf9b2a9152f2a3fa9f87c695dd11da7bb4809fa38fcecdcb7b512cfd9f0bfbab"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3e66e188b9b6bec4fc6329e503d9acc8549dbe79c81d8a9b957fc2b44774dff2",
-                                "uncompressed-sha256": "eae79edea4fc099a6912c799505de670ad5127c43707d3e0bc0749d8614e40b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "60eaf9478ad71ea8dc1c4fb4b238919b4a807a331091a567d31e8c5d15fe77a6",
+                                "uncompressed-sha256": "46443a3a66b50c3f7d013c5930879c3d36202df0cfcc74de87f52281472f6312"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "608e0d700ab3dddca1f3653d3a061a3b54e81380a536b7c2f83e64b09972f6dd",
-                                "uncompressed-sha256": "dce3ef43306a88420d7650db697625ab43f674f601e7747deb2b297767ba9df2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "03b35af5f621fa5d4c1ef56a435ad2e90fba9064ccdcc4a9f55d31f27acb46ae",
+                                "uncompressed-sha256": "9167046bd9fd57ecdc69d9422e99e10aeffd21ffe98881e44d73e6164a0d693e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "4452906a1b175f5f3baa83aa83980e6e367e062bc449b4176746235b6229b6d8",
-                                "uncompressed-sha256": "5df2c83c515147d808380058aa83311353a3a5c86fc956fba2318a9e434a9d33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "5e04a32574e97f433b93d1b7d92e8af3f0f494c8361b82fb78e7a3dd68d8ace3",
+                                "uncompressed-sha256": "57bbda03e08923eabfbe91a46421df970982df5ebdd278b53aa8b0efe4e5bb1e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "578aa95469b24c6f2c2c252626f6a52df188be6fd351356287e46773f8d16987",
-                                "uncompressed-sha256": "f4786f59c30f0419e07e6b4665dbeada3cc1761a20f6c6ff1078e0d5d3b997f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9e0e2df3cc031c4565863990440e74e5645b6576838f27b46d540990c5b8ccd3",
+                                "uncompressed-sha256": "47765ac7c6093821ef85c8cfacd2b76e2ff51d9c03215a6f6733fbee71750431"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "e7b4f93d0bd4a8481b20f3a773294b32c9b568bd8a00e8417a7a13dda0d31d16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "30507a149a39484c69d663e4571dee036e4cdc36410cccbd199866db8d871d56"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6191cc8344a594ae44ef9800a5026b88df3896ad8effc7d3436338e219c82255",
-                                "uncompressed-sha256": "e1747a7692be60d57539140b743cc5dfbf93297a5391ec817ab8457bfe18b2d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a500a6243d78518288e189bb6b08cbd58e06f46196d097016f715731af4cf22e",
+                                "uncompressed-sha256": "bcaca909acf24a4d936832bc744db71334c6435b0e236ffed053eb97b630d22d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live.x86_64.iso.sig",
-                                "sha256": "298e7d015db7eebd396724f940589ca900840650efd68cf45c0075557cddbc2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live.x86_64.iso.sig",
+                                "sha256": "6bce921200bbb6c9c5a0a01dc420fa3884057f096a5cb390f05a8e8f37617037"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-kernel-x86_64.sig",
-                                "sha256": "4cc5bd7bdf413e0fdba2dcb986e909f69461e3d54c1714bc698043f66e7b86dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-kernel-x86_64.sig",
+                                "sha256": "c4d885839268e5943c8ebe731bbfd66e8d888db4a85497473a5bc9e91b0a2128"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9b0d515d104d54863e5a527bfcf2e6ab8105922e73c1b8ca16e53989a4913fe3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1cbe62dbdb0f67c27ebd5d2ef9abc9d32deede3b7b8c7317e511e030154a8e6f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1f6a43ed0abccf63e12e6da4393ca1a15475a715dcb13da00675812dc0e676b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "4e97b1462cb1abd76c76e1d596bbafea75b157e82b8fd81d26396adcd4aa3550"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "ee6f9d518bbee17cd97b6a43b8fcffe0f63fcd920059c9b5a8053c5a8317f195",
-                                "uncompressed-sha256": "435b74c8152e1c42683bd224dce17e6830252c4f61606311bf7969f872b1bf20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "44b495f9725174855cb85976718612129d5360317c7be03596af111e87afecc8",
+                                "uncompressed-sha256": "8d116d706024ba9b24e3c5722fbb0429972c2d033d31f0b1b8abf52627b4c707"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ffd957c9f9eaa9ca3856760c650cf9ded1c34c421ede14efffdede4103c62799"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "bf2698f43eddd77c15408477b695571eec8a51f5074422b440667dae49a7d5c0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ef2c0d93f9b6bb6f2a39dae8bec056bbf591998c36cbb9e1bdab6a1f356c645d",
-                                "uncompressed-sha256": "8079115d1fffe4de3b290f529aba0cd2a24f1b9fc5a9afc478d411aba487dd87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ae93c28c702629275e71ae7db57c3f501eaae7e7f3a5a8664b894d4d141fd095",
+                                "uncompressed-sha256": "07b39eb21fa817d01c4e7eacc380718ef831f7b7b91862c04ddb1e8a684387fa"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5ed8d7b0786ec58b4c6978f2c19972acd872c4fd42f669e528d191dc7def237a",
-                                "uncompressed-sha256": "3b23600ef7f8554367ef038bf8a897e4d57bd7b7389e3233c6f33d9a01368852"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "dd33a6fce3a2ad47c592d642eabfe58252c7e2d7939641ae67c508c559262e47",
+                                "uncompressed-sha256": "e59dfe3dbbc7bebbadfaa33bd8fd3fa2a836bf20012767140532d3cacbe71c6b"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "1b5b7618475856d26408d54fb3cf3b7c9fe63998c2bfcf093916a88328bb8156"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7ec7fc01581ccca51cd747bb2e945287f017d63a8d7864fdafe8db5e92c38a35"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "915b8ed6a2b942ceec47320c869c686156dbd6b200091c97b1ef61bac7079584"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "a1fe765d9971f9ebaf018341237c8c923d7401d1943d167d0d9bf864557e78c8"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250117.2.0/x86_64/fedora-coreos-41.20250117.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "e12450f1a0c7dd9081a40f25a4716ed8c245d6fe2e66a4c6ab9f04088e0e8e5c",
-                                "uncompressed-sha256": "ab42b9225a04194791d1ed4b91cdf7af2948e9ee5c1edfeb86f1c0936ff5b744"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7b8893e163f7b9fcdf1bfbd826b25a9b1f629c47f0b59da5fd3649d601591dc5",
+                                "uncompressed-sha256": "90a7a4eef756d42d826757a1212f94331aa707d0bb245c13228f19e497a013c7"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-042998a1ab05b079c"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-05a293c15272336ba"
                         },
                         "ap-east-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0d4abbb883cef6f5e"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0ebb5f59a0ce76331"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-05efd0c51a964937d"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0da9406a2f7e653dc"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0dc7715a507d3f99e"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0350c56a5927df832"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-04cb192b0ab172d72"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-08f5f928d3e6949db"
                         },
                         "ap-south-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-09ce9c052067ac075"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0bb8e418b281f68f1"
                         },
                         "ap-south-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-019fc7ca58b74980c"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-00a6d422eb093e287"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-055129e333c314a84"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0c0c36e481fc96502"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-094fffba3cbbf29f6"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0135fbdc88572a5ef"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-09ec86022450790d1"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-07559b3a5aefd9709"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0f030d18f2a929ac7"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-00f4764e7f88b1195"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-08bb55f7935452f0a"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-056cf96c5632fee71"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-06445b271bc5fa5fd"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-016056778ec3637a7"
                         },
                         "ca-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0eb2331ace5d4f203"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0102ba89e497506a4"
                         },
                         "ca-west-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0ab8d1de20bf37aaf"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-05067d911e0343a35"
                         },
                         "eu-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-028c447973e0eca80"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0a7a660e153a65225"
                         },
                         "eu-central-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0758ae5b448249889"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0271fe87950e09e33"
                         },
                         "eu-north-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0084c8a00e26d36ba"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-034e5925023751d88"
                         },
                         "eu-south-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0aaff39d3688dfb46"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-07e27a07d18d29da8"
                         },
                         "eu-south-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0de5e9e2719cd4853"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-08849611183a5fc8e"
                         },
                         "eu-west-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-071d64a6af6c5c603"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0153ab262a9a97e34"
                         },
                         "eu-west-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0019f26c9a21ad5ac"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-01ea1c2ebeb7295e2"
                         },
                         "eu-west-3": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-062c54c7111632ebe"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0de0f2a335bf3932b"
                         },
                         "il-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0c6b4840385195ce9"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0bd21f783d482f799"
                         },
                         "me-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0acc30872029c7765"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0f9acab4d5df0913b"
                         },
                         "me-south-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0d135c07dfdbebcb5"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-03a21b130b8a60818"
                         },
                         "mx-central-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-031c69eb236a9b35b"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0b9b02e7b67e0110c"
                         },
                         "sa-east-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0d4bc506008a1a532"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-054940aecfe276f43"
                         },
                         "us-east-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-070f6cf71956797fe"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-020e7ac0031fe0417"
                         },
                         "us-east-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-063270c97b0fc798a"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-021809175e1a60fe6"
                         },
                         "us-west-1": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0aeddc44ce21f5a95"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-0ff0aaf132b7a9a0d"
                         },
                         "us-west-2": {
-                            "release": "41.20250117.2.0",
-                            "image": "ami-0b9e0ac3d32708b57"
+                            "release": "41.20250130.2.0",
+                            "image": "ami-078f4b11e0a60902f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20250117-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250130-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250117.2.0",
+                    "release": "41.20250130.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9890277dd786bc4716434055966766024e67f8209411aa45ee792f327c9fc17e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a16129ba83847720e5dd98fbed35fc44c1f391e040afafc9b2d3ca68ab6bf428"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-01-21T22:49:16Z"
+    "last-modified": "2025-02-04T22:27:20Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20250105.1.1",
+      "version": "41.20250117.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20250117.1.0",
+      "version": "41.20250130.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1737554400,
+          "duration_minutes": 2880,
+          "start_epoch": 1738710000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-01-21T22:49:14Z"
+    "last-modified": "2025-02-04T22:27:18Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "41.20241215.3.0",
+      "version": "41.20250105.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "41.20250105.3.0",
+      "version": "41.20250117.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1737554400,
+          "duration_minutes": 2880,
+          "start_epoch": 1738710000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-01-21T22:49:15Z"
+    "last-modified": "2025-02-04T22:27:19Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20250105.2.0",
+      "version": "41.20250117.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20250117.2.0",
+      "version": "41.20250130.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2160,
-          "start_epoch": 1737554400,
+          "duration_minutes": 2880,
+          "start_epoch": 1738710000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).