### PR TITLE
Roll out stable 41.20250130.3.0, testing 41.20250215.2.0, next 41.20250215.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-02-04T22:27:19Z",
+        "last-modified": "2025-02-18T17:33:24Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "2aa342e302642247b49aebf39b29581ee5cd46eb34669900f446ca7c7b5b23f3",
-                                "uncompressed-sha256": "3a0d3d3c0d3b6f0358735f97a1815308feb1aef1a9471f0667cc5f888089fd6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f4f06be3fa8e1c9a22c8a815bc3713a4ce334ec2ea0e514aa5a4a9b397a224b8",
+                                "uncompressed-sha256": "4fc0f45e5ea3dd19978d845b40cc5b58bf3e1539afb672e2d75e684533b17376"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8fa77ad8fd98e817837b7148866626b3f9b4beb636263013c0b4cbf8f5840f5b",
-                                "uncompressed-sha256": "70da23ddb0cfd027680d33e0f346b424cce0c3e17d27442a8335f076a9aae748"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "aea8c23d9de5e34ef87d39405c2fa4f1fa5b82dc2772cefcf310a6fea868cfcb",
+                                "uncompressed-sha256": "19c3d39e16508ff254e480c155ada9b5ce47c77813d0a287c5636a94687d9c68"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "652c78a9bb8ad0d35d46b64173c86df9d5d0aedf9ef98d0cc5882b2158c1c028",
-                                "uncompressed-sha256": "8b790aaea7499e5874fd75e574880e3551d0ba04aa3f8d937672565d8d6bbd75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9cfe0f97832db88acd1570e8c551ade4b288c844ca28e89a65c7b8a35f1444c0",
+                                "uncompressed-sha256": "0c8ed67395def3ea5a6010534452e757e45f51efc5aba4e27a30afc6d3428126"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "bee342eadb7e8eea371ec882dbecb1ce54d816411ac44e0de44009ceb6e7b46f",
-                                "uncompressed-sha256": "c15eb7e986c12c4532a6a1ac5055a3731a8c9d5f1f69ee51ff2948f3b8ff00cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "3f7c0eef74617805323f07effb3a52120f68f910a7a8328a10965ce9b2017fba",
+                                "uncompressed-sha256": "7aa24d93f041a3bdefe090b4f72b057f33b6c24015fbb48df5c9544be0631ff5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "f32ff731e807953709e6399eb04a2276458e5d31ae05b5309d19c4bcf81eadc1",
-                                "uncompressed-sha256": "247f271295692a46ae08c4d783a0582cb98dfd2d93b3385b6e2a086f3c23a515"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "109753d145b4fa016c564834a266098bfbc99bbd71a6e4bee1ff872d5cb11a2c",
+                                "uncompressed-sha256": "41a4694b1506745bcbd4187971b71b931369f600730c8b3990d2bfb79d6e707e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "74f4d27bd46505bb1ae12ffac10560cb724584a187aab4a30ecb3be3ab39cb5b",
-                                "uncompressed-sha256": "d4b7e9703fbc3c96b7f7780e5bdfba4291c186d07e8ebea34ca1b9b04a1c0dd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ede95ef7ad33d3387bc6de77a1abf0a65e8eb66113957d565c6f1f344b778f99",
+                                "uncompressed-sha256": "e8eab8ee61bb9749fc29cadde2ceb2c5a2013d6152373619d2a74f79e4850d37"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live.aarch64.iso.sig",
-                                "sha256": "b66132895efb27bd20de874603191985c0b9f55bd4b8e2730bf2229ab04f294e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live.aarch64.iso.sig",
+                                "sha256": "9d434af959f92e83039377ddb282ab55d581095a693b00a587e0e11182410450"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-kernel-aarch64.sig",
-                                "sha256": "487e48c1483a5dce5e531699acef9740f57570f6d1cdcaa0cf7a9fa492b2fcc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-kernel-aarch64.sig",
+                                "sha256": "82a27007dc137f3290634d0a90ec081f0225508b078078d4b60543112f6f9251"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "b2b0e02c7fb9e21a3285076ea62477d43d1a4189b96da9b719163914b1d2e5d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "8768be95795bb204da5a4b4b10b1bcf86ea2b75ec9acf6493466978df41dbd7f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "4c004c9fa36e0a139d0fa3dacb3860c86ec6153537f56fb305e40f77579dce9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "54d920becc1f8d2bec16643b78f1c6fdd85b94b262c11ae3bf8e1c1c387412e2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "838134ac88b261cee291af4e4d5defd43ff50cd767987147bd60d90137c2ab21",
-                                "uncompressed-sha256": "11d179bdc94b6db7cb83e7a4c096d6677b5be0dc60f15b43d80b4d0c01cbb4c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "d1594ef67a1ec58e19d6737c29ee1085066c56e4671e22fc04093a93f96e210a",
+                                "uncompressed-sha256": "da0546d589022dff98175051c5e78d40170d0d0cede9e9708004652afa2d7325"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1c945a54d6db8686eec008c99af716388c06d1569eb7e61b11fd7119fd2c61ca",
-                                "uncompressed-sha256": "588ae6c515b5f21ba77ce79ab70321cb7b3eb22e7b573af5cacd09c926aa8ac0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d004187cd7d286271f1d247c8017f960f83776473aadc2fa6b8411c6c928aa02",
+                                "uncompressed-sha256": "f709a4e43e196d21bae80e90946afe07762f913fc451cecc0dec4eb84742b6ec"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/aarch64/fedora-coreos-41.20250130.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7ab024384d64354fbc7abf0fc403b76be47c12de17bf20e1cf3823e1c8704022",
-                                "uncompressed-sha256": "4a1f6cf90b559aa0cc7ba38f3f4d69f45d6dd6801c7c1cca40ee3adaba1709de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "93745fb5c909b8152118363edeb9146a4fa15d0b2ae5d76af3dbbb7ae0717368",
+                                "uncompressed-sha256": "ea53c2664c2cde229c3c720a0c19115093fde84f20db7832e2e196a52b119a2c"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0346ed5f6798b39f3"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-04aa3a24fcc3ae205"
                         },
                         "ap-east-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0e3de5953b069ac47"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0527437685a9ed909"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0dc2491341e9ecea9"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0b4f508c14528b35b"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0b602fc48a99c06ea"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0fe32d255b488e0d6"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0a254c8ca0cecc727"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-01658071b078a5d8a"
                         },
                         "ap-south-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0e2cdaf539187c946"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0f158f725e85be7a9"
                         },
                         "ap-south-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0f2079194beb73e13"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-077a952bd877a0e03"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0dd754cfbf7b02994"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0b657ca4b752c5485"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-02ad21868c7c55f7e"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0ec302117dd0bcb5f"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0eff6f14160f41886"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-031895bdfc2c05a12"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0d497bd0ae36b63cd"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0b8ad693ee745f391"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0a0ae4cd575601fff"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0ba5728f6d0a08b32"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-070a4c5f7cd1e2812"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0cb05209abfe86c67"
                         },
                         "ca-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-087fa19c4ce8a3315"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0deb45b91b626e9ec"
                         },
                         "ca-west-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-02326791adcec063d"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-08e564090d435f1f1"
                         },
                         "eu-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-05d31eea5d5222fd1"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-06c6b498e3f50d875"
                         },
                         "eu-central-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-03ae415b9ed5feabe"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0e606adc9c3f98589"
                         },
                         "eu-north-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0957bcbf1a68cb8e4"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0ecee81eae6a0b5b0"
                         },
                         "eu-south-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-03e724e2e0c1169af"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0f8adc6eced2c8bb7"
                         },
                         "eu-south-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0b4093689e391a5ef"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0efefd7aadcf756ff"
                         },
                         "eu-west-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0bf4a4dc2a19b8a4b"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0c0d4036d0e9ede6c"
                         },
                         "eu-west-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-080049846d3960cd1"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0e478a4a15cd0ad98"
                         },
                         "eu-west-3": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-061bc8ab18af1972f"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0d4f4a15e44cb0c6d"
                         },
                         "il-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-011b0a7114956ca10"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0c3302d2007ff989d"
                         },
                         "me-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0c4ffb6e6ba3ed470"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0b68b9296d7f1f8ff"
                         },
                         "me-south-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-03780661d366ceaa5"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0f41d18b7c5b97276"
                         },
                         "mx-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-050053cdedb639671"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0d684da5c98879df1"
                         },
                         "sa-east-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0c9afda1207a1284f"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0ef88fc12a9d371ef"
                         },
                         "us-east-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-02484b031ab100ae4"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0bf81dae6c04838dc"
                         },
                         "us-east-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-059b27fcfcdfe1be3"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0e160647b1c2bbdb3"
                         },
                         "us-west-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0c609e69362b7d8b9"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-05f90cca4c2ebc83c"
                         },
                         "us-west-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0770b84af22c42832"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-06483d1a25899ee18"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20250130-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250215-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "bd424c4704be93d130c408b3184e5883ebd0c16c9d8722489be28b9a65d49a07",
