### PR TITLE
Roll out stable 41.20250302.3.2, testing 41.20250315.2.0, next 42.20250316.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,144 +1,143 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-03-06T00:58:43Z",
+        "last-modified": "2025-03-18T13:57:21Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "289a15d626583e91003daccb3c927cbd4eee8699539b02ac8bea1c1ff0b592d6",
-                                "uncompressed-sha256": "670b540f06f7c691375012174a690555b699e9c7e0fd1a42c1ffd152876a7eac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "82a9371ccb3994c4133c94bf80ba03419f5ef10516c03775dff8e9a2b29c86e0",
+                                "uncompressed-sha256": "b7c9e147268e5327628b13bde70161cc4c98b7027b6d9cfbed238dbfe6f24a8f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3027f5a4bc640d4c5aae18e37cf2bf5b62b100f1f04b698a898caa79bd2c491e",
-                                "uncompressed-sha256": "ad9745537935ec80adfdab19dcd8376dfe54f30d152826390e1f70e355928211"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d34333b074725094fd1d48a063f1327d18d4635548b7910ddd214b841d8eaaa7",
+                                "uncompressed-sha256": "e7dce12aeccaf5482b3342d6776297ac4cdd8c41da48ec7db6b37e87e1272473"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "daabef684f92e70637766675a68a2f59d12ce8237bbd4f224a488ebb38ba55cd",
-                                "uncompressed-sha256": "33c55e97cceb8b890cc25b78d0bb5830fa70dade224542e5f290a3ed60079ff9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b834ed8ccb1ebc421781eca20fa26c9d3843386bc5ab061c51e33bb878f98b8c",
+                                "uncompressed-sha256": "b2aab7ee714e31fc31f20647bad9a79bc6206cb17084314e0704cc819f2c43c1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "cec83bfbb0e5b8548a37e675a837c135cd1133a2823b9b456b92f02257721a2d",
-                                "uncompressed-sha256": "b024b78dd943e7d2a20231f8d780ea8ba0d9db6e5dc71d9043eccabcc474c333"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "89eacddd0fa7a32ddd6a95740a3cbb454b5a1228b462cecc4d592d8952b49562"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "29853ae168d75ca90f47d51e835c983c025e092bd190de6c7e71b82deca68fe6",
-                                "uncompressed-sha256": "d0abb3c5fbbaab9294a025d9cb197a7c3625aceedb5cbe3a703d847c6461d462"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "d8de206e6a5c27714b90a2886b25995ec25f0ba554f324ac117d805c8f63d0e5",
+                                "uncompressed-sha256": "f1d804a66bc58eb67e8c969e65ccf9a0821685dc85314d5e2f3ea75c5168ee1f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "50ba3db4ffc15670e29a9a602fa3768d37268e7523a497d636292b6e0074f701",
-                                "uncompressed-sha256": "5b3b61be8f2eed815b83b1b8dcc55dde02a1509732add73b386731e98f9974b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a1cdb445a0ebd0e689d9b48c64c75a590e7305ad98116d38a56d180aeac8d163",
+                                "uncompressed-sha256": "1b6b73c4884e577a68c7a14031ebb8d53d567d18751a9aaee81760f55d763295"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live.aarch64.iso.sig",
-                                "sha256": "42f496709cede86cab38b76ab3b2e2473edaa0e17b29824c29c61761f10fea46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "8fa463ca94c617e6c0ab07b296d2f4ee2ae119479e458a6f254598cd53f18956"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-kernel-aarch64.sig",
-                                "sha256": "559c4ffc501353644ed6a541708e8015a561efda1f6dda29cca8eaf74f58a460"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-kernel.aarch64.sig",
+                                "sha256": "7d2188a4937cbdf8aa32dc78265689da4263cfd3746629cba0913301ef5a3186"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "3c6e87809ca857f3b47b3a3c3c8b25725ca7cddbd0bd74e96fe1649fd316531b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "2adae2e068fbb70c64372eed6deb4820641a3b2cf1267c5938f11e599a06b17d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a4175df0544dcf692290ab5259e5765976555c99a189e99d9153e3b2b4c77338"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a0b9d549ffea44d5b6a0aaaced6ddc101cd1c196f75ac8347e1ee1c76d6184d4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "fdfcb8377b277ca63097b9b41ec201ed2b56b68e1818c348efcd24dda180d97e",
-                                "uncompressed-sha256": "08a5d4fdac98c71e9462317adcba2f60d3f36e414f78d909041faaa416faeaaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "5c0aadadd59cf6f52ad10f258917f135066e47fe4a671b578e9dec881a6c8381",
+                                "uncompressed-sha256": "57c30ec124fa24812629669277f5b34347d50ef5a16708d3ec6622bdd6f758db"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c966c2b643bcbb43ecc47f9c8fab2c73f4bd793555b936d4bd628912e3a42edf",
-                                "uncompressed-sha256": "a3fcfaff550b8c1e9255f90f5d415d1f3b2c8f11ff6f4daccd7b2952aaca3719"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "98f98c749f99d9aa051a5eb0d4f6097ac6ca2ed49cfd21064e8afdb1d7d781d0",
+                                "uncompressed-sha256": "da2d358c9c3c3ffcd56460b71bf677a0750bec6464ef4086aa21faec8398ae26"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/aarch64/fedora-coreos-41.20250302.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a1dfb59e42c5ec943b8ec2e3a4fa77af7fdbed0412777b0d889f5e2d3ca09fe7",
-                                "uncompressed-sha256": "832c6183070dc5436cd605b352b57f73c685f1ec111a304ccf0fd22d5a3d6dfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9bc43d31f110a71e795d9558f70706592b3bcf798975851e536159f9161607c7",
+                                "uncompressed-sha256": "170acfc25f13245793385e2f4dfee4973b81d0f68000664174412ccad74040b4"
                             }
                         }
                     }
@@ -148,225 +147,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0c566d43c316ad8d8"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0d30ea9c1edb16bda"
                         },
                         "ap-east-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0751847f8a69656bc"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0c7d9a80b94e607a4"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0dcb9d9af51dcd469"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0c60ce39a8ce155ba"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-09a5477f3d456fbba"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0b2da3e1e2d85de72"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0f1e6dad3becdebb3"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0e4b30f12ee0faf00"
                         },
                         "ap-south-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0eb99ce3cc4ef9f8c"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ee232160dfbe40d0"
                         },
                         "ap-south-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0992ea88d142c37f9"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-035188ab4af82215e"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0983fc4e9a81d9aca"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-084cacc4561d9e17b"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-02f47748f103cd390"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0873d2ee0c2e644c8"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-09804ee207f9efb00"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0b706cd3d9ab37fb4"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-02ae1da7777a07522"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-088843d6f6cc1f5d2"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-05083d2c6469c8418"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-02ac7d2c9e427041a"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-04eba4328d63c29b0"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-01eb75a37a076de02"
                         },
                         "ca-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-06358f73a3bb0d1d9"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0c8f1a2cdfc3eb3dd"
                         },
                         "ca-west-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-009dfb18108c4194f"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-03464944bf7eeb5ce"
                         },
                         "eu-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0c1932f533c4cb3b0"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0652c96e9e98c794f"
                         },
                         "eu-central-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-00871dbb511e6db12"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-03f6877fc9cc97e76"
                         },
                         "eu-north-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-05e136252e098805b"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-09db7a2362119b7ca"
                         },
                         "eu-south-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0a5563c999c425b93"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ddb68001f52aa11e"
                         },
                         "eu-south-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0363e7be78f5537ca"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0769a8061f37be723"
                         },
                         "eu-west-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0d55db46c3e55ebce"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0f55ffa612c4154ab"
                         },
                         "eu-west-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-00968b2827ab475db"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-00a244bf35803de02"
                         },
                         "eu-west-3": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0be75bc47fca87425"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0a1d9526df507dab3"
                         },
                         "il-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0852adc3de57df643"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0d561abc387e54aa7"
                         },
                         "me-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0c31a853a98811437"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-079b42ac4ba32bf1f"
                         },
                         "me-south-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-09e9aa319a3f8539d"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0a06889137554d1d8"
                         },
                         "mx-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-05ed928ab6b10c70b"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-094000680b76da3d9"
                         },
                         "sa-east-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-05de56df432c38c7f"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-05c52e1cee4371da9"
                         },
                         "us-east-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0ec93a477eebdb9be"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0dc8687e850bfa269"
                         },
                         "us-east-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0c043fd381abcf6e7"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-052fb57c4ab9bd0c3"
                         },
                         "us-west-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0cda577e3a995f51f"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-08fd4fddc28c0c56d"
                         },
                         "us-west-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0b64655e1f68a4ad2"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0a626e43f4a28175a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-41-20250302-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250316-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6bc314a9f8482ec10496702b02f2c0fb7b25349a93c197324805a9efaebd80ca",
-                                "uncompressed-sha256": "68a0eb7163da4471641829771f4c44c543ce4717c5f261da1a00a4569605b0f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "fa5545a02ce05125d80be1eb531f588642d2393b7e628667da38d0559a169381",
+                                "uncompressed-sha256": "c0cd48cbe7bdc06f1297f84c31dd6c455b79abf0833c14c75a0f6aec29cbe52e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live.ppc64le.iso.sig",
-                                "sha256": "9bb4994000fcd2f2453caad8d69893ebb74dd53979544418f5ee4be37406ebf4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "27fe5beb962f6d9982984b1b12c5b7ad695a78d7319aabad71431b71f7422088"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "f5400f8662573474ca8c1d058016f67f845d9063d262569b7ae6b38951498677"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "819fb464461cc6d581898b30bffdc91447aa9cdb8c165b440f3612305508b43c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "8ca29b83a93081d7122cb25e0005a417bc6e5c814a12a69fc0236b722f4a4776"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "47b5615ed6149a6779a6421c25aa82983274e6a099acd5e13a549135a2a2037f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "df1f3764fe946dc81ea18427a92118115a8a2b2c3f1e97b4c5b267ab00488334"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "3e211d203adbd90ced0e8400ac45e91c05fd7b13979a3ba439497121f5fbde40"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "3170fdf5182546037d3b154a8bf8d0e8f382aa7166972f73550b1c2a11d6dd55",
-                                "uncompressed-sha256": "a9dd6a9cd70c4dd0e0491d60f8aaba60b5e6ed2a3d4f78f012baf040227dcdc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "49070ef13082eb6b9da159589ce0e59ba9575b19b5428a1020c09a0e41aa077a",
+                                "uncompressed-sha256": "ae289ca7964c4b158f12643ee34b33ffde6400b2b70b0074a35a52b193b51636"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "59a0cc59bee1af7fcbbcd5bf6700af03bf8fb82794abba00db951cc259f000ee",
-                                "uncompressed-sha256": "2ae84ab5d4a2d57a873f3b70662acd5a96c95a3ed75c91dc2f3330b1ec5914d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "cdba4188884f4a9269a980cfe70a3317ccaf0cd411fbdb95db95d3663b498d35",
+                                "uncompressed-sha256": "a9181a0a717f1140e49ab6ab28cd2bc2546ba95ffaf232a45e60d04f8110a638"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "9b0246f4a6c6177515587377ef8fe8a87dd08e1469051f7ef6a4584207326968",
-                                "uncompressed-sha256": "2d8716e8cdccba482ee1f64590c2683db8332c81bc769ba523c48fdf75ccea67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "de4ae95d3d32c488becfe71c00b1e6914d6c3bcbe64c124e24525f574cd0b1fc",
+                                "uncompressed-sha256": "495d542d72ad71b675dbd1934259e9fb3c22788f36668476e3f24e76318250ac"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/ppc64le/fedora-coreos-41.20250302.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "758bebee132b0ae0448e96cee41f53991ed682a6e01dd072d571d20cda6ce09d",
-                                "uncompressed-sha256": "e69eb43de366ae7f53c5be9fcf9d61472b2df0506c3985b58a8606494be304f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "e0542cbdc1835ec24c93434ac03a1fa3891dcdc63863b3a98385878fc04b31fb",
+                                "uncompressed-sha256": "826d11fa2fd1fa2c5572993253a2ad3ebcb7378a588588c0b11c8c0cb8cf5941"
                             }
                         }
                     }
