### PR TITLE
Roll out stable 41.20250215.3.0, testing 41.20250302.2.0, next 41.20250302.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,144 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-02-18T17:33:24Z",
+        "last-modified": "2025-03-06T00:58:43Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "f4f06be3fa8e1c9a22c8a815bc3713a4ce334ec2ea0e514aa5a4a9b397a224b8",
-                                "uncompressed-sha256": "4fc0f45e5ea3dd19978d845b40cc5b58bf3e1539afb672e2d75e684533b17376"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "289a15d626583e91003daccb3c927cbd4eee8699539b02ac8bea1c1ff0b592d6",
+                                "uncompressed-sha256": "670b540f06f7c691375012174a690555b699e9c7e0fd1a42c1ffd152876a7eac"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "aea8c23d9de5e34ef87d39405c2fa4f1fa5b82dc2772cefcf310a6fea868cfcb",
-                                "uncompressed-sha256": "19c3d39e16508ff254e480c155ada9b5ce47c77813d0a287c5636a94687d9c68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3027f5a4bc640d4c5aae18e37cf2bf5b62b100f1f04b698a898caa79bd2c491e",
+                                "uncompressed-sha256": "ad9745537935ec80adfdab19dcd8376dfe54f30d152826390e1f70e355928211"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "9cfe0f97832db88acd1570e8c551ade4b288c844ca28e89a65c7b8a35f1444c0",
-                                "uncompressed-sha256": "0c8ed67395def3ea5a6010534452e757e45f51efc5aba4e27a30afc6d3428126"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "daabef684f92e70637766675a68a2f59d12ce8237bbd4f224a488ebb38ba55cd",
+                                "uncompressed-sha256": "33c55e97cceb8b890cc25b78d0bb5830fa70dade224542e5f290a3ed60079ff9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3f7c0eef74617805323f07effb3a52120f68f910a7a8328a10965ce9b2017fba",
-                                "uncompressed-sha256": "7aa24d93f041a3bdefe090b4f72b057f33b6c24015fbb48df5c9544be0631ff5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "cec83bfbb0e5b8548a37e675a837c135cd1133a2823b9b456b92f02257721a2d",
+                                "uncompressed-sha256": "b024b78dd943e7d2a20231f8d780ea8ba0d9db6e5dc71d9043eccabcc474c333"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "109753d145b4fa016c564834a266098bfbc99bbd71a6e4bee1ff872d5cb11a2c",
-                                "uncompressed-sha256": "41a4694b1506745bcbd4187971b71b931369f600730c8b3990d2bfb79d6e707e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "29853ae168d75ca90f47d51e835c983c025e092bd190de6c7e71b82deca68fe6",
+                                "uncompressed-sha256": "d0abb3c5fbbaab9294a025d9cb197a7c3625aceedb5cbe3a703d847c6461d462"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ede95ef7ad33d3387bc6de77a1abf0a65e8eb66113957d565c6f1f344b778f99",
-                                "uncompressed-sha256": "e8eab8ee61bb9749fc29cadde2ceb2c5a2013d6152373619d2a74f79e4850d37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "50ba3db4ffc15670e29a9a602fa3768d37268e7523a497d636292b6e0074f701",
+                                "uncompressed-sha256": "5b3b61be8f2eed815b83b1b8dcc55dde02a1509732add73b386731e98f9974b2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live.aarch64.iso.sig",
-                                "sha256": "9d434af959f92e83039377ddb282ab55d581095a693b00a587e0e11182410450"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live.aarch64.iso.sig",
+                                "sha256": "42f496709cede86cab38b76ab3b2e2473edaa0e17b29824c29c61761f10fea46"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-kernel-aarch64.sig",
-                                "sha256": "82a27007dc137f3290634d0a90ec081f0225508b078078d4b60543112f6f9251"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-kernel-aarch64.sig",
+                                "sha256": "559c4ffc501353644ed6a541708e8015a561efda1f6dda29cca8eaf74f58a460"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8768be95795bb204da5a4b4b10b1bcf86ea2b75ec9acf6493466978df41dbd7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "3c6e87809ca857f3b47b3a3c3c8b25725ca7cddbd0bd74e96fe1649fd316531b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "54d920becc1f8d2bec16643b78f1c6fdd85b94b262c11ae3bf8e1c1c387412e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a4175df0544dcf692290ab5259e5765976555c99a189e99d9153e3b2b4c77338"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "d1594ef67a1ec58e19d6737c29ee1085066c56e4671e22fc04093a93f96e210a",
-                                "uncompressed-sha256": "da0546d589022dff98175051c5e78d40170d0d0cede9e9708004652afa2d7325"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "fdfcb8377b277ca63097b9b41ec201ed2b56b68e1818c348efcd24dda180d97e",
+                                "uncompressed-sha256": "08a5d4fdac98c71e9462317adcba2f60d3f36e414f78d909041faaa416faeaaa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d004187cd7d286271f1d247c8017f960f83776473aadc2fa6b8411c6c928aa02",
-                                "uncompressed-sha256": "f709a4e43e196d21bae80e90946afe07762f913fc451cecc0dec4eb84742b6ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c966c2b643bcbb43ecc47f9c8fab2c73f4bd793555b936d4bd628912e3a42edf",
+                                "uncompressed-sha256": "a3fcfaff550b8c1e9255f90f5d415d1f3b2c8f11ff6f4daccd7b2952aaca3719"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/aarch64/fedora-coreos-41.20250215.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "93745fb5c909b8152118363edeb9146a4fa15d0b2ae5d76af3dbbb7ae0717368",
-                                "uncompressed-sha256": "ea53c2664c2cde229c3c720a0c19115093fde84f20db7832e2e196a52b119a2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a1dfb59e42c5ec943b8ec2e3a4fa77af7fdbed0412777b0d889f5e2d3ca09fe7",
+                                "uncompressed-sha256": "832c6183070dc5436cd605b352b57f73c685f1ec111a304ccf0fd22d5a3d6dfa"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-04aa3a24fcc3ae205"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0c566d43c316ad8d8"
                         },
                         "ap-east-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0527437685a9ed909"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0751847f8a69656bc"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0b4f508c14528b35b"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0dcb9d9af51dcd469"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0fe32d255b488e0d6"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-09a5477f3d456fbba"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-01658071b078a5d8a"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0f1e6dad3becdebb3"
                         },
                         "ap-south-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0f158f725e85be7a9"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0eb99ce3cc4ef9f8c"
                         },
                         "ap-south-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-077a952bd877a0e03"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0992ea88d142c37f9"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0b657ca4b752c5485"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0983fc4e9a81d9aca"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0ec302117dd0bcb5f"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-02f47748f103cd390"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-031895bdfc2c05a12"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-09804ee207f9efb00"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0b8ad693ee745f391"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-02ae1da7777a07522"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0ba5728f6d0a08b32"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-05083d2c6469c8418"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0cb05209abfe86c67"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-04eba4328d63c29b0"
                         },
                         "ca-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0deb45b91b626e9ec"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-06358f73a3bb0d1d9"
                         },
                         "ca-west-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-08e564090d435f1f1"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-009dfb18108c4194f"
                         },
                         "eu-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-06c6b498e3f50d875"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0c1932f533c4cb3b0"
                         },
                         "eu-central-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0e606adc9c3f98589"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-00871dbb511e6db12"
                         },
                         "eu-north-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0ecee81eae6a0b5b0"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-05e136252e098805b"
                         },
                         "eu-south-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0f8adc6eced2c8bb7"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0a5563c999c425b93"
                         },
                         "eu-south-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0efefd7aadcf756ff"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0363e7be78f5537ca"
                         },
                         "eu-west-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0c0d4036d0e9ede6c"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0d55db46c3e55ebce"
                         },
                         "eu-west-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0e478a4a15cd0ad98"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-00968b2827ab475db"
                         },
                         "eu-west-3": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0d4f4a15e44cb0c6d"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0be75bc47fca87425"
                         },
                         "il-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0c3302d2007ff989d"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0852adc3de57df643"
                         },
                         "me-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0b68b9296d7f1f8ff"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0c31a853a98811437"
                         },
                         "me-south-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0f41d18b7c5b97276"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-09e9aa319a3f8539d"
                         },
                         "mx-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0d684da5c98879df1"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-05ed928ab6b10c70b"
                         },
                         "sa-east-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0ef88fc12a9d371ef"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-05de56df432c38c7f"
                         },
                         "us-east-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0bf81dae6c04838dc"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0ec93a477eebdb9be"
                         },
                         "us-east-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0e160647b1c2bbdb3"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0c043fd381abcf6e7"
                         },
                         "us-west-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-05f90cca4c2ebc83c"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0cda577e3a995f51f"
                         },
                         "us-west-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-06483d1a25899ee18"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0b64655e1f68a4ad2"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20250215-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250302-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "3e9b051d66587a5a22dbfc6b330e8733d0f9fe88d7308997ef8dedaa22b7d402",