-                                "uncompressed-sha256": "357d4602eca5f998fdc3876c8c4e8584000a10e6729a1c5cc2bddffd432cb018"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "3e9b051d66587a5a22dbfc6b330e8733d0f9fe88d7308997ef8dedaa22b7d402",
+                                "uncompressed-sha256": "19545ccdbcfe537f17fa5eecb4fc95c6f365743b2e52d5cd657e93bb1d82872e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live.ppc64le.iso.sig",
-                                "sha256": "483c29ff0392e88686afed2278e88acf814897b442ff4165aa804b6d7a3b4f6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live.ppc64le.iso.sig",
+                                "sha256": "29c6eee6c211d187c598b7b8324a95247b60f3ccdd0d48eddeb18c8a66a4ff39"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "686db5ecb4c80c0cac4fb9d22e79cf18a0f694abdc31c65fdfef2f6ba0776391"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "bb8e92d5a64191c32abe1a21ce2e4ed6b2423844079747617f3f8c923f219db6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "9cdc5bd276f2aae9d96b3c1113104a4aab28b150a7a7ab87c96177ac4e919638"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "cb3cea929b1ed1a88a558342514edd091196218fb84707296d236c2a27cc61b4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "512079b2afd8ab980323bd21b66ca5b81b1438ae618238a4fd9a5214871ca53a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "54d3fae8c284c7a86d58f12e944948b66802e6816936d66e34b99f3201192ec1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "a3f3a080f077184a6abfada0191d6a8832b7b32c2ccf6a9eeb551db6263defb8",
-                                "uncompressed-sha256": "174c06e1ef6d7c00052411aae1f99e751500e254e3f3d0c31a4eac611464c7f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "b8e7368426b7fadb8d5398718dc346d8e0c4a71a64810ea6c51a024541c6eda1",
+                                "uncompressed-sha256": "e13eba2a99d99076ee05e35b62aa7045c9fac1284d48e5b465b63e653eed4004"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "ceebd60e52e068d5359b358673a3b53d993a9cb59fa15946716c1b71b2309786",
-                                "uncompressed-sha256": "7e66a0f096fb6469ab67b3c957f67ac8b9d0d927bebcc31f7ceb1994c4ca4b97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "de40173bfc39ae8289d69dd4b6c33b3579c8a71c3ade0caa25389a6374ea6c8f",
+                                "uncompressed-sha256": "10e76de2c4ae6d84c20cd5b387d1dec19dd1580ce6a0b7fb357cce185731209b"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "0658a23c069bb252f7bb0a2ee5f5f4ad9c961fa17e7f7626085871259b5aae11",
-                                "uncompressed-sha256": "3079e8b986f33b9211eb2f76f090d01adc958c5c6d1012ed5edd9665aa48ab08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "d7b97fc11ad275dff299882a9c5b79dd11bb4cd1dcb126322bc733e09f0814f2",
+                                "uncompressed-sha256": "30caf6901b03a2f14e3de4ea35a82f74a2126e5217e9dbade746079414a2b2a0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/ppc64le/fedora-coreos-41.20250130.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "a283ba0b7c3c08771bce43c654d4f3ca5ea6326a0e7f82c78ad436167147d095",
-                                "uncompressed-sha256": "af084f1676a9a2b54cbb60435289e9f4711b212dda16eb8fd1f3a782b8d6f395"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "05602b47d91f0281693c18b567df77b2795066c4fe60d7817a81d5e04da5fec5",
+                                "uncompressed-sha256": "036196fd8ad693af388e7500cda5da3d931db9faab17b28275029874266fa555"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4848aab1cdb891de1a40543e24e821bce6890797b64565742c2c80b679e509d4",
-                                "uncompressed-sha256": "7fe7f5707c000c198fd331d9d31dfc0ebdfe0b44a52b7010abe96bdf73a790ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "af19c08f7927f8e3c9a9168bed9253848072151aa6d871ee16c128bc88011d7d",
+                                "uncompressed-sha256": "2b2d261ef8efde292e4a4cf4f30fefd67a6894fa03881497dbdb1324b8c91eeb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b1282f72856697a80368f524947339107e1cb3ebcc9a102cbfa2b640ff1c9888",
-                                "uncompressed-sha256": "eb74ecb883b1a78c7e7be651b5ca71138a03b215407b160eff7ff164d88b121f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b7827badb0553386081ce3dea73e46e6a18d591fbda13bb75703900fe6083a6d",
+                                "uncompressed-sha256": "2aad11b1a749e295cfcb188917ad5d37eebe8206ebd753bbecabf5f72540af61"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live.s390x.iso.sig",
-                                "sha256": "4b728fef8419f19876d1fdcc224dc50f29f7410637d9e91a60905359b94e7c7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live.s390x.iso.sig",
+                                "sha256": "5eaefae263c62df29214a81f29367abc04c3fb4daa0f5f23778a1d0996865c86"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-kernel-s390x.sig",
-                                "sha256": "ba1f9d5805906df2acffcb10f407d1acdd3d5c6c4024e13acb3a3df2d0feb3c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-kernel-s390x.sig",
+                                "sha256": "953e18830a6d76e8b3dc56df7008f318c26deba1d0dafe4d8238e5107c12beb4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "bcab5f9e16102f18de4467340243a0e877fcff0ccf1cd4ef23e61087b89b75a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "107f38c88bf4f8b203552c6f4d01da35f5f6b591b15569f7e7c4dd0b0b125058"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "f1c714f13b135e54c4b6c87f3c4cf278523c8199248618c80a9e4920af97886e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b441531357f62ddfdda770ef71b51a95e2233995e6045ee561e3ac4bf9373993"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e0de1fd357fbbddf5ac95117ebcfb5119a9e05ff5c60407d329160f1cb671499",
-                                "uncompressed-sha256": "e1509354368a961babccc40a7b5e1d5064fa270e77c2caa9a83f17b4c20b8c60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "1e7226d97892dd78669fb39b90a71cdc95a261333c63aebff80e7041c9b58aae",
+                                "uncompressed-sha256": "9ba00b68ad998267d9c5e605b689920bedda24202ca21bb22902acdddab04e09"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "1113194d72981c97f3eacf64384afbb1a2235450070cdfbb8c6b3c41458761d5",
-                                "uncompressed-sha256": "8755a9397114ff51007d7a2993b049ec0e12660bf2d1cab8fb838bfc9d84a17c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "15c6b334d7cf165301df35748acd1fa12bede44c8ae8669998ae9c56f6459898",
+                                "uncompressed-sha256": "084fe65124c315ee568b204f9b28b5b2cacb8b5a3ba408670cad69dfb2e86fdf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/s390x/fedora-coreos-41.20250130.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ee93d5285d1134fdb2cfe98d71970b85546a73e29e576cf3ab3ff1c2a5383b0d",
-                                "uncompressed-sha256": "3d745902314ae2abb8588bc54bdeb7e2806ace461c2a871e39c4898bd0932961"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6ffca174ddb73137d25876e90ac7a764f49ad4f2b9a4882fb45834130248eac3",
+                                "uncompressed-sha256": "c18ad3209645fbfdc1cd853119ff9ff586ef6f54514bade226b2f0d812f20b5f"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5d1d4a1d3e51553fd3df81d8e6ed476d787ac8151fe9609378277eda134bcdb3",
-                                "uncompressed-sha256": "9b4298a3d5c9dd06270e6f8049d45c9a61a395501b48537f7ea22bf132327f1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "3b4b6d69fd3c7e80623d88fad7c882c89e040f78668355c86188f36e0f13e999",
+                                "uncompressed-sha256": "978dd58f923de7c2e359f680fa9afa5dc872daa9acc1a147d1656464b3f909db"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "3d2cea2d27d4bcc2a87ef8d239bd1e04f06b98f7a9d01337160f2be6924760be",
-                                "uncompressed-sha256": "3de51c4b71679a6c177f45ca1fca26ae084316dc325afb9c0bb3bb36c135e36b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "6739ffb8abb296e7807e42d6b2cd78c3fb31dada89ad191975e61ce56a4f0769",
+                                "uncompressed-sha256": "48d44fe09ea5cfbcea5fff41bdfc3ec6864a33f377f9aee472ef7b7b367c87a5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "228d22bdb7f948fdf5884b7a305b0acf412af0267fafcc6cca45a3b10c9bd0b7",
-                                "uncompressed-sha256": "d4fe9d7dacd66ff91623b9957ae3b6cdf500079a923c5703649697ee07e3f2f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9dcd156fa3f62f5f6d9de3144f1b541e992ec28e1cf808d9957529dffb6133a4",
+                                "uncompressed-sha256": "fb3a484b94bc3273f1b980a2bc7ad7e1c9726bd7f699e759d19b087042aae3f5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3a96907348bd76da33d382f775a97f4b0fa53052abcd912c831d34af0b3f18ae",
-                                "uncompressed-sha256": "017a3c33e9ac06e8107f3e36e63a1f34592390724f2bbe0bb4f4372428447bf1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f5203720be4eb23bf2b415f1e7d57b78874619c61630efb05f3b64537bceee53",
+                                "uncompressed-sha256": "cbd663a72d7c9fa3e29ec1f5ad82998ee5585b3d5bf726a2191c226aee57b8b9"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "836fe3e6769ba6ee200494ab42988852044d03c68ae194e640c92be2b5f977ab",
-                                "uncompressed-sha256": "e0288c536009888d2118908bd130e527ebf8a7f3d7065e8228fa3abfacaac55f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8341fbea36aab0085b05178750e3cdfa92152fe68c241c311acd5d43ddaf3006",
+                                "uncompressed-sha256": "6952021079a423ad5a46689998f53758f7cb777985a2d1d45d772e61e2f1becd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "db740c470ef78f4ccad983ed59a849bfc8ee0944afdc127bd4b722491cb977c8",
-                                "uncompressed-sha256": "8475678e3620efd853455ce53edc2b8ecc4817aec3a2cf86ab2d328736e8d451"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "dc7b8b7d5939a6cf23368183ff1eb03fdd388991e2036f2104edb5b2cf0f0a71",
+                                "uncompressed-sha256": "1cc583d25fc16df3bf6f55658e08dc255ba1a4a639190dcf2745ef9866271d4f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "0fbf5ee9bd3c1b447d5f246ecd6b218ad7db60fb49404646bcb00e138e6d652a",
-                                "uncompressed-sha256": "6c9472fd16a7b392d07cc10029cf33ec77b113fd91c6946b192ed70f34edf30d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e87f89dbee1c221d28095402f2e284a09bd3c009c2189e4f27854d8bc43d1f66",
+                                "uncompressed-sha256": "84179c5292385999488337ca3d799fd1db1a30322fc71de06aa00ac2a146dea2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2b79b2ed58ba0e0cf9a3e9973315aa592adecafab72cc25a09122c325671106c",
-                                "uncompressed-sha256": "d9136434dc41d40fb95ee7d05baf211f852f9b0873cf139d7fbbe62ea6b78aa7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "440c97d1058a2eac1f21770cb408ba1517e61b21849a0a69daad27217303a9b6",
+                                "uncompressed-sha256": "7386097032c24161258150b66dfd1014fff0c38ff5bb90deaddff87781f9f4e6"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "0a456f3948393378e14f2ff3fd120a07065cec5b9abce6d7e487de04b9564590",
-                                "uncompressed-sha256": "821a7137e8d2c87b3b60c6cc5825a715bcedd8f0b42e4c74c8ffcfc0bf86d8a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "91762cf40039a6ff9134b874bcc78a74f1553246ebf1ca473f412d3f41a222c2",
+                                "uncompressed-sha256": "c7e67ef6273f4ab37834f3fd33d1c18682a8efddbec186dca0c7959b100c060a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5618551bbec7ac96c69ea83a151f82ff284da3ba6225f7ad975ac1b8dda07508",
-                                "uncompressed-sha256": "64a839bdb1c8e98873bdde76bfe7d4bc6ebb07c064e40b09cf38a4a596885835"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4e5cb4ae12f310b9658df7e0eee500f46f2cd72442127b9e5d2bce1e4519bd04",
+                                "uncompressed-sha256": "1495e05c6dbe6bf2e467420747356c7f9f5a5bfe2fa0b88eb23a863b3902d85f"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "f2efd9d9271cc62dda14b17ea64d532a0596682f69c8acb81eaac3dba60282a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a673515c43fadf7796a4b6a7aa1aedd044b83631e9692b8ee6a765f960c8d127"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2d6ad1f5c73aca616419cc10d01a081e4f4320af1519fa39be6aa3bfffd57fe1",
-                                "uncompressed-sha256": "19d0f5a5fd7994321d153dec920a2266fddfba74559922a5ca37ec60e1c04ead"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b42b8ac8f1f981980b339db08430d58b182dadd1f4457211e650457e721fab1f",
+                                "uncompressed-sha256": "8f5a2b6943d03d1c77bb81e493a5190fa4eda4e4e99383b40a88eba3367e4998"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live.x86_64.iso.sig",
-                                "sha256": "e49889053f75902b96e35bb3ff3a5c55ad897cb30861774eabe8244f635a4b39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live.x86_64.iso.sig",
+                                "sha256": "27a55a708c423641128b12d5efa87b3d32b4877bfb107810ca3f6655cace6db8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-kernel-x86_64.sig",
-                                "sha256": "c4d885839268e5943c8ebe731bbfd66e8d888db4a85497473a5bc9e91b0a2128"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-kernel-x86_64.sig",
+                                "sha256": "abe7791d5967aa9bcaf9940fcb2aab047279b7534ed0d81376b1ac3553aedd60"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8fb64821c19bc36ccefa57cf4a83aefc598af24aa61372897155887123cc51af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "5864383028b0ac9469a66f362be1b83a7a51af09fb66eed22d1339f5e40f0fc0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "00eeaa17d350a2e2ab80b5caae04e5797fae55e0a78fd4487dbb8a8b3da2331e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "a3d732d96d505eb5e910d67e6cb940bb005d1cd70441d3965c1c05459c1c253f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "fbbabd0cb8a5fb729498fa5effc25aa173b7ae089e56928780e9bb15f99a1ade",
-                                "uncompressed-sha256": "c377a8d11c011275d0346f1b19ff4aaecc0107a0d562764443e2613f9d863a83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e2a1073f8256a5a85b3ab58a18d729bbfd9c6fffc1b950512ca461c461ca7d29",
+                                "uncompressed-sha256": "0ef223f38d025409bcefc707d34c33933915e1d6afa9239a44863fcae44c1b59"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "68277670bf940629167bd89fa2b435fec84664957aae2b5e71e7b098af58eef7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "8173a737032484c797304f2ff227d8702a8e94a96c7ec58841b796f5bee2e450"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0d4e7f20fd10825d2dc2824ad9e7b8fe85bbd3ae89885625e3584fc72cabec64",
-                                "uncompressed-sha256": "f6ae05016195e7d7cf6c2b01f713512588e011fba5f83a25bbeaaed9bb961de5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "15bfbe8f281842ded05db89aabbefd70f7bef48769d164fe13d0698abaf5355a",
+                                "uncompressed-sha256": "bc942bb471bebadaea35a45af238e14f599f6560ab96755b84bbce1672668d52"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1ce31bad5580870efe7bf6bb311ab0ead4bb0f0e64f2c7d91346391afba8eaf3",
-                                "uncompressed-sha256": "fafa3416591835a3187763a61203ac3c9e31d764f4148c06eec354403c55891d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d2d737702955cfb073e9491ebd0325dccac361b956762a7df0b49dac4337aa18",
+                                "uncompressed-sha256": "9c3322522a84232d04248f2375bace7391932e075613d14ae4a66bf722a5f7e0"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "dd8c66b0906ab35dd53244c3cba930f8a542c10dd04f0aeb5fd9ea6345ce0683"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "16f258753250b173bb71e70f52163725002bf5677363136c310bd6a98425d258"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "3882378f36cf8c3cb5a62f7565680e0f72cae820eac7072cdc39ed883e12ced5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "652721b9739db912d0fc7243ad1f4d91f2dab2f382a10a8a291416aa997fed4b"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250130.1.0/x86_64/fedora-coreos-41.20250130.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "09ba29215b313115965ecbf8f692804087a7cdebff75e328e36ddc43485a8595",
-                                "uncompressed-sha256": "9b336b67e5de691e1285db91bee7ebc652caf35e4ffc21a588640d428826ccab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "2270046b539d51fda94e99732010ae78ff36cc9a65bc3c8ff6aa78e3318643ac",
+                                "uncompressed-sha256": "8891faac3d98b71afda543dff71f8952db7ca97430555f0aa482b2effcd8b733"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-000d6965867a8dd0f"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0c27aaa6034ff5f0a"
                         },
                         "ap-east-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-02565bb6c6ca85412"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-00d49db1465dca84e"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-05ba1baa279acd2ee"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0c6bb664ad868a2e0"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-068e47e647359959b"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-07ccae71c9d615623"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0959b79eb72032fc9"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-03b841d4ec5b127a2"
                         },
                         "ap-south-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-00a6959ed135b96aa"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-03c6ff771c8d6c732"
                         },
                         "ap-south-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-05e47e89cd9a98b0b"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-035e2885686804a54"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-032d6143a0a126f89"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-00d8b8f953f8c599f"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-034e6cdd13c59d52d"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0610973700d89c4cf"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0e44d5937ffe14160"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-09b6fe778ab7cdf87"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-03ac74744137303c0"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0d715670eba746e73"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0e88958077ee0057c"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-02244e23ecc62f9f9"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0d9640811486c003b"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-038514e71d40b52ec"
                         },
                         "ca-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0b4abbc4e198a1319"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-009db68a8a2aa2395"
                         },
                         "ca-west-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-04cad4355bac91994"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-05e91c4c260586b58"
                         },
                         "eu-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-054f0294175c01654"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-02ecf9b3bc5b2497c"
                         },
                         "eu-central-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-076bec48fac31e877"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-07fa0cb1b5c10d16f"
                         },
                         "eu-north-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-048edf6182b2ff1e2"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-05138c01e9b5f48d0"
                         },
                         "eu-south-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-03ef5cb32636bfdcc"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-03c32484048ce3e9d"
                         },
                         "eu-south-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0b1ca9f85ad81795e"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-08e48ef545afef8c5"
                         },
                         "eu-west-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-06403376e69048f51"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-07299f3ff69fb2995"
                         },
                         "eu-west-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-025e431dce11ed4d9"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0729050e135f7e8e5"
                         },
                         "eu-west-3": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0257c714e2d8012dc"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-098f8d86059adc4c5"
                         },
                         "il-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-014b7c4e94f7a5947"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0998879257ac22f3e"
                         },
                         "me-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-062c2facd3c9982b7"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-01f77494177ff9dac"
                         },
                         "me-south-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0e73a05237eab0e8d"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0f9c7521291cb610a"
                         },
                         "mx-central-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0e7bb47d90a71b33e"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-07c14b1e648442c51"
                         },
                         "sa-east-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-02b70f959e5a05d9c"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0b6b80cfb27dc2f2e"
                         },
                         "us-east-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-02245eb0c82f5e644"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-08632e1a8cf44944e"
                         },
                         "us-east-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-013adf83204a33532"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0bca23bf09489249a"
                         },
                         "us-west-1": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0bccc84e36649f072"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0076b15e3b2f7bf8d"
                         },
                         "us-west-2": {
-                            "release": "41.20250130.1.0",
-                            "image": "ami-0294af67595968d0f"
+                            "release": "41.20250215.1.0",
+                            "image": "ami-0370980b183289ceb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20250130-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250215-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250130.1.0",
+                    "release": "41.20250215.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:178d16b5472bda3a90cc4e6dc90a806d81a0b2f35e91937fa5775ea1118506f1"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a082f297df870b863ef3a1d6c8c4916bcbd116b4a3cca6f74f4c28f9ce8ee328"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-02-04T22:27:18Z",
+        "last-modified": "2025-02-18T17:33:22Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "a4f6d6912aecc412b5264fbce78b5c157123955fb88463509151b0ad8166c53d",
-                                "uncompressed-sha256": "da59897262c0b5f0a59425f74a576d3ad01d10b8295f1480c42a469f30864f7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "0afcd499cd7264b17f81ceb2ff4d51d07eaa5a8e76427b42a49b5e6d7c9e3c60",
+                                "uncompressed-sha256": "07cb7fd83446d68cfd96e112b8205b4d83eb746d5a10d94e7fce1973143c1b8b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d52f2795c908e8dcc60ae8900297b858d34ec296cc0590820983c06e88b48322",
-                                "uncompressed-sha256": "8040ecf9bf42295f77282951c72fd518af351d53080f88f01aa1610711d71f5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c8d18137a91fe6414e1fb4bf8709c84dcfc825c5805ff12f99be24cc0c150c7a",
+                                "uncompressed-sha256": "82702a56077d4828c2450d7ca255aac364a89874bb0a21a28d0dbbd5a49f28e0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7226050bf1a1508061b0d1dfc3260a56af4a85e7786f9ee151c3bef385ff3202",
-                                "uncompressed-sha256": "61127871ef5ca0b40072239b1e5b595b4c8b3ce504a88d4ef2aa468acd29f28e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c72424d6a0699a1958105702837e7ea46b3d58a736cc70c70ab9a971060040d0",
+                                "uncompressed-sha256": "4feb3268eca8317d38ca1d4246e3d16e257fb868c41df4efcb0ccec63875896d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "8106dbcc027f6282bf5f22bc5a781a92643f552ff9c912929833b007da706f58",
-                                "uncompressed-sha256": "514465c949a197d657bad6b07ee2be77646d4bdd05e4001bdb3cd68fc0c9dcf4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "6edf9ecd6c86eafd3ad59c175832554f47ac9b836112924f13a0bf7b5bced254",
+                                "uncompressed-sha256": "5125dde7f78af25ec61b915652866ec4687206c9a3d7ba451d5cee8d956ba607"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "b05ecea29d3584cbd7145d803870dfbdf27f3177fe23fd5727c315689c17b882",
-                                "uncompressed-sha256": "7beffc24082dca00d8ae9ed88c5153832e139936ca67282f4bb0ec0ae1fe2a57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "d5eefc86de4a6b540d554baa2cb6bca3f77b461f04ea3e98f55d6a741684b8a4",
+                                "uncompressed-sha256": "9df51a2f87b854ae7a1cd99f3371e3004d2212dc9b882f9664d4a24e2f995bcf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "86523487d3b59598405218497b0a224b3bcd87777275e9c803eb4d9207d4a296",
-                                "uncompressed-sha256": "c560454201afe45999ad0314bfe6d5b55498adbd1ca6c5831692dc68f65477e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "bbf8e03239e1d0375d09ebcc2aff70491a5ddeea4c6b9622d8d38aadfbeee793",
+                                "uncompressed-sha256": "03d35e1c9fee93a23389e90137a189acf7f7c289a358026b4106a5a29ed31e0f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live.aarch64.iso.sig",
-                                "sha256": "70c9285e718c1b35d6db7fb0d5d40af06ad5ddef8e3a34b4649768a4de37dca3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live.aarch64.iso.sig",
+                                "sha256": "7fbf1344b5e1fec853039a8859460810390c12be9cd070f8780b3c017b49b217"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-kernel-aarch64.sig",
-                                "sha256": "b6b69d9b21a4e68e6778c76cbdc77d8b3f4a9b30b0e8581378c885dee605cc20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-kernel-aarch64.sig",
+                                "sha256": "487e48c1483a5dce5e531699acef9740f57570f6d1cdcaa0cf7a9fa492b2fcc7"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "b8e17a9f75b5ba582c96eb1a9db50a031bf890d1eba12b42d44c078879ece4f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "c93ad75aeb9fb4f13f7c4fcae7274c7559ec099121fc0696949c25f35249c822"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "46f83845b42147f9c4ed90bff15a212491989ceb9d662cc17fa220849055c41f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "4b09115ee93e1f5a45429b387e8863a11e22efc7acdfc514b5fe6aa0ec6dfd1d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "cff978e9f892a8b230f83cff927d32e080825dc30dffa320cd9f472468036bfd",
-                                "uncompressed-sha256": "65263c14bb56e26c7fdf6ad50d5199528fef9d5467ffeec3bc15a2c7e8311b5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "42acbd2e54baf7752837a1651461203e2eb341a7231f0fe3d5749fbf06d8100a",
+                                "uncompressed-sha256": "49b03516b7497fb3cbc180f62140343bc4b91d1a7b793bfab7bf130cad7bcef6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d81c5831b1049314dee6273b0743dd1c40ecf2b2c446b726f2049ad142e72b86",
-                                "uncompressed-sha256": "9f8871390a5bbb62b99f8888d3b754c505c12707d8d1b749c6edf04963dc4d47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6f9c62d92645c903e5f7792271937697c6b9b95677f766f78964d04ee1a9b2db",
+                                "uncompressed-sha256": "fd08bd6865e3dbac024081857d798bd20f557962193f81b6b3d5b2eb14e5d248"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/aarch64/fedora-coreos-41.20250117.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a837e3a7154849df5ab36ddc5ef0a99f8f2b3d6e472639cebe9ab6aa7be2192f",
-                                "uncompressed-sha256": "cd315f9ead5d9384b3b844443f1f6095f3b3e000fd956c5966e0324f935bf18b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "806470ddca5ebc79bb2c8d1f1e6b0ee910a87a6545eb165467c43485e001d717",
+                                "uncompressed-sha256": "3307c996df1281b470de8bd3fae3e7eacac25e9d0d327b580a6bd21f163cdbb8"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-04daa34f1ec60b848"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-05efded029c8e771b"
                         },
                         "ap-east-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0ce32849ba180e0f4"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-057e6b750da38efec"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-03d2871f44b132541"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0a5c5a90b49e2bfd2"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0878f1aa2fada0554"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0af03b6bccb3f8de9"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0559fd591dead4c3c"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0f314c85dde5bbb68"
                         },
                         "ap-south-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-037810c6f4454eb98"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-08bb5c4642f3f86ba"
                         },
                         "ap-south-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0e31bfd610bd26539"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0d6b84e2884752ace"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-04d9710f4ca40343e"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0dd6a0ff9b94e6133"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-039f69755dac6d57c"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0342b4012ff8b7af9"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0c07428e1a94c14fa"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-00178de10f81719fa"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-094abd940d12ec5fe"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-09c0dfcff4f96393b"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-038e2c049126bd860"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-05afde9269a5e6833"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0571412b8d61b3269"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0af97b33e0faf9b13"
                         },
                         "ca-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0044be21dda3b87e0"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0e9f1c668ae9e6181"
                         },
                         "ca-west-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0e020ccf877bacf0a"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-020af70063b066c6e"
                         },
                         "eu-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-05169cda2a4491fd9"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0e4ac80f40d195650"
                         },
                         "eu-central-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-031e833667f40f8e8"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-085e46cecc6b2e82c"
                         },
                         "eu-north-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-08319f5c1b9052a2a"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-06f16e3c2c14556cf"
                         },
                         "eu-south-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0ef1146e1be180cac"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0cff2d0b1a2e97805"
                         },
                         "eu-south-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0dcf36f774ea1d754"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-00289f2da7f95635e"
                         },
                         "eu-west-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-06dcc514a5151db1b"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0288e0a60b451ba2e"
                         },
                         "eu-west-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0b38506274dcf7b76"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0378eb49cb4049388"
                         },
                         "eu-west-3": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0305a380109eb4482"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0c695cdbc5c886040"
                         },
                         "il-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0e3ab0f03f7cb9b3c"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0ec80aa01d4464a69"
                         },
                         "me-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-04ae4f0fa11c35292"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-057911f0f7398f2b6"
                         },
                         "me-south-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0d9b8022c55bbda3d"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-03bfa363fd6fc0f50"
                         },
                         "mx-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0812f6044abbf6e99"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0cedf28bdbae3c010"
                         },
                         "sa-east-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0de6f681925d44580"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-01646a1cfb95e15b3"
                         },
                         "us-east-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-063f63080c849ae3b"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0652c86b327db02c6"
                         },
                         "us-east-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-02b27491a4d2d9a5a"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0f75afed78e2f4e85"
                         },
                         "us-west-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-082272b98fae4f02b"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0301e01c828035a56"
                         },
                         "us-west-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-016e378c0c29c1254"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-037b6d6a7b7519e9a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20250117-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250130-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "3728b236dd2a779e98d6629379b0d07dbe16fc7ff7e312c8d1fc4ece67c140c9",