@@ -377,85 +376,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "fc0706c2cc3174272e5ab7fa0484e7f263265514b1db007bf6240aae53ce2214",
-                                "uncompressed-sha256": "c105c99b0789c5adb1ec2b0a888d9b89f2e87477eb4f6f14f35bd5f7b8197ca6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cd1f883dadf76222c7cc8c0c0549f42e451eac1f830c8830de5e5cff7446be5c",
+                                "uncompressed-sha256": "fdae5605cea23ff71d33550d0c46b9b5e9e2d4a80ed699a541fc4666f59ed568"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "97acc1237243aaea290356f241d930150239db623879f148510393ad5226f019",
-                                "uncompressed-sha256": "00a274332a6d822fcbd75c95ff784d0cd68b4d35a642a9b375f97e461224ec5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "5ff6d30e2a4712f24d33c7bfed7801af599be207871795f00ed1b8d91177aa9b",
+                                "uncompressed-sha256": "ed0f7495b2ba0711d43438e87c4854a7489bfaf721591285e633ea856d676582"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live.s390x.iso.sig",
-                                "sha256": "748544b761c47968cc47e1a173aac9b5c7b3306cb74b402849d04179a8f4e0a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "f989889081beef90d86b07dde01ca944b181a586d606b8393c7148fc7955fe32"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-kernel-s390x.sig",
-                                "sha256": "876c34c02c22d99c19af62913af5d7b1f77fd009831cf985cd8f73e00ac89aaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-kernel.s390x.sig",
+                                "sha256": "8fe769b1d70bd3f210625bf54f651efff53fa2c4ad3e62c70f5a300120ead28a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "21af9eaef030e2f6b539d2d2dc0a13287f1120bfeebb6734fa6545be35ae895c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "785d40540739a0b6b1b85b6df05d969a490b597f7eabf6bced8bedc5f3063689"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "4aad01de583e8f52e0decfa7b0a51538d72b8a3805ce0578647bee9fa9ef5be1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "9c9ee505fa2d7fdd0ebc9e1fae1915d346c5f4925653e8c7f47c65aec5350850"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "44eb2036bfea096dd3c4a5871871cf3231c19a349ebd111ee7a45d7c65cad2ac",
-                                "uncompressed-sha256": "91e06d22c7ec236c075f5349c5a081f04cfecfb0b36176d23ac894d71c4aa49c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "86e01dc08f7845f0efcea5bc3930f0ae342bd684e8f3b60b770b188eab0f749a",
+                                "uncompressed-sha256": "467098be3c49ad91f70d00fa687796fe4299951ebfc56f8807a95b04438eb63e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "85567492808e2d36740e498372139a62b0b2a3ec13983661c1f925e86775bfb7",
-                                "uncompressed-sha256": "ec2892779702d1f7b069b3a646aab8b14b7a9c327c2c2686af933713c9997e8d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "7d5abaa4b580a643ab65e87429a0cb19200ab81f50f58cb07d382443f18564d4",
+                                "uncompressed-sha256": "4aa8d90ce0edddac4e15a07bca95c7cde5c0a88b2990c6f60ec0dba0884e9a51"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/s390x/fedora-coreos-41.20250302.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4d707af7e4a1aa34d436a85e050efbabd47b42060fad4b79523211b88c9a6d80",
-                                "uncompressed-sha256": "91d1736b0476675595cc95d578c79f842a5852fba807529e66635033d0ce74c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4eabb4654b9b7c746abf92b966cc3f55c40a88973aab7aea56ab36a962914ef2",
+                                "uncompressed-sha256": "bfd2a7c91af03d0133a345b1e909af9e1b2f50d80f7bc0dbc690feccdccd132f"
                             }
                         }
                     }
@@ -466,263 +465,262 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0298b0d259d054395c1b16adb41a99498b9f1ad1d31270523f25cf69fe5cbeb1",
-                                "uncompressed-sha256": "0ea6890fcd67cddf98f6ed4e8e5e9a4ceb93d138beef5f304179926bfbad3b0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "51eb49d26a164a371820d4eb847a7510090bfa86f33d5f7352568274fcf05370",
+                                "uncompressed-sha256": "c4a02e3327358d6112e35f763c46ece62133a0430ef1b48547e9def05beaa184"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "2689b615ae55b267801306737bfd3b6701122abfe0c003d7330994230a8ea1b8",
-                                "uncompressed-sha256": "078aa609b655c7cd8613ef25150960af947ee4eb52fe5ffed6cc95717a6578cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "fc4e6fc7050f65aeb50c064d4c06de258a2bf0f49ebd19ece94cc4df18f73a20",
+                                "uncompressed-sha256": "50681a52138545081373f0760cb34e5628b7232ef916568e57e542a25e349ace"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2a2a8bbde18134a1266a1538625fdf78892aff57f66c42116300c3eba14f196d",
-                                "uncompressed-sha256": "21c5616fa86902586e135bb2f2c88a830a4ccb01db8a51c55587e3d52e42129a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "48a7f483387fcab3a24f162d88437f4b68db577764105bf244c8b00134085ded",
+                                "uncompressed-sha256": "f7c086a35a176d6d0fe69988e40544a08115e54f7c04d30f9b3a615f5ca15772"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "eaa56bd7dec9aa2fe347fef23692ddbcb032f45078efddf7c690878507d9b7c0",
-                                "uncompressed-sha256": "26ac04f54b67ddc2a24e3d22b52d423ab31024a794edf3935e105c8436c7b47e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a93744cf0ddf237e773b4e2166efb4792cf15fe737726bac1dc4a50f03ab30ae",
+                                "uncompressed-sha256": "21caac9aa538bc3fea0cf99b26002f2ead15d286b23a34dd8461f036f6012e19"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "71190ab2df24c819b12c8b5f99d2e4a53364c8847bc9607fb59e58916d4517b4",
-                                "uncompressed-sha256": "c1f6e0da65e01d396231f1f0ea11de20a5c85f39f11b497d8468241bc2203e75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d9c075c235bddc6f2f8561b7f5c41d1fb52f8c12afb5177b3b8c4e9b3a77b4ef",
+                                "uncompressed-sha256": "a0b612c9dd996505a9c3504f070194bf75c63ee87664ce2f6b3b4c63ad2813bd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "06f69c97066b19cb7d09c0b20e4914cf3b665fb0aea13a676932bf655410829e",
-                                "uncompressed-sha256": "107adc061adf4feb006879b2b79a984881b35daf1fcf8fd463f348c6fd1995d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1d6a692924358df58caf0acd5a184a43e880a9f4b7c6b11e0ff306f03f769c0d",
+                                "uncompressed-sha256": "1362ef748b2fcc205f584059b3774f038387bee930d547456499141c3b62beee"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4cb8cd271ffb7451dec2bcd77d779bb47e2beb78e66d5f5b0f9a0be0f46716f8",
-                                "uncompressed-sha256": "bc1da439aca7ee802cbb0be60709515f9adaf5681f9b26affe3f0d8dcaaa830a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c31a0b5678027620f5f1730c69d91ee4f0e590d21cf84e67cef5bab7744ab971",
+                                "uncompressed-sha256": "85b6cecfe30b97e11d836653fbd6845276d199e4a97756d3bfd1b1a156f947ed"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "037f8faa86ff95b1bbbf84ff8dc37213b918c00edde2bdd6e9c116f34d504958",
-                                "uncompressed-sha256": "970c046d2bc267a5343bec43dcec71e9f70658c8756664dd269b953898bbc76c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3a9e1f9b9047fa89e6b4f2203b79b0423bac66a620b10fa1a384e4c7216804c3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "88a68656c36c5078dae474c2fc2606945cfa1f619b6f8cf7f4cf73385c4f1166",
-                                "uncompressed-sha256": "002a0e84c49a43b5c4343b360a6dcceeae777383d323a3794808061cf70299df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e35f911ef6941bec3e87a894a1633f9681deeef431d6c1538bfb6366974a4e5c",
+                                "uncompressed-sha256": "4565487a81f82ae3848526f3fc16d47ff131e906faf67baf4d8ad7a0f8fb304d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5d202af152bbba4ab0e5bacb5d2b07dc6b301f653d91201137eccfdb86a0efc5",
-                                "uncompressed-sha256": "863237880bd0f9eeec0723e5be31d8983df19c3e98596412b3db02d09e9206bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "8eaad56b987156521dc7ae89507fffa8839182d48c94339f5c66a343a9d60ba4",
+                                "uncompressed-sha256": "ab3f64fd574e0e80fde07df892512cdc52e187a802226d57e171af1a56e52e69"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b19e7eebbda792ecd6359afa20aeeb977b139a8dd27eee669ca72c9a14626fd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "26739d46f0bfd78683b9b555ff8619a30fc1354dd3347e88664fe947e756ccfa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5d6664c7d12e6ca774aea407ebca6b5801dc47df0a062f4413bb6de242926efd",
-                                "uncompressed-sha256": "fc19d16381b40c7100a1d65e6c8bb3476fcc665ad271dcb90e8f20143b3498ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3b3ffa923da666f422acbc808a58b6364e4427e6213ae499dc913ce92017aee2",
+                                "uncompressed-sha256": "16b319350adb88969764629a9cb68a80b320c4487814a34fd7aca1d8a6b5ba33"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live.x86_64.iso.sig",
-                                "sha256": "68df0c63a4875d0153be1d30a24f33c4f5b86ace274ea86ee633bf2350066a3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "d29d7f256e8696ee17742be87420e17b605b16b4c4db6b3dfa3cee91c56418d9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-kernel-x86_64.sig",
-                                "sha256": "99d05c2995250da75ecc704627a51b914467aa386c838b9c95d7a1f2a28cba00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-kernel.x86_64.sig",
+                                "sha256": "4b77dd608391f5dd945411cb194812e6ca2394b6bfb5eb6e501fb0f87127e41f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1a56f960b96804e6b5a606fd273df7930a37cd260f45b10869dda3f8c7a1c9aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3a37d2a88ee232a55063c0b40081c1ffb033dee731689d3bfe188cc16233e1e3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "be3cd24e92694397cb382928a9f03bf9250c6fded48a705866c4556d9445b1f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1b74051edb08b37b4c3c250b56c4e29013dd6a6bf8c7d52276429d3449488d40"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "035fddf414335e976407a207398d645c896b7fb6539ec607a7a37f30e84b4168",
-                                "uncompressed-sha256": "dbcedaad70b7c7a61f79ec38af5f771fc8d928a4bd8075cd8e78245cee6e5344"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1b1ae948cbc27ec66be7603ac44366941e155e35a6a8368eaaf0a8174c75f2ef",
+                                "uncompressed-sha256": "9a66056cc4893314052ef838edf17a53d48acc1daec980303fecb8a51c886ac5"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "af4a34a587ae230450e7b21e512ce861a941cad49db7b8ccabe247d363eee5b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "2a80ed4d9aaf7a604e37477da05705ba48aedfdf44316398116b7bcaf12d4f6f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "85ab55b712977ccfb2c9f466b13e70a6717a1e29ec50049299f1e80cbeed36a1",
-                                "uncompressed-sha256": "bf640bed5cbe9799c95719232b3fdc8217b69cb1dbcd6d3b7cc9c893b4e8422f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2cade8efd339079f0e2134c3e80897d906d121144937542ea29d3c2b1605f915",
+                                "uncompressed-sha256": "9953b7827096a4d2c5b771a405605d14265daacb3bf6dc9d9b70625bc67c37ef"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "5b60a418fcb4d6753a09f6e7827ca00b161be9d7da33cb74bec125aebb33ee7f",
-                                "uncompressed-sha256": "6c743fd07e17a5dc393cd691f14d23dca3ed8e7a80bad7ed496ea4089f432014"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e2f0189afac145dc2795d6c2a07e6dcb518ebb9455fbf9fc5186a38a13f75fcf",
+                                "uncompressed-sha256": "edafd45d9d54beef8f634b45ecfa5ef68ca529edbab7e3905bbdb40629e0baa7"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "5f375c348b758c0c91a0bd5ef9edbf4aa396dfd1722bb86dff51834a1a381837"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7c65e3091f6528b8175865f5e8ce7a9ed3f6357c8d914b6d44b4055d19afdd39"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "135350587b7b58d0a571d82aea28b00f84b70d3cae28aa1dbe341a50fdfcf255"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "95baf0a3a94fbe6083a11803cf9c64a48d52b3a3e646e23a0b29e2d984aec989"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/41.20250302.1.0/x86_64/fedora-coreos-41.20250302.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6314b5c4f1886eff1cc862101ca9eb67f611c36d15f0aa676b227b52715c4f14",
-                                "uncompressed-sha256": "514963150f6cde083b77ea2c7d9b54889946965a12e6e387342648bf45de5d93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "aefbb554fc7b8c296bdca3127f3fd3b00b545fc404274c63f5b9a183dd2c3a9e",
+                                "uncompressed-sha256": "81ee75abcc93354d670d1a032a43e595477b800ac7b80eaab5c82306b5025b4c"
                             }
                         }
                     }
