### PR TITLE
release-notes: updates for the 2025-03-05 releases

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,4 +1,6 @@
 releases:
+  41.20250302.1.0:
+    issues: []
   41.20250215.1.0:
     issues:
       - text: "Support `Intel TDX` instances on GCP"

--- a/release-notes/stable.yml
+++ b/release-notes/stable.yml
@@ -1,4 +1,8 @@
 releases:
+  41.20250215.3.0:
+    issues:
+      - text: "Support `Intel TDX` instances on GCP"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1814"
   41.20250130.3.0:
     issues: []
   41.20250117.3.0:

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -1,4 +1,6 @@
 releases:
+  41.20250302.2.0:
+    issues: []
   41.20250215.2.0:
     issues:
       - text: "Support `Intel TDX` instances on GCP"


### PR DESCRIPTION
```
marmijo@andromeda:~/coreos/fedora-coreos-config$ git shortlog --no-merges a4e1fd2..793cabb
Adam Piasecki (1):
      tests/aws: Modify xen-assert to find xen entry in hypervisor string

CoreOS Bot (8):
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest

Dusty Mabe (2):
      .cci.jenkinsfile: build live and metal* together
      tests/manual: trim saved state in coreos-builds-bisect.py

Jonathan Lebon (1):
      tests/kola/root-reprovision/luks: don't use `root` label for LUKS device

Poorna Gottimukkula (1):
      tests/kola: add test for LUKS + multipath

jbtrystram (3):
      overlay/core: update target for coreos-live module
      overlay/05core: coreos-ignition dracut: use vendored sgdisk for el10
      overlay/05core: ignition-ostree dracut: use vendored sgdisk for el10

```