-                                "uncompressed-sha256": "9983176b6efb250039d4edfbf092c873f9ba73bc9b251bdcfcbced837062879a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "27041eb5a4380aa8573e219330a38d8ad563417842757c7076a65ac6e8a67f06",
+                                "uncompressed-sha256": "b352049bd4380d9439d14f502718d73cfcc8435ccd5e207efb55f09087d985be"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live.ppc64le.iso.sig",
-                                "sha256": "eba2682196413b2e1f90a2a2c902e8639a8763e74016e91c10dfa265f854017b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live.ppc64le.iso.sig",
+                                "sha256": "4bdf21575eee618fe8adc9d58c837405a77d16d61c2c222c0d17094af28e69dd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "bedf2b9b1f4d7897a093680bce908bf7fe43e59b76fe2b2d96ee28d74d5ac6c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "686db5ecb4c80c0cac4fb9d22e79cf18a0f694abdc31c65fdfef2f6ba0776391"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "7e6c7ac5903a10c470bd08879cd66bb4c79342d35f9065d6c6394dcdc91f35e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "82e29a5c671efaa9965d8ce01b547175761c4be8c0933bcf822059f404bb4ff7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "ed8dcd6a22d45dc1d70b8d12f3af23154fbc092ce50f825cdcffe2b86483c312"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "5e46030d4513e353026520c27dda51005bb9ee45120bcfe4f17e701e5d408011"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "8ca581db43ea683e2e3f4131e0eff21094f29d8c01eb34937ea6a5fccb6d8149",
-                                "uncompressed-sha256": "b634aec7411eaa5222c2ecc56dffff6bd3629c717e63486c09948183ba5fdca6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "899ffd2cd014c0d1ca4ff7a3434922f49c4c3bb9596f31acb24eca6562981ab4",
+                                "uncompressed-sha256": "3293ed487dff71bcbd86a66352a720c7baf78aa362256982fb1d3bd286dc5789"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "0698aef78b280de69840a5af78393fbbd2ad7c8d30a0d77f13a6614f4f85e73e",
-                                "uncompressed-sha256": "25d0268b5270b6e28a5648767becc19e534c0ed0f91202f378bbcc2688e9e1d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e9f6eaf96a10889ed18c88916be2984c83ead47495045439fb26633f1b37a678",
+                                "uncompressed-sha256": "a2443258f77b104ba3998318c45a5af36e40307547e4a13a9edf5a45072f41ce"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "37eb36317006857057359ad0104db2971f3b9cf118a14467e1b9b55babfef1a3",
-                                "uncompressed-sha256": "15738b01ea61044385060933407835a5c024dbef5fb1094526f437c25eb0138f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c109bcd369cad144e934458c58f973f79a7397d3383d02a50ade750a34bba329",
+                                "uncompressed-sha256": "3ee972e05321d23c7d1dd7fd3de7ee0df98e08263f4e7fe1f7e6dad0cd368725"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/ppc64le/fedora-coreos-41.20250117.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "e32891e5300dd14ec8e8013eaedbb9ac2b2865a9b71727820c1d9c524ecb3c7b",
-                                "uncompressed-sha256": "2776ba1d273f0b5be3076cc7b78ea94762b51e43d26f6924cfac308526466be0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "36da4a883f43a63cb5152bc6e8dd1a5dede65aff5a6254dc9637c934d0c22fe7",
+                                "uncompressed-sha256": "0c66feb79562c97a17f5b973c4c779f864f0e5a9505fca63e2206e71be4e58c8"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "7c163667e6cf1307d4abadd644d6b0f4d00141d5b11543127070a61db154f3e9",
-                                "uncompressed-sha256": "c5a003416ea859055dd3e94cea2faf7bdc71a9f9f0951e95ae758490bab05885"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e41f42265f7cb0f900a55723bd37828b91971b78e40f40dc4de37ad46f14f6bb",
+                                "uncompressed-sha256": "37e19177a2e11ec8cb47dbb4a4be9d260e2979dc1242c6735488d011de9dc217"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f233dc3aa45f6c782b7faaea9ed3e2201d9d2da2339db86737d80d3d24dc92cd",
-                                "uncompressed-sha256": "81fa6bc267f9dc89608f0a7d10ad878af21b09cc7bcb292f18639469e0736d55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "23eba25c5f8d42ac659b2e0383d9c16dd65734bbbf682c470007cfb551f020af",
+                                "uncompressed-sha256": "c0d240f0c6ebddbead11e3337b71cc422ac188ac115f0f1a419360be987d5607"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live.s390x.iso.sig",
-                                "sha256": "ec5f70fa5dd3f56de0bcf6df7e35b0dfb0e614442df9b4c693c1251099edd845"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live.s390x.iso.sig",
+                                "sha256": "a7992ae595b9dddef992b4e3e133d856d5c0869cea4d22d3bf6b280eb25b25a5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-kernel-s390x.sig",
-                                "sha256": "00d59a35fe27244bcf89afbad1844536659c2f26f0f483310a625bb3cd0b04bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-kernel-s390x.sig",
+                                "sha256": "ba1f9d5805906df2acffcb10f407d1acdd3d5c6c4024e13acb3a3df2d0feb3c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b570c85d6008436cb8934fba865fd110e9d4e3ca2b316d0778c6180eaf853e62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "92e4b87a1db8a1dec4aab0826bb315be4fca65c2c8c8cadf92d92a1ed831e412"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "4c756d3c7f706fe7de8ae3f21674a9c95538098d7fc4affa9c9e3111c81dca56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "a52beccf9838b6a92244d20a4eddfe745a7354c67c2f9c540e0bedc109707ebc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "8d87855d1fb6e358fbe61d12f08d58b7d448ba26a8fac0af93bbd652960e901b",
-                                "uncompressed-sha256": "74a0463cec344340492c77020de21d8669959d7351ad8653d43035001ff0e988"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "1e96c2f853c125e25bb789fab436aaa0a811a7a09f170605998f138a33d7c9ce",
+                                "uncompressed-sha256": "6ba0f109ae6c6651cf65a6b120d115944b8a249cf84f8a9a12cc757000508d38"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "59ce9dd8803de0d9b3f03589b4f03dc16b2873f0a4128e46933a06601d1eeb95",
-                                "uncompressed-sha256": "a441d5650a7b30981bee7c0214c8ab1c1150e61103bb76f4d135d1ed069d66a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "61b6c2352ef16b779f8f0815895016e92b725ff8d407452606e4f58cbf3b7a95",
+                                "uncompressed-sha256": "3d5bc88ca1269386b75fc5e5b03cf58a597c20f04c05663335934c1748f4da41"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/s390x/fedora-coreos-41.20250117.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "92ec64b644d6438ae72a34cf104350892e6a1d6511726e39a1f8e8b9778ad75e",
-                                "uncompressed-sha256": "075325d85b67201af8dc35af928524fcefe79bf58352d8ec1977fbcb29edc28c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "7a4e5f02f4d8a64db5de00c35fbd889fd79fc310b38289c1d1d20c2195ae5f17",
+                                "uncompressed-sha256": "aca86539f43430e99cef2e48b30aa9e8cb767540e0c55285e4aee6c550ee9364"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "64c1c8daa7290d8e6a5cd1b57816dfdd2b34932707bad4da868fd71852b5d16f",
-                                "uncompressed-sha256": "a78d71d1fb1f3c049cad88513bfb2331f61cd3ca8bd041713edeacbf893f2505"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4bbd3e7504eefbcbf94e0b5cd2fd92c9964cf29ca894a221a0738f0f7278847b",
+                                "uncompressed-sha256": "871e8f921e39ce23cf52ee3f675dfe8652c10500a6bd8b892d2ff3c5a1cad3ee"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "b0aaca3e632351e6a8ae33599e7b8f45ebf1aab912f040cfaa2d773d841cf069",
-                                "uncompressed-sha256": "5e9e77f7456e1fae8063f52e92756630e98f1e5b146e7e4e94c55d4547ede242"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "caecb4aea567ecf9ad312d7fa0f9769d756938632150725a242338fd0f3265f5",
+                                "uncompressed-sha256": "b0efd3e43ce114853e30f35f90eb5c989852397815d1ba6003ad4103ac5c5028"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1884427f8601672fb4786ef5ae3d88f30f950ff0f98ecfb6fb6acc3a70aa9ed3",
-                                "uncompressed-sha256": "b84ae8d17d5892283702c1cc8be8d41dd7fa42b5d776fdba7bf2f313ee9fbf43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "861044f8a1b2fd5033d5b4f83b32b8e5aceeaa882bbf7b92be2debc6128fa8e4",
+                                "uncompressed-sha256": "475d7bb25d0ad80378886984a16a852649f3cb3a0751868cf8f2638396691413"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1d22686510aad160b77ebc0b6c42bb626b195e06920de48122c874160743a32b",
-                                "uncompressed-sha256": "f40f567902e0b167e5abe4633aacd55c1e8d2fad6e34477c19e20b84933e8789"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ac885d4ee590f5f3ae46229a618354db26c5db490355b3ab1fc579882348ca5e",
+                                "uncompressed-sha256": "ea4fd4c8c8956e85cc281d9c6a7107d315346d663d631bcfb67f44f3af336fca"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "246d490dc64a42d8a0af0799862cc3ad2386a7df068788edc4462de0e759ed06",
-                                "uncompressed-sha256": "d558a67d1f75f17480c7249c16abd079519b5fc733778025a368d8ec60de5d7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "83f5dc9fc39c2a8beb801f18b43d4766bcfc3714c562dd50d43802ea5ccaebe4",
+                                "uncompressed-sha256": "dd19b1c4e150897cc1ef7ad08ce8bb86143427fc556faa4e71c0af73b7862a42"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "09a54fe6f76e0fd446e62887a33d4ea2b1e353999fa2e218868cf9ead9b4c2bc",
-                                "uncompressed-sha256": "c2f787947251851baf973f40ed73429c45bb8db92282c1bd965a64d93aea606a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c429bb5c51f134a575d8240c01cb2dc4ad4ab5fa2448cef0b75a782d31f838a2",
+                                "uncompressed-sha256": "93f6ee82ad289a36e5639e0158144c36d3d20e4bbe8c01a6a66b3d08359a8f0e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "739da27030a5993b5d286ccb9c9aca7e547eb6423a227505f0782c44a633797b",
-                                "uncompressed-sha256": "de77ef431f46f6a71f1aa72a5161431bbfb001191f3d0216360b00a9f9247bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "5077fca4d666927204a60230a97d5cab800deb1cac8bf398ddba6afee6a506e9",
+                                "uncompressed-sha256": "aa61cb50e7549139ac541ee19c589ddd9d592116f6b2fd7168e6dba5357df7d1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "e97a93ec8f9a7fc2949fefe615819138af8d7598e404064c57ebe883c22bdc2c",
-                                "uncompressed-sha256": "ff788d7fdccaf641be6ff2c8ab1c7ac0006659f8e20ed2cda760fc6dac6210f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2928021b89e9a46f521941f3a2b214ed9ca57f24b1410537c6a4d3228164b387",
+                                "uncompressed-sha256": "d6d392376cd9447881b542d28f91e43acf207e78ce8e257a29a432e08545ad78"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "9bc41a42cb7411898d296b4e54a2c5af84fa142e21e3d17ad75a3b6c2995e4ec",
-                                "uncompressed-sha256": "a9c7f794dc61cec4970e949c40d788b24c62fb6a6e2854103d3b6863e1b46944"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "528d3980d3424abf58c817c5423732351d3b8e609f333a39a41dbd8fc890d795",
+                                "uncompressed-sha256": "8a41740503878a095c11710f271802ebe3942d687965d4b9cbbc05ec3a332ab3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0a74ed531bf2a8d7bbfed15a67bdcdded1b9f78f504495a12661af14d3305dbe",
-                                "uncompressed-sha256": "be141907df051f6c4c40c69d123f4866abe36de71f472d6014b835fbf438ebca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7ae53623f101069c20f61f6a22cf09c3a8c34cd4e696e800c5ccfb30850d1c2f",
+                                "uncompressed-sha256": "370b2460690b85e33a2ce024b6252ee692fdf14da5067955b37ef48dfb138660"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "8e48f04d68df4dd08435243bf66f86ab2054fa25680c28d20260c2c744e39cb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "33d976699cffc43fb03e49a83325300ff2dc597bda6c166475f18e5398f377f1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c42e586044ceb372467cbf49c8b092c57b811cabc055c92d35694fae5a7e2115",
-                                "uncompressed-sha256": "db57df0d524c796c8c0736b481c1a07e5d217da65f761856b75e69e24ae4f60a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "e35cef7e63e84293213388ab4d9e019f943de1cef6d6c5a23b8972b3dcb9d926",
+                                "uncompressed-sha256": "a43e375485e52b0643faf5404de77cc643557cdc03e206a3f80d459c652e5e94"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live.x86_64.iso.sig",
-                                "sha256": "8b784e4fd951299b43a006aeecba6acecfe68c875e55dc6778b4982c2c8e2b45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live.x86_64.iso.sig",
+                                "sha256": "f43780c2db3d03959e22c4f44d6facf47e892517c9e931339389672f8b6ce2f9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-kernel-x86_64.sig",
-                                "sha256": "4cc5bd7bdf413e0fdba2dcb986e909f69461e3d54c1714bc698043f66e7b86dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-kernel-x86_64.sig",
+                                "sha256": "c4d885839268e5943c8ebe731bbfd66e8d888db4a85497473a5bc9e91b0a2128"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8b8f28db15e4dd27b7c1b7f3e6c6f7485f0a4e578e77c1456ce8cd095ebb9cef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "a10bb21c8b519013af49dce5d77f9d34a371317d2b4bec3468fa4bc82c43613a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "52d070796ed1448315696228b3e990ff4665092eff8169d9b5bb50f27ddb4a5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "49f90539c60a3d1447854d1b41f967d34ef9b09404bcd50b8271c619026d3dc0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "d179af03c3b4b296bfbe2cc9918243aaedfab22875530332e23cdc0e853e9066",
-                                "uncompressed-sha256": "c67f30295285cbb58c6746400e9cb9ca31c70f1c54a67331e374756e2f3deedb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e6e1420a9c77cd90d0ebfc1813432e026c928917bd6386fd17a8911bf5e05f7b",
+                                "uncompressed-sha256": "2d3cf752d2af618087165332cb568246d6751dfd8b4477bcfa6a8925fd77f7f6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "457389dbd7e35144e2eaed391afa676f8139fe65e3f98b937f110e017293296b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e677bb8298f60290e1f9fa41d87822588c1eb178aaf7e574c61c7ce488c2448d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "399e983e58ccc59f8518a06a75d839075ab4c6d9778f3678691132a25fd98f15",
-                                "uncompressed-sha256": "bad68406bd71c676eaad867df72f685c6bbb741234b3c97b63a8bd327c353aaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "d43666d540867677209d3506dfa44986458fc65e71d1cbf667d23e87df88c5df",
+                                "uncompressed-sha256": "c67920b2ceab01079a550d4774859b4b3d86bc17d949a6ca74a8b0cf074eb52d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "22bd18dd1634f347e4bffc175444d56a1b57d24567dff5097ccb8916b9b12bb2",
-                                "uncompressed-sha256": "1eddda9f86a0536a132a5b984f684fb730e33759af428cb9281c7ba3ce6be6d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "653a5ec2338dad5357d904c163d371562286906746d245e88149767e8dc67573",
+                                "uncompressed-sha256": "5000d726ae55d6e6aaffcf617dc1c6523d2357299e3bb914fd7ab447c26162c2"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a8db85dc03a883f480e2f34833b6637a64f68674dab8cc3f409446b22bae7ab0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "519340207ca89d4d0a38f8b14767abb8368f289248e5460e560cd022bd6ce5bb"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "606882401552a56ac533b2f58f8f5b9e098fbfeebc7adb3a23706ca92058bf22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "c8eac97d4930b52fd1656c349d8572861491d424abc05fe2925b9f3ab30a9919"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250117.3.0/x86_64/fedora-coreos-41.20250117.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d7b7f4acd9a5f7c394ae44e238925c4a44f7198b9d77fbf7a9d3b40edd1981ed",
-                                "uncompressed-sha256": "be37b781b6217ac61246bc66c4d3f787a59a1c1bdccb0b1d9d097b0b7fbd796e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "07d8defc20c83d8dbbc5798e6034d1cd568d73261a328ea9618d5311b329dffb",
+                                "uncompressed-sha256": "494f0a0893a7cd9b61522126807659c949401406404224493729093a0fde3295"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-008a25df042db77ea"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-094cca077ee665160"
                         },
                         "ap-east-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0c6d17cb5909f0ea6"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-05149db1e1c51c456"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-03f5ef8646d6c5633"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0554455d2fab16b1e"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-02d1ec39c65163ded"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0241b733c8f61c4b5"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0fe34e24213c43b2f"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-06f43284b4e0d5ed4"
                         },
                         "ap-south-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-054259f83df585431"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-02063b7ad3b50b5a3"
                         },
                         "ap-south-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-09a11e1264497f299"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0c5d2e4d12b49019e"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-095e3b8e727a66a97"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-03a5929818d62d15d"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-086c3a3ed3515149c"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-03a92cbcdb75aae1c"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-044cba46d34565e24"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0e8ff5c1332205fe4"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-04d05d16b26e54581"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0a8d1528fe363df93"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-05c83fd688e82d02a"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-09c1f20e82787548f"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-09ab4ada49e1eab0c"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-05d09278ad56a4be1"
                         },
                         "ca-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-03772df60637eb1af"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0f37cd4ceb06f944a"
                         },
                         "ca-west-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0b12ea8b4f516d6a3"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-024043a6ad2676d7a"
                         },
                         "eu-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-008d51fa523dad5da"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-024cf48b90a3e1408"
                         },
                         "eu-central-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-070316b80a44d207d"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0472758f37dd15911"
                         },
                         "eu-north-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0ccb00e6d315d3ccf"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-07311afe12593bd3e"
                         },
                         "eu-south-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-09c82b412079ecf12"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0395fa539faf5e2a0"
                         },
                         "eu-south-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-05f8052337c616303"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-099114b6fa5bb1e7d"
                         },
                         "eu-west-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-091f3347e51feb69c"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0716ec73d6cdfda38"
                         },
                         "eu-west-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-046943fff0fe43812"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0ed33d2f02cc4aead"
                         },
                         "eu-west-3": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0df41d1a1ee289547"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-01f1587fc86d4b44c"
                         },
                         "il-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0ac38f24c9dd991c1"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-024b8d651c70589d1"
                         },
                         "me-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0bacc8acc89cda4a4"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-00e97302218c848a2"
                         },
                         "me-south-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-08363a43e4ec62ad3"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0fbf202d2ae031d4d"
                         },
                         "mx-central-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0c33b7e5de79a2a3c"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0804668f0789bac35"
                         },
                         "sa-east-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-04be58cb00376d4ab"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0945263b1826b0244"
                         },
                         "us-east-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-021dff822684a8347"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-0425dfc74117c3e12"
                         },
                         "us-east-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-026534ac716c55c4a"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-02b8953a6995864ce"
                         },
                         "us-west-1": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-0f5893565cc743bb4"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-01e29d0ce6ce8ed13"
                         },
                         "us-west-2": {
-                            "release": "41.20250117.3.0",
-                            "image": "ami-08734d76de917ea0d"
+                            "release": "41.20250130.3.0",
+                            "image": "ami-00a3dcbea2eb702f7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20250117-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250130-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250117.3.0",
+                    "release": "41.20250130.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b63ab7a17e3ff37645b88363aabe7fc24a5ed7a59169e6899d955a712bd1f902"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d147a30a4840498b0cf82cfd2940cf17b275c4c8a69d5b2c07f225b1a2269356"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-02-04T22:27:18Z",
+        "last-modified": "2025-02-18T17:33:23Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "98b4d0e516280ce7d86841f696c7fdbe8ce1223436d42b5d15bd20491b2acfa7",
-                                "uncompressed-sha256": "4250dde337d682be28480af9746b4ca957de0a68d1233c573c2655d601db6d4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "dba7fc68767a2ed2ad255cf95ca7351826a6cfc7faa2aea58b5b6b6b4d3b2051",
+                                "uncompressed-sha256": "b0feda873dc340f17ced71b4fae03120e4e265448d23409f673dba407341357d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "070a45ae106cc5b03debe1f94c359cb1686dd963cf1f28dddabe9c8d6d217e4f",
-                                "uncompressed-sha256": "50b25aa6e267e5dc6a284a6b183e04467bc811ae4e911e617b7a82e4b6419749"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5a7712c67920caee8b1091b1b467b260960be4ef106421c27800b4836a9e6b19",
+                                "uncompressed-sha256": "a19ff2639df3fc7243e3db2ff3b997e22cf805a4f24053ad3f46898fa86061a6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "5cdfb19e25f4e34b2789e86f02bf7b04278fdd4b3100dcf09092dd793a1dd33d",
-                                "uncompressed-sha256": "6d8b17fc4521f123bb78cd03120ea4f87dc4bdaedb755a952b2eb32a43e0d82f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0a99da87c3d7f2b031b7af2f3c67ca723fc728c6e004765f2777a7f8e8da48b4",
+                                "uncompressed-sha256": "93977e293b95ad547b8a5fe099c2a1f699ef3661d7319f0c1b025164e05bc58f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "5179dd69d0285e57970034552ff117a7c0689ecbb8d3f0547f3cec20726fea59",
-                                "uncompressed-sha256": "9dd3ebecacb3251c801fdeff2aea3d47129b768d3bed38120174cef818613af8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "76a9e89882de639271bcd02996b86ddc06e7d5e55e25f4fb6450b3283a255110",
+                                "uncompressed-sha256": "0c38b2163c83dc67aad10a26e3bbb150fba91eefeabd4eca1d10b9fd9bdc01dc"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "ab3be8dfa929789ecafbbc877799ebc2cba7d1338293b646a9c07ca4136dd3d7",
-                                "uncompressed-sha256": "712eccf6b36718c061be6318a87e7525cc41f2881b3ec0cb0e4536c12114a899"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "edbd07933975c759c5041d10a0643d0a2c46a58e376019fccf8e2a890410a8d6",
+                                "uncompressed-sha256": "1fe9d0ad3798ac5b5ca1de3e3b8e912f22683c27c7ec7fb5d4d44f00faedc9cf"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5461128ff62d776b307d9c24b1d8374827c988957717adeeca067af3c709be25",
-                                "uncompressed-sha256": "a0414ab98814466485cb6ebed54055234e280333468356e31e81dc8067a89ca0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e68ffc3d9d2f9b93808ca8e7921e88942762ac5b7ebd6a0c559a05ab24c0bb3d",
+                                "uncompressed-sha256": "2459a694c60f5e5848bc3c66564d51d7e1c839cd75dc911210e06abff827e0a9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live.aarch64.iso.sig",
-                                "sha256": "0a6e34773c9f7c85de980833bb6c5153a19f19644bb96b29bf8bb405fbfef815"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live.aarch64.iso.sig",
+                                "sha256": "1e97d37eb5cd764e92fed11f3e289e2e556b7106a79620d6496ba1de0e67d9cb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-kernel-aarch64.sig",
-                                "sha256": "487e48c1483a5dce5e531699acef9740f57570f6d1cdcaa0cf7a9fa492b2fcc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-kernel-aarch64.sig",
+                                "sha256": "82a27007dc137f3290634d0a90ec081f0225508b078078d4b60543112f6f9251"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "45947226ccb9117b528ccc3a3f988d4b2435b1fa202b77b73f504a0ee8c8a220"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "187e85f98bf3cfd56b74b60409afe0daf0e7607700dcda29988d3c6fd772fd00"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a565c15b85f668b75003117295e15e68bf3a0a145c2fca1785b0fb77312cbd9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "936aac83a690649e9fdf458ed547b42e748f6125ce31d53b7186fcce674ad7d3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "2328ef21210bc22cdb10e32abd1625a23545dcf78c53ff4dfe93e1df90ca1c84",
-                                "uncompressed-sha256": "47fd24173bf610838242700b6f6d22376f1fe4d1779e629b3d81d7d974b2dcd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c40619ee3a0d1f4d80a651b3a316cb13e82ec39b01af0daa7948e2e4345d2b81",
+                                "uncompressed-sha256": "ee867f53fc0ed85b6c2742ae30d2a06e05fb1026bdac864b4d55189f0ecc8681"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "febf966263e645bbdb73d9c703bf2c6fb23f83974f742cf5c57685830c851282",
-                                "uncompressed-sha256": "f7b4cdbee62ed5339d6bd7df10a45bf402a026f1bb7f06c9a0f1f0d3cd138acf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "44379d1ce4512159e68c885ea04071f4ee28d9a3a22ab2414834d523175d7e3a",
+                                "uncompressed-sha256": "e850454f86556cfc969366eed3bed2da3b159f6eebbeca3dd2060f1a87dfd420"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/aarch64/fedora-coreos-41.20250130.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f55a3bfc654a26656e651a31795f5239091aa4fef1ddb2797e2d1de7d4056e1c",
-                                "uncompressed-sha256": "c796ced5ccf61c9784842f0ba1d1b3f8f585ed02d99c19a20e175f6c8e3295cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "14af8c35b71d096228ef3484b304bb7fc803ffd24b4ae180ed97a7dcd6cab283",
+                                "uncompressed-sha256": "06d0ac24781dd190ce48a6d67c81fb0935557b883c1785b56c190878eb134fb2"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-07c08ecd75d54ef2e"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-07c69176c67032a98"
                         },
                         "ap-east-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-06e4a2791965483fe"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0b20b6b1d958f9e85"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0862d67b715d7b3ac"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0dac91284e8917a79"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0db88b2ebb4677121"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0b0131d5ab7d3b7c7"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-050b861fb4a4cbe9a"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-050e1b5a49cdb1d7b"
                         },
                         "ap-south-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0f493a48ddf0985ca"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-005cdb9da9ce373ea"
                         },
                         "ap-south-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0ffc46d0016d65fdf"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-016842a74ee4cc1df"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-08fa9636a4bc6feab"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0a7d4d17bf7d9602c"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-00fa194587065780d"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0d134cc9b95b82a6d"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0e3b7f9e1ec20b645"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-073cc401350891085"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0875bff0e0ab8d7ef"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-03fe64ee3e593750e"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0c8f43361cd385b27"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0cfd37653eae5b159"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-054101fdfd90468b9"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0ac5a7322e10b7766"
                         },
                         "ca-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-06ddebcd02913614b"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0f931fcb666758bf0"
                         },
                         "ca-west-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0eb319810e510a5dc"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-06715a7ad5dc9a7bb"
                         },
                         "eu-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0e7dcc35e5b84a417"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0d4db08a81ff153d2"
                         },
                         "eu-central-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-00e96403dc8d747b9"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0df171784d6131b62"
                         },
                         "eu-north-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-095dd9d350b269421"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-022955a60b03f741e"
                         },
                         "eu-south-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-02b86f70ca1c50042"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0c477e7e6a9297ebf"
                         },
                         "eu-south-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0c7a90dfa925aa04c"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0c130eb1008555d21"
                         },
                         "eu-west-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-083f3029c37492f2a"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0f8d70e2d587c4412"
                         },
                         "eu-west-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-00509bd37037f82c3"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0282aed63d72450f1"
                         },
                         "eu-west-3": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0c9ddf6eec79359ca"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-00e03745e63ef7a77"
                         },
                         "il-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0ac3478f2830b5b13"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0932eba3de7a41ca0"
                         },
                         "me-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-06546da68ad2936a3"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-09316c2af4fedf341"
                         },
                         "me-south-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-011dbc0dc95675a30"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0549d482b146f89f8"
                         },
                         "mx-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-07c517c3a4e73654a"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-06b1615dcb094106c"
                         },
                         "sa-east-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-08c219ea84f6a3e2e"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0353c5d4295595948"
                         },
                         "us-east-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-00f1b579e44ea9f79"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0bcef5a1b8ccad77f"
                         },
                         "us-east-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0d860d93b64dcd50b"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0d7aaea1945a232a9"
                         },
                         "us-west-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0a4b7353c5a1b145a"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0a01444b7a4a76bc5"
                         },
                         "us-west-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-030bda1920f9511c2"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0a41ffacba40a7076"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20250130-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250215-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "cb4646ec500ae329d27d2e72220908c8b7cc53a535b6856f3a69eafecaa7f376",