@@ -732,145 +730,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0bb31df91ecacda4c"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-04b005df2818b8b39"
                         },
                         "ap-east-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-033c77e28a1bb7a71"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0eb35ae049f88ee09"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-04c0eedc058aa8795"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ce2cf66461f3d7e3"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0e5eb51f046c8835c"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-095880ebac53e3042"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-090161d1b3c583661"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-05f0325bb0116af27"
                         },
                         "ap-south-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-02b4a2aaebf45b483"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ef0fb53db37e430d"
                         },
                         "ap-south-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-040ab89197df9aa6b"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0971e34f2f11384f4"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-059f4d87a3c045d24"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-04dd46cc4b66764bf"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0536976c9d12cddee"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-08bea244e091e652c"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0fdcde4542b40f5ed"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0e26de6228f3c7f9d"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0374d1573a59949be"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-062b34909652c061f"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-06393f1e2cd48d05e"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0aaf30e0de182ecc8"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0ee2e164ff8a38e83"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-080e80f906f8b1fa1"
                         },
                         "ca-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0d9ed5ead31daf030"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-026884590b8dfec73"
                         },
                         "ca-west-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0c293bc2f3b559ad0"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0094375aaf2e70ab6"
                         },
                         "eu-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-01ebfc1d0c71eda59"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ed12e24bf022b8c8"
                         },
                         "eu-central-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-05c8d3950895d6bff"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0be547b7ea970029d"
                         },
                         "eu-north-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0fc302370e25f4a9a"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0815f90acdbdd1aec"
                         },
                         "eu-south-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-03b1f09da8c181fa7"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-057256c55fc9383cf"
                         },
                         "eu-south-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0f0e75a9f29254922"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-04796b6fddd68926c"
                         },
                         "eu-west-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0268e11f2a0e3cf6d"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0fa2fde508a63a57b"
                         },
                         "eu-west-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0ffd1ec2b6fee417d"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0db3fba7cea1722dc"
                         },
                         "eu-west-3": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-090553b06791f73c2"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0d98fe489e616ce90"
                         },
                         "il-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-02c93170e619c6e65"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0269e075e269af18e"
                         },
                         "me-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0326c4d2b126d6f90"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ecf8527024d75a24"
                         },
                         "me-south-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0c50d12baa33e469f"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0f8aec517ead710d7"
                         },
                         "mx-central-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-093b207136b7b24e8"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0dce0ad062afd150d"
                         },
                         "sa-east-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0c10cb03fc9e38067"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0db2bac4029db54d5"
                         },
                         "us-east-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0f3ee4976c4c776de"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-072601703af85d2ab"
                         },
                         "us-east-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0002a21e5b7100688"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0acb3168f9c209cbc"
                         },
                         "us-west-1": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-007e57373fd3135a6"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0e721efcbf00e67d6"
                         },
                         "us-west-2": {
-                            "release": "41.20250302.1.0",
-                            "image": "ami-0d8cb19162a158d60"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-018e0a0c5c4332bb9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-41-20250302-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250316-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250302.1.0",
+                    "release": "42.20250316.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:21e755eda2505f3be376833689134234e3edd9d23234052a2f2a0ba3f81154bc"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bf06bc8f9edd5301a9c003faa63762cedf2fa0522d1eda696c6d553919d52634"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,144 +1,144 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-03-06T00:58:41Z",
+        "last-modified": "2025-03-18T13:57:20Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "7f1ac4c00385013880661bbd72bff3ab7012379c414d3e2b37d6957bcb37d53c",
-                                "uncompressed-sha256": "028949b68982796eddfe0b845ebcaca72c23736c9e047bdfe7f93f466ba27a63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-applehv.aarch64.raw.gz.sig",
+                                "sha256": "ea573eaa6a4ec223b96870d45169bec8603b813697548d75776c8c81e82f4b7c",
+                                "uncompressed-sha256": "2acab7e10102f17ab54dcbea5ce055927c53f7ec5df3b7c0668af30751a2152c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "2be07d1fa925a63054e685b3aea3a24460220166818dd18078bed76b32819e66",
-                                "uncompressed-sha256": "17d68aa1881519ae5c8be5b5016594523856962558e711696693b4478e516d10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c86be13117a6aaeb729d83e383e613b90718dee91a7b270800a2b99967a68564",
+                                "uncompressed-sha256": "5e15033edcda5fa615266acabff4edca3913d831ac175da65a5cb351949e4f42"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "3136279ba9ae1875446f6c0050ce5722ee1f52b5c9dbb96fa102b1c3959b12a9",
-                                "uncompressed-sha256": "1862c02ff0614fdb464f11e59999c44a22dc2c67d8d771ad45e1f4b0e4e4806f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ce9e53f0e91e7a937666a4972a2b80987cd6a1216c19e2bc111c95579eb436d2",
+                                "uncompressed-sha256": "ac254fe29c82cbcf92c16f6407717ad9cdf756543465e4d701e3a66ddcd347e4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "9498dc363a4345ec397c502931865f300364e1a0ae2390778cb48d363d75ba66",
-                                "uncompressed-sha256": "541c64dae2fc240846ed1ab9602b4f6f5d15b87c717d566a61bdba171448ec17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-gcp.aarch64.tar.gz.sig",
+                                "sha256": "850e320c41dd19fd92c48440336f6f53e0e412abcdf1906a1c641e20294fd63c",
+                                "uncompressed-sha256": "b0ef195e7c0e562b3469bacc11edb98eb492bd8fab588a41655c749fb98e35d8"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "27a5653891be642c403e3b4b58962a5bd616a2737ea67b8aec4cd034a96cb5d7",
-                                "uncompressed-sha256": "0932a4588387c44b230c510521ffb1debf7fc5785072cb8705e4baff45bc06c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "5fbdb04393d2f7e6811c02086e42e0493f55d8c2335dfbf6d8a6b6fe038b03b7",
+                                "uncompressed-sha256": "cdad31de0fd9ff5d184428f1a9422dd65b9bd229ae7a68a600a60d918e7874d1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "dcf60279658b29a3b24f4383c571110de54f2e3bbbfd80bca25dedffe52a817c",
-                                "uncompressed-sha256": "4d7dec16493f80631a5a18f355bbbe7fd4e12b73de469bc9ccafba28a62de4cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "53c2daa999845defa522a39ae9e77388bfd98b6dd20b98330b7117b35b9134e6",
+                                "uncompressed-sha256": "bedfd3850b46252d58e5ad85c527e22e2c1c565aa256c1262ebe612d50825f0f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live.aarch64.iso.sig",
-                                "sha256": "6491e8a52b37a56e903170455d5316cad57b56cd6db12f04cbb3025c2f806b6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-live.aarch64.iso.sig",
+                                "sha256": "0d02a9a037ce47a5f83025952de5ce0b073145160162eb8046b497e18c5ad47d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-kernel-aarch64.sig",
-                                "sha256": "82a27007dc137f3290634d0a90ec081f0225508b078078d4b60543112f6f9251"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-live-kernel-aarch64.sig",
+                                "sha256": "559c4ffc501353644ed6a541708e8015a561efda1f6dda29cca8eaf74f58a460"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "bc0a0fe109160ff1749ff4b65ff0239a7c1b32c32cca83587dc06eb6099b98e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "b74cb11ee84f4f63301fb48955463874b68d6be65d1b865d2d51ecd1a4474087"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "817a87480cad2b2c1c90394dd8fc8c51384b92db0768e24031bc9df29e410f3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "7bd4b4baf29a97cf02db689134e0490949e99f0442b7d00fceae63a00b9dcb37"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "c41fca3789b3c1e7379d343570d5d990f1f8801de8a4dd82def663bf1e4cac48",
-                                "uncompressed-sha256": "2b94eb8c8a1cc8bd3195b59a5bd976354bf17c09fbeb92b0f88016371e848024"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "efcfadab3af8b5886fb353efd3394b55d95b90138ea077d485692aa1410acefb",
+                                "uncompressed-sha256": "f0b2ac52b44ca225744390beb72c60271a82f9418600ac2e54371d25ac7760bc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "bd0f9715b6c5f70190bcf49aa8e465cc6611541ab5e62573c97419bd24a7a22c",
-                                "uncompressed-sha256": "01577882ce9bf2cac1d34bf3211fe519a314e0094b6961cf72370281586a1cb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "834d11f8b9f2341f91bdd1be18144e98fd7512393477ac1968866a7e8bf4b349",
+                                "uncompressed-sha256": "00fac3ab12dd9e9db187070673ad79ef956e051a9ca5c8224abb750927af6a11"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/aarch64/fedora-coreos-41.20250215.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e0e9c16536111e634e8a16c56f0ef19c5109ecb2a48ab85383ec6559b084abf3",
-                                "uncompressed-sha256": "69795229f5b2924a34948cadc1e0b74f82223c6ee6e00d10135341ee6fb51e26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/aarch64/fedora-coreos-41.20250302.3.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d8cb11041b7f631fc2e7895765bebe3dfdcc063b613991c3a26f1be85a412753",
+                                "uncompressed-sha256": "77c17000fde008fc11ce9f41159c919fcbaf683b088f005e77ae8c6b74419fb6"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-03f84ab62b1e6d71f"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0aea8d5b3f865b302"
                         },
                         "ap-east-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0db4cf0a93ee68674"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0306b587a5bdcdb05"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0a86d1c835ab2a7ad"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-06a393b398a8f28fb"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-013aa6078d4edf677"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-054d88af85b1a4143"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-01c94b24ab350ce5a"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0af1b2fa0d2cf7604"
                         },
                         "ap-south-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0ffd361db7e7b4c22"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-05e29e01ca37d2e63"
                         },
                         "ap-south-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0f9b1e87bc876cace"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-00fb61889a1282763"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-01acc66935bdc4e61"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-07922f29b199b9842"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-015853767eb5a244d"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0e8a6cfb4f03d640c"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-00244d04872be3b24"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0697b500174578eb8"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-098b0dcedc5fbaca0"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-09c63a85e74f981a8"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-088659dd53e3f6ca2"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0e8875a2b7d0365ff"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-074738d0ac2b8e640"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-05e9939a86f5ff860"
                         },
                         "ca-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-06fece272a50ed447"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0c43b17f5aead3040"
                         },
                         "ca-west-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-04a1000155d9d9719"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-05823777e10f58559"
                         },
                         "eu-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0c91601e1fe69c194"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0a5bea882fce79a2a"
                         },
                         "eu-central-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0c81196e0d0c2cc73"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0cf505dcac56124df"
                         },
                         "eu-north-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0043204e087b45e2d"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-003e96f4e34d30345"
                         },
                         "eu-south-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-06039b0441babc97a"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-00db739ad4b107b30"
                         },
                         "eu-south-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-06750f23f316b341e"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-06c0fd8a73c57c774"
                         },
                         "eu-west-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0ed18028572da8d96"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-078295278db85182f"
                         },
                         "eu-west-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-020e1167622090232"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-044ad5d61ad4aedc0"
                         },
                         "eu-west-3": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0808763f7a5b2d0f9"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-035314727dcacf4f9"
                         },
                         "il-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0e270ee57f8402628"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0d7c376b7af56e166"
                         },
                         "me-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-05710fa6e5d25fb5b"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0ee57f2cb5724ef06"
                         },
                         "me-south-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0b2af4ce6325f51db"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0dfd14b2e37689318"
                         },
                         "mx-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0c83bb76d196552fd"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0968cd0f27922f951"
                         },
                         "sa-east-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-09184aa884a7f1d2e"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-046f699d40a39f20f"
                         },
                         "us-east-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0a802fb1b69c371e0"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-06426b35cb6ef59c6"
                         },
                         "us-east-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0ab5b1ae37791ccab"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-07a08a05546188db7"
                         },
                         "us-west-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0d15806d134bcbaff"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-00f90bafdee25e201"
                         },
                         "us-west-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0b31c0e195a527062"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-016a76ac451ef5f3c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20250215-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250302-3-2-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "877da5fac28b238188e3671593eceacb66ec9215bbc18d3e2549b6112c44d2b4",
