### PR TITLE
workflows/print-rollouts: bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/print-rollouts.yml
+++ b/.github/workflows/print-rollouts.yml
@@ -33,7 +33,8 @@ jobs:
           echo "${{ github.event.number }}" > validation-results/PR
           mv rollouts validation-results/
       - name: Upload state for PR comment
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: validation-results
           path: validation-results/
+          overwrite: true


### PR DESCRIPTION
`actions/upload-artifact` version 3 was deprecated and starting January 30, 2025, users are no longer able to use it`[1]`. Update the use of upload-artifact in the print-rollouts workflow to version 4. Uploaded artifacts are now immutable, so add `overwrite: true` as noted in the "breaking changes"`[2]`

`[1]`: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
`[2]`: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#overwriting-an-artifact