-                                "uncompressed-sha256": "19545ccdbcfe537f17fa5eecb4fc95c6f365743b2e52d5cd657e93bb1d82872e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6bc314a9f8482ec10496702b02f2c0fb7b25349a93c197324805a9efaebd80ca",
+                                "uncompressed-sha256": "68a0eb7163da4471641829771f4c44c543ce4717c5f261da1a00a4569605b0f8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live.ppc64le.iso.sig",
-                                "sha256": "29c6eee6c211d187c598b7b8324a95247b60f3ccdd0d48eddeb18c8a66a4ff39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live.ppc64le.iso.sig",
+                                "sha256": "9bb4994000fcd2f2453caad8d69893ebb74dd53979544418f5ee4be37406ebf4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "bb8e92d5a64191c32abe1a21ce2e4ed6b2423844079747617f3f8c923f219db6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "f5400f8662573474ca8c1d058016f67f845d9063d262569b7ae6b38951498677"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "cb3cea929b1ed1a88a558342514edd091196218fb84707296d236c2a27cc61b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "8ca29b83a93081d7122cb25e0005a417bc6e5c814a12a69fc0236b722f4a4776"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "54d3fae8c284c7a86d58f12e944948b66802e6816936d66e34b99f3201192ec1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "df1f3764fe946dc81ea18427a92118115a8a2b2c3f1e97b4c5b267ab00488334"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "b8e7368426b7fadb8d5398718dc346d8e0c4a71a64810ea6c51a024541c6eda1",
-                                "uncompressed-sha256": "e13eba2a99d99076ee05e35b62aa7045c9fac1284d48e5b465b63e653eed4004"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3170fdf5182546037d3b154a8bf8d0e8f382aa7166972f73550b1c2a11d6dd55",
+                                "uncompressed-sha256": "a9dd6a9cd70c4dd0e0491d60f8aaba60b5e6ed2a3d4f78f012baf040227dcdc0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "de40173bfc39ae8289d69dd4b6c33b3579c8a71c3ade0caa25389a6374ea6c8f",
-                                "uncompressed-sha256": "10e76de2c4ae6d84c20cd5b387d1dec19dd1580ce6a0b7fb357cce185731209b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "59a0cc59bee1af7fcbbcd5bf6700af03bf8fb82794abba00db951cc259f000ee",
+                                "uncompressed-sha256": "2ae84ab5d4a2d57a873f3b70662acd5a96c95a3ed75c91dc2f3330b1ec5914d3"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "d7b97fc11ad275dff299882a9c5b79dd11bb4cd1dcb126322bc733e09f0814f2",
-                                "uncompressed-sha256": "30caf6901b03a2f14e3de4ea35a82f74a2126e5217e9dbade746079414a2b2a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "9b0246f4a6c6177515587377ef8fe8a87dd08e1469051f7ef6a4584207326968",
+                                "uncompressed-sha256": "2d8716e8cdccba482ee1f64590c2683db8332c81bc769ba523c48fdf75ccea67"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/ppc64le/fedora-coreos-41.20250215.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "05602b47d91f0281693c18b567df77b2795066c4fe60d7817a81d5e04da5fec5",
-                                "uncompressed-sha256": "036196fd8ad693af388e7500cda5da3d931db9faab17b28275029874266fa555"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "758bebee132b0ae0448e96cee41f53991ed682a6e01dd072d571d20cda6ce09d",
+                                "uncompressed-sha256": "e69eb43de366ae7f53c5be9fcf9d61472b2df0506c3985b58a8606494be304f8"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "af19c08f7927f8e3c9a9168bed9253848072151aa6d871ee16c128bc88011d7d",
-                                "uncompressed-sha256": "2b2d261ef8efde292e4a4cf4f30fefd67a6894fa03881497dbdb1324b8c91eeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "fc0706c2cc3174272e5ab7fa0484e7f263265514b1db007bf6240aae53ce2214",
+                                "uncompressed-sha256": "c105c99b0789c5adb1ec2b0a888d9b89f2e87477eb4f6f14f35bd5f7b8197ca6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b7827badb0553386081ce3dea73e46e6a18d591fbda13bb75703900fe6083a6d",
-                                "uncompressed-sha256": "2aad11b1a749e295cfcb188917ad5d37eebe8206ebd753bbecabf5f72540af61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "97acc1237243aaea290356f241d930150239db623879f148510393ad5226f019",
+                                "uncompressed-sha256": "00a274332a6d822fcbd75c95ff784d0cd68b4d35a642a9b375f97e461224ec5a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live.s390x.iso.sig",
-                                "sha256": "5eaefae263c62df29214a81f29367abc04c3fb4daa0f5f23778a1d0996865c86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live.s390x.iso.sig",
+                                "sha256": "748544b761c47968cc47e1a173aac9b5c7b3306cb74b402849d04179a8f4e0a7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-kernel-s390x.sig",
-                                "sha256": "953e18830a6d76e8b3dc56df7008f318c26deba1d0dafe4d8238e5107c12beb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-kernel-s390x.sig",
+                                "sha256": "876c34c02c22d99c19af62913af5d7b1f77fd009831cf985cd8f73e00ac89aaf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "107f38c88bf4f8b203552c6f4d01da35f5f6b591b15569f7e7c4dd0b0b125058"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "21af9eaef030e2f6b539d2d2dc0a13287f1120bfeebb6734fa6545be35ae895c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "b441531357f62ddfdda770ef71b51a95e2233995e6045ee561e3ac4bf9373993"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "4aad01de583e8f52e0decfa7b0a51538d72b8a3805ce0578647bee9fa9ef5be1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "1e7226d97892dd78669fb39b90a71cdc95a261333c63aebff80e7041c9b58aae",
-                                "uncompressed-sha256": "9ba00b68ad998267d9c5e605b689920bedda24202ca21bb22902acdddab04e09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "44eb2036bfea096dd3c4a5871871cf3231c19a349ebd111ee7a45d7c65cad2ac",
+                                "uncompressed-sha256": "91e06d22c7ec236c075f5349c5a081f04cfecfb0b36176d23ac894d71c4aa49c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "15c6b334d7cf165301df35748acd1fa12bede44c8ae8669998ae9c56f6459898",
-                                "uncompressed-sha256": "084fe65124c315ee568b204f9b28b5b2cacb8b5a3ba408670cad69dfb2e86fdf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "85567492808e2d36740e498372139a62b0b2a3ec13983661c1f925e86775bfb7",
+                                "uncompressed-sha256": "ec2892779702d1f7b069b3a646aab8b14b7a9c327c2c2686af933713c9997e8d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/s390x/fedora-coreos-41.20250215.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6ffca174ddb73137d25876e90ac7a764f49ad4f2b9a4882fb45834130248eac3",
-                                "uncompressed-sha256": "c18ad3209645fbfdc1cd853119ff9ff586ef6f54514bade226b2f0d812f20b5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4d707af7e4a1aa34d436a85e050efbabd47b42060fad4b79523211b88c9a6d80",
+                                "uncompressed-sha256": "91d1736b0476675595cc95d578c79f842a5852fba807529e66635033d0ce74c0"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3b4b6d69fd3c7e80623d88fad7c882c89e040f78668355c86188f36e0f13e999",
-                                "uncompressed-sha256": "978dd58f923de7c2e359f680fa9afa5dc872daa9acc1a147d1656464b3f909db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "0298b0d259d054395c1b16adb41a99498b9f1ad1d31270523f25cf69fe5cbeb1",
+                                "uncompressed-sha256": "0ea6890fcd67cddf98f6ed4e8e5e9a4ceb93d138beef5f304179926bfbad3b0d"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "6739ffb8abb296e7807e42d6b2cd78c3fb31dada89ad191975e61ce56a4f0769",
-                                "uncompressed-sha256": "48d44fe09ea5cfbcea5fff41bdfc3ec6864a33f377f9aee472ef7b7b367c87a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "2689b615ae55b267801306737bfd3b6701122abfe0c003d7330994230a8ea1b8",
+                                "uncompressed-sha256": "078aa609b655c7cd8613ef25150960af947ee4eb52fe5ffed6cc95717a6578cc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9dcd156fa3f62f5f6d9de3144f1b541e992ec28e1cf808d9957529dffb6133a4",
-                                "uncompressed-sha256": "fb3a484b94bc3273f1b980a2bc7ad7e1c9726bd7f699e759d19b087042aae3f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2a2a8bbde18134a1266a1538625fdf78892aff57f66c42116300c3eba14f196d",
+                                "uncompressed-sha256": "21c5616fa86902586e135bb2f2c88a830a4ccb01db8a51c55587e3d52e42129a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f5203720be4eb23bf2b415f1e7d57b78874619c61630efb05f3b64537bceee53",
-                                "uncompressed-sha256": "cbd663a72d7c9fa3e29ec1f5ad82998ee5585b3d5bf726a2191c226aee57b8b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "eaa56bd7dec9aa2fe347fef23692ddbcb032f45078efddf7c690878507d9b7c0",
+                                "uncompressed-sha256": "26ac04f54b67ddc2a24e3d22b52d423ab31024a794edf3935e105c8436c7b47e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8341fbea36aab0085b05178750e3cdfa92152fe68c241c311acd5d43ddaf3006",
-                                "uncompressed-sha256": "6952021079a423ad5a46689998f53758f7cb777985a2d1d45d772e61e2f1becd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "71190ab2df24c819b12c8b5f99d2e4a53364c8847bc9607fb59e58916d4517b4",
+                                "uncompressed-sha256": "c1f6e0da65e01d396231f1f0ea11de20a5c85f39f11b497d8468241bc2203e75"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "dc7b8b7d5939a6cf23368183ff1eb03fdd388991e2036f2104edb5b2cf0f0a71",
-                                "uncompressed-sha256": "1cc583d25fc16df3bf6f55658e08dc255ba1a4a639190dcf2745ef9866271d4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "06f69c97066b19cb7d09c0b20e4914cf3b665fb0aea13a676932bf655410829e",
+                                "uncompressed-sha256": "107adc061adf4feb006879b2b79a984881b35daf1fcf8fd463f348c6fd1995d4"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e87f89dbee1c221d28095402f2e284a09bd3c009c2189e4f27854d8bc43d1f66",
-                                "uncompressed-sha256": "84179c5292385999488337ca3d799fd1db1a30322fc71de06aa00ac2a146dea2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4cb8cd271ffb7451dec2bcd77d779bb47e2beb78e66d5f5b0f9a0be0f46716f8",
+                                "uncompressed-sha256": "bc1da439aca7ee802cbb0be60709515f9adaf5681f9b26affe3f0d8dcaaa830a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "440c97d1058a2eac1f21770cb408ba1517e61b21849a0a69daad27217303a9b6",
-                                "uncompressed-sha256": "7386097032c24161258150b66dfd1014fff0c38ff5bb90deaddff87781f9f4e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "037f8faa86ff95b1bbbf84ff8dc37213b918c00edde2bdd6e9c116f34d504958",
+                                "uncompressed-sha256": "970c046d2bc267a5343bec43dcec71e9f70658c8756664dd269b953898bbc76c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "91762cf40039a6ff9134b874bcc78a74f1553246ebf1ca473f412d3f41a222c2",
-                                "uncompressed-sha256": "c7e67ef6273f4ab37834f3fd33d1c18682a8efddbec186dca0c7959b100c060a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "88a68656c36c5078dae474c2fc2606945cfa1f619b6f8cf7f4cf73385c4f1166",
+                                "uncompressed-sha256": "002a0e84c49a43b5c4343b360a6dcceeae777383d323a3794808061cf70299df"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4e5cb4ae12f310b9658df7e0eee500f46f2cd72442127b9e5d2bce1e4519bd04",
-                                "uncompressed-sha256": "1495e05c6dbe6bf2e467420747356c7f9f5a5bfe2fa0b88eb23a863b3902d85f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5d202af152bbba4ab0e5bacb5d2b07dc6b301f653d91201137eccfdb86a0efc5",
+                                "uncompressed-sha256": "863237880bd0f9eeec0723e5be31d8983df19c3e98596412b3db02d09e9206bd"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a673515c43fadf7796a4b6a7aa1aedd044b83631e9692b8ee6a765f960c8d127"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b19e7eebbda792ecd6359afa20aeeb977b139a8dd27eee669ca72c9a14626fd8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b42b8ac8f1f981980b339db08430d58b182dadd1f4457211e650457e721fab1f",
-                                "uncompressed-sha256": "8f5a2b6943d03d1c77bb81e493a5190fa4eda4e4e99383b40a88eba3367e4998"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "5d6664c7d12e6ca774aea407ebca6b5801dc47df0a062f4413bb6de242926efd",
+                                "uncompressed-sha256": "fc19d16381b40c7100a1d65e6c8bb3476fcc665ad271dcb90e8f20143b3498ae"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live.x86_64.iso.sig",
-                                "sha256": "27a55a708c423641128b12d5efa87b3d32b4877bfb107810ca3f6655cace6db8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live.x86_64.iso.sig",
+                                "sha256": "68df0c63a4875d0153be1d30a24f33c4f5b86ace274ea86ee633bf2350066a3b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-kernel-x86_64.sig",
-                                "sha256": "abe7791d5967aa9bcaf9940fcb2aab047279b7534ed0d81376b1ac3553aedd60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-kernel-x86_64.sig",
+                                "sha256": "99d05c2995250da75ecc704627a51b914467aa386c838b9c95d7a1f2a28cba00"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "5864383028b0ac9469a66f362be1b83a7a51af09fb66eed22d1339f5e40f0fc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1a56f960b96804e6b5a606fd273df7930a37cd260f45b10869dda3f8c7a1c9aa"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "a3d732d96d505eb5e910d67e6cb940bb005d1cd70441d3965c1c05459c1c253f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "be3cd24e92694397cb382928a9f03bf9250c6fded48a705866c4556d9445b1f9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e2a1073f8256a5a85b3ab58a18d729bbfd9c6fffc1b950512ca461c461ca7d29",
-                                "uncompressed-sha256": "0ef223f38d025409bcefc707d34c33933915e1d6afa9239a44863fcae44c1b59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "035fddf414335e976407a207398d645c896b7fb6539ec607a7a37f30e84b4168",
+                                "uncompressed-sha256": "dbcedaad70b7c7a61f79ec38af5f771fc8d928a4bd8075cd8e78245cee6e5344"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8173a737032484c797304f2ff227d8702a8e94a96c7ec58841b796f5bee2e450"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "af4a34a587ae230450e7b21e512ce861a941cad49db7b8ccabe247d363eee5b7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "15bfbe8f281842ded05db89aabbefd70f7bef48769d164fe13d0698abaf5355a",
-                                "uncompressed-sha256": "bc942bb471bebadaea35a45af238e14f599f6560ab96755b84bbce1672668d52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "85ab55b712977ccfb2c9f466b13e70a6717a1e29ec50049299f1e80cbeed36a1",
+                                "uncompressed-sha256": "bf640bed5cbe9799c95719232b3fdc8217b69cb1dbcd6d3b7cc9c893b4e8422f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d2d737702955cfb073e9491ebd0325dccac361b956762a7df0b49dac4337aa18",
-                                "uncompressed-sha256": "9c3322522a84232d04248f2375bace7391932e075613d14ae4a66bf722a5f7e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "5b60a418fcb4d6753a09f6e7827ca00b161be9d7da33cb74bec125aebb33ee7f",
+                                "uncompressed-sha256": "6c743fd07e17a5dc393cd691f14d23dca3ed8e7a80bad7ed496ea4089f432014"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "16f258753250b173bb71e70f52163725002bf5677363136c310bd6a98425d258"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "5f375c348b758c0c91a0bd5ef9edbf4aa396dfd1722bb86dff51834a1a381837"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "652721b9739db912d0fc7243ad1f4d91f2dab2f382a10a8a291416aa997fed4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "135350587b7b58d0a571d82aea28b00f84b70d3cae28aa1dbe341a50fdfcf255"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250215.1.0/x86_64/fedora-coreos-41.20250215.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "2270046b539d51fda94e99732010ae78ff36cc9a65bc3c8ff6aa78e3318643ac",
-                                "uncompressed-sha256": "8891faac3d98b71afda543dff71f8952db7ca97430555f0aa482b2effcd8b733"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6314b5c4f1886eff1cc862101ca9eb67f611c36d15f0aa676b227b52715c4f14",
+                                "uncompressed-sha256": "514963150f6cde083b77ea2c7d9b54889946965a12e6e387342648bf45de5d93"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0c27aaa6034ff5f0a"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0bb31df91ecacda4c"
                         },
                         "ap-east-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-00d49db1465dca84e"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-033c77e28a1bb7a71"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0c6bb664ad868a2e0"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-04c0eedc058aa8795"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-07ccae71c9d615623"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0e5eb51f046c8835c"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-03b841d4ec5b127a2"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-090161d1b3c583661"
                         },
                         "ap-south-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-03c6ff771c8d6c732"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-02b4a2aaebf45b483"
                         },
                         "ap-south-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-035e2885686804a54"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-040ab89197df9aa6b"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-00d8b8f953f8c599f"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-059f4d87a3c045d24"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0610973700d89c4cf"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0536976c9d12cddee"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-09b6fe778ab7cdf87"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0fdcde4542b40f5ed"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0d715670eba746e73"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0374d1573a59949be"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-02244e23ecc62f9f9"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-06393f1e2cd48d05e"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-038514e71d40b52ec"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0ee2e164ff8a38e83"
                         },
                         "ca-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-009db68a8a2aa2395"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0d9ed5ead31daf030"
                         },
                         "ca-west-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-05e91c4c260586b58"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0c293bc2f3b559ad0"
                         },
                         "eu-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-02ecf9b3bc5b2497c"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-01ebfc1d0c71eda59"
                         },
                         "eu-central-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-07fa0cb1b5c10d16f"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-05c8d3950895d6bff"
                         },
                         "eu-north-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-05138c01e9b5f48d0"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0fc302370e25f4a9a"
                         },
                         "eu-south-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-03c32484048ce3e9d"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-03b1f09da8c181fa7"
                         },
                         "eu-south-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-08e48ef545afef8c5"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0f0e75a9f29254922"
                         },
                         "eu-west-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-07299f3ff69fb2995"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0268e11f2a0e3cf6d"
                         },
                         "eu-west-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0729050e135f7e8e5"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0ffd1ec2b6fee417d"
                         },
                         "eu-west-3": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-098f8d86059adc4c5"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-090553b06791f73c2"
                         },
                         "il-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0998879257ac22f3e"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-02c93170e619c6e65"
                         },
                         "me-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-01f77494177ff9dac"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0326c4d2b126d6f90"
                         },
                         "me-south-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0f9c7521291cb610a"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0c50d12baa33e469f"
                         },
                         "mx-central-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-07c14b1e648442c51"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-093b207136b7b24e8"
                         },
                         "sa-east-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0b6b80cfb27dc2f2e"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0c10cb03fc9e38067"
                         },
                         "us-east-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-08632e1a8cf44944e"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0f3ee4976c4c776de"
                         },
                         "us-east-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0bca23bf09489249a"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0002a21e5b7100688"
                         },
                         "us-west-1": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0076b15e3b2f7bf8d"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-007e57373fd3135a6"
                         },
                         "us-west-2": {
-                            "release": "41.20250215.1.0",
-                            "image": "ami-0370980b183289ceb"
+                            "release": "41.20250302.1.0",
+                            "image": "ami-0d8cb19162a158d60"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20250215-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250302-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250215.1.0",
+                    "release": "41.20250302.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a082f297df870b863ef3a1d6c8c4916bcbd116b4a3cca6f74f4c28f9ce8ee328"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:21e755eda2505f3be376833689134234e3edd9d23234052a2f2a0ba3f81154bc"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-02-18T17:33:22Z",
+        "last-modified": "2025-03-06T00:58:41Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "0afcd499cd7264b17f81ceb2ff4d51d07eaa5a8e76427b42a49b5e6d7c9e3c60",
-                                "uncompressed-sha256": "07cb7fd83446d68cfd96e112b8205b4d83eb746d5a10d94e7fce1973143c1b8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "7f1ac4c00385013880661bbd72bff3ab7012379c414d3e2b37d6957bcb37d53c",
+                                "uncompressed-sha256": "028949b68982796eddfe0b845ebcaca72c23736c9e047bdfe7f93f466ba27a63"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c8d18137a91fe6414e1fb4bf8709c84dcfc825c5805ff12f99be24cc0c150c7a",
-                                "uncompressed-sha256": "82702a56077d4828c2450d7ca255aac364a89874bb0a21a28d0dbbd5a49f28e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2be07d1fa925a63054e685b3aea3a24460220166818dd18078bed76b32819e66",
+                                "uncompressed-sha256": "17d68aa1881519ae5c8be5b5016594523856962558e711696693b4478e516d10"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "c72424d6a0699a1958105702837e7ea46b3d58a736cc70c70ab9a971060040d0",
-                                "uncompressed-sha256": "4feb3268eca8317d38ca1d4246e3d16e257fb868c41df4efcb0ccec63875896d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "3136279ba9ae1875446f6c0050ce5722ee1f52b5c9dbb96fa102b1c3959b12a9",
+                                "uncompressed-sha256": "1862c02ff0614fdb464f11e59999c44a22dc2c67d8d771ad45e1f4b0e4e4806f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "6edf9ecd6c86eafd3ad59c175832554f47ac9b836112924f13a0bf7b5bced254",
-                                "uncompressed-sha256": "5125dde7f78af25ec61b915652866ec4687206c9a3d7ba451d5cee8d956ba607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "9498dc363a4345ec397c502931865f300364e1a0ae2390778cb48d363d75ba66",
+                                "uncompressed-sha256": "541c64dae2fc240846ed1ab9602b4f6f5d15b87c717d566a61bdba171448ec17"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "d5eefc86de4a6b540d554baa2cb6bca3f77b461f04ea3e98f55d6a741684b8a4",
-                                "uncompressed-sha256": "9df51a2f87b854ae7a1cd99f3371e3004d2212dc9b882f9664d4a24e2f995bcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "27a5653891be642c403e3b4b58962a5bd616a2737ea67b8aec4cd034a96cb5d7",
+                                "uncompressed-sha256": "0932a4588387c44b230c510521ffb1debf7fc5785072cb8705e4baff45bc06c3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "bbf8e03239e1d0375d09ebcc2aff70491a5ddeea4c6b9622d8d38aadfbeee793",
-                                "uncompressed-sha256": "03d35e1c9fee93a23389e90137a189acf7f7c289a358026b4106a5a29ed31e0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "dcf60279658b29a3b24f4383c571110de54f2e3bbbfd80bca25dedffe52a817c",
+                                "uncompressed-sha256": "4d7dec16493f80631a5a18f355bbbe7fd4e12b73de469bc9ccafba28a62de4cf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live.aarch64.iso.sig",
-                                "sha256": "7fbf1344b5e1fec853039a8859460810390c12be9cd070f8780b3c017b49b217"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live.aarch64.iso.sig",
+                                "sha256": "6491e8a52b37a56e903170455d5316cad57b56cd6db12f04cbb3025c2f806b6e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-kernel-aarch64.sig",
-                                "sha256": "487e48c1483a5dce5e531699acef9740f57570f6d1cdcaa0cf7a9fa492b2fcc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-kernel-aarch64.sig",
+                                "sha256": "82a27007dc137f3290634d0a90ec081f0225508b078078d4b60543112f6f9251"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "c93ad75aeb9fb4f13f7c4fcae7274c7559ec099121fc0696949c25f35249c822"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "bc0a0fe109160ff1749ff4b65ff0239a7c1b32c32cca83587dc06eb6099b98e5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "4b09115ee93e1f5a45429b387e8863a11e22efc7acdfc514b5fe6aa0ec6dfd1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "817a87480cad2b2c1c90394dd8fc8c51384b92db0768e24031bc9df29e410f3c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "42acbd2e54baf7752837a1651461203e2eb341a7231f0fe3d5749fbf06d8100a",
-                                "uncompressed-sha256": "49b03516b7497fb3cbc180f62140343bc4b91d1a7b793bfab7bf130cad7bcef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c41fca3789b3c1e7379d343570d5d990f1f8801de8a4dd82def663bf1e4cac48",
+                                "uncompressed-sha256": "2b94eb8c8a1cc8bd3195b59a5bd976354bf17c09fbeb92b0f88016371e848024"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6f9c62d92645c903e5f7792271937697c6b9b95677f766f78964d04ee1a9b2db",
-                                "uncompressed-sha256": "fd08bd6865e3dbac024081857d798bd20f557962193f81b6b3d5b2eb14e5d248"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "bd0f9715b6c5f70190bcf49aa8e465cc6611541ab5e62573c97419bd24a7a22c",
+                                "uncompressed-sha256": "01577882ce9bf2cac1d34bf3211fe519a314e0094b6961cf72370281586a1cb5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/aarch64/fedora-coreos-41.20250130.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "806470ddca5ebc79bb2c8d1f1e6b0ee910a87a6545eb165467c43485e001d717",
-                                "uncompressed-sha256": "3307c996df1281b470de8bd3fae3e7eacac25e9d0d327b580a6bd21f163cdbb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e0e9c16536111e634e8a16c56f0ef19c5109ecb2a48ab85383ec6559b084abf3",
+                                "uncompressed-sha256": "69795229f5b2924a34948cadc1e0b74f82223c6ee6e00d10135341ee6fb51e26"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-05efded029c8e771b"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-03f84ab62b1e6d71f"
                         },
                         "ap-east-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-057e6b750da38efec"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0db4cf0a93ee68674"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0a5c5a90b49e2bfd2"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0a86d1c835ab2a7ad"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0af03b6bccb3f8de9"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-013aa6078d4edf677"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0f314c85dde5bbb68"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-01c94b24ab350ce5a"
                         },
                         "ap-south-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-08bb5c4642f3f86ba"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0ffd361db7e7b4c22"
                         },
                         "ap-south-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0d6b84e2884752ace"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0f9b1e87bc876cace"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0dd6a0ff9b94e6133"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-01acc66935bdc4e61"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0342b4012ff8b7af9"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-015853767eb5a244d"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-00178de10f81719fa"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-00244d04872be3b24"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-09c0dfcff4f96393b"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-098b0dcedc5fbaca0"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-05afde9269a5e6833"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-088659dd53e3f6ca2"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0af97b33e0faf9b13"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-074738d0ac2b8e640"
                         },
                         "ca-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0e9f1c668ae9e6181"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-06fece272a50ed447"
                         },
                         "ca-west-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-020af70063b066c6e"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-04a1000155d9d9719"
                         },
                         "eu-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0e4ac80f40d195650"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0c91601e1fe69c194"
                         },
                         "eu-central-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-085e46cecc6b2e82c"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0c81196e0d0c2cc73"
                         },
                         "eu-north-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-06f16e3c2c14556cf"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0043204e087b45e2d"
                         },
                         "eu-south-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0cff2d0b1a2e97805"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-06039b0441babc97a"
                         },
                         "eu-south-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-00289f2da7f95635e"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-06750f23f316b341e"
                         },
                         "eu-west-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0288e0a60b451ba2e"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0ed18028572da8d96"
                         },
                         "eu-west-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0378eb49cb4049388"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-020e1167622090232"
                         },
                         "eu-west-3": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0c695cdbc5c886040"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0808763f7a5b2d0f9"
                         },
                         "il-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0ec80aa01d4464a69"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0e270ee57f8402628"
                         },
                         "me-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-057911f0f7398f2b6"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-05710fa6e5d25fb5b"
                         },
                         "me-south-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-03bfa363fd6fc0f50"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0b2af4ce6325f51db"
                         },
                         "mx-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0cedf28bdbae3c010"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0c83bb76d196552fd"
                         },
                         "sa-east-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-01646a1cfb95e15b3"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-09184aa884a7f1d2e"
                         },
                         "us-east-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0652c86b327db02c6"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0a802fb1b69c371e0"
                         },
                         "us-east-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0f75afed78e2f4e85"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0ab5b1ae37791ccab"
                         },
                         "us-west-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0301e01c828035a56"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0d15806d134bcbaff"
                         },
                         "us-west-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-037b6d6a7b7519e9a"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0b31c0e195a527062"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20250130-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250215-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "27041eb5a4380aa8573e219330a38d8ad563417842757c7076a65ac6e8a67f06",