-                                "uncompressed-sha256": "be25feac8e8f4621825c216248357547c75ae05a20469ebef5f178b64fa6d716"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "b2498cd3b4f7fc6d962660562e8efd39c8df17560423d81a1489f4e6a2d5944d",
+                                "uncompressed-sha256": "4b116a71a387acac5282dc4fa74e9267f88b67c580dc134540eca790fe6d2026"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live.ppc64le.iso.sig",
-                                "sha256": "d3c7572d6d17514ed744ee973a21b63dd0bc05d2cf52cb1599f4a00ca5417859"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-live.ppc64le.iso.sig",
+                                "sha256": "253405531f29f1b56ddba4cd8e942bedc971c28268ec754c259bb8290b9ffeeb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "bb8e92d5a64191c32abe1a21ce2e4ed6b2423844079747617f3f8c923f219db6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-live-kernel-ppc64le.sig",
+                                "sha256": "f5400f8662573474ca8c1d058016f67f845d9063d262569b7ae6b38951498677"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5df6865d4bef6b005e74ee95c1c2f782de31dfc1e705c38a3ede717b4f20ad33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-live-initramfs.ppc64le.img.sig",
+                                "sha256": "d8d9ee42b23e5e0a41b8dd4b74eda2cbfe64f1ed677930d03b1a5944de5c3173"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "980fc6878d2ac4cbd5f9a595bc7f5ff552c4d3a69a590357181f3c7d23a4f9b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a3a27ffa89de75da0b1dfb470f91c3c5eaac2893c0ab9b881a4fc4f5c222baf2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "3d9261cd950d21620f7a403a44f067add466365d8c4d8c1d80db3422f772303c",
-                                "uncompressed-sha256": "0942e45574d05276b28663a6fff78c03f7beedb0601dd8f8fdc443eaba074d80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-metal.ppc64le.raw.xz.sig",
+                                "sha256": "f2e044f8528a2a9e2b6110655973a25662202ce05f4ff39685cdaf0f19e9ebb5",
+                                "uncompressed-sha256": "3328311cb723bbef35bffda831110bb89ac1876659d5ecb051b35015dc4dd92e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "98cf3fa6d6c86476f6cc46e0baf7cee7d644c5c88da9c8714b02dcc579b6f561",
-                                "uncompressed-sha256": "f978f6990cc1af7c638fbc92507e8ae6db7d96d6ea68dae931fee7a70997890e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "22d34d8759acae3c7ebf04e7577835db9e3731df291f19274470798a6bea26d6",
+                                "uncompressed-sha256": "d6fa4801a27b7ff3ac6ce431dc1a21feedac1462359faac44c9116ec15f879a2"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "6c08e84ab91c1039f4e72dc66aac76d64fdf31f72703fd6c27124791b60b0b4a",
-                                "uncompressed-sha256": "d7dfebcb8a2bcb4c09bbadf25535d95853891d8f9aac57ebbb755b40bbb3d537"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "850696fee026f0d1b3173cb9fb248480cd81146984be58cb2388ed574062000b",
+                                "uncompressed-sha256": "931919a054ea075e08247d4f6ae179c04573e7297c5260b3ac18cd661a229081"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/ppc64le/fedora-coreos-41.20250215.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "bfd06b040db31eb774aa9a17da9f6987014a342f44f69c9628d6f55273b87b6c",
-                                "uncompressed-sha256": "b1e562c8dcdc7a9002744018209d0f2847885bc0e990d80c6708142d3c9397bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/ppc64le/fedora-coreos-41.20250302.3.2-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "912a471fd50a379bb06d28a73c3f3b411f016980cef39db5dbb4d6749ab38dec",
+                                "uncompressed-sha256": "97ec3787051a67551726524355d6458f133e1a42142210cbfc46a78e4fa0a579"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "c0cca0f6babe70b199c4dcf4a10b1735392271618f3fe4ff80a9836cd4eedc73",
-                                "uncompressed-sha256": "b8df713b78ba6f1c56f37191032e82e294128e680544e328b7baa4f7f78628fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "30dfbb1f3049fdad952069d7b9f820b049412974a2cc21b43dbac06107f0c792",
+                                "uncompressed-sha256": "eb094410666befd70736447c1a56a1aced44bf63b97ea1c6638761378ff27a5e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "acb8ff28f30bebd65ec587302b73e22fbaded6d38a22cc44cb7e812e11a1d494",
-                                "uncompressed-sha256": "8485262ef85cbe50b24ac6edfd313a61df7d649399a2d030965c67f8e9c49838"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "cb70cfba6dca566bc0947749354e66bdd3cbacf2d85079f5f5c02428d4ed3bcf",
+                                "uncompressed-sha256": "dfad9ccad65837628b17a72752a1e79b684d6670f38d73dee7cdbdbd57893b78"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live.s390x.iso.sig",
-                                "sha256": "05a683ac36d1375a2fc7fca90c6d6e039346d27b5b03f075fbfcd9f82325890a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-live.s390x.iso.sig",
+                                "sha256": "bc45fd2acea2c22c8781d8d073c318aca1c9eb5fde3e58184838bb0cc930a77f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-kernel-s390x.sig",
-                                "sha256": "953e18830a6d76e8b3dc56df7008f318c26deba1d0dafe4d8238e5107c12beb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-live-kernel-s390x.sig",
+                                "sha256": "876c34c02c22d99c19af62913af5d7b1f77fd009831cf985cd8f73e00ac89aaf"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "383b3dde078ede8a4bb54976580dbc546e91d0a58d7e859f86e516d053e223a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-live-initramfs.s390x.img.sig",
+                                "sha256": "4a03d50b0ba986607e2308503788e76a594fcc32341dce4674aff8a2e9d94819"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "62097720b012e8bf751b4929f8539f32ef8b03afa1db87de66d05907412efcb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-live-rootfs.s390x.img.sig",
+                                "sha256": "103f80109da74fbc40fd4bc33b1824cf612bae95479a6d16371871876b00906e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "870d00fe73adf9f92fd0a2f410762e0ae5cd9035b64d5c0e4257e40ca4daaa8a",
-                                "uncompressed-sha256": "cf2e39c5a884483de226012b5044101173e93ec714416e0cfdeda95df3805082"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-metal.s390x.raw.xz.sig",
+                                "sha256": "61956d176d131959b4409d340d4e886872964f0e1dd36fa0bb47e43c2c270907",
+                                "uncompressed-sha256": "09b2fb5e444e0ddfd317328c8b100849dfcdcbc677e9bebefc3ccde95b8586ea"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "fd51387e8bc51ae78043b129323e87bb907957f3ede2ef1a6ba41c4c50b107e0",
-                                "uncompressed-sha256": "4cb45fc7462ded57ccc5738ae3400f76a9595c43503e752029629d4d467d51a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "6f7259a627db920438e71ea519f23be19d676ca1b7c3b1dc418e047b6849ba41",
+                                "uncompressed-sha256": "6862bd40f92fe3045c88557242d7402a8345ab95c72aff41a3bb61946bb21e51"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/s390x/fedora-coreos-41.20250215.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6ef5f5533b514b6c2e86918fd11e870e24749fd55eb97721bd5cbc2daf72f486",
-                                "uncompressed-sha256": "b346a91cf59c0e2ca2f2115adbab70f852436655546c1d4c1f8e18ddde2fc468"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/s390x/fedora-coreos-41.20250302.3.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "280256f144518b9caf2b96f60df81e0da5a8a38f5741cd6ac2d1dc3d060dcb9d",
+                                "uncompressed-sha256": "ec3f29fd2e4b0d8f0f2d10bcd31e8abcea3785355460554f2b2ae1d37c801e8d"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e0f278b53bd67cdf92fbd3a77d8ddfa4c4331c25e2546b7db8f17d66e97db87f",
-                                "uncompressed-sha256": "46b03a62586dc869767ae3dfdaf88388adbcc05b8479f0b8123fe82fe55d2513"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cec4a7d12fe5b40eeec580818d6b28739b49f9a0062c7654ce04d3c9f2b661ba",
+                                "uncompressed-sha256": "6895b2d22cf14b76a6b44cd546a3700c371103d6c103ea9ff48869efe1d9dd43"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "10917f493ed8f3b3c38e1c7d60fbca34651dbc454e357ca7877d642251b66bdf",
-                                "uncompressed-sha256": "93d239aae6c9d3abba739228d78f1ebaf1ae3ea386ecbf01008eb1f70c9e1baf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-applehv.x86_64.raw.gz.sig",
+                                "sha256": "9324ac380761652f440fc13b014cee59ac31958c37814387139340aceb811b65",
+                                "uncompressed-sha256": "1a79ae73894fdc7591cf55568ddf09bd591e375144420a451c45594ba61de2a2"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "fe3399181100e23ba44529c3f52c62a5471dd5064a723871279b344917e93987",
-                                "uncompressed-sha256": "20cb26c8dae90d3991fe10bff65b304c9a2d728be276d2925b1107b94048f1e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b9bb4cf06727ff0b3fdf3f1646d6c16c21422366794ed35a62a4c6003170045e",
+                                "uncompressed-sha256": "5650bd2629a99e73b0923591882897b43a0ee35569af458e59e552e57fbc6b5e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "535fa963c93050ffc82271f1fd3a7530b14f37ca20c1ff88ae682d14dd4e1253",
-                                "uncompressed-sha256": "4cec54081094a1c9478d6aa8412086b9d98e58cc5c91d6c142a9dd2901c655c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6e3c3b7c9bdfd1a28ce5864f84191cc8869aeb98601633a90d805a447f8f0f8b",
+                                "uncompressed-sha256": "d4aae8202d6172ccffd9e6c28bd73293094d4d1676cb68b2603446c7a8ea6351"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "07901ba558f11a122fd0cc3f5bb2fce9633786bdbacaf5ec3594a26b652b16fa",
-                                "uncompressed-sha256": "6958aca68d7a4135537f37a232b0765a71b3d287258883a4bac373e84f883952"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e0a4ff14cfc752a72ea96f30a46bbb8613eed5a98964d73c5faac18a94540ce7",
+                                "uncompressed-sha256": "6f8a99b79c3057308fddf6178cde236eeda2e519f012363d8d77ec4a0fc51de2"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "a5f05758f8104f3e4aad8e2af74049a558c66a1a09d499b187ee73ffdbe4b538",
-                                "uncompressed-sha256": "dce30a25c2efb5703ee76a4dde7b0ba7bebd857afd9bde2d02c2afe29ab22346"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8e48a76010cf78fa7f6141bf8ecb9bd1e6dbdd50113e5b20a15a483b702c3ee2",
+                                "uncompressed-sha256": "4b49c74ee23223018a237fc1fdf1a34a2c9db05c4e4bfe0592f6c36249f82648"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "01d844ad2d075fe7181460ff4ef8a1a952131b982b5c21179ff1de1aeafd8115",
-                                "uncompressed-sha256": "50d5a8380b10ead06ba429644d264d57d623a66ebdf4da606c69a0006c27741b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e03e2253c19bcfe9a7a2cfd9af3ec5d34c353311cc321c21daf79e99c9bbdc99",
+                                "uncompressed-sha256": "4a7ffb0b4d750f52d22aa2b2f16021d9bea333616f43e027b482d83aaa22c4a8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "125594780fdfa285ff480a0434c1f0d30b87a4528555f8ab0520059570386dac",
-                                "uncompressed-sha256": "e71ac67ae3774febb2abe6a20b4afea0440f17383d53770a2b6f195c93c63128"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "e4b6daa61960898b9521aa05f58ee1e346c5e8513ffa7fa61642b449ef3de65e",
+                                "uncompressed-sha256": "af4ae7fcc50cb73d3947a837dca6a69dc589fd0e8853db8dc7c5b1de4900734c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "1d438f1bb430abc1d0cddf2b5655b917a56a340789669604cbd5a0a869148e1b",
-                                "uncompressed-sha256": "4a26e97bd3394fd18934cc0378b184aa7d5197bb860032d1b3c1953b77f9c1f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "613d58eabb1ccec3ffef2ecf86087f65189a9707940ae1e7b1c78435b07df2f8",
+                                "uncompressed-sha256": "2cd3ab94addee7cd59f254b3830955654ffce641e0d430c5f2b3a9387262f41c"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "aab34a5fba06c32f2f0f383b6274fd7b653b2b29897c9a0dd59bc15525b3ded1",
-                                "uncompressed-sha256": "7fe4d30dbad5f14b031ccd0247f783905912ae70d90d63be03327aeac2e808d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d540c73a42ed48df30602c01d7d1b681cad564ad36448704959afdfdf4ec21ce",
+                                "uncompressed-sha256": "456479c18e20b7b8ac115445e67a0dd06794a5ac4ddc289e0bd7fe79c0c585be"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "e9706a598a57c3ca18765f4275ca692ff81e19b234edf5944cce1f9dae3f0c9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a39e2244aa85753fff83c9d9cb3a56bc91570870f097af65d7f38224d287e246"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "8cfeba9afdf9642615d1764f76e6bb7b1fdd89347b7a533a4395893476640249",
-                                "uncompressed-sha256": "1b02f0c514ac924c9dcb07a798edad2e26cff6a2aa3bba67bb0eb8228aa40004"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "a548311a90f70fee995d87a1df1ad05beec5c5bb4d3dbf1eb6e7d287d60dde60",
+                                "uncompressed-sha256": "f1f80026895071ec43065b565d1a21d907da22d384f9f7205cf336db4d634ced"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live.x86_64.iso.sig",
-                                "sha256": "90ec664ed09f54cd79dba217b7ee0e2387d35193b3027595587d6a65dbf77a12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-live.x86_64.iso.sig",
+                                "sha256": "a8d611a3f2d8d0659e28cc2221afc64d9b4ac4dca31ae474fd49663ec0fdef87"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-kernel-x86_64.sig",
-                                "sha256": "abe7791d5967aa9bcaf9940fcb2aab047279b7534ed0d81376b1ac3553aedd60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-live-kernel-x86_64.sig",
+                                "sha256": "99d05c2995250da75ecc704627a51b914467aa386c838b9c95d7a1f2a28cba00"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1734e749542b56688f75aeafaa09282b8e9bedab1576fb43766b5170fa2e5517"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "5038f77740fab8811d29ad5419eaea388aac3ea8a7e46d40d2e8df65906a33a6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "0262cfb66ecbd8bfd540f9d27d7eeb822a85de316ed790722fe3284c04175ec6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "24c7b98ffbb22736feb967e4737134b931402332b7b4c73a169f140753ecd98a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7d57a227fa9577fa8019eb48df60f199652890cab2af194e17be5917547b18a6",
-                                "uncompressed-sha256": "7f97b178ea781a46f563602077b480647fcf90e741ed1ada1817042ac8a95387"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "71d3da1d3cf5610dd36389a7fb971822926bb8779d152c85e6d356ce1a40cbef",
+                                "uncompressed-sha256": "7387201bc898431e68406fd471e1ca8a11698b40f9758185c64b30dfe1d889e0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "a735656049ea26925676f3d6bd315270622e4b22559d83c6cb5614c611bc53ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "aa7ac1d09d85e47d15cf2a848016594670ce1ed3ca61656db0cf2cf84baf1895"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "84a7748b782d8da2213bdb492bf89b6cacc5f91deff5e54e67cac22a05bd0d25",
-                                "uncompressed-sha256": "705ab03447ef631aacaa326dfcc48371a1e58ee724a8fb1f3ab9612832917096"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "db0214f3c8b2d2696034091041cc6c460ebe14aa0dbcccebdfad158f935cb15f",
+                                "uncompressed-sha256": "9d3c52662c4028f9448fea82e08c599f41ce87f3b721013b4e4a3c9b9db87cb8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "4396fb568da6046aed2bdfade7f1b51046b1af032a36f460ff50436414f8c129",
-                                "uncompressed-sha256": "9332dd76423b16bb6e425a958e8a3b2fe4ad65833663cdec09b5cabf1557fad8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "49f42308233ed373252d60f991eef41266185c687187277a3f303bcd57b0068d",
+                                "uncompressed-sha256": "0edc7f691e4a01d97e0b98e42909eeab9767d396142c46200c52487d0635107e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "1b65e59c93e2cb50c2cc36476f521c0f75e1a7bf77c1ce7043163ba5b4e2ca41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "1c36cf6633e24b2d66a41a64ec373e683a80bc29ef3dd918711fa1af5dfb13b3"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "45bfa83d78bb4881c1fd63d0c09a994f336620e6c0e4c02c168b2e1fcd3b9ce2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-vmware.x86_64.ova.sig",
+                                "sha256": "b35eda22f73f1730f987651c225945d431f972a96821c8610d9bfe2867aac404"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250215.3.0/x86_64/fedora-coreos-41.20250215.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6a04dffbd95f14243a84b932043473b6722ee45f038adc4e45cceb58fa6fc680",
-                                "uncompressed-sha256": "6af190be1ffed9eeb9d2318b77d40b900d440ccd870646d14394fb61d6c88e36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250302.3.2/x86_64/fedora-coreos-41.20250302.3.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8369e621562f9619953eaeb83ffe5d221b6349e38ea9c478e9ac3eded2172b05",
+                                "uncompressed-sha256": "90ff5239cda84bb78150a6e6abd6513367f2ed797c31b95b8d27b3de4acbd30f"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-03fbb12a259936441"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-074e303c902e030a7"
                         },
                         "ap-east-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-002217170fb396880"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0ed6931ce259a30a1"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0ce5c23f5ad117d41"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0c44cb512607f9ac9"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0c4349f834cf7ba33"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-01ba62149dfa77e7b"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-083b6edd7ecc90d3d"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0984a5a782b720ab3"
                         },
                         "ap-south-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-09fd4fa07d680b472"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0ba019c6449605b38"
                         },
                         "ap-south-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0a8d0a93e5186d99c"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-07c265075682f9278"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0175e34b808490a72"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-047ec36bac7e97430"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-09cacc19cbab1feb9"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0105c038d98abadee"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0aa77f9eb86bc13cb"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-006ad21bb0c823a28"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0e2186e160c0b468f"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-052ba4c8fd67a25f2"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-00a226ce06e04d527"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0329045febce9406a"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-092f0e773a5e898ac"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0ca5d3b43c80de92e"
                         },
                         "ca-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-07b5774522db5c44a"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0e1a74505bf34a645"
                         },
                         "ca-west-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0199bfa30f045301a"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0cbe798d36b07dfab"
                         },
                         "eu-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-04f45602c12ca8a4a"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0d1b47f5980dbed51"
                         },
                         "eu-central-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0db78815b6def2d25"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0b3c29a10ad883eac"
                         },
                         "eu-north-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-083fce083a018ca0b"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-078b8032a0b5a16aa"
                         },
                         "eu-south-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-03c3fc36ada11430b"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-072ca590df3466c41"
                         },
                         "eu-south-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0f3ac68c06dc9ee3c"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0e2fb4630ef5e5be6"
                         },
                         "eu-west-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-02006c0a4cd12f906"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-089680af33a2c2eec"
                         },
                         "eu-west-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-096ccedd7ffe1271c"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-011bba027e2d13c6e"
                         },
                         "eu-west-3": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-014b981ba944e2d47"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-08395434841b8cdea"
                         },
                         "il-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-076da9f4dc1375456"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-04139bb22fb337822"
                         },
                         "me-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-099623e450a572cba"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-06e0d645605a2dd46"
                         },
                         "me-south-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-00f995501bed2792b"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0fc2ffd15865d9cc0"
                         },
                         "mx-central-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0536c8b77ea14db75"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-091cfa12905eb3734"
                         },
                         "sa-east-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-02839fad396f1d919"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0105b736520178dc8"
                         },
                         "us-east-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-017a40d47f7dfc606"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0673840ff419bd09f"
                         },
                         "us-east-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-0db71f7d99c3cff80"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0a8fcd35df8bc4a2e"
                         },
                         "us-west-1": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-08b525eb12cfd43cd"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-0c048f93665769762"
                         },
                         "us-west-2": {
-                            "release": "41.20250215.3.0",
-                            "image": "ami-03293305775504676"
+                            "release": "41.20250302.3.2",
+                            "image": "ami-036ef13a8886e9a63"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20250215-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250302-3-2-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250215.3.0",
+                    "release": "41.20250302.3.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4f6e878ec43a377d38a69039a6d39f292733438af5a5a7a925a14c30487c633c"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1299c451001b848a98ab6183949474cda4db6cdfbd4fed53dff98598e1d7816a"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-03-06T00:58:42Z",
+        "last-modified": "2025-03-18T13:57:21Z",
         "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "38b66851d491b72e8aa16918ce79a1fbf86785a5d12e294df8962cec8008b37b",
-                                "uncompressed-sha256": "24e3b8ffed89750f50cfc019aeea9bf69a88dc2bf8e357e0247774d3df0053dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f2a014a2fec3d2d928fb970bfe34407854fcbbe4a3d904a80bd2c8048b82083e",
+                                "uncompressed-sha256": "14ab54c47c85f0e916961624c754634ccd76ab34c7c9af302ffa1671d5977f0f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "82b427be3b1cada9785c4a11a1bf048d9b45a0c17474bcdf106190936075f494",
-                                "uncompressed-sha256": "d57ecba5a466b0a76289a12c5ed7adc183f16e97a17db8a3567544b20ed7faf4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "9115357a57094041c11a80551cd1c530acf8751b4c6cf49fd5633d30bb77f5f0",
+                                "uncompressed-sha256": "fc1a9c2a3dad2a85172c108b7ab33c2355ff5b3fbb5c0016553a3c7e846cdbac"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "877b3f6f7849c584046ffe3ace95f9f2d65386eb1e979ca7bd016f1139c6746a",
-                                "uncompressed-sha256": "6bbd05a673e149df5d4b802e3cd2992efa27b9292e7e890ace932b35379611a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8659ccb687bd5742e83d37b4c5f9f6323e6f4fd49d0e1b924ffb72cd3545f579",
+                                "uncompressed-sha256": "4740e5bd0f4398a43d14a89cbf9a1e59163376b29f866e7da713a2c119b91355"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0c30898caf1f1b8340548f4d810ae5ae795b6437cf9c5d042101ca9f5576caeb",
-                                "uncompressed-sha256": "75e5bd20a5d93c75c49a6328b88e3c4f237ad33d7557df6ee32a85fa3390fd90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "e29aecf3583cffd553c86e2205ab42dd7c00d0d9d8223c50681825e35be742ec",
+                                "uncompressed-sha256": "b4a4132bb8db21940a2022500335a00870289b5216269d27d6e44327f95b6ffd"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "c69d0dc86dedfb23c935ed6c03f20c99a3864d6d1884dfdefc96a8a9b9b22bc9",
-                                "uncompressed-sha256": "9d6a109cf11c42c7420b7a7afd8ee1b6d10fa78817b16204badfc74abcfac36c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "7633a297f7b28b719c29facca0b49b2595daaf7e6972209e7de5fb0315e3b85b",
+                                "uncompressed-sha256": "e3202d03a2228900f47711d57d8435a009d0822e3c7ba8c5565963197f3b7e50"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "285b4bf5c190fe6b4646dc10cc310774dfef86dc819e6349ed033a409b7251fa",
-                                "uncompressed-sha256": "7d21930128b9997be8b92108d5976887463806c874b8ab79312ad1127a675b05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "8b0183ed55ec79f1e045cdc9927a3a026bb8699769e3ec0d307a914bc5853dd3",
+                                "uncompressed-sha256": "4f4fca64063970c566d15d9e4a1bf3234effc01da0798d326600840459645651"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live.aarch64.iso.sig",
-                                "sha256": "54b334b932c1ca0d9abe92ebaa391d76def0d918446a9cfa555302fbc0d3c60f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live.aarch64.iso.sig",
+                                "sha256": "458da03b470fc17a8f0c7accd3a2782640a0954343e454cd4a7ea3d536f4349b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-kernel-aarch64.sig",
-                                "sha256": "559c4ffc501353644ed6a541708e8015a561efda1f6dda29cca8eaf74f58a460"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-kernel-aarch64.sig",
+                                "sha256": "3f9059fd030ec42582d5e5ad580fe9b94ef10d63bf91d23d14bded40db89b18f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "f073f4d89c540f321843db2e9eafe07d76e68909c4f435d879f2be244f36d80e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "55e2bd8eeb7bc02e1f761e8bbfeb7cef7eaafe9561dadb4ecd0c70b17e46fd1b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "746804bd521e5dc342f5968df1141244e8dfcc4f6ead6cb60fbc8bb4884446b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "7e41df242872d09c6953a4904b64a89f80563bc489e75ae430e7cc0be17101d1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "6edd7e2e3a0d1192b0d826161a3c2377bfddee8e469fe48e59a39bca34cb241d",
-                                "uncompressed-sha256": "64dfa1843d10c3a143bcb0bd1e92f77eb017c50317a8baa986be70e1ccfd5b80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "d391f5de21a4b1ff5efba7dea055094abe438a6f2a16a03b622547bd121269ba",
+                                "uncompressed-sha256": "1cf18a7f84cb221d1bf5201aa1a7e699b8f3edf31351232c94099d09fe3960b2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "9ec6117a2784daee6feb8c35b8dbf2fd54bb5d140cfc1c42649902125271dfab",
-                                "uncompressed-sha256": "189c311a1c84965c2e8986d0db246c50510bcc8d7cc1e0be95ca05ec70f786ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "22345dc0aaf7b93e465a49129f5e870f6ebf9c09fcf2dcf1a6befc5a8683a819",
+                                "uncompressed-sha256": "266da96f8ac4f8bbd12e95c288bc8bcb5ea28b9af3dd2ed108e09341449b7f31"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/aarch64/fedora-coreos-41.20250302.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "852f1b24ae81626c0f2070ab429f7f2e9e30c369d620cce95af9da393b6f355f",
-                                "uncompressed-sha256": "f5b3601113d3ea99d7d65bca8b5e3d87e1a5539fb2fef12d86380d400355d4d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "ea1086ed28c62c5e0c83b7454c605a763d5d0607c6e4c47cf4afc41e4602d4bb",
+                                "uncompressed-sha256": "6b253f76f25998ef770ed8bb8ff23bef7e17a0f8da4d0ddbebf8cc39d1ab6e6e"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-08a3921cdbda9ea2c"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-02056836158e309e3"
                         },
                         "ap-east-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0228f7a3df9f66c0b"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-019f3bf43ee22a0f4"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0872f57a52e254a10"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-01862aa1dca1c9bb7"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-082ca9182cc49b942"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-041e01d40bab48e8d"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0ec945fd574b50be9"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0a185ca0cc796569a"
                         },
                         "ap-south-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0cb9dc3050b132b18"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0721f9b5e1189cd0a"
                         },
                         "ap-south-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0a43ca940523097a3"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0bd84baa9f8ef09e8"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-01b25c38fb5c94ce9"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-018e16efc6af2d676"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0c34f915de6e90c8a"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0d003c97f1e667df1"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-02d73551081017adf"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0d60d15e24f1ea0c1"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-026d97c30a64b618b"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0052c122d7a7ab779"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0b0ab26ae598fa714"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0f8dd60fb361ced9a"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0b840b1badce5b629"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-069428aacafe2fe3e"
                         },
                         "ca-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-03f0cdd49f724d607"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0c091ee6bf393d52e"
                         },
                         "ca-west-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0c43debb4cdd9ac4e"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0451879cded51acf6"
                         },
                         "eu-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0df9490eb0f436f1f"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0d81fb4ca570208d2"
                         },
                         "eu-central-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-03ec74869c1ca913e"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0f065173baf0fa738"
                         },
                         "eu-north-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0aaade8cb2b291777"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-048b0d943e9f5d3c1"
                         },
                         "eu-south-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-00080c952a2a0d548"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-06353ca1964f29d63"
                         },
                         "eu-south-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0b6b4487eb9bdb391"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-051456a6253cb5796"
                         },
                         "eu-west-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0226db91a1eb001d4"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0d1f704d4d2745b53"
                         },
                         "eu-west-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-09a12cbaf163bd58e"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-05d5b4ba705228b29"
                         },
                         "eu-west-3": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0c6d9f7b499512fd8"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0c70696676c6d8014"
                         },
                         "il-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0c16559609325dc78"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-023e82dba5d565763"
                         },
                         "me-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-05d1cb1d8eaeaa448"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0441ffcf8d8a4d436"
                         },
                         "me-south-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-02e307a324a1bd05c"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-066a4f73e3ea6bca1"
                         },
                         "mx-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-05ef789fda6e1afaa"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0aa473160612eb970"
                         },
                         "sa-east-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0120414280d3e994a"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-08748b21489ac635e"
                         },
                         "us-east-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0b245c16ae8c53e93"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0a9f2538f537f5b34"
                         },
                         "us-east-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0f98db1b27785ec64"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0090fe56abf9f5e9f"
                         },
                         "us-west-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-00be5dc1d2b9d40d4"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-083338f45259ee907"
                         },
                         "us-west-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0d0aa93ae8ee3c8e5"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0bab8335ec5c4c7f4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20250302-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250315-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "0eeeed97d0c6aade8e413d6346c3718566a56bf5386e99fdf3c3a6a77717ac48",