-                                "uncompressed-sha256": "9630dc36c502cb074706f81fb00fc81dd1194b809eb5765bc234ecb7cec82b98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "b670749dd74e7ba51b9fbad5a209fe58aad91ed522099ee63baf3671678ba87f",
+                                "uncompressed-sha256": "cc8e1d9809fcef225bc5c8ee81a663ee59aa91ef227ff06987712268ede66197"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live.ppc64le.iso.sig",
-                                "sha256": "947b1412eea2574f3544a194b0093bf3b777e5ae5f63f9ccff67f7b8c5471333"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live.ppc64le.iso.sig",
+                                "sha256": "a1ac3393748f3d009d6d53e9116e18ddea791ccccf542fcb8b6b83dd2222b26c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "686db5ecb4c80c0cac4fb9d22e79cf18a0f694abdc31c65fdfef2f6ba0776391"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "bb8e92d5a64191c32abe1a21ce2e4ed6b2423844079747617f3f8c923f219db6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "34d297bbcad0867c854837271f4ae9b5638ec2516e3b81aa3c9cfd3a00a79ca0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "c675b8150a66fa471c03b23449db2f8cefafd37f4119b6f4f37cf4f54064fe2d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b1e8fe9eed532b86150f68176fe334af65b367b005cca88b73904118fd8bee9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "4f8fdcd21a134cb0dea522870fccb51b890e6307dbf4537f481d491762286a27"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "bcd608a8116899d41999ac188ad56a6d4ce4f6319dcca724c9cd9a1dfe9396d7",
-                                "uncompressed-sha256": "678eb63b9f68b9eba90ef72a4b7ac349914e61472f8f213cd241958d62540470"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3ca74c3160f1668e2bfb344995dc0b80a9a90a6b5fd3e584a7c2f3d902e202d0",
+                                "uncompressed-sha256": "cd88421d5e75e39af75f4c11d246885747e33174736eb0d3b4890c5263f34d39"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "be4da98882dc3d2290324e6b6ac6de85226b8819992cc5db651dcaa41d1b45b5",
-                                "uncompressed-sha256": "903009c6b142c406d838d5456dc8498ad1f643e7aeb583f5c37ccf2ef068b8e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e3d1df6c9c00caf8f5ad349a3f7ef3b0cafcf7f884f72eb2c2fe558dc174fc53",
+                                "uncompressed-sha256": "2b9c53dc1c9d22d6c01042387ba681c3f417fdc893107f516be1cb504987c06c"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "81fbb926b96dbf336555bd615d78682c033d297b9a5254bec468aa65b0c3b481",
-                                "uncompressed-sha256": "ace982fe51dbded237f77ced52425718e636fdcfbab42792858b7ef646067a78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c9637a2e1120c5a4fbb7da399c8d1bf8a4874f1dd68b3543c69cef0e2ee80894",
+                                "uncompressed-sha256": "5713b717b14b6def6822da626145f00588e56a9da36772f22087226c057b3013"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/ppc64le/fedora-coreos-41.20250130.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "be956b79f0166cc5d5c717fe313779781882ff2ae22eafcedb0b6f9a9915c817",
-                                "uncompressed-sha256": "f076de5c28a67ab8ebaaf1d79d5de98a5f0a3eba8678a010a1b90846b5b412e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "7e97d3d118406abe36f7b8a2438b97b9e707755e5a8b01d7974d361cb936e032",
+                                "uncompressed-sha256": "b0a3df7caec1cffb6cc31b636d7e00a58122fb586387d8a59a9e3d2867da9c42"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "40d531bbaecd42f38790c95456b1d5e768371cbf09b37bb21a34f7b784610ba4",
-                                "uncompressed-sha256": "3310e7ef23b821014f03721a3a6ac08d90faa18dd52337eddf1059949bdf9ea1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e7f17507dc753d4b84b45c73900abec878212754841116d894ad556bb7a2e5cb",
+                                "uncompressed-sha256": "177f053bdbff331e14e517ca1e20214338cb08c94b85bf40e0f10c41144b96e2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "42c91792e4dc1b853b606a3665fada6601169217a471457fd1309f6903250791",
-                                "uncompressed-sha256": "8d386f78abe0cdaafb46ebc8521ed6c8325fc6fdba6dc70e670cacbcce6e8917"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4007f83fc7f0e2d77900af35c56effd855369389db56be99ffee7ececdd77070",
+                                "uncompressed-sha256": "42210eca27934abc8a4777974f5b46e8c49d2f304c15fbf729be85cb678976d6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live.s390x.iso.sig",
-                                "sha256": "4d5d905fc70071ed2e610b979054e29ca4e7e979b8d00ccdf170251929556421"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live.s390x.iso.sig",
+                                "sha256": "d4063e294eb2913bb1ade5b5bf28fa4d140107ce6ae11823a91c8a481d4d3e71"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-kernel-s390x.sig",
-                                "sha256": "ba1f9d5805906df2acffcb10f407d1acdd3d5c6c4024e13acb3a3df2d0feb3c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-kernel-s390x.sig",
+                                "sha256": "953e18830a6d76e8b3dc56df7008f318c26deba1d0dafe4d8238e5107c12beb4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "f5ce62fff69a4bec1a147261d7300dc78827804804077363742a653cdf5054f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "3825485bd9865794f812bf31f1d7f2bad66e71f646fc1140bb681c2d45e910a8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e0986d913b44a88aff4a778f4e993d5551525ebecdcf0c2be425ceeb7c20008c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "874b5642499eed368b41f55ab2c5736c00061b78837a0e5aa5aa13318627b08a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "44c11153abb8c8161791f5ebfb67e9d3d8a9bbc91e9654d3f74a801cec5f5d37",
-                                "uncompressed-sha256": "0abdc03e7b638e35a165c5245336e10b17fb49a1c6ab255e2916e6dbb55c6533"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "0300e66a0a00517c90e08e21e00d036570b31b73ab956bf2dc7bd92edf4ab971",
+                                "uncompressed-sha256": "a8f2a286465d1ddc06dea509b3455c1d277c2de2590aaaca36e655604d3874d8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c723d7f335b3d34f4deb5e438cc23fdf2be4c9bfa9ebccb3b4563a83675969d5",
-                                "uncompressed-sha256": "c88d19bf5dec73e10b22c1d9fa179a27dc259c1a314acf6e1fb5070560d04a0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "213ae19aa7e4a9b5d30b45ef7a1fcab15891c3b639fbaf59fac1da8fdfe72b21",
+                                "uncompressed-sha256": "07dd6c5dfa1e254e9d968661348a688868ef2ebb5c334852f0a4bd4847fdbc50"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/s390x/fedora-coreos-41.20250130.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3df1b43b3e7765789869e4a90b2e39655880b14ff59b1febf824ccdfb5af6948",
-                                "uncompressed-sha256": "c630ca2a047d48aa99fd3a28b0c8e6156560a213d969723af77060c7d1e07ad0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "615a1aeb4b821a6d90250450d79a4d8b17821941be80b1767fb7912633ce1e0e",
+                                "uncompressed-sha256": "3dbd560a980584569625b0e32f438763cd0eed2dcf541136fae842290bbcbce6"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8b2b903e8ffc0f1f2e21b6137a7c85de94b5d2810c045d75f39607a7e47ef721",
-                                "uncompressed-sha256": "a7380b953d1bddfae507d6fcc45cdca9554b9a3652d6d8a230a242c999d004ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "7261d18d06eeb54fe23ce73462104c1be54fd24e5272fb8f74f7559cdcadf01d",
+                                "uncompressed-sha256": "48b56c1411ac1b04fd9c18d0696d7a49f5cb47ca8f41c150a341db5a14ef8c4f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "22d903d829fea7d8a1a6cc1d97064096bc8a49571c405eba21f5c9a3d5112e49",
-                                "uncompressed-sha256": "07c7365e05a521989313df475da3cf7e6c13ea23587b34877e22fbec78101555"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "85908ae7dc30bd7238f8db517136d4fd6c179e4e616f936eda38474ef8db8541",
+                                "uncompressed-sha256": "39541e8c22efb4a662c666b58f9214a3d2ec1dd9967eca0f10c888c8e2c29058"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "774854ae255932a6d0218444f58d7f0f439f6f39762a7987eaa5eec440562c14",
-                                "uncompressed-sha256": "216cf8892257ada692d36b7427aa7bcb85205e965c25864b16b988159576fa08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1f2a8ebfd278699f89a717669c829b8ed672b9a2f40721a90b90010e9b68eddb",
+                                "uncompressed-sha256": "0c7437e6de6ed097e4bb20f8b2754dfbb17aabcc24a1f5126577fcb803dd1107"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "5f43ce4c833b312ec66ced35891d4bb58ae5d4aa710d609f68c2ade0c3dcf91b",
-                                "uncompressed-sha256": "8e648ade51e8b451533405d20676d907d8a5e95475f64a30723b4aa7a3a9c391"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0ba46a9298a8f523fde9905b0c527f42886c77152d5800f2b7ba77033cc10708",
+                                "uncompressed-sha256": "6eb19258785d9e07a281a3992fd22f95e9976ab57035c9d5d78d8e7fb2ea19b4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "3b11ad467d4b9c82aa356ec0c96f25eca9e6a044f8cdf380e3c2f5d4add2b985",
-                                "uncompressed-sha256": "169da678895487ff1b70cfe95e3966319ce6931ab7645f2530f71bf82358e6bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "2f775ead5567a665bcb5ee679e9d0a346b929b8b39848b106b708f61fd108a2c",
+                                "uncompressed-sha256": "45c960a1efabce804fd10de19c92ca4044fafe26575135428bcedaa655b23563"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "866889115a83efd10e6defbe7658f23910f0c64890fc092aea901aff775e8cb2",
-                                "uncompressed-sha256": "bf9b2a9152f2a3fa9f87c695dd11da7bb4809fa38fcecdcb7b512cfd9f0bfbab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "6190ffa56900434c7a06707482cb4d84634487f352585aad8d857db828026b93",
+                                "uncompressed-sha256": "381a1ff60dabc2dd62d0ebab52d5982059631e1ae7105240f799445147559e3d"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "60eaf9478ad71ea8dc1c4fb4b238919b4a807a331091a567d31e8c5d15fe77a6",
-                                "uncompressed-sha256": "46443a3a66b50c3f7d013c5930879c3d36202df0cfcc74de87f52281472f6312"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e6542f0491378ad3271fbe5fca9e3f9339a265f95d914b74bfa5b37925dd62b0",
+                                "uncompressed-sha256": "bc91e9b305b7088d08a5009c7138922c573c586b8bc9290def97efbfdc37aad7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "03b35af5f621fa5d4c1ef56a435ad2e90fba9064ccdcc4a9f55d31f27acb46ae",
-                                "uncompressed-sha256": "9167046bd9fd57ecdc69d9422e99e10aeffd21ffe98881e44d73e6164a0d693e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ab4222e7cb8145014cc2c3964bf3707d6d6b1c81a77f9e56a98edb3c9cc076c9",
+                                "uncompressed-sha256": "72717c2059aee186e24bbb2be2532abcb89dd27c442ab298c23f15a9947f9141"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "5e04a32574e97f433b93d1b7d92e8af3f0f494c8361b82fb78e7a3dd68d8ace3",
-                                "uncompressed-sha256": "57bbda03e08923eabfbe91a46421df970982df5ebdd278b53aa8b0efe4e5bb1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "b9407b89a19ae0969b3e4378c6c9f6eb19933fa3ab0ae1580b7fd0fd20074bc5",
+                                "uncompressed-sha256": "f90a609f53af0120dd6243839388c011a0736d1ec2895c1f10db2b7a609aa7ba"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9e0e2df3cc031c4565863990440e74e5645b6576838f27b46d540990c5b8ccd3",
-                                "uncompressed-sha256": "47765ac7c6093821ef85c8cfacd2b76e2ff51d9c03215a6f6733fbee71750431"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "de29a047cb371cf6ffc026bbf371bce3bf6a8eba8838c63303cc91feff3498c8",
+                                "uncompressed-sha256": "436ab6658f85839184cb9f5b9b42d3ef29c1e4d8ab36425f23bc5463f8fa4fc0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "30507a149a39484c69d663e4571dee036e4cdc36410cccbd199866db8d871d56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "7b18822b039aec22dcc540ca5d5d963ac2f6aa135d955bef86787eabb43eed5f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "a500a6243d78518288e189bb6b08cbd58e06f46196d097016f715731af4cf22e",
-                                "uncompressed-sha256": "bcaca909acf24a4d936832bc744db71334c6435b0e236ffed053eb97b630d22d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "fce851788c30c08fefd60db1734d26f450f7175f173ec1ad228a1a0ae0fdb216",
+                                "uncompressed-sha256": "14383047b652a2f076b0a02bb0956f7d99b16c302e47379785ed92c8ad9ec71c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live.x86_64.iso.sig",
-                                "sha256": "6bce921200bbb6c9c5a0a01dc420fa3884057f096a5cb390f05a8e8f37617037"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live.x86_64.iso.sig",
+                                "sha256": "f7a689f7a1107b1f3f6bec02f1227a4b2cac89303a15916b45a9147f4486d554"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-kernel-x86_64.sig",
-                                "sha256": "c4d885839268e5943c8ebe731bbfd66e8d888db4a85497473a5bc9e91b0a2128"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-kernel-x86_64.sig",
+                                "sha256": "abe7791d5967aa9bcaf9940fcb2aab047279b7534ed0d81376b1ac3553aedd60"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1cbe62dbdb0f67c27ebd5d2ef9abc9d32deede3b7b8c7317e511e030154a8e6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "377e55c66fa6b4394cb4a707e7a2b38ca4e6111513d13f732f547d0168cef659"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "4e97b1462cb1abd76c76e1d596bbafea75b157e82b8fd81d26396adcd4aa3550"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "4859e3f304abc1ff3ac2b7071f6a71174ae1ec76040a1d4869796aea28e8123f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "44b495f9725174855cb85976718612129d5360317c7be03596af111e87afecc8",
-                                "uncompressed-sha256": "8d116d706024ba9b24e3c5722fbb0429972c2d033d31f0b1b8abf52627b4c707"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "f499efce325b3dc9f5c42a8617870354a526e8bd3e160323cb433bcba58fdd64",
+                                "uncompressed-sha256": "f80ef4f65b93eb72a9447c4af2362ebbf74e680c6f88d17cfa397b5ddb2f4c69"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "bf2698f43eddd77c15408477b695571eec8a51f5074422b440667dae49a7d5c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ae419e19eb577fa2484ca9262ad13679140dfaa00c5b03ba8edad7dbb4f216bc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ae93c28c702629275e71ae7db57c3f501eaae7e7f3a5a8664b894d4d141fd095",
-                                "uncompressed-sha256": "07b39eb21fa817d01c4e7eacc380718ef831f7b7b91862c04ddb1e8a684387fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "38de79e40c5ca3dc044f61c62b9905f69a0b97b9f1d0acd5c137eaabe03aca9b",
+                                "uncompressed-sha256": "164e94fed1ae35089160a5eacb80a76d190ed4be54e77ae2e01a38ca151f9aa3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "dd33a6fce3a2ad47c592d642eabfe58252c7e2d7939641ae67c508c559262e47",
-                                "uncompressed-sha256": "e59dfe3dbbc7bebbadfaa33bd8fd3fa2a836bf20012767140532d3cacbe71c6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3d6b3ae9efdffd6ebe903ab51f0f9ec77e7f8b53aa1ae56611173ee1b6609983",
+                                "uncompressed-sha256": "c224466cae8b55b3765c8c507976d75018d4670090da07d953b19f4fb02f590e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7ec7fc01581ccca51cd747bb2e945287f017d63a8d7864fdafe8db5e92c38a35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "de89763449a845901dfc3bcac4169618d17c2f7b5f96a8ffab8c4aeec407da8c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "a1fe765d9971f9ebaf018341237c8c923d7401d1943d167d0d9bf864557e78c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "b12f5e9f7d008749d86fcc10cb242054e1511f8b40cbfaa84bcb74c496a4712a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250130.2.0/x86_64/fedora-coreos-41.20250130.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7b8893e163f7b9fcdf1bfbd826b25a9b1f629c47f0b59da5fd3649d601591dc5",
-                                "uncompressed-sha256": "90a7a4eef756d42d826757a1212f94331aa707d0bb245c13228f19e497a013c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "345f2d3dd91d1deaced4cccb1155c0a5ef5f0346c0b2f40c227c04768b5133c6",
+                                "uncompressed-sha256": "b0f346e1bd022da8fe8cca5cb7553649fb9686550fdf95bda730313d967cf2ea"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-05a293c15272336ba"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0c13f683f2f8d35a4"
                         },
                         "ap-east-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0ebb5f59a0ce76331"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-00b4c2d8062412c4e"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0da9406a2f7e653dc"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0a92c255e7589e8f2"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0350c56a5927df832"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0190c35d87ecb3a87"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-08f5f928d3e6949db"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0e428a843e3d623f0"
                         },
                         "ap-south-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0bb8e418b281f68f1"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0e898b7412a0c0901"
                         },
                         "ap-south-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-00a6d422eb093e287"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-073392b7bb7169b52"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0c0c36e481fc96502"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-07c507ce50426bc50"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0135fbdc88572a5ef"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-073fe2b8abd2ee8f8"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-07559b3a5aefd9709"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0a402de41414c8a12"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-00f4764e7f88b1195"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0bdf7fa4b29d21977"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-056cf96c5632fee71"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-026d2ffba9561af00"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-016056778ec3637a7"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0cd03e0a3b91abf3e"
                         },
                         "ca-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0102ba89e497506a4"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0611538640e2ebaf3"
                         },
                         "ca-west-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-05067d911e0343a35"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-01dede39527e981b2"
                         },
                         "eu-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0a7a660e153a65225"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0570fa9327a55b3e2"
                         },
                         "eu-central-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0271fe87950e09e33"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-084abc3883a39bd52"
                         },
                         "eu-north-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-034e5925023751d88"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0168a3d913cde82ca"
                         },
                         "eu-south-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-07e27a07d18d29da8"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-087b85fa8433dfbbe"
                         },
                         "eu-south-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-08849611183a5fc8e"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-010b3966e711f06c4"
                         },
                         "eu-west-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0153ab262a9a97e34"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0f313bd602af3e7b6"
                         },
                         "eu-west-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-01ea1c2ebeb7295e2"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0a9f3fd8dad4866a3"
                         },
                         "eu-west-3": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0de0f2a335bf3932b"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0ac94bca619e3b849"
                         },
                         "il-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0bd21f783d482f799"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0e60f9ad79e963478"
                         },
                         "me-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0f9acab4d5df0913b"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0a412a0ad30570e21"
                         },
                         "me-south-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-03a21b130b8a60818"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0dc4e8058ddf49f2a"
                         },
                         "mx-central-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0b9b02e7b67e0110c"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0499d233bc1ab8988"
                         },
                         "sa-east-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-054940aecfe276f43"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-045abc5e20358cec4"
                         },
                         "us-east-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-020e7ac0031fe0417"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-090fc951b91f4455a"
                         },
                         "us-east-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-021809175e1a60fe6"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-01f03d0ace007028a"
                         },
                         "us-west-1": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-0ff0aaf132b7a9a0d"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-0661c32808ef25950"
                         },
                         "us-west-2": {
-                            "release": "41.20250130.2.0",
-                            "image": "ami-078f4b11e0a60902f"
+                            "release": "41.20250215.2.0",
+                            "image": "ami-010fb57d66fa663cc"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20250130-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250215-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250130.2.0",
+                    "release": "41.20250215.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a16129ba83847720e5dd98fbed35fc44c1f391e040afafc9b2d3ca68ab6bf428"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:cf1d62b08534cb023049edd1cb089ca47269ee744cbd3bd58b3e00bd5cb4e8b0"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-02-04T22:27:20Z"
+    "last-modified": "2025-02-18T17:33:24Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20250117.1.0",
+      "version": "41.20250130.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20250130.1.0",
+      "version": "41.20250215.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1738710000,
+          "start_epoch": 1739901600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-02-04T22:27:18Z"
+    "last-modified": "2025-02-18T17:33:23Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "41.20250105.3.0",
+      "version": "41.20250117.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "41.20250117.3.0",
+      "version": "41.20250130.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1738710000,
+          "start_epoch": 1739901600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-02-04T22:27:19Z"
+    "last-modified": "2025-02-18T17:33:23Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20250117.2.0",
+      "version": "41.20250130.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20250130.2.0",
+      "version": "41.20250215.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1738710000,
+          "start_epoch": 1739901600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).