-                                "uncompressed-sha256": "b352049bd4380d9439d14f502718d73cfcc8435ccd5e207efb55f09087d985be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "877da5fac28b238188e3671593eceacb66ec9215bbc18d3e2549b6112c44d2b4",
+                                "uncompressed-sha256": "be25feac8e8f4621825c216248357547c75ae05a20469ebef5f178b64fa6d716"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live.ppc64le.iso.sig",
-                                "sha256": "4bdf21575eee618fe8adc9d58c837405a77d16d61c2c222c0d17094af28e69dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live.ppc64le.iso.sig",
+                                "sha256": "d3c7572d6d17514ed744ee973a21b63dd0bc05d2cf52cb1599f4a00ca5417859"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "686db5ecb4c80c0cac4fb9d22e79cf18a0f694abdc31c65fdfef2f6ba0776391"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "bb8e92d5a64191c32abe1a21ce2e4ed6b2423844079747617f3f8c923f219db6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "82e29a5c671efaa9965d8ce01b547175761c4be8c0933bcf822059f404bb4ff7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "5df6865d4bef6b005e74ee95c1c2f782de31dfc1e705c38a3ede717b4f20ad33"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "5e46030d4513e353026520c27dda51005bb9ee45120bcfe4f17e701e5d408011"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "980fc6878d2ac4cbd5f9a595bc7f5ff552c4d3a69a590357181f3c7d23a4f9b4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "899ffd2cd014c0d1ca4ff7a3434922f49c4c3bb9596f31acb24eca6562981ab4",
-                                "uncompressed-sha256": "3293ed487dff71bcbd86a66352a720c7baf78aa362256982fb1d3bd286dc5789"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3d9261cd950d21620f7a403a44f067add466365d8c4d8c1d80db3422f772303c",
+                                "uncompressed-sha256": "0942e45574d05276b28663a6fff78c03f7beedb0601dd8f8fdc443eaba074d80"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e9f6eaf96a10889ed18c88916be2984c83ead47495045439fb26633f1b37a678",
-                                "uncompressed-sha256": "a2443258f77b104ba3998318c45a5af36e40307547e4a13a9edf5a45072f41ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "98cf3fa6d6c86476f6cc46e0baf7cee7d644c5c88da9c8714b02dcc579b6f561",
+                                "uncompressed-sha256": "f978f6990cc1af7c638fbc92507e8ae6db7d96d6ea68dae931fee7a70997890e"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "c109bcd369cad144e934458c58f973f79a7397d3383d02a50ade750a34bba329",
-                                "uncompressed-sha256": "3ee972e05321d23c7d1dd7fd3de7ee0df98e08263f4e7fe1f7e6dad0cd368725"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "6c08e84ab91c1039f4e72dc66aac76d64fdf31f72703fd6c27124791b60b0b4a",
+                                "uncompressed-sha256": "d7dfebcb8a2bcb4c09bbadf25535d95853891d8f9aac57ebbb755b40bbb3d537"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/ppc64le/fedora-coreos-41.20250130.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "36da4a883f43a63cb5152bc6e8dd1a5dede65aff5a6254dc9637c934d0c22fe7",
-                                "uncompressed-sha256": "0c66feb79562c97a17f5b973c4c779f864f0e5a9505fca63e2206e71be4e58c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "bfd06b040db31eb774aa9a17da9f6987014a342f44f69c9628d6f55273b87b6c",
+                                "uncompressed-sha256": "b1e562c8dcdc7a9002744018209d0f2847885bc0e990d80c6708142d3c9397bb"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e41f42265f7cb0f900a55723bd37828b91971b78e40f40dc4de37ad46f14f6bb",
-                                "uncompressed-sha256": "37e19177a2e11ec8cb47dbb4a4be9d260e2979dc1242c6735488d011de9dc217"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "c0cca0f6babe70b199c4dcf4a10b1735392271618f3fe4ff80a9836cd4eedc73",
+                                "uncompressed-sha256": "b8df713b78ba6f1c56f37191032e82e294128e680544e328b7baa4f7f78628fe"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "23eba25c5f8d42ac659b2e0383d9c16dd65734bbbf682c470007cfb551f020af",
-                                "uncompressed-sha256": "c0d240f0c6ebddbead11e3337b71cc422ac188ac115f0f1a419360be987d5607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "acb8ff28f30bebd65ec587302b73e22fbaded6d38a22cc44cb7e812e11a1d494",
+                                "uncompressed-sha256": "8485262ef85cbe50b24ac6edfd313a61df7d649399a2d030965c67f8e9c49838"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live.s390x.iso.sig",
-                                "sha256": "a7992ae595b9dddef992b4e3e133d856d5c0869cea4d22d3bf6b280eb25b25a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live.s390x.iso.sig",
+                                "sha256": "05a683ac36d1375a2fc7fca90c6d6e039346d27b5b03f075fbfcd9f82325890a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-kernel-s390x.sig",
-                                "sha256": "ba1f9d5805906df2acffcb10f407d1acdd3d5c6c4024e13acb3a3df2d0feb3c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-kernel-s390x.sig",
+                                "sha256": "953e18830a6d76e8b3dc56df7008f318c26deba1d0dafe4d8238e5107c12beb4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "92e4b87a1db8a1dec4aab0826bb315be4fca65c2c8c8cadf92d92a1ed831e412"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "383b3dde078ede8a4bb54976580dbc546e91d0a58d7e859f86e516d053e223a4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "a52beccf9838b6a92244d20a4eddfe745a7354c67c2f9c540e0bedc109707ebc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "62097720b012e8bf751b4929f8539f32ef8b03afa1db87de66d05907412efcb6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "1e96c2f853c125e25bb789fab436aaa0a811a7a09f170605998f138a33d7c9ce",
-                                "uncompressed-sha256": "6ba0f109ae6c6651cf65a6b120d115944b8a249cf84f8a9a12cc757000508d38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "870d00fe73adf9f92fd0a2f410762e0ae5cd9035b64d5c0e4257e40ca4daaa8a",
+                                "uncompressed-sha256": "cf2e39c5a884483de226012b5044101173e93ec714416e0cfdeda95df3805082"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "61b6c2352ef16b779f8f0815895016e92b725ff8d407452606e4f58cbf3b7a95",
-                                "uncompressed-sha256": "3d5bc88ca1269386b75fc5e5b03cf58a597c20f04c05663335934c1748f4da41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "fd51387e8bc51ae78043b129323e87bb907957f3ede2ef1a6ba41c4c50b107e0",
+                                "uncompressed-sha256": "4cb45fc7462ded57ccc5738ae3400f76a9595c43503e752029629d4d467d51a5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/s390x/fedora-coreos-41.20250130.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "7a4e5f02f4d8a64db5de00c35fbd889fd79fc310b38289c1d1d20c2195ae5f17",
-                                "uncompressed-sha256": "aca86539f43430e99cef2e48b30aa9e8cb767540e0c55285e4aee6c550ee9364"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6ef5f5533b514b6c2e86918fd11e870e24749fd55eb97721bd5cbc2daf72f486",
+                                "uncompressed-sha256": "b346a91cf59c0e2ca2f2115adbab70f852436655546c1d4c1f8e18ddde2fc468"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4bbd3e7504eefbcbf94e0b5cd2fd92c9964cf29ca894a221a0738f0f7278847b",
-                                "uncompressed-sha256": "871e8f921e39ce23cf52ee3f675dfe8652c10500a6bd8b892d2ff3c5a1cad3ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e0f278b53bd67cdf92fbd3a77d8ddfa4c4331c25e2546b7db8f17d66e97db87f",
+                                "uncompressed-sha256": "46b03a62586dc869767ae3dfdaf88388adbcc05b8479f0b8123fe82fe55d2513"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "caecb4aea567ecf9ad312d7fa0f9769d756938632150725a242338fd0f3265f5",
-                                "uncompressed-sha256": "b0efd3e43ce114853e30f35f90eb5c989852397815d1ba6003ad4103ac5c5028"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "10917f493ed8f3b3c38e1c7d60fbca34651dbc454e357ca7877d642251b66bdf",
+                                "uncompressed-sha256": "93d239aae6c9d3abba739228d78f1ebaf1ae3ea386ecbf01008eb1f70c9e1baf"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "861044f8a1b2fd5033d5b4f83b32b8e5aceeaa882bbf7b92be2debc6128fa8e4",
-                                "uncompressed-sha256": "475d7bb25d0ad80378886984a16a852649f3cb3a0751868cf8f2638396691413"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "fe3399181100e23ba44529c3f52c62a5471dd5064a723871279b344917e93987",
+                                "uncompressed-sha256": "20cb26c8dae90d3991fe10bff65b304c9a2d728be276d2925b1107b94048f1e9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ac885d4ee590f5f3ae46229a618354db26c5db490355b3ab1fc579882348ca5e",
-                                "uncompressed-sha256": "ea4fd4c8c8956e85cc281d9c6a7107d315346d663d631bcfb67f44f3af336fca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "535fa963c93050ffc82271f1fd3a7530b14f37ca20c1ff88ae682d14dd4e1253",
+                                "uncompressed-sha256": "4cec54081094a1c9478d6aa8412086b9d98e58cc5c91d6c142a9dd2901c655c9"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "83f5dc9fc39c2a8beb801f18b43d4766bcfc3714c562dd50d43802ea5ccaebe4",
-                                "uncompressed-sha256": "dd19b1c4e150897cc1ef7ad08ce8bb86143427fc556faa4e71c0af73b7862a42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "07901ba558f11a122fd0cc3f5bb2fce9633786bdbacaf5ec3594a26b652b16fa",
+                                "uncompressed-sha256": "6958aca68d7a4135537f37a232b0765a71b3d287258883a4bac373e84f883952"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c429bb5c51f134a575d8240c01cb2dc4ad4ab5fa2448cef0b75a782d31f838a2",
-                                "uncompressed-sha256": "93f6ee82ad289a36e5639e0158144c36d3d20e4bbe8c01a6a66b3d08359a8f0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a5f05758f8104f3e4aad8e2af74049a558c66a1a09d499b187ee73ffdbe4b538",
+                                "uncompressed-sha256": "dce30a25c2efb5703ee76a4dde7b0ba7bebd857afd9bde2d02c2afe29ab22346"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "5077fca4d666927204a60230a97d5cab800deb1cac8bf398ddba6afee6a506e9",
-                                "uncompressed-sha256": "aa61cb50e7549139ac541ee19c589ddd9d592116f6b2fd7168e6dba5357df7d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "01d844ad2d075fe7181460ff4ef8a1a952131b982b5c21179ff1de1aeafd8115",
+                                "uncompressed-sha256": "50d5a8380b10ead06ba429644d264d57d623a66ebdf4da606c69a0006c27741b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2928021b89e9a46f521941f3a2b214ed9ca57f24b1410537c6a4d3228164b387",
-                                "uncompressed-sha256": "d6d392376cd9447881b542d28f91e43acf207e78ce8e257a29a432e08545ad78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "125594780fdfa285ff480a0434c1f0d30b87a4528555f8ab0520059570386dac",
+                                "uncompressed-sha256": "e71ac67ae3774febb2abe6a20b4afea0440f17383d53770a2b6f195c93c63128"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "528d3980d3424abf58c817c5423732351d3b8e609f333a39a41dbd8fc890d795",
-                                "uncompressed-sha256": "8a41740503878a095c11710f271802ebe3942d687965d4b9cbbc05ec3a332ab3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "1d438f1bb430abc1d0cddf2b5655b917a56a340789669604cbd5a0a869148e1b",
+                                "uncompressed-sha256": "4a26e97bd3394fd18934cc0378b184aa7d5197bb860032d1b3c1953b77f9c1f7"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7ae53623f101069c20f61f6a22cf09c3a8c34cd4e696e800c5ccfb30850d1c2f",
-                                "uncompressed-sha256": "370b2460690b85e33a2ce024b6252ee692fdf14da5067955b37ef48dfb138660"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "aab34a5fba06c32f2f0f383b6274fd7b653b2b29897c9a0dd59bc15525b3ded1",
+                                "uncompressed-sha256": "7fe4d30dbad5f14b031ccd0247f783905912ae70d90d63be03327aeac2e808d9"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "33d976699cffc43fb03e49a83325300ff2dc597bda6c166475f18e5398f377f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "e9706a598a57c3ca18765f4275ca692ff81e19b234edf5944cce1f9dae3f0c9b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e35cef7e63e84293213388ab4d9e019f943de1cef6d6c5a23b8972b3dcb9d926",
-                                "uncompressed-sha256": "a43e375485e52b0643faf5404de77cc643557cdc03e206a3f80d459c652e5e94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "8cfeba9afdf9642615d1764f76e6bb7b1fdd89347b7a533a4395893476640249",
+                                "uncompressed-sha256": "1b02f0c514ac924c9dcb07a798edad2e26cff6a2aa3bba67bb0eb8228aa40004"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live.x86_64.iso.sig",
-                                "sha256": "f43780c2db3d03959e22c4f44d6facf47e892517c9e931339389672f8b6ce2f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live.x86_64.iso.sig",
+                                "sha256": "90ec664ed09f54cd79dba217b7ee0e2387d35193b3027595587d6a65dbf77a12"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-kernel-x86_64.sig",
-                                "sha256": "c4d885839268e5943c8ebe731bbfd66e8d888db4a85497473a5bc9e91b0a2128"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-kernel-x86_64.sig",
+                                "sha256": "abe7791d5967aa9bcaf9940fcb2aab047279b7534ed0d81376b1ac3553aedd60"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a10bb21c8b519013af49dce5d77f9d34a371317d2b4bec3468fa4bc82c43613a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1734e749542b56688f75aeafaa09282b8e9bedab1576fb43766b5170fa2e5517"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "49f90539c60a3d1447854d1b41f967d34ef9b09404bcd50b8271c619026d3dc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "0262cfb66ecbd8bfd540f9d27d7eeb822a85de316ed790722fe3284c04175ec6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "e6e1420a9c77cd90d0ebfc1813432e026c928917bd6386fd17a8911bf5e05f7b",
-                                "uncompressed-sha256": "2d3cf752d2af618087165332cb568246d6751dfd8b4477bcfa6a8925fd77f7f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "7d57a227fa9577fa8019eb48df60f199652890cab2af194e17be5917547b18a6",
+                                "uncompressed-sha256": "7f97b178ea781a46f563602077b480647fcf90e741ed1ada1817042ac8a95387"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e677bb8298f60290e1f9fa41d87822588c1eb178aaf7e574c61c7ce488c2448d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "a735656049ea26925676f3d6bd315270622e4b22559d83c6cb5614c611bc53ce"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "d43666d540867677209d3506dfa44986458fc65e71d1cbf667d23e87df88c5df",
-                                "uncompressed-sha256": "c67920b2ceab01079a550d4774859b4b3d86bc17d949a6ca74a8b0cf074eb52d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "84a7748b782d8da2213bdb492bf89b6cacc5f91deff5e54e67cac22a05bd0d25",
+                                "uncompressed-sha256": "705ab03447ef631aacaa326dfcc48371a1e58ee724a8fb1f3ab9612832917096"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "653a5ec2338dad5357d904c163d371562286906746d245e88149767e8dc67573",
-                                "uncompressed-sha256": "5000d726ae55d6e6aaffcf617dc1c6523d2357299e3bb914fd7ab447c26162c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4396fb568da6046aed2bdfade7f1b51046b1af032a36f460ff50436414f8c129",
+                                "uncompressed-sha256": "9332dd76423b16bb6e425a958e8a3b2fe4ad65833663cdec09b5cabf1557fad8"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "519340207ca89d4d0a38f8b14767abb8368f289248e5460e560cd022bd6ce5bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "1b65e59c93e2cb50c2cc36476f521c0f75e1a7bf77c1ce7043163ba5b4e2ca41"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "c8eac97d4930b52fd1656c349d8572861491d424abc05fe2925b9f3ab30a9919"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "45bfa83d78bb4881c1fd63d0c09a994f336620e6c0e4c02c168b2e1fcd3b9ce2"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250130.3.0/x86_64/fedora-coreos-41.20250130.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "07d8defc20c83d8dbbc5798e6034d1cd568d73261a328ea9618d5311b329dffb",
-                                "uncompressed-sha256": "494f0a0893a7cd9b61522126807659c949401406404224493729093a0fde3295"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6a04dffbd95f14243a84b932043473b6722ee45f038adc4e45cceb58fa6fc680",
+                                "uncompressed-sha256": "6af190be1ffed9eeb9d2318b77d40b900d440ccd870646d14394fb61d6c88e36"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-094cca077ee665160"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-03fbb12a259936441"
                         },
                         "ap-east-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-05149db1e1c51c456"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-002217170fb396880"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0554455d2fab16b1e"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0ce5c23f5ad117d41"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0241b733c8f61c4b5"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0c4349f834cf7ba33"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-06f43284b4e0d5ed4"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-083b6edd7ecc90d3d"
                         },
                         "ap-south-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-02063b7ad3b50b5a3"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-09fd4fa07d680b472"
                         },
                         "ap-south-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0c5d2e4d12b49019e"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0a8d0a93e5186d99c"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-03a5929818d62d15d"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0175e34b808490a72"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-03a92cbcdb75aae1c"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-09cacc19cbab1feb9"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0e8ff5c1332205fe4"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0aa77f9eb86bc13cb"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0a8d1528fe363df93"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0e2186e160c0b468f"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-09c1f20e82787548f"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-00a226ce06e04d527"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-05d09278ad56a4be1"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-092f0e773a5e898ac"
                         },
                         "ca-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0f37cd4ceb06f944a"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-07b5774522db5c44a"
                         },
                         "ca-west-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-024043a6ad2676d7a"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0199bfa30f045301a"
                         },
                         "eu-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-024cf48b90a3e1408"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-04f45602c12ca8a4a"
                         },
                         "eu-central-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0472758f37dd15911"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0db78815b6def2d25"
                         },
                         "eu-north-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-07311afe12593bd3e"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-083fce083a018ca0b"
                         },
                         "eu-south-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0395fa539faf5e2a0"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-03c3fc36ada11430b"
                         },
                         "eu-south-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-099114b6fa5bb1e7d"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0f3ac68c06dc9ee3c"
                         },
                         "eu-west-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0716ec73d6cdfda38"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-02006c0a4cd12f906"
                         },
                         "eu-west-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0ed33d2f02cc4aead"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-096ccedd7ffe1271c"
                         },
                         "eu-west-3": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-01f1587fc86d4b44c"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-014b981ba944e2d47"
                         },
                         "il-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-024b8d651c70589d1"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-076da9f4dc1375456"
                         },
                         "me-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-00e97302218c848a2"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-099623e450a572cba"
                         },
                         "me-south-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0fbf202d2ae031d4d"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-00f995501bed2792b"
                         },
                         "mx-central-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0804668f0789bac35"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0536c8b77ea14db75"
                         },
                         "sa-east-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0945263b1826b0244"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-02839fad396f1d919"
                         },
                         "us-east-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-0425dfc74117c3e12"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-017a40d47f7dfc606"
                         },
                         "us-east-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-02b8953a6995864ce"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-0db71f7d99c3cff80"
                         },
                         "us-west-1": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-01e29d0ce6ce8ed13"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-08b525eb12cfd43cd"
                         },
                         "us-west-2": {
-                            "release": "41.20250130.3.0",
-                            "image": "ami-00a3dcbea2eb702f7"
+                            "release": "41.20250215.3.0",
+                            "image": "ami-03293305775504676"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20250130-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250215-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250130.3.0",
+                    "release": "41.20250215.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d147a30a4840498b0cf82cfd2940cf17b275c4c8a69d5b2c07f225b1a2269356"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4f6e878ec43a377d38a69039a6d39f292733438af5a5a7a925a14c30487c633c"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-02-18T17:33:23Z",
+        "last-modified": "2025-03-06T00:58:42Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "dba7fc68767a2ed2ad255cf95ca7351826a6cfc7faa2aea58b5b6b6b4d3b2051",
-                                "uncompressed-sha256": "b0feda873dc340f17ced71b4fae03120e4e265448d23409f673dba407341357d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "38b66851d491b72e8aa16918ce79a1fbf86785a5d12e294df8962cec8008b37b",
+                                "uncompressed-sha256": "24e3b8ffed89750f50cfc019aeea9bf69a88dc2bf8e357e0247774d3df0053dd"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5a7712c67920caee8b1091b1b467b260960be4ef106421c27800b4836a9e6b19",
-                                "uncompressed-sha256": "a19ff2639df3fc7243e3db2ff3b997e22cf805a4f24053ad3f46898fa86061a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "82b427be3b1cada9785c4a11a1bf048d9b45a0c17474bcdf106190936075f494",
+                                "uncompressed-sha256": "d57ecba5a466b0a76289a12c5ed7adc183f16e97a17db8a3567544b20ed7faf4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "0a99da87c3d7f2b031b7af2f3c67ca723fc728c6e004765f2777a7f8e8da48b4",
-                                "uncompressed-sha256": "93977e293b95ad547b8a5fe099c2a1f699ef3661d7319f0c1b025164e05bc58f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "877b3f6f7849c584046ffe3ace95f9f2d65386eb1e979ca7bd016f1139c6746a",
+                                "uncompressed-sha256": "6bbd05a673e149df5d4b802e3cd2992efa27b9292e7e890ace932b35379611a7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "76a9e89882de639271bcd02996b86ddc06e7d5e55e25f4fb6450b3283a255110",
-                                "uncompressed-sha256": "0c38b2163c83dc67aad10a26e3bbb150fba91eefeabd4eca1d10b9fd9bdc01dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0c30898caf1f1b8340548f4d810ae5ae795b6437cf9c5d042101ca9f5576caeb",
+                                "uncompressed-sha256": "75e5bd20a5d93c75c49a6328b88e3c4f237ad33d7557df6ee32a85fa3390fd90"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "edbd07933975c759c5041d10a0643d0a2c46a58e376019fccf8e2a890410a8d6",
-                                "uncompressed-sha256": "1fe9d0ad3798ac5b5ca1de3e3b8e912f22683c27c7ec7fb5d4d44f00faedc9cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "c69d0dc86dedfb23c935ed6c03f20c99a3864d6d1884dfdefc96a8a9b9b22bc9",
+                                "uncompressed-sha256": "9d6a109cf11c42c7420b7a7afd8ee1b6d10fa78817b16204badfc74abcfac36c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e68ffc3d9d2f9b93808ca8e7921e88942762ac5b7ebd6a0c559a05ab24c0bb3d",
-                                "uncompressed-sha256": "2459a694c60f5e5848bc3c66564d51d7e1c839cd75dc911210e06abff827e0a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "285b4bf5c190fe6b4646dc10cc310774dfef86dc819e6349ed033a409b7251fa",
+                                "uncompressed-sha256": "7d21930128b9997be8b92108d5976887463806c874b8ab79312ad1127a675b05"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live.aarch64.iso.sig",
-                                "sha256": "1e97d37eb5cd764e92fed11f3e289e2e556b7106a79620d6496ba1de0e67d9cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live.aarch64.iso.sig",
+                                "sha256": "54b334b932c1ca0d9abe92ebaa391d76def0d918446a9cfa555302fbc0d3c60f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-kernel-aarch64.sig",
-                                "sha256": "82a27007dc137f3290634d0a90ec081f0225508b078078d4b60543112f6f9251"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-kernel-aarch64.sig",
+                                "sha256": "559c4ffc501353644ed6a541708e8015a561efda1f6dda29cca8eaf74f58a460"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "187e85f98bf3cfd56b74b60409afe0daf0e7607700dcda29988d3c6fd772fd00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "f073f4d89c540f321843db2e9eafe07d76e68909c4f435d879f2be244f36d80e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "936aac83a690649e9fdf458ed547b42e748f6125ce31d53b7186fcce674ad7d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "746804bd521e5dc342f5968df1141244e8dfcc4f6ead6cb60fbc8bb4884446b3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c40619ee3a0d1f4d80a651b3a316cb13e82ec39b01af0daa7948e2e4345d2b81",
-                                "uncompressed-sha256": "ee867f53fc0ed85b6c2742ae30d2a06e05fb1026bdac864b4d55189f0ecc8681"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "6edd7e2e3a0d1192b0d826161a3c2377bfddee8e469fe48e59a39bca34cb241d",
+                                "uncompressed-sha256": "64dfa1843d10c3a143bcb0bd1e92f77eb017c50317a8baa986be70e1ccfd5b80"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "44379d1ce4512159e68c885ea04071f4ee28d9a3a22ab2414834d523175d7e3a",
-                                "uncompressed-sha256": "e850454f86556cfc969366eed3bed2da3b159f6eebbeca3dd2060f1a87dfd420"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "9ec6117a2784daee6feb8c35b8dbf2fd54bb5d140cfc1c42649902125271dfab",
+                                "uncompressed-sha256": "189c311a1c84965c2e8986d0db246c50510bcc8d7cc1e0be95ca05ec70f786ad"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/aarch64/fedora-coreos-41.20250215.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "14af8c35b71d096228ef3484b304bb7fc803ffd24b4ae180ed97a7dcd6cab283",
-                                "uncompressed-sha256": "06d0ac24781dd190ce48a6d67c81fb0935557b883c1785b56c190878eb134fb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "852f1b24ae81626c0f2070ab429f7f2e9e30c369d620cce95af9da393b6f355f",
+                                "uncompressed-sha256": "f5b3601113d3ea99d7d65bca8b5e3d87e1a5539fb2fef12d86380d400355d4d4"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-07c69176c67032a98"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-08a3921cdbda9ea2c"
                         },
                         "ap-east-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0b20b6b1d958f9e85"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0228f7a3df9f66c0b"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0dac91284e8917a79"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0872f57a52e254a10"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0b0131d5ab7d3b7c7"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-082ca9182cc49b942"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-050e1b5a49cdb1d7b"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0ec945fd574b50be9"
                         },
                         "ap-south-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-005cdb9da9ce373ea"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0cb9dc3050b132b18"
                         },
                         "ap-south-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-016842a74ee4cc1df"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0a43ca940523097a3"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0a7d4d17bf7d9602c"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-01b25c38fb5c94ce9"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0d134cc9b95b82a6d"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0c34f915de6e90c8a"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-073cc401350891085"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-02d73551081017adf"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-03fe64ee3e593750e"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-026d97c30a64b618b"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0cfd37653eae5b159"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0b0ab26ae598fa714"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0ac5a7322e10b7766"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0b840b1badce5b629"
                         },
                         "ca-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0f931fcb666758bf0"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-03f0cdd49f724d607"
                         },
                         "ca-west-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-06715a7ad5dc9a7bb"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0c43debb4cdd9ac4e"
                         },
                         "eu-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0d4db08a81ff153d2"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0df9490eb0f436f1f"
                         },
                         "eu-central-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0df171784d6131b62"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-03ec74869c1ca913e"
                         },
                         "eu-north-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-022955a60b03f741e"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0aaade8cb2b291777"
                         },
                         "eu-south-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0c477e7e6a9297ebf"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-00080c952a2a0d548"
                         },
                         "eu-south-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0c130eb1008555d21"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0b6b4487eb9bdb391"
                         },
                         "eu-west-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0f8d70e2d587c4412"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0226db91a1eb001d4"
                         },
                         "eu-west-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0282aed63d72450f1"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-09a12cbaf163bd58e"
                         },
                         "eu-west-3": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-00e03745e63ef7a77"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0c6d9f7b499512fd8"
                         },
                         "il-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0932eba3de7a41ca0"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0c16559609325dc78"
                         },
                         "me-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-09316c2af4fedf341"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-05d1cb1d8eaeaa448"
                         },
                         "me-south-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0549d482b146f89f8"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-02e307a324a1bd05c"
                         },
                         "mx-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-06b1615dcb094106c"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-05ef789fda6e1afaa"
                         },
                         "sa-east-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0353c5d4295595948"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0120414280d3e994a"
                         },
                         "us-east-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0bcef5a1b8ccad77f"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0b245c16ae8c53e93"
                         },
                         "us-east-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0d7aaea1945a232a9"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0f98db1b27785ec64"
                         },
                         "us-west-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0a01444b7a4a76bc5"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-00be5dc1d2b9d40d4"
                         },
                         "us-west-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0a41ffacba40a7076"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0d0aa93ae8ee3c8e5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20250215-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250302-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "b670749dd74e7ba51b9fbad5a209fe58aad91ed522099ee63baf3671678ba87f",