-                                "uncompressed-sha256": "c0c111d6efa994365f569460661fc8edb44bc236e72e88b09150ffbfa040313f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "432dc29061582523d2b44374cfa02a50e25fec830bbf4d19f770ca71f1bd93ec",
+                                "uncompressed-sha256": "cf641e5e7cff81325bbb57db73905a53f96428f0412ad574ad40c9bc2f2409e9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live.ppc64le.iso.sig",
-                                "sha256": "f57d2880af2ab925e344c81a553c85ecf3d9b2ebcd0e106db426ffa3bc6a02da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live.ppc64le.iso.sig",
+                                "sha256": "14e589324e83c58ea11e2c0fcc1dc770656810b3385b15bb873cf917c9bd1deb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "f5400f8662573474ca8c1d058016f67f845d9063d262569b7ae6b38951498677"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "66386609d72461f9c442af0cfc014cc0a9eb17cc73b7ed779b64047fc63c217e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "22c0da9baaf0a60ca4231133396c141783e46878e0bd550fdac77fe4da7cf9ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "2bef10671179fa7ebc7f5a695fb57bf5fc0ee4ea50f1b95daad5f9d2dbed5f7d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c2fc52311a9e1164be2dd3ea795090b27f67f8b3b4cb8d62fc3f550c56ec8a25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "d628ae0d2630d87258c7b882c63f1be7c0b17d022550698adc7c7cacd907b944"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "b0f5707d6bda765eab78feb9eecc76e88335a2eec8306c5f7be82d172059a70c",
-                                "uncompressed-sha256": "52b4be51d53167fe54a2af08e828bade044c30b0d8f432a41a3bc5ce0eeddb5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "54c1707a5b68bf5c338249e406adee3e02500864b39ed5b9021ec4ce688bfd99",
+                                "uncompressed-sha256": "d7ba9c17990cb718c86cdf01bf4e7d152b1221cff61c6833663462c50f75640d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "51e8321a3e1742f17d1242534830f6726da625c26ddf6a11cb8e8557c2a59651",
-                                "uncompressed-sha256": "fdd3afdf801cd9e41c732edae6e633053ca518c8f5f493b2f1c022cbdd091e5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "0f8493b249ce659f5e7f9e12f8b561e31a8921c0cc724b9c34b8a84f61953c41",
+                                "uncompressed-sha256": "363bc89145fc1cc099e422bbc990710692f89e5fc880b8b1e907b0406344780e"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "37283c699bfea6dc0d11fff01f078d1344b22800998adbd16d01c6269718f8d4",
-                                "uncompressed-sha256": "0a38337803a0e7638d31e0d082d2eec7f828d6f36dc7fe7ce91278ee27709fbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "1d9506dbe5cf777d5f955141a19abf1706ca8afa3b0751fb22a278c448696d4c",
+                                "uncompressed-sha256": "638887b69cadf0aa0baaf7e782e8b41cc04bd7996c69fbaacfdf8bb67de87fee"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/ppc64le/fedora-coreos-41.20250302.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "3bf6cee34b658ab580df76a087f259d6ce6f04746964f09f54e7de4032e82208",
-                                "uncompressed-sha256": "7ebf09f8114c7b5e8a75e025409244d0a2af16952f1c2c4a46751d05d7995a20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "530b08b9a877e8d891a59e92103e2e31d973a552d769c1c14fcd90ea16e90d4c",
+                                "uncompressed-sha256": "98112a0a342a3c3eee283390e5238bda18edfd90aa619431b508c2ee527129d2"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "887ae443e3374761444f1d9490c3b9f40002fc83b3d71a4480d3aad2806e9505",
-                                "uncompressed-sha256": "426f0ce72b805934d0d57e691df3305f1944bd6a399384c451fead89be15706a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "af81f08553c5ce9fbf07a3fdd6b861ed526607e94198ca09ac39591f19448dc2",
+                                "uncompressed-sha256": "69dd89f1316eeaaaca95abb18dcaeefe6b5ee793e5bc82275935197075c9ffa1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "23f5db712529ab02ad97ec9281804ae66c82e2846c281f61d02140273f335bca",
-                                "uncompressed-sha256": "abde76dfddde0963438f2b4508b2bc29bc4bb589bc91f3a5c3ad01726a5e51e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "da63986c0ff564bc098254f43794a5e3924de52f6cd71fb8f0533a83d94e29f0",
+                                "uncompressed-sha256": "e8fcc609acbdd4bdabe97efd8fb49d62d3763e2471f40378495b0d183f9f6de3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live.s390x.iso.sig",
-                                "sha256": "6992f734d9fa8e8189d1a5f873d6f555e584f07424931219c8810bb91220217b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live.s390x.iso.sig",
+                                "sha256": "17031d0b4e5f1ebe11a0a773c81bfd14280f052df5d02e6ded2e490a811652a2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-kernel-s390x.sig",
-                                "sha256": "876c34c02c22d99c19af62913af5d7b1f77fd009831cf985cd8f73e00ac89aaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-kernel-s390x.sig",
+                                "sha256": "0e11af135d30cca630bcf0971cc54b8445d2c32a6c5875963c24b661910d1e42"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "3a2b7c7097e8abf6c93035ee3a701b6935ccb795e00f38861334c68adbba4f51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ecc790e061166f1d1ecb76ea17514060330f2c7da9cfb7e32a3c03065e31da2f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "091f2330e9937bc35ec18b28c452f1b90959b4dc761d98465fcda3ff56ce225b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "ffddcf0d161f20cfcb580c88e823e2232a749cf7fda7d5669dae19d1b5676213"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "2ab850ea5a548b0c01d14824ce3fbaffa3a0b3439143ec776804b85076b36492",
-                                "uncompressed-sha256": "ed74c31a7f64b86fc042edf97f01a3cc1cee2c4f5bf5d259fa221ccbcc551dbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "015c7c747e53a6a39aff02a35368c1ca13c8ec954a030f85ceb105a84773ab02",
+                                "uncompressed-sha256": "1c06ecdd67e37e00917338a25396166f0962140e78ef05c1cf29493678815632"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "623b2a141526cd1fa975cd91b3eeeec4a8cd3337e0d73aa91e368c2583ec76b5",
-                                "uncompressed-sha256": "e22cfe03ebb34c69af3364115e170058858176f55bef4ca752f423a058c6a57d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2270caa16a58d88d46b47371bc7f8c837f5d51a513623d157e664ce449102599",
+                                "uncompressed-sha256": "bbe7b9b05a54b26e20948ccae0dbc1b26065802e1d7cb1ae651d99e6b1e50486"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/s390x/fedora-coreos-41.20250302.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d794a00c5e02e2dbe940864ded91561f41210e5baac042fedfb45f81f3032309",
-                                "uncompressed-sha256": "d4dd31723bb2b455bd9edd29d333ab3b07e4239aa30680dcdea8ccb069bdfedf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "74537eae7f118948dd1b549845d48f656e13cf01956208d7bc27a9bd33359078",
+                                "uncompressed-sha256": "099a04aff0dc6ce5d3e3a124007554615565841a733fe3103c3ba1dbb42547b7"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9daddf686adcc4bc3aa4563f3090877038232c0fce29e39c4da03af51e082e0e",
-                                "uncompressed-sha256": "e0656f511df63fe9e04ca950d4ddd34d09730ff11ad29432ef2d7874910effc4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "550cc27e3358a7810a8aebc7268a9164da5daf006b1d386c7c157f594a4e5da1",
+                                "uncompressed-sha256": "f2e3b6c6be7a7ef4b3e405ef3728b293ecd76257a12c8b85cc56870574f86b0f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "697bbf5e30486fb570f6612a523055bdfc936ae7dc68d26d6f6abb2797e02cc8",
-                                "uncompressed-sha256": "3d6b8f2f31ec21e63c23ce5faf95ba9d50f30ec63d5fb8ede5119d649a82dbeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "8c93d5c58affdda17f2bee779e5f8cf1c8b1df062455f26007b3b532c04bc715",
+                                "uncompressed-sha256": "09c096842f152d5041135471b0f9f25cdf85186d59770e815092cd20528ef755"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "25a04b10989efd29e050822f06a9f663b0801224c19db0d18edffae5dce3a908",
-                                "uncompressed-sha256": "d17c20651bde2b492cd98652d35894f52fe3ac880a092b03d7f6b88723c2198e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "76b79a5b4eeb774c0a289a85477bd2ad1c8cc1b0c4e1c51771c94829077fe484",
+                                "uncompressed-sha256": "17e8fbf03e7f72d4f96b7241be1cac1c063f1efa98729ba1399b8f7a02b0c38d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e006938268835f8f44da90acb66b67f5d2e92a8402916458bbcf6c9151646a8f",
-                                "uncompressed-sha256": "3ef3ebd2bc56b189c8368d0ffa6551953a1d6c66aee22f03800d64d88fdb17f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b6ced53d6b9fe844ed250edd254bd5be17098b3e5227e7597df141f7733034fd",
+                                "uncompressed-sha256": "af3481c86945b2043dc18aeea517be599fba6b628e7cab9f0cabf8f49da23581"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8d361d25e4933828aaf4c6cc55d90f1206a3f2398d0b1f2e756a78258ed60173",
-                                "uncompressed-sha256": "b4450d0bc75b2ce113c73d5511ffaf6c16089bcac8d7dbc05deb0afcf593ce0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "aeb4a4d3186211fd0a767b2d5356dbde0087e1c603db3ee1740e7fd90667838a",
+                                "uncompressed-sha256": "021553cb1d105d58268df35f5c22f83570a089ce3682936d0789f67e3558d877"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d542c00bd1f6555b3e39548cf253e85a31db7dfe34649f924bdd6b42f5896263",
-                                "uncompressed-sha256": "cad2196b8e3397bac1ec259dcd6fd13edb98f55d340f8213aee82ad6785fb702"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8a43029696170041ecc7ebb627f2ac087369d959a87c55c3cb02670d722be110",
+                                "uncompressed-sha256": "6165939b223bbe2ac3b762fb87a55fbf7e33ec18afc6c677b8b6d0b1d1050074"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "926ce1148816c032a505450bb473b377c73ee3b99ff29f0b5f0fe570fd194576",
-                                "uncompressed-sha256": "a16cc3c23d9225197ccc246c28dfe375ce73b7bad71ec339ba9b8e32d0a53bce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "18c757936fad0596007222fee848eb77b6f3f88bf03298c18b519bab3b9f9e8d",
+                                "uncompressed-sha256": "b583fbe6ddc76360de7085f931a18b3fc71849bb4de26a1eeeff7a2ff3f3b85b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "324dd98b0ac8b5b1b06e13d311eec623744c3a1bbdc82db891b6e580bf9b3af5",
-                                "uncompressed-sha256": "17c418f30a5458eb623e79db81f8c8fa619f7be1ffde18178fe1eaa542356796"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "538554cd3189b223f79de8b388f1cb5c34ea75ebf48aaa719ad1455fda556bb3",
+                                "uncompressed-sha256": "3af10241b57c6bf092e94491758e91b4a5d5f9ebc3ae3eb385a0b2752fa2a2fc"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "25ec71ed118b0d1fc88561eaa70ebb69e61bf05a749a78e600094a0c753a6a9a",
-                                "uncompressed-sha256": "30c696d03ae9b3a50a854b8ee6a2cb13bd66c6f7370f1986631a8b77ffff930f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "90d22e119b7d976111b8682b8784c5b7e1a2b3d77a6dabeea32e9bc96754ff4b",
+                                "uncompressed-sha256": "1691ce7ed1098d676cdd361d6b1f26ca482e57f4b50be201dfaa1de926e5863b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "30c9d8fee0aeefaaa4e6d190aace78cddc369ca43cf771d0dc0c231bfef16125",
-                                "uncompressed-sha256": "b6adf848f424d40f30608f4ccbc4332f007e6c85309a6739e1516644baed2225"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "844a7311e2aeac05a07d309ecb82b823fa892dcfb105f0dee5948f0d36e7ce78",
+                                "uncompressed-sha256": "3d3c63b9ea8fa32bdffa978c7ba8cdb261744b1755cd9257fa63fe1fea9349f8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "3ea50e7fe5272b9c31f19c63d4a0eb51de9340b361da5842bd893b3bc6f93604"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "bebe7d163540f3ae5889dbac56a44430c533e8ac12fb41abe351cf7408f62938"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1889980a9ba571ae26a5992c8d755d46f0abefd3f90534d7ee248bdb073f1fac",
-                                "uncompressed-sha256": "1f839d2185a58c608fe49fe19b7493f22a9b9d8ed8b1994f55bf094f3381f8cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7df3c4d93ec3f48cacac990ae48dd879beab802946d47f9cdbfcf8f4d37d148d",
+                                "uncompressed-sha256": "548e8c5a202f642045df521dc7d371f1455042271081a1d45e791491ba7399e9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live.x86_64.iso.sig",
-                                "sha256": "b2e392f375e1b8ccec06de4a807aa2d79e68d5a1c13c8b00e4ea6e9da0b1fe9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live.x86_64.iso.sig",
+                                "sha256": "4bebccb0ae402c8378b2dfb687a9625d1cffdb07a9c8ebbcc7d20e4c32b96e39"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-kernel-x86_64.sig",
-                                "sha256": "99d05c2995250da75ecc704627a51b914467aa386c838b9c95d7a1f2a28cba00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-kernel-x86_64.sig",
+                                "sha256": "297f232fdedaa8dfc5e81b478fb5467536e47da28982cb95051e496576ea6bd4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ed8691cc5b688a4ae78e8db98c39aee9164680ccc462458cc98080c9054043bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "1423d738964edd7dff9031cb1796d695f600e41c16b3e75c682eb4d1b77071bf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "f0cead182d30a91ede720f88721a2a22fb30d189041c3a1dee0df5d0d261a271"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6e63bea1a44b03dac09ac42f444294ea56a0dc53ee880ecf04f9d46184413873"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "5f75c6ced502eb75112193858cbab51baa8a1e537a359d99ac892c3b90453a51",
-                                "uncompressed-sha256": "389e510f192745004777301f25dca2e19b2b0c7dee3646f6bbbab86c2078bc0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b5ad8c2045c9415d9ead81e1591a0a5ddb7ecf820380fc07f5dd0c98eef2a467",
+                                "uncompressed-sha256": "dab4451ffeac5ebd7357d3b768c1e5d69a394b91cde2a349ed0bb0a36b1b872f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4428922470f0c6746df371c3aa1ffdd877e8de9349d8301abfb32247d99e585b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "32037badaa051e66155190e9adc7b23414126232c470af581f77dd79d106a13f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "037ee928c0f2cb0fc853c08e07d4e5ce5caf223cbcf112334f684c45db6c535a",
-                                "uncompressed-sha256": "2d3cfe7783b3305670ebfabec44ec99f6698212e72aabe78c79574b0397b3f27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "e1fc606d243e2567573c2bce99a1220f06a1ade4c4670e833dc5835fababff43",
+                                "uncompressed-sha256": "1a04702f066427396827a5ab7c6eeee52bf9ff6072241eddc6de71f8afdb772a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "178f0ec7bda59b12d1d1e0a286d890dd013691b4780fc3e210141347ad432b96",
-                                "uncompressed-sha256": "46de1cfd05ded1e2f28d98296b64713a50c8afe5a9b384f646b6ffde084e0fea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "36a917412fbcc2e9d921f0c50d2059847fb68915ec4dec523b16d0c7e4c8cbd3",
+                                "uncompressed-sha256": "368611368424460bd0d5f13da97c616944ddc4ba743064bb7c223625043740ce"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "a333f118c071b33c48becf78bd4cdf916d64c630e8a6efc6eaee58f06f5906bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "3eced6579c5db3b12220bbfc6ce1be0c9d3a320e509a28d30cdfe18107ee161a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "d2d70689d55d7b294277d8f6313c2275efc360bf949a0a427d8cca397ff64233"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "e212b687490b01c29c406c7710e7795a3f7ab5f8ba240423033ed6bcda944109"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250302.2.0/x86_64/fedora-coreos-41.20250302.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "14c30b265b02ddf416e937f8a755f00e84ba11203696a151b50242ea1eab76b1",
-                                "uncompressed-sha256": "a2ffcf7754a3b3bfd139ad9424951e944eb6debecb048d7176b5fd5cf12daf59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b1492e15d469bb6abb954f890efa3c951942191b7ea275ec42637527036006b2",
+                                "uncompressed-sha256": "c694040af6d4873074e542d52f12aa837ae02f2b741a36f16feb2d3b786015db"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0e00b1254f17b7cf1"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0fc2a5b6b171d3de6"
                         },
                         "ap-east-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-062dc66c33d4cebc6"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0f3fea7ec66e15781"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-01adda76894111ea0"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-06089d7cbb6f126d4"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0965b806dd375f8a2"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0e02abbf599d17e6e"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0dd52847e6975058e"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-02c705fa703154293"
                         },
                         "ap-south-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-08787fb94a76ae833"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0d3ea7aee8f6b35a2"
                         },
                         "ap-south-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-078e29cc5b013460c"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-08e4cf75443351cbb"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0e27f89d9b4d736df"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0a025e217e5128832"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-03fdfc153dec920d7"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-07b76b1bc88f5e6ea"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-048a4aa71668e6381"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-031af5787daf952e4"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-01f2d82486f7c0dbc"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-00c00db6d996bd06a"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0bb8efd4a367e2c29"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0a37cb976c331e73f"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0b7943153361883db"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-08ac4c7cf46b26a83"
                         },
                         "ca-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0da850ac51b01266d"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-09e3bf7537265c906"
                         },
                         "ca-west-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0ed91546f33007bef"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-026ff7b83d5e29fd3"
                         },
                         "eu-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-04773ad21b0ebd3c4"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-067f1e95dbaf59823"
                         },
                         "eu-central-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-09b416e0fc1f4531f"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0b1ae2f1c982a345d"
                         },
                         "eu-north-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-00702f705ccc37766"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0dc9161130988ac5f"
                         },
                         "eu-south-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0390dbdbed7517041"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0392e23160841996b"
                         },
                         "eu-south-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-078633d330fd1ecb7"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-04ea6ca58e92c6b6a"
                         },
                         "eu-west-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0c1a92e97eb8b1f2d"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0217931afb736f51f"
                         },
                         "eu-west-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0f8630bb52455a1ee"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-09a333ab7f784db46"
                         },
                         "eu-west-3": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0bda20311364fb5eb"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0fa1c69a6d4c17f60"
                         },
                         "il-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-07a62b570cadbd73b"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-09c214e6e7f24172b"
                         },
                         "me-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0deedc2c1cc848a14"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-06d9656ebdffc6721"
                         },
                         "me-south-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0b49d55cc4e4f62d4"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0746801344f5200d7"
                         },
                         "mx-central-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-00b9974c3057b7478"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0ab682ef0dd808ab9"
                         },
                         "sa-east-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0afb175661f3fdbec"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0662d4d67a630ee0b"
                         },
                         "us-east-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-01b41efb8513f2779"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0339eb2b77966cb50"
                         },
                         "us-east-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0fd64816e29439771"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-02a7b49f77278c9db"
                         },
                         "us-west-1": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0f7e088d78c96d274"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0fc7010a897da1668"
                         },
                         "us-west-2": {
-                            "release": "41.20250302.2.0",
-                            "image": "ami-0e4597346f199fe07"
+                            "release": "41.20250315.2.0",
+                            "image": "ami-0640bfdc6402889f5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20250302-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250315-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250302.2.0",
+                    "release": "41.20250315.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4ff4f581fc8fd065b0a0c80897e85da58e14c41801e18ae43a43f4926b73c4ce"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:274d7a19bdc3677b4a7350be86db9662598ef25a4ae529e1dc80821415a90bf6"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-03-06T00:58:43Z"
+    "last-modified": "2025-03-18T13:57:22Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "41.20250215.1.0",
+      "version": "41.20250302.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "41.20250302.1.0",
+      "version": "42.20250316.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1680,
-          "start_epoch": 1741266000,
+          "duration_minutes": 2880,
+          "start_epoch": 1742308200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-03-06T00:58:42Z"
+    "last-modified": "2025-03-18T13:57:20Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "41.20250130.3.0",
+      "version": "41.20250215.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "41.20250215.3.0",
+      "version": "41.20250302.3.2",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1680,
-          "start_epoch": 1741266000,
+          "duration_minutes": 2880,
+          "start_epoch": 1742308200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-03-06T00:58:43Z"
+    "last-modified": "2025-03-18T13:57:21Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20250215.2.0",
+      "version": "41.20250302.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20250302.2.0",
+      "version": "41.20250315.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1680,
-          "start_epoch": 1741266000,
+          "duration_minutes": 2880,
+          "start_epoch": 1742308200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).