### PR TITLE
release-notes: updates for the last three releases

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,4 +1,12 @@
 releases:
+  41.20250215.1.0:
+    issues:
+      - text: "Support `Intel TDX` instances on GCP"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1814"
+  41.20250130.1.0:
+    issues: []
+  41.20250117.1.0:
+    issues: []
   41.20250105.1.1:
     issues: []
   41.20241215.1.0:

--- a/release-notes/stable.yml
+++ b/release-notes/stable.yml
@@ -1,4 +1,10 @@
 releases:
+  41.20250130.3.0:
+    issues: []
+  41.20250117.3.0:
+    issues: []
+  41.20250105.3.0:
+    issues: []
   41.20241215.3.0:
     issues:
       - text: "change coreos dracut configs file name convention"

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -1,4 +1,12 @@
 releases:
+  41.20250215.2.0:
+    issues:
+      - text: "Support `Intel TDX` instances on GCP"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1814"
+  41.20250130.2.0:
+    issues: []
+  41.20250117.2.0:
+    issues: []
   41.20250105.2.0:
     issues: []
   41.20241215.2.0:


### PR DESCRIPTION
Updates for the following releases:
- 2025-01-21
- 2025-02-04
- 2025-02-18

Not much of note. Recent changes primarily include updates to kola tests and fedora-bootc submodule bumps.