-                                "uncompressed-sha256": "cc8e1d9809fcef225bc5c8ee81a663ee59aa91ef227ff06987712268ede66197"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "0eeeed97d0c6aade8e413d6346c3718566a56bf5386e99fdf3c3a6a77717ac48",
+                                "uncompressed-sha256": "c0c111d6efa994365f569460661fc8edb44bc236e72e88b09150ffbfa040313f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live.ppc64le.iso.sig",
-                                "sha256": "a1ac3393748f3d009d6d53e9116e18ddea791ccccf542fcb8b6b83dd2222b26c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live.ppc64le.iso.sig",
+                                "sha256": "f57d2880af2ab925e344c81a553c85ecf3d9b2ebcd0e106db426ffa3bc6a02da"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "bb8e92d5a64191c32abe1a21ce2e4ed6b2423844079747617f3f8c923f219db6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "f5400f8662573474ca8c1d058016f67f845d9063d262569b7ae6b38951498677"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "c675b8150a66fa471c03b23449db2f8cefafd37f4119b6f4f37cf4f54064fe2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "22c0da9baaf0a60ca4231133396c141783e46878e0bd550fdac77fe4da7cf9ad"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "4f8fdcd21a134cb0dea522870fccb51b890e6307dbf4537f481d491762286a27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "c2fc52311a9e1164be2dd3ea795090b27f67f8b3b4cb8d62fc3f550c56ec8a25"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "3ca74c3160f1668e2bfb344995dc0b80a9a90a6b5fd3e584a7c2f3d902e202d0",
-                                "uncompressed-sha256": "cd88421d5e75e39af75f4c11d246885747e33174736eb0d3b4890c5263f34d39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "b0f5707d6bda765eab78feb9eecc76e88335a2eec8306c5f7be82d172059a70c",
+                                "uncompressed-sha256": "52b4be51d53167fe54a2af08e828bade044c30b0d8f432a41a3bc5ce0eeddb5d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e3d1df6c9c00caf8f5ad349a3f7ef3b0cafcf7f884f72eb2c2fe558dc174fc53",
-                                "uncompressed-sha256": "2b9c53dc1c9d22d6c01042387ba681c3f417fdc893107f516be1cb504987c06c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "51e8321a3e1742f17d1242534830f6726da625c26ddf6a11cb8e8557c2a59651",
+                                "uncompressed-sha256": "fdd3afdf801cd9e41c732edae6e633053ca518c8f5f493b2f1c022cbdd091e5f"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "c9637a2e1120c5a4fbb7da399c8d1bf8a4874f1dd68b3543c69cef0e2ee80894",
-                                "uncompressed-sha256": "5713b717b14b6def6822da626145f00588e56a9da36772f22087226c057b3013"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "37283c699bfea6dc0d11fff01f078d1344b22800998adbd16d01c6269718f8d4",
+                                "uncompressed-sha256": "0a38337803a0e7638d31e0d082d2eec7f828d6f36dc7fe7ce91278ee27709fbb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/ppc64le/fedora-coreos-41.20250215.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "7e97d3d118406abe36f7b8a2438b97b9e707755e5a8b01d7974d361cb936e032",
-                                "uncompressed-sha256": "b0a3df7caec1cffb6cc31b636d7e00a58122fb586387d8a59a9e3d2867da9c42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "3bf6cee34b658ab580df76a087f259d6ce6f04746964f09f54e7de4032e82208",
+                                "uncompressed-sha256": "7ebf09f8114c7b5e8a75e025409244d0a2af16952f1c2c4a46751d05d7995a20"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e7f17507dc753d4b84b45c73900abec878212754841116d894ad556bb7a2e5cb",
-                                "uncompressed-sha256": "177f053bdbff331e14e517ca1e20214338cb08c94b85bf40e0f10c41144b96e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "887ae443e3374761444f1d9490c3b9f40002fc83b3d71a4480d3aad2806e9505",
+                                "uncompressed-sha256": "426f0ce72b805934d0d57e691df3305f1944bd6a399384c451fead89be15706a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4007f83fc7f0e2d77900af35c56effd855369389db56be99ffee7ececdd77070",
-                                "uncompressed-sha256": "42210eca27934abc8a4777974f5b46e8c49d2f304c15fbf729be85cb678976d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "23f5db712529ab02ad97ec9281804ae66c82e2846c281f61d02140273f335bca",
+                                "uncompressed-sha256": "abde76dfddde0963438f2b4508b2bc29bc4bb589bc91f3a5c3ad01726a5e51e2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live.s390x.iso.sig",
-                                "sha256": "d4063e294eb2913bb1ade5b5bf28fa4d140107ce6ae11823a91c8a481d4d3e71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live.s390x.iso.sig",
+                                "sha256": "6992f734d9fa8e8189d1a5f873d6f555e584f07424931219c8810bb91220217b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-kernel-s390x.sig",
-                                "sha256": "953e18830a6d76e8b3dc56df7008f318c26deba1d0dafe4d8238e5107c12beb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-kernel-s390x.sig",
+                                "sha256": "876c34c02c22d99c19af62913af5d7b1f77fd009831cf985cd8f73e00ac89aaf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "3825485bd9865794f812bf31f1d7f2bad66e71f646fc1140bb681c2d45e910a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "3a2b7c7097e8abf6c93035ee3a701b6935ccb795e00f38861334c68adbba4f51"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "874b5642499eed368b41f55ab2c5736c00061b78837a0e5aa5aa13318627b08a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "091f2330e9937bc35ec18b28c452f1b90959b4dc761d98465fcda3ff56ce225b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "0300e66a0a00517c90e08e21e00d036570b31b73ab956bf2dc7bd92edf4ab971",
-                                "uncompressed-sha256": "a8f2a286465d1ddc06dea509b3455c1d277c2de2590aaaca36e655604d3874d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "2ab850ea5a548b0c01d14824ce3fbaffa3a0b3439143ec776804b85076b36492",
+                                "uncompressed-sha256": "ed74c31a7f64b86fc042edf97f01a3cc1cee2c4f5bf5d259fa221ccbcc551dbf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "213ae19aa7e4a9b5d30b45ef7a1fcab15891c3b639fbaf59fac1da8fdfe72b21",
-                                "uncompressed-sha256": "07dd6c5dfa1e254e9d968661348a688868ef2ebb5c334852f0a4bd4847fdbc50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "623b2a141526cd1fa975cd91b3eeeec4a8cd3337e0d73aa91e368c2583ec76b5",
+                                "uncompressed-sha256": "e22cfe03ebb34c69af3364115e170058858176f55bef4ca752f423a058c6a57d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/s390x/fedora-coreos-41.20250215.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "615a1aeb4b821a6d90250450d79a4d8b17821941be80b1767fb7912633ce1e0e",
-                                "uncompressed-sha256": "3dbd560a980584569625b0e32f438763cd0eed2dcf541136fae842290bbcbce6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "d794a00c5e02e2dbe940864ded91561f41210e5baac042fedfb45f81f3032309",
+                                "uncompressed-sha256": "d4dd31723bb2b455bd9edd29d333ab3b07e4239aa30680dcdea8ccb069bdfedf"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7261d18d06eeb54fe23ce73462104c1be54fd24e5272fb8f74f7559cdcadf01d",
-                                "uncompressed-sha256": "48b56c1411ac1b04fd9c18d0696d7a49f5cb47ca8f41c150a341db5a14ef8c4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9daddf686adcc4bc3aa4563f3090877038232c0fce29e39c4da03af51e082e0e",
+                                "uncompressed-sha256": "e0656f511df63fe9e04ca950d4ddd34d09730ff11ad29432ef2d7874910effc4"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "85908ae7dc30bd7238f8db517136d4fd6c179e4e616f936eda38474ef8db8541",
-                                "uncompressed-sha256": "39541e8c22efb4a662c666b58f9214a3d2ec1dd9967eca0f10c888c8e2c29058"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "697bbf5e30486fb570f6612a523055bdfc936ae7dc68d26d6f6abb2797e02cc8",
+                                "uncompressed-sha256": "3d6b8f2f31ec21e63c23ce5faf95ba9d50f30ec63d5fb8ede5119d649a82dbeb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1f2a8ebfd278699f89a717669c829b8ed672b9a2f40721a90b90010e9b68eddb",
-                                "uncompressed-sha256": "0c7437e6de6ed097e4bb20f8b2754dfbb17aabcc24a1f5126577fcb803dd1107"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "25a04b10989efd29e050822f06a9f663b0801224c19db0d18edffae5dce3a908",
+                                "uncompressed-sha256": "d17c20651bde2b492cd98652d35894f52fe3ac880a092b03d7f6b88723c2198e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0ba46a9298a8f523fde9905b0c527f42886c77152d5800f2b7ba77033cc10708",
-                                "uncompressed-sha256": "6eb19258785d9e07a281a3992fd22f95e9976ab57035c9d5d78d8e7fb2ea19b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e006938268835f8f44da90acb66b67f5d2e92a8402916458bbcf6c9151646a8f",
+                                "uncompressed-sha256": "3ef3ebd2bc56b189c8368d0ffa6551953a1d6c66aee22f03800d64d88fdb17f6"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "2f775ead5567a665bcb5ee679e9d0a346b929b8b39848b106b708f61fd108a2c",
-                                "uncompressed-sha256": "45c960a1efabce804fd10de19c92ca4044fafe26575135428bcedaa655b23563"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8d361d25e4933828aaf4c6cc55d90f1206a3f2398d0b1f2e756a78258ed60173",
+                                "uncompressed-sha256": "b4450d0bc75b2ce113c73d5511ffaf6c16089bcac8d7dbc05deb0afcf593ce0c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "6190ffa56900434c7a06707482cb4d84634487f352585aad8d857db828026b93",
-                                "uncompressed-sha256": "381a1ff60dabc2dd62d0ebab52d5982059631e1ae7105240f799445147559e3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d542c00bd1f6555b3e39548cf253e85a31db7dfe34649f924bdd6b42f5896263",
+                                "uncompressed-sha256": "cad2196b8e3397bac1ec259dcd6fd13edb98f55d340f8213aee82ad6785fb702"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e6542f0491378ad3271fbe5fca9e3f9339a265f95d914b74bfa5b37925dd62b0",
-                                "uncompressed-sha256": "bc91e9b305b7088d08a5009c7138922c573c586b8bc9290def97efbfdc37aad7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "926ce1148816c032a505450bb473b377c73ee3b99ff29f0b5f0fe570fd194576",
+                                "uncompressed-sha256": "a16cc3c23d9225197ccc246c28dfe375ce73b7bad71ec339ba9b8e32d0a53bce"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ab4222e7cb8145014cc2c3964bf3707d6d6b1c81a77f9e56a98edb3c9cc076c9",
-                                "uncompressed-sha256": "72717c2059aee186e24bbb2be2532abcb89dd27c442ab298c23f15a9947f9141"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "324dd98b0ac8b5b1b06e13d311eec623744c3a1bbdc82db891b6e580bf9b3af5",
+                                "uncompressed-sha256": "17c418f30a5458eb623e79db81f8c8fa619f7be1ffde18178fe1eaa542356796"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "b9407b89a19ae0969b3e4378c6c9f6eb19933fa3ab0ae1580b7fd0fd20074bc5",
-                                "uncompressed-sha256": "f90a609f53af0120dd6243839388c011a0736d1ec2895c1f10db2b7a609aa7ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "25ec71ed118b0d1fc88561eaa70ebb69e61bf05a749a78e600094a0c753a6a9a",
+                                "uncompressed-sha256": "30c696d03ae9b3a50a854b8ee6a2cb13bd66c6f7370f1986631a8b77ffff930f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "de29a047cb371cf6ffc026bbf371bce3bf6a8eba8838c63303cc91feff3498c8",
-                                "uncompressed-sha256": "436ab6658f85839184cb9f5b9b42d3ef29c1e4d8ab36425f23bc5463f8fa4fc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "30c9d8fee0aeefaaa4e6d190aace78cddc369ca43cf771d0dc0c231bfef16125",
+                                "uncompressed-sha256": "b6adf848f424d40f30608f4ccbc4332f007e6c85309a6739e1516644baed2225"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "7b18822b039aec22dcc540ca5d5d963ac2f6aa135d955bef86787eabb43eed5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "3ea50e7fe5272b9c31f19c63d4a0eb51de9340b361da5842bd893b3bc6f93604"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "fce851788c30c08fefd60db1734d26f450f7175f173ec1ad228a1a0ae0fdb216",
-                                "uncompressed-sha256": "14383047b652a2f076b0a02bb0956f7d99b16c302e47379785ed92c8ad9ec71c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1889980a9ba571ae26a5992c8d755d46f0abefd3f90534d7ee248bdb073f1fac",
+                                "uncompressed-sha256": "1f839d2185a58c608fe49fe19b7493f22a9b9d8ed8b1994f55bf094f3381f8cc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live.x86_64.iso.sig",
-                                "sha256": "f7a689f7a1107b1f3f6bec02f1227a4b2cac89303a15916b45a9147f4486d554"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live.x86_64.iso.sig",
+                                "sha256": "b2e392f375e1b8ccec06de4a807aa2d79e68d5a1c13c8b00e4ea6e9da0b1fe9b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-kernel-x86_64.sig",
-                                "sha256": "abe7791d5967aa9bcaf9940fcb2aab047279b7534ed0d81376b1ac3553aedd60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-kernel-x86_64.sig",
+                                "sha256": "99d05c2995250da75ecc704627a51b914467aa386c838b9c95d7a1f2a28cba00"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "377e55c66fa6b4394cb4a707e7a2b38ca4e6111513d13f732f547d0168cef659"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "ed8691cc5b688a4ae78e8db98c39aee9164680ccc462458cc98080c9054043bf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "4859e3f304abc1ff3ac2b7071f6a71174ae1ec76040a1d4869796aea28e8123f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "f0cead182d30a91ede720f88721a2a22fb30d189041c3a1dee0df5d0d261a271"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f499efce325b3dc9f5c42a8617870354a526e8bd3e160323cb433bcba58fdd64",
-                                "uncompressed-sha256": "f80ef4f65b93eb72a9447c4af2362ebbf74e680c6f88d17cfa397b5ddb2f4c69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "5f75c6ced502eb75112193858cbab51baa8a1e537a359d99ac892c3b90453a51",
+                                "uncompressed-sha256": "389e510f192745004777301f25dca2e19b2b0c7dee3646f6bbbab86c2078bc0b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ae419e19eb577fa2484ca9262ad13679140dfaa00c5b03ba8edad7dbb4f216bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4428922470f0c6746df371c3aa1ffdd877e8de9349d8301abfb32247d99e585b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "38de79e40c5ca3dc044f61c62b9905f69a0b97b9f1d0acd5c137eaabe03aca9b",
-                                "uncompressed-sha256": "164e94fed1ae35089160a5eacb80a76d190ed4be54e77ae2e01a38ca151f9aa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "037ee928c0f2cb0fc853c08e07d4e5ce5caf223cbcf112334f684c45db6c535a",
+                                "uncompressed-sha256": "2d3cfe7783b3305670ebfabec44ec99f6698212e72aabe78c79574b0397b3f27"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3d6b3ae9efdffd6ebe903ab51f0f9ec77e7f8b53aa1ae56611173ee1b6609983",
-                                "uncompressed-sha256": "c224466cae8b55b3765c8c507976d75018d4670090da07d953b19f4fb02f590e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "178f0ec7bda59b12d1d1e0a286d890dd013691b4780fc3e210141347ad432b96",
+                                "uncompressed-sha256": "46de1cfd05ded1e2f28d98296b64713a50c8afe5a9b384f646b6ffde084e0fea"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "de89763449a845901dfc3bcac4169618d17c2f7b5f96a8ffab8c4aeec407da8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "a333f118c071b33c48becf78bd4cdf916d64c630e8a6efc6eaee58f06f5906bf"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "b12f5e9f7d008749d86fcc10cb242054e1511f8b40cbfaa84bcb74c496a4712a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "d2d70689d55d7b294277d8f6313c2275efc360bf949a0a427d8cca397ff64233"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250215.2.0/x86_64/fedora-coreos-41.20250215.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "345f2d3dd91d1deaced4cccb1155c0a5ef5f0346c0b2f40c227c04768b5133c6",
-                                "uncompressed-sha256": "b0f346e1bd022da8fe8cca5cb7553649fb9686550fdf95bda730313d967cf2ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "14c30b265b02ddf416e937f8a755f00e84ba11203696a151b50242ea1eab76b1",
+                                "uncompressed-sha256": "a2ffcf7754a3b3bfd139ad9424951e944eb6debecb048d7176b5fd5cf12daf59"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0c13f683f2f8d35a4"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0e00b1254f17b7cf1"
                         },
                         "ap-east-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-00b4c2d8062412c4e"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-062dc66c33d4cebc6"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0a92c255e7589e8f2"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-01adda76894111ea0"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0190c35d87ecb3a87"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0965b806dd375f8a2"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0e428a843e3d623f0"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0dd52847e6975058e"
                         },
                         "ap-south-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0e898b7412a0c0901"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-08787fb94a76ae833"
                         },
                         "ap-south-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-073392b7bb7169b52"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-078e29cc5b013460c"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-07c507ce50426bc50"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0e27f89d9b4d736df"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-073fe2b8abd2ee8f8"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-03fdfc153dec920d7"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0a402de41414c8a12"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-048a4aa71668e6381"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0bdf7fa4b29d21977"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-01f2d82486f7c0dbc"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-026d2ffba9561af00"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0bb8efd4a367e2c29"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0cd03e0a3b91abf3e"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0b7943153361883db"
                         },
                         "ca-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0611538640e2ebaf3"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0da850ac51b01266d"
                         },
                         "ca-west-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-01dede39527e981b2"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0ed91546f33007bef"
                         },
                         "eu-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0570fa9327a55b3e2"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-04773ad21b0ebd3c4"
                         },
                         "eu-central-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-084abc3883a39bd52"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-09b416e0fc1f4531f"
                         },
                         "eu-north-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0168a3d913cde82ca"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-00702f705ccc37766"
                         },
                         "eu-south-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-087b85fa8433dfbbe"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0390dbdbed7517041"
                         },
                         "eu-south-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-010b3966e711f06c4"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-078633d330fd1ecb7"
                         },
                         "eu-west-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0f313bd602af3e7b6"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0c1a92e97eb8b1f2d"
                         },
                         "eu-west-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0a9f3fd8dad4866a3"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0f8630bb52455a1ee"
                         },
                         "eu-west-3": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0ac94bca619e3b849"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0bda20311364fb5eb"
                         },
                         "il-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0e60f9ad79e963478"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-07a62b570cadbd73b"
                         },
                         "me-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0a412a0ad30570e21"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0deedc2c1cc848a14"
                         },
                         "me-south-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0dc4e8058ddf49f2a"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0b49d55cc4e4f62d4"
                         },
                         "mx-central-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0499d233bc1ab8988"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-00b9974c3057b7478"
                         },
                         "sa-east-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-045abc5e20358cec4"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0afb175661f3fdbec"
                         },
                         "us-east-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-090fc951b91f4455a"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-01b41efb8513f2779"
                         },
                         "us-east-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-01f03d0ace007028a"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0fd64816e29439771"
                         },
                         "us-west-1": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-0661c32808ef25950"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0f7e088d78c96d274"
                         },
                         "us-west-2": {
-                            "release": "41.20250215.2.0",
-                            "image": "ami-010fb57d66fa663cc"
+                            "release": "41.20250302.2.0",
+                            "image": "ami-0e4597346f199fe07"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20250215-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250302-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250215.2.0",
+                    "release": "41.20250302.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:cf1d62b08534cb023049edd1cb089ca47269ee744cbd3bd58b3e00bd5cb4e8b0"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4ff4f581fc8fd065b0a0c80897e85da58e14c41801e18ae43a43f4926b73c4ce"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-02-18T17:33:24Z"
+    "last-modified": "2025-03-06T00:58:43Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20250130.1.0",
+      "version": "41.20250215.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20250215.1.0",
+      "version": "41.20250302.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1739901600,
+          "duration_minutes": 1680,
+          "start_epoch": 1741266000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-02-18T17:33:23Z"
+    "last-modified": "2025-03-06T00:58:42Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "41.20250117.3.0",
+      "version": "41.20250130.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "41.20250130.3.0",
+      "version": "41.20250215.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1739901600,
+          "duration_minutes": 1680,
+          "start_epoch": 1741266000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-02-18T17:33:23Z"
+    "last-modified": "2025-03-06T00:58:43Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20250130.2.0",
+      "version": "41.20250215.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20250215.2.0",
+      "version": "41.20250302.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1739901600,
+          "duration_minutes": 1680,
+          "start_epoch": 1741266000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).