### PR TITLE
Roll out testing 41.20250331.2.0, next 42.20250331.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,143 +1,143 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-03-18T13:57:21Z",
-        "generator": "fedora-coreos-stream-generator v0.2.15"
+        "last-modified": "2025-04-01T15:04:53Z",
+        "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "82a9371ccb3994c4133c94bf80ba03419f5ef10516c03775dff8e9a2b29c86e0",
-                                "uncompressed-sha256": "b7c9e147268e5327628b13bde70161cc4c98b7027b6d9cfbed238dbfe6f24a8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "4c1d97601a064de8999d05e9c70d7e9d714514754ba6390de873f16a422c8174",
+                                "uncompressed-sha256": "8b899034fe919f1304ef6f28ffddf4d52a835b1e16e16809441044109b531c62"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d34333b074725094fd1d48a063f1327d18d4635548b7910ddd214b841d8eaaa7",
-                                "uncompressed-sha256": "e7dce12aeccaf5482b3342d6776297ac4cdd8c41da48ec7db6b37e87e1272473"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "bae6f579b311f600317d0ac080ec5041ecd88eadf08b449f27e862a04c65e17c",
+                                "uncompressed-sha256": "d9fe33d7d427b7a7907341762b232909134315cb1cb9e90538f2b3c9192da46d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b834ed8ccb1ebc421781eca20fa26c9d3843386bc5ab061c51e33bb878f98b8c",
-                                "uncompressed-sha256": "b2aab7ee714e31fc31f20647bad9a79bc6206cb17084314e0704cc819f2c43c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "022958e10b096e77e6ef818f9084b2d0492584f745a005e117029ee52df99981",
+                                "uncompressed-sha256": "eb3ce219fd750162865872faaa70a63274993c31bf545fc086a0f69385268a31"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "89eacddd0fa7a32ddd6a95740a3cbb454b5a1228b462cecc4d592d8952b49562"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "e341b624404f3cc457fa8750824a1179f234005d56a403b08aa0e997c0e21179"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "d8de206e6a5c27714b90a2886b25995ec25f0ba554f324ac117d805c8f63d0e5",
-                                "uncompressed-sha256": "f1d804a66bc58eb67e8c969e65ccf9a0821685dc85314d5e2f3ea75c5168ee1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "573d83983fa48a889ef24bf721bcef2d86103c3ceacc52f7632e7234acb1ae9f",
+                                "uncompressed-sha256": "8658a626afe3e7e33cb0b1c57f0ff0eadf8457ae1aece404338dbab0f63b1675"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a1cdb445a0ebd0e689d9b48c64c75a590e7305ad98116d38a56d180aeac8d163",
-                                "uncompressed-sha256": "1b6b73c4884e577a68c7a14031ebb8d53d567d18751a9aaee81760f55d763295"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b8f4e96613653470351c096aa454a43c2779f3783729b2e38b0c03d3cb681e44",
+                                "uncompressed-sha256": "cb0e2b5fcae64fd58583efa57607397fd704d67197e5db15cf6e1f44d20317a9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "8fa463ca94c617e6c0ab07b296d2f4ee2ae119479e458a6f254598cd53f18956"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "84e8156650d90ccf19a4f81661a2c7fcebda9a8b385782f6ca50dfcc2b7a38b4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-kernel.aarch64.sig",
-                                "sha256": "7d2188a4937cbdf8aa32dc78265689da4263cfd3746629cba0913301ef5a3186"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-kernel.aarch64.sig",
+                                "sha256": "e249c9d6d365dc640215ab759e18d2a8ff06db2aea29fcb4f4d13e3392f4a25a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "2adae2e068fbb70c64372eed6deb4820641a3b2cf1267c5938f11e599a06b17d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "471042243300eaf87c13bb6319df9d23abfdb294002a7f6ce426eae51fec7040"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a0b9d549ffea44d5b6a0aaaced6ddc101cd1c196f75ac8347e1ee1c76d6184d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "f44fee2cacae298067068985b82489bda6df89cce00e45f14cd5103c3dfe0cf0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5c0aadadd59cf6f52ad10f258917f135066e47fe4a671b578e9dec881a6c8381",
-                                "uncompressed-sha256": "57c30ec124fa24812629669277f5b34347d50ef5a16708d3ec6622bdd6f758db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "293e80b574b1b09e196b22380a6ab46b42386fb4763b469b6953c0bb35351d49",
+                                "uncompressed-sha256": "e2b3c8c60f240b0995c08e5741608a845ed44da9d55771f62ffa8a9cb42bccab"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "98f98c749f99d9aa051a5eb0d4f6097ac6ca2ed49cfd21064e8afdb1d7d781d0",
-                                "uncompressed-sha256": "da2d358c9c3c3ffcd56460b71bf677a0750bec6464ef4086aa21faec8398ae26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "563ba00de85d258f3ad90d2d1f0ed4674f1148659c06a1f0c139c89211948af4",
+                                "uncompressed-sha256": "b29b53bc661bab997c91542d6c377b2e1455264642764824213cff7825b365c1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "9bc43d31f110a71e795d9558f70706592b3bcf798975851e536159f9161607c7",
-                                "uncompressed-sha256": "170acfc25f13245793385e2f4dfee4973b81d0f68000664174412ccad74040b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "514cc4c9950562dd3d1eed4ee91f5a270d3ca84a7c65583ef32e0db519c092a2",
+                                "uncompressed-sha256": "30548963d0ca48c752caef8849a6218904515ecd65c713418b10b2b957bd4ef3"
                             }
                         }
                     }
@@ -147,225 +147,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0d30ea9c1edb16bda"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0246310c575d6941e"
                         },
                         "ap-east-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0c7d9a80b94e607a4"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-08efc970f74d4c61a"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0c60ce39a8ce155ba"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-037102c844ef28346"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0b2da3e1e2d85de72"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0e55e0d55fde18816"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0e4b30f12ee0faf00"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0c470cc3354334585"
                         },
                         "ap-south-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0ee232160dfbe40d0"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0abea6f0c050dc23a"
                         },
                         "ap-south-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-035188ab4af82215e"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0b57d0caed88ed822"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-084cacc4561d9e17b"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-07520472593ce53cb"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0873d2ee0c2e644c8"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0920d4ae7922b6538"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0b706cd3d9ab37fb4"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0e6cb02d4e905cb54"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-088843d6f6cc1f5d2"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0a62ecea8b2e388e3"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-02ac7d2c9e427041a"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0a4b022313e5d36e8"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-01eb75a37a076de02"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-02c0cca5c1e8b9836"
                         },
                         "ca-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0c8f1a2cdfc3eb3dd"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0599bd1bc407af645"
                         },
                         "ca-west-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-03464944bf7eeb5ce"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0b1a7dd376d3f7439"
                         },
                         "eu-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0652c96e9e98c794f"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0aa925c72658c05e7"
                         },
                         "eu-central-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-03f6877fc9cc97e76"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-018e4fda54d622c98"
                         },
                         "eu-north-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-09db7a2362119b7ca"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0d252f3283d1cb1e4"
                         },
                         "eu-south-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0ddb68001f52aa11e"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0fdc8c5f1fd7c32fb"
                         },
                         "eu-south-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0769a8061f37be723"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-047536802eab107f1"
                         },
                         "eu-west-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0f55ffa612c4154ab"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0f83a0c77b00fd85e"
                         },
                         "eu-west-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-00a244bf35803de02"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-00045063d75d0fa74"
                         },
                         "eu-west-3": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0a1d9526df507dab3"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-057c3ff67055cd430"
                         },
                         "il-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0d561abc387e54aa7"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-013753929a7543c68"
                         },
                         "me-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-079b42ac4ba32bf1f"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0ec6658b41bdadb44"
                         },
                         "me-south-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0a06889137554d1d8"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-061c6c8f97d8ea01d"
                         },
                         "mx-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-094000680b76da3d9"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0c7412fc5727bc375"
                         },
                         "sa-east-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-05c52e1cee4371da9"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0de3e465543d01a7e"
                         },
                         "us-east-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0dc8687e850bfa269"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-034b6435f3e9daaf9"
                         },
                         "us-east-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-052fb57c4ab9bd0c3"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-05b0f82cf3859d607"
                         },
                         "us-west-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-08fd4fddc28c0c56d"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-04d64ac1f0fe76f1f"
                         },
                         "us-west-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0a626e43f4a28175a"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0f0fae32d02e391f4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250316-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250331-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "fa5545a02ce05125d80be1eb531f588642d2393b7e628667da38d0559a169381",
-                                "uncompressed-sha256": "c0cd48cbe7bdc06f1297f84c31dd6c455b79abf0833c14c75a0f6aec29cbe52e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "dc83f98188d4d58f37b0308ef0c1c6ea55fb0cd41e02a49231cc6e49ba5df493",
+                                "uncompressed-sha256": "c3ad509448ef8cc1d4a378d131755701d3cf7519841b0327e1d7cde5e6f3ca85"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "27fe5beb962f6d9982984b1b12c5b7ad695a78d7319aabad71431b71f7422088"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "f964f0b41fe852c73c51faa6bbc1d4a5d9bed2ba0fdc5c9eb702a2ac9245aaf6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "819fb464461cc6d581898b30bffdc91447aa9cdb8c165b440f3612305508b43c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "4a522a1b85554d5f4f7aa0aa0cee8d1ccf877165c5c4751247956a51d4a1958b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "47b5615ed6149a6779a6421c25aa82983274e6a099acd5e13a549135a2a2037f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "f0d65b6b06a15a2bea77babd60ae81ace0cad17c7bc048abcce768d3006da0df"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3e211d203adbd90ced0e8400ac45e91c05fd7b13979a3ba439497121f5fbde40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "441398a203cc283d26de363d7532f94c087fe17a04b9b3611973473d894579db"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "49070ef13082eb6b9da159589ce0e59ba9575b19b5428a1020c09a0e41aa077a",
-                                "uncompressed-sha256": "ae289ca7964c4b158f12643ee34b33ffde6400b2b70b0074a35a52b193b51636"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "f1f32a668e857350a18e0fb2e1d84dcdbc7f9a095168be5a10606386b090f806",
+                                "uncompressed-sha256": "aa1a34c27425da594a737ff5aa50d681801482624bceb34adb917f6c55e48b98"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "cdba4188884f4a9269a980cfe70a3317ccaf0cd411fbdb95db95d3663b498d35",
-                                "uncompressed-sha256": "a9181a0a717f1140e49ab6ab28cd2bc2546ba95ffaf232a45e60d04f8110a638"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2d5b3f2a46992cceb74eeaddc2520a9232ea6c45a97e80e7c81c6be9c72d9358",
+                                "uncompressed-sha256": "04a0d75b346dcab5d72a9e1a41ed4779532e42fedd5c2e17c462d72d5f0c1a2a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "de4ae95d3d32c488becfe71c00b1e6914d6c3bcbe64c124e24525f574cd0b1fc",
-                                "uncompressed-sha256": "495d542d72ad71b675dbd1934259e9fb3c22788f36668476e3f24e76318250ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "0073d6fa0c7c0d0b83f65cf26085692968f94ab0d1a51b4c9da70c8c679a67a1",
+                                "uncompressed-sha256": "05412b88fb7c360e82f59b398e8a8b92d5ea0edc619d8f7827f08c9d20dbce20"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "e0542cbdc1835ec24c93434ac03a1fa3891dcdc63863b3a98385878fc04b31fb",
-                                "uncompressed-sha256": "826d11fa2fd1fa2c5572993253a2ad3ebcb7378a588588c0b11c8c0cb8cf5941"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "a6ef1588e1e344a892c167307fb2bb979ae2f1277a251e35f8776157e3d11398",
+                                "uncompressed-sha256": "214f3f6ea6170ba97c41f8eb8fef5e556aa650b5bcf089250fcf6acd92221371"
                             }
                         }
                     }
@@ -376,85 +376,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "cd1f883dadf76222c7cc8c0c0549f42e451eac1f830c8830de5e5cff7446be5c",
-                                "uncompressed-sha256": "fdae5605cea23ff71d33550d0c46b9b5e9e2d4a80ed699a541fc4666f59ed568"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "44fb6810022554c492c1f339fdce752865f2cb04deb2dd5e3eb2408df44afe1a",
+                                "uncompressed-sha256": "d94c2e0eb44d2b52414194a39f484398eea432e45c72b09ef0dccd35d155e902"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "5ff6d30e2a4712f24d33c7bfed7801af599be207871795f00ed1b8d91177aa9b",
-                                "uncompressed-sha256": "ed0f7495b2ba0711d43438e87c4854a7489bfaf721591285e633ea856d676582"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1ecc0569417dfa29ca92399efbed6fa4b571d6478ea2a74a0b5e0bc3dd124f33",
+                                "uncompressed-sha256": "bcba2e8dd14d8f59461daa11ae8f6920ccc840d3f5c00b18323527ac12dc03a3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "f989889081beef90d86b07dde01ca944b181a586d606b8393c7148fc7955fe32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "4083aa7e1366401aa83601b903f368ed4865407760cbe1321109cd004b6c9a95"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-kernel.s390x.sig",
-                                "sha256": "8fe769b1d70bd3f210625bf54f651efff53fa2c4ad3e62c70f5a300120ead28a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-kernel.s390x.sig",
+                                "sha256": "1e340eca4d780fbf5ebc94e683060463acd1725ceb437bc0c7e30994701cf835"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "785d40540739a0b6b1b85b6df05d969a490b597f7eabf6bced8bedc5f3063689"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "95247d152ade3560d029e6db28d2cac86fb2242cbc8831b3ce55e8d9d8d0d894"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "9c9ee505fa2d7fdd0ebc9e1fae1915d346c5f4925653e8c7f47c65aec5350850"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "0496011d6ef1aa5168ef1dc7c049e07b47e7cfdd2e1f7c6489de8b13e6543cd8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "86e01dc08f7845f0efcea5bc3930f0ae342bd684e8f3b60b770b188eab0f749a",
-                                "uncompressed-sha256": "467098be3c49ad91f70d00fa687796fe4299951ebfc56f8807a95b04438eb63e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "fc95601f60a14c3abe683b207e07baa347a33b93aa91ce5a23a8ddea05307fa6",
+                                "uncompressed-sha256": "18b432c997a13f02445759ae24fd6a2afdc9a4b588b1bcd62a83a61961d6a2dc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "7d5abaa4b580a643ab65e87429a0cb19200ab81f50f58cb07d382443f18564d4",
-                                "uncompressed-sha256": "4aa8d90ce0edddac4e15a07bca95c7cde5c0a88b2990c6f60ec0dba0884e9a51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "fdfb5a36bf35ccea6f9b3610f0835c299893e5e395b8cbd61a1ea29a2021a291",
+                                "uncompressed-sha256": "e4eb57bb0f8627c881b7501c26bd2a89f74cf751f186256a030c58822475194f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4eabb4654b9b7c746abf92b966cc3f55c40a88973aab7aea56ab36a962914ef2",
-                                "uncompressed-sha256": "bfd2a7c91af03d0133a345b1e909af9e1b2f50d80f7bc0dbc690feccdccd132f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6f7c9da6ef27e3672efd795a2b528904af92656a5c773defbd9782b7f5663154",
+                                "uncompressed-sha256": "f0fbb14bcc749d4275171a385f4a6dccff06289eb8fa097f7192cca594c58ee1"
                             }
                         }
                     }
@@ -465,262 +465,262 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "51eb49d26a164a371820d4eb847a7510090bfa86f33d5f7352568274fcf05370",
-                                "uncompressed-sha256": "c4a02e3327358d6112e35f763c46ece62133a0430ef1b48547e9def05beaa184"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e1ec9fbb6534709b9accf8fd4e1dc6ce7c1121e1e4e0c1cfc028a992ea627e26",
+                                "uncompressed-sha256": "001df0c1d3e4a1b96cbf644cf937de650cc5007073306374d49c1da8241a6f2a"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "fc4e6fc7050f65aeb50c064d4c06de258a2bf0f49ebd19ece94cc4df18f73a20",
-                                "uncompressed-sha256": "50681a52138545081373f0760cb34e5628b7232ef916568e57e542a25e349ace"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "46d0164d4fcb81e8fcbbf5395a317f2287c1903fb57729aa72ee9fcafd9ec6bf",
+                                "uncompressed-sha256": "f3d82f2fbc13202072115b77bf12bb4ccbcd5926833afb386fd3469217e1d421"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "48a7f483387fcab3a24f162d88437f4b68db577764105bf244c8b00134085ded",
-                                "uncompressed-sha256": "f7c086a35a176d6d0fe69988e40544a08115e54f7c04d30f9b3a615f5ca15772"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e450d12cd6fcbcf419f4e83f1b60935f4d1983590f87b3f94ac5cb855d1e1030",
+                                "uncompressed-sha256": "f088053a102c367bbd6df8ff29fe74bf2bd8eb260b0095edf66b6470a7b43f78"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a93744cf0ddf237e773b4e2166efb4792cf15fe737726bac1dc4a50f03ab30ae",
-                                "uncompressed-sha256": "21caac9aa538bc3fea0cf99b26002f2ead15d286b23a34dd8461f036f6012e19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "f3d424dcf583ee857fcec386de4ae12bdda48c60a6722670b04d602096a525f6",
+                                "uncompressed-sha256": "46d8aa3eb6b78e47ba2c0a365a0975ddab1442c0925aa4653d773203f6a10d22"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "d9c075c235bddc6f2f8561b7f5c41d1fb52f8c12afb5177b3b8c4e9b3a77b4ef",
-                                "uncompressed-sha256": "a0b612c9dd996505a9c3504f070194bf75c63ee87664ce2f6b3b4c63ad2813bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ae1cea2dac784ec71a62c8c732a049684145f26ffed2478eb65d97be5a9412a1",
+                                "uncompressed-sha256": "64ed3ab26d5af8f8374ee50211a64269f4ada1d51c7dec7c235fd85c5fa49b05"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "1d6a692924358df58caf0acd5a184a43e880a9f4b7c6b11e0ff306f03f769c0d",
-                                "uncompressed-sha256": "1362ef748b2fcc205f584059b3774f038387bee930d547456499141c3b62beee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "db288e626833373650d0038c9247e11ad0644a3714da2a432f645cca46df47a4",
+                                "uncompressed-sha256": "c590e25dcce3c034deb5f5f975629322a2d88cdad4cde1f5b32af2c369b8212e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c31a0b5678027620f5f1730c69d91ee4f0e590d21cf84e67cef5bab7744ab971",
-                                "uncompressed-sha256": "85b6cecfe30b97e11d836653fbd6845276d199e4a97756d3bfd1b1a156f947ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "0e481d90becb63ad513b75ca4e5937f7188b7ac7b4898917da378c50f17d0ed3",
+                                "uncompressed-sha256": "35643a12db563bd9af5122fd06476874103c30492ef9959b73ac39c418fd23d3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3a9e1f9b9047fa89e6b4f2203b79b0423bac66a620b10fa1a384e4c7216804c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f642c524578419fc1a7efb164cc288cb3981c0916ceeb451a35791c96ca5697a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e35f911ef6941bec3e87a894a1633f9681deeef431d6c1538bfb6366974a4e5c",
-                                "uncompressed-sha256": "4565487a81f82ae3848526f3fc16d47ff131e906faf67baf4d8ad7a0f8fb304d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "bee3e12340e0fee19987e66a303d3e39fc7baef103716dc9abdab8b04abe8edc",
+                                "uncompressed-sha256": "751e0e2bbac960fccd9c271f71b753b2a292444714e0bd00d91a6adcd1a504c4"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "8eaad56b987156521dc7ae89507fffa8839182d48c94339f5c66a343a9d60ba4",
-                                "uncompressed-sha256": "ab3f64fd574e0e80fde07df892512cdc52e187a802226d57e171af1a56e52e69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e7014ed33d9b302a2e4515d72f8cd4c2cc4335de806930db3d94c536292d72e3",
+                                "uncompressed-sha256": "3bf0efa1203d409f0e525108d2d85108c6236580655ba9053220f9630af74321"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "26739d46f0bfd78683b9b555ff8619a30fc1354dd3347e88664fe947e756ccfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "95fb072f9001412bd37dcc90ffb49debfd4a2cfd5055b113a2e92cb9554b37de"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3b3ffa923da666f422acbc808a58b6364e4427e6213ae499dc913ce92017aee2",
-                                "uncompressed-sha256": "16b319350adb88969764629a9cb68a80b320c4487814a34fd7aca1d8a6b5ba33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9aa3ba8f8f48a67973f5ed1cb371ada28e72fd718e691cb7dcf377170a47dc37",
+                                "uncompressed-sha256": "3159939841dedee904eaaf6a0a4f611f047f9e4ed2f1de1fa737fed8638f1f37"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "d29d7f256e8696ee17742be87420e17b605b16b4c4db6b3dfa3cee91c56418d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "9dfdfdeea187a45c63a57e38523e60599a61ec7b4ef5f91a0a083ca6b9d0fcce"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-kernel.x86_64.sig",
-                                "sha256": "4b77dd608391f5dd945411cb194812e6ca2394b6bfb5eb6e501fb0f87127e41f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-kernel.x86_64.sig",
+                                "sha256": "507b2265becc1125b372233c43b044ca68d8cdeba9ed7da2544e1c98529ec289"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3a37d2a88ee232a55063c0b40081c1ffb033dee731689d3bfe188cc16233e1e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "59f3bc7d75523a0826b93210beeb989f1079701709fb9656977f6e883266b879"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "1b74051edb08b37b4c3c250b56c4e29013dd6a6bf8c7d52276429d3449488d40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "c306eab01843153e25b7c5e21779b6debfc91aedebe91b955051a8f025bdfce3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1b1ae948cbc27ec66be7603ac44366941e155e35a6a8368eaaf0a8174c75f2ef",
-                                "uncompressed-sha256": "9a66056cc4893314052ef838edf17a53d48acc1daec980303fecb8a51c886ac5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "c08250d15d44773db3c1c05b7b27faeb9224015649c455e34469dab34758c394",
+                                "uncompressed-sha256": "c136683fbf7bb384604cb852d9af55df3715c6f5db3143ef226292fdaa9837b6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "2a80ed4d9aaf7a604e37477da05705ba48aedfdf44316398116b7bcaf12d4f6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "928f41d502cf6e4b0102356455346f68c0a234dfd10f62eb486aa368cb250e72"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2cade8efd339079f0e2134c3e80897d906d121144937542ea29d3c2b1605f915",
-                                "uncompressed-sha256": "9953b7827096a4d2c5b771a405605d14265daacb3bf6dc9d9b70625bc67c37ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "67188c00e74cfbbbb7ac83d31571d36468f1018688ffed52162e7b541712a927",
+                                "uncompressed-sha256": "05e51fdf63a9676c13f0b5caa556325747089a2148d4de05c27af21a4b0a9664"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e2f0189afac145dc2795d6c2a07e6dcb518ebb9455fbf9fc5186a38a13f75fcf",
-                                "uncompressed-sha256": "edafd45d9d54beef8f634b45ecfa5ef68ca529edbab7e3905bbdb40629e0baa7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3b8a08d07264ebcae0f833362eaddd4f9accae0e80df322032be9fb5bbfad7d1",
+                                "uncompressed-sha256": "1fc506ea1a151a6bb39148c9977ad8c5a353de59d38280b06800644d44e81221"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7c65e3091f6528b8175865f5e8ce7a9ed3f6357c8d914b6d44b4055d19afdd39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "90114916a673e0923c9dfad5cca0b6ffc19ae10476be2569bbe28de2ce82f685"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "95baf0a3a94fbe6083a11803cf9c64a48d52b3a3e646e23a0b29e2d984aec989"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "28b74a8a2f1e61695ddcf7feef701cc1ea1347b7a3c515699e62af8532094e62"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "aefbb554fc7b8c296bdca3127f3fd3b00b545fc404274c63f5b9a183dd2c3a9e",
-                                "uncompressed-sha256": "81ee75abcc93354d670d1a032a43e595477b800ac7b80eaab5c82306b5025b4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "16b3acae69189d71e2b776f3bcd8ff97b62f7a029416b62ffe0991a65c32f2f6",
+                                "uncompressed-sha256": "c5aa08ba79a3e582135dcc7c6bc146ff0cd2e9f06c4503333911a13d18ad7ef1"
                             }
                         }
                     }
@@ -730,145 +730,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-04b005df2818b8b39"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0532f7f6ef33d9bfa"
                         },
                         "ap-east-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0eb35ae049f88ee09"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-02b1d8dde34ec7b1d"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0ce2cf66461f3d7e3"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-067461d0a834c2f66"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-095880ebac53e3042"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-05ecd743124a1f0d0"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-05f0325bb0116af27"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0acb62ecb05d11f60"
                         },
                         "ap-south-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0ef0fb53db37e430d"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0d57e6bf6f14ad568"
                         },
                         "ap-south-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0971e34f2f11384f4"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-07930543d3e8dbdcd"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-04dd46cc4b66764bf"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-03249d91ec6937f43"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-08bea244e091e652c"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0fb104e02a6a1732a"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0e26de6228f3c7f9d"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-08b2cb5135fcc56c1"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-062b34909652c061f"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-08424f23ddf49f0b2"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0aaf30e0de182ecc8"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0c00efb36b1b726c3"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-080e80f906f8b1fa1"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0c0fdc7abf6a79ef0"
                         },
                         "ca-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-026884590b8dfec73"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-02500d1b588ddd850"
                         },
                         "ca-west-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0094375aaf2e70ab6"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-035439a11b9c92b71"
                         },
                         "eu-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0ed12e24bf022b8c8"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0236798ad8c1a90ff"
                         },
                         "eu-central-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0be547b7ea970029d"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-005f0ab3e0d4f4141"
                         },
                         "eu-north-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0815f90acdbdd1aec"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0cd190fc3eb3999f9"
                         },
                         "eu-south-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-057256c55fc9383cf"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-02f7a3b3415b15bc2"
                         },
                         "eu-south-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-04796b6fddd68926c"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0e14535b3352323c6"
                         },
                         "eu-west-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0fa2fde508a63a57b"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-01e471cf8af8d9e06"
                         },
                         "eu-west-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0db3fba7cea1722dc"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-02e59bcda8311aa75"
                         },
                         "eu-west-3": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0d98fe489e616ce90"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0bc57efda7e74f1f4"
                         },
                         "il-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0269e075e269af18e"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0b1aca02f491b29ca"
                         },
                         "me-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0ecf8527024d75a24"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0b93dc043df0ae11f"
                         },
                         "me-south-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0f8aec517ead710d7"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-058ed50d20809488b"
                         },
                         "mx-central-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0dce0ad062afd150d"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-07c5538544666cb4f"
                         },
                         "sa-east-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0db2bac4029db54d5"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-0b9ed7d2fe95463c3"
                         },
                         "us-east-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-072601703af85d2ab"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-08f59037eb8a18a5d"
                         },
                         "us-east-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0acb3168f9c209cbc"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-06c7775bca03c9b8f"
                         },
                         "us-west-1": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-0e721efcbf00e67d6"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-090706e5c4dbb79ea"
                         },
                         "us-west-2": {
-                            "release": "42.20250316.1.0",
-                            "image": "ami-018e0a0c5c4332bb9"
+                            "release": "42.20250331.1.0",
+                            "image": "ami-08b869354f43e0dce"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250316-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250331-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250316.1.0",
+                    "release": "42.20250331.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bf06bc8f9edd5301a9c003faa63762cedf2fa0522d1eda696c6d553919d52634"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9277b21ef5a0d76030fdf5815efad737df622a59dfa07a9d53281b150d67da38"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,144 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-03-18T13:57:21Z",
-        "generator": "fedora-coreos-stream-generator v0.2.15"
+        "last-modified": "2025-04-01T15:04:51Z",
+        "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "f2a014a2fec3d2d928fb970bfe34407854fcbbe4a3d904a80bd2c8048b82083e",
-                                "uncompressed-sha256": "14ab54c47c85f0e916961624c754634ccd76ab34c7c9af302ffa1671d5977f0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "7d5261b0e971fb9d499f437fb2870af89f0527a6fe1b00918015fdf05fd92902",
+                                "uncompressed-sha256": "d9306c627fb27e6da6274fb03b1b1b6abced80803a1be1967ed94ece4076ae1b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9115357a57094041c11a80551cd1c530acf8751b4c6cf49fd5633d30bb77f5f0",
-                                "uncompressed-sha256": "fc1a9c2a3dad2a85172c108b7ab33c2355ff5b3fbb5c0016553a3c7e846cdbac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8d43c1b72dbd55631d1c53c9c699b86b1d7c68f9375e04b76f906ea9029252f3",
+                                "uncompressed-sha256": "f5c4595c9b6982be24aba0afcc316d7d70cddabc3c36de2bc14c756685bf5622"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "8659ccb687bd5742e83d37b4c5f9f6323e6f4fd49d0e1b924ffb72cd3545f579",
-                                "uncompressed-sha256": "4740e5bd0f4398a43d14a89cbf9a1e59163376b29f866e7da713a2c119b91355"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5b308e937debbfcc82e3a033c6f31635ad9821f88defddfa10bbe7e88f1f1c6d",
+                                "uncompressed-sha256": "982126def9ab6f2021ccecd438fe2adba2b6bd7702c4efa1c2aeb29c3605992f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "e29aecf3583cffd553c86e2205ab42dd7c00d0d9d8223c50681825e35be742ec",
-                                "uncompressed-sha256": "b4a4132bb8db21940a2022500335a00870289b5216269d27d6e44327f95b6ffd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "4dfc97b0c67df1a2964ed0bbdf43aa67b81233adcb3c2fb4508d0102e7f3dedb",
+                                "uncompressed-sha256": "3970a81f6d2cb7ca86c5a7d8a330786dd299f7add61ed6e2d92341a0cf8664bb"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "7633a297f7b28b719c29facca0b49b2595daaf7e6972209e7de5fb0315e3b85b",
-                                "uncompressed-sha256": "e3202d03a2228900f47711d57d8435a009d0822e3c7ba8c5565963197f3b7e50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "d949b217afb3403be77397d2ae2499629e67935dfccb38639c32d7c25aabd343",
+                                "uncompressed-sha256": "45638d109e93d773e30cee4325026873e26a2859e3bf87eb284b33cd1a4ca205"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "8b0183ed55ec79f1e045cdc9927a3a026bb8699769e3ec0d307a914bc5853dd3",
-                                "uncompressed-sha256": "4f4fca64063970c566d15d9e4a1bf3234effc01da0798d326600840459645651"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "9fcfcb09e954f0705e0ca828acd07c32b9e272573cedb0d46d236d51a8c24d39",
+                                "uncompressed-sha256": "a821368c8b0f7dd2278cd905425af6083d566c0fcd22e49009e88046d3539777"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live.aarch64.iso.sig",
-                                "sha256": "458da03b470fc17a8f0c7accd3a2782640a0954343e454cd4a7ea3d536f4349b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live.aarch64.iso.sig",
+                                "sha256": "a3686235bfd99159389713daf48b5929201b464ca4e671e120ce66a17def2b80"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-kernel-aarch64.sig",
-                                "sha256": "3f9059fd030ec42582d5e5ad580fe9b94ef10d63bf91d23d14bded40db89b18f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-kernel-aarch64.sig",
+                                "sha256": "194210ba81810e428a4ef7a94ac4202afd87f97b3c038b53111a082ed31660e4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "55e2bd8eeb7bc02e1f761e8bbfeb7cef7eaafe9561dadb4ecd0c70b17e46fd1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "4d1955012ecf47a022a80c7db4395d683c485cf3f831af102b9df5992c7dacff"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "7e41df242872d09c6953a4904b64a89f80563bc489e75ae430e7cc0be17101d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "9cc21ab91db14ac27ab7ae95da429db2df94b331acb762b2dd22db2373a93129"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "d391f5de21a4b1ff5efba7dea055094abe438a6f2a16a03b622547bd121269ba",
-                                "uncompressed-sha256": "1cf18a7f84cb221d1bf5201aa1a7e699b8f3edf31351232c94099d09fe3960b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "fb66c65823d8898ca65c5d9e6abb4d77fd1c0a1eacc3423a0321a736753d40d8",
+                                "uncompressed-sha256": "cd06199f87ddba9d34c30ef0035a6a795c372fc119367ac64659c361a1e180a6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "22345dc0aaf7b93e465a49129f5e870f6ebf9c09fcf2dcf1a6befc5a8683a819",
-                                "uncompressed-sha256": "266da96f8ac4f8bbd12e95c288bc8bcb5ea28b9af3dd2ed108e09341449b7f31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2ef5f3028eeef354f51cc0748da610237e0c56c37630d6fb42bb71dd47eb5bbf",
+                                "uncompressed-sha256": "650ea320a61571a00b2d37b4664f26c7337560f43c2c6bbafeda71f7a1755d20"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/aarch64/fedora-coreos-41.20250315.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "ea1086ed28c62c5e0c83b7454c605a763d5d0607c6e4c47cf4afc41e4602d4bb",
-                                "uncompressed-sha256": "6b253f76f25998ef770ed8bb8ff23bef7e17a0f8da4d0ddbebf8cc39d1ab6e6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "655151c943eb6cab4ec4e51c5d1e3155278eadb1ae46bbd72da288c0ad5022e6",
+                                "uncompressed-sha256": "faa861e5dd0797108a441f5430f4d1eb364ba3888c69e9a70d7a20835f5ae872"
                             }
                         }
                     }
@@ -148,225 +148,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-02056836158e309e3"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-04bfe078080b91ffb"
                         },
                         "ap-east-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-019f3bf43ee22a0f4"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-02f8823104ab6a4ce"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-01862aa1dca1c9bb7"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0e45085837beed6d8"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-041e01d40bab48e8d"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0afc19fcb4867bdac"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0a185ca0cc796569a"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0890bdcf03026bcae"
                         },
                         "ap-south-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0721f9b5e1189cd0a"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0978d84838e95e8ed"
                         },
                         "ap-south-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0bd84baa9f8ef09e8"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-01ea403ce75f1c38e"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-018e16efc6af2d676"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0bc02e75e4c71b8e3"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0d003c97f1e667df1"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0c15029be3263389e"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0d60d15e24f1ea0c1"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-09f6de1322ce2ac4e"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0052c122d7a7ab779"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0fe982cba4c49f76d"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0f8dd60fb361ced9a"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0600ca9555f376a71"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-069428aacafe2fe3e"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-09c9174bf398a40bd"
                         },
                         "ca-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0c091ee6bf393d52e"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-082e4317b1fb90dc7"
                         },
                         "ca-west-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0451879cded51acf6"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0147eff2fc8ee7bb5"
                         },
                         "eu-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0d81fb4ca570208d2"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-04813a459faf297af"
                         },
                         "eu-central-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0f065173baf0fa738"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0540cb7476f440f50"
                         },
                         "eu-north-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-048b0d943e9f5d3c1"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0720d84f66564a4bd"
                         },
                         "eu-south-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-06353ca1964f29d63"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-06383e6906aec45fd"
                         },
                         "eu-south-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-051456a6253cb5796"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-05809caa87e81ecc7"
                         },
                         "eu-west-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0d1f704d4d2745b53"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-09f611a2d44448c45"
                         },
                         "eu-west-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-05d5b4ba705228b29"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-016a67453b9a6e734"
                         },
                         "eu-west-3": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0c70696676c6d8014"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0a9e7f19233262dac"
                         },
                         "il-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-023e82dba5d565763"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-004ef22e7ae2cd0cc"
                         },
                         "me-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0441ffcf8d8a4d436"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0da4e76c43e39e5a5"
                         },
                         "me-south-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-066a4f73e3ea6bca1"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-04fa3511429ef0ae1"
                         },
                         "mx-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0aa473160612eb970"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0f4db3b71af4cef02"
                         },
                         "sa-east-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-08748b21489ac635e"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0dae54e6ef2ef105b"
                         },
                         "us-east-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0a9f2538f537f5b34"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0ef9817fa31fc23ee"
                         },
                         "us-east-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0090fe56abf9f5e9f"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-057d2d35120fbe0c4"
                         },
                         "us-west-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-083338f45259ee907"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-05c1fed68ad653cd7"
                         },
                         "us-west-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0bab8335ec5c4c7f4"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0dcfb1bf1f627fc54"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20250315-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250331-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "432dc29061582523d2b44374cfa02a50e25fec830bbf4d19f770ca71f1bd93ec",
-                                "uncompressed-sha256": "cf641e5e7cff81325bbb57db73905a53f96428f0412ad574ad40c9bc2f2409e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "8f7b6c6e15a0cc5ab38bd5aa7895e0fdbbda7b8c3d193f65216530c61f86d6c1",
+                                "uncompressed-sha256": "fc37158dfaf863d5dcdc0396f972b204fdb7ad703d0d515fa77ba196a0e15c7a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live.ppc64le.iso.sig",
-                                "sha256": "14e589324e83c58ea11e2c0fcc1dc770656810b3385b15bb873cf917c9bd1deb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live.ppc64le.iso.sig",
+                                "sha256": "06bb7fa1ea46495e06ad7a75346f91212fd00921eeb2b43b1969edb381bd184c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "66386609d72461f9c442af0cfc014cc0a9eb17cc73b7ed779b64047fc63c217e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-kernel-ppc64le.sig",
+                                "sha256": "56fd0720eac7f0f5cc20964eaae934e14b0559c9f6a50e4cce1d4a499f7b9a0c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "2bef10671179fa7ebc7f5a695fb57bf5fc0ee4ea50f1b95daad5f9d2dbed5f7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "816365dee4999ff8bff46442081eea119448c3ee22ee5548d2173cec9804bb13"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "d628ae0d2630d87258c7b882c63f1be7c0b17d022550698adc7c7cacd907b944"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "37e33bfd14ec6da800dfde919ce79605b8b52ef75bc58cffe76cc5d0a58abc89"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "54c1707a5b68bf5c338249e406adee3e02500864b39ed5b9021ec4ce688bfd99",
-                                "uncompressed-sha256": "d7ba9c17990cb718c86cdf01bf4e7d152b1221cff61c6833663462c50f75640d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "edee3e754ffecdba05856c925625845a2794c7d48ca6dd964f5d7f054d8fa400",
+                                "uncompressed-sha256": "87ff34c1aa4ad285f381dddf8f23969c51aef465bf37864b542c4bbc7289b229"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "0f8493b249ce659f5e7f9e12f8b561e31a8921c0cc724b9c34b8a84f61953c41",
-                                "uncompressed-sha256": "363bc89145fc1cc099e422bbc990710692f89e5fc880b8b1e907b0406344780e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "dd46491924a33cf813eaebdd9a693b84950f2a7d9b6f2a6d7efc8b44394024a0",
+                                "uncompressed-sha256": "eb8a63d3c7b42644f82aca2f737eed0712c964dacfa444b0562255ffa8bad9c0"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "1d9506dbe5cf777d5f955141a19abf1706ca8afa3b0751fb22a278c448696d4c",
-                                "uncompressed-sha256": "638887b69cadf0aa0baaf7e782e8b41cc04bd7996c69fbaacfdf8bb67de87fee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f1ca0040105813d58de54ae1dbbb3e04344f26d253184353ed9748a6138d8115",
+                                "uncompressed-sha256": "eac4bf44ff27eef1451eaa04616be4ac12f5c421e6721607571373cb807a4e84"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/ppc64le/fedora-coreos-41.20250315.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "530b08b9a877e8d891a59e92103e2e31d973a552d769c1c14fcd90ea16e90d4c",
-                                "uncompressed-sha256": "98112a0a342a3c3eee283390e5238bda18edfd90aa619431b508c2ee527129d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2c450da9475c2c971f3ef0bd0cd5507e0140a59ce0f50faa174440dbefa21594",
+                                "uncompressed-sha256": "b4ccb6e95dc3fd6c7c6fd49fa92b92ace9f60b864a906ddf95278fdebc629756"
                             }
                         }
                     }
@@ -377,85 +377,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "af81f08553c5ce9fbf07a3fdd6b861ed526607e94198ca09ac39591f19448dc2",
-                                "uncompressed-sha256": "69dd89f1316eeaaaca95abb18dcaeefe6b5ee793e5bc82275935197075c9ffa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "5e84651657ac39602c527fd834d63adc26f1af67a873f7806fb88cb2af0b3363",
+                                "uncompressed-sha256": "9fe3a3f258ce76fabc63c41ec0d232a2992d64960b2d4a5b5c1023fdd949c28d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "da63986c0ff564bc098254f43794a5e3924de52f6cd71fb8f0533a83d94e29f0",
-                                "uncompressed-sha256": "e8fcc609acbdd4bdabe97efd8fb49d62d3763e2471f40378495b0d183f9f6de3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ad554ec032809660d730d33b6527c518cd3147eb9c26e444600e6a7b9c94bee9",
+                                "uncompressed-sha256": "5a0c6e4d9fbde33b2f3893a5f91929cfe5561626657b2b3c914127fc5020267f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live.s390x.iso.sig",
-                                "sha256": "17031d0b4e5f1ebe11a0a773c81bfd14280f052df5d02e6ded2e490a811652a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live.s390x.iso.sig",
+                                "sha256": "7c07d392d38f5da12da08e9abb35d81affad37580f71c3b5c9f204fb7031543b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-kernel-s390x.sig",
-                                "sha256": "0e11af135d30cca630bcf0971cc54b8445d2c32a6c5875963c24b661910d1e42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-kernel-s390x.sig",
+                                "sha256": "275a7b3dc386d98eba56452a04526b1b7e5a68e78f86ec62e2bd7778f0483791"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ecc790e061166f1d1ecb76ea17514060330f2c7da9cfb7e32a3c03065e31da2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "0562a8140ed3047b1726f56fd1d9bfa0afcc7a20b4a316e835e570985a32600a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "ffddcf0d161f20cfcb580c88e823e2232a749cf7fda7d5669dae19d1b5676213"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "4267bedc3a87c70633167f959cfb66c3512321df2f0d742b65e1391073754a5d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "015c7c747e53a6a39aff02a35368c1ca13c8ec954a030f85ceb105a84773ab02",
-                                "uncompressed-sha256": "1c06ecdd67e37e00917338a25396166f0962140e78ef05c1cf29493678815632"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "a7deb8c397e603569ae5e440a34aa8bdcc3bf5ce5f7f4a28b9e85deb757cb0b2",
+                                "uncompressed-sha256": "7337479dfebdce9b1cde93ad80f535759545a0c64876843a369badfeaad6bb34"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2270caa16a58d88d46b47371bc7f8c837f5d51a513623d157e664ce449102599",
-                                "uncompressed-sha256": "bbe7b9b05a54b26e20948ccae0dbc1b26065802e1d7cb1ae651d99e6b1e50486"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "916d9fac6202cf96165c347fadf57eb8b1cc877c4697f7f8a9098e182987b85d",
+                                "uncompressed-sha256": "784c4d6552bc82739613b7b413c9f7d2fc4c26b19bc1cf22dbba376164a30aab"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/s390x/fedora-coreos-41.20250315.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "74537eae7f118948dd1b549845d48f656e13cf01956208d7bc27a9bd33359078",
-                                "uncompressed-sha256": "099a04aff0dc6ce5d3e3a124007554615565841a733fe3103c3ba1dbb42547b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "0b79ce146a32028d5c4691fd86ef65bdd8159b8f4035c983228b301fdc76b4f8",
+                                "uncompressed-sha256": "cde57cbd065eae30742b08e0d6723aa27957062e7d62b75fc3727b2b4cb336f8"
                             }
                         }
                     }
@@ -466,263 +466,263 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "550cc27e3358a7810a8aebc7268a9164da5daf006b1d386c7c157f594a4e5da1",
-                                "uncompressed-sha256": "f2e3b6c6be7a7ef4b3e405ef3728b293ecd76257a12c8b85cc56870574f86b0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "777f89379b11a47b8d38230dbe045e3b6810f1e9b87eaba603d3823f8978bb59",
+                                "uncompressed-sha256": "2e962b611d33d9164db5ec333290c6b7b6e83dc9aa072b0af5e0419cbbcf6898"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "8c93d5c58affdda17f2bee779e5f8cf1c8b1df062455f26007b3b532c04bc715",
-                                "uncompressed-sha256": "09c096842f152d5041135471b0f9f25cdf85186d59770e815092cd20528ef755"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "a9f1b2df0e61c9b85f1a4b05d179ee8e9a050d4a95140d79d0fb6f95fe9a7aae",
+                                "uncompressed-sha256": "b92224b7c07cf81a69de71b397f982c859ab376f781b68126c1a09ff3fc78208"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "76b79a5b4eeb774c0a289a85477bd2ad1c8cc1b0c4e1c51771c94829077fe484",
-                                "uncompressed-sha256": "17e8fbf03e7f72d4f96b7241be1cac1c063f1efa98729ba1399b8f7a02b0c38d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "77068c14d41a57ebba97d6cda007492829f25df93c0a7407b78d88a9b23dffb5",
+                                "uncompressed-sha256": "9768a124bc192bffa9e6cd382dd423ec02f8fab0f1ae9530ee1f4d29d6c17c35"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b6ced53d6b9fe844ed250edd254bd5be17098b3e5227e7597df141f7733034fd",
-                                "uncompressed-sha256": "af3481c86945b2043dc18aeea517be599fba6b628e7cab9f0cabf8f49da23581"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "13229b28e78ff0cbdee50a1bd3c914f63dbc4e38bfb5d995f75d43f613949116",
+                                "uncompressed-sha256": "d82ff7940f4b63aa34a8a3ea60e3f9bca1861358a68d238425ede160c808cfab"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "aeb4a4d3186211fd0a767b2d5356dbde0087e1c603db3ee1740e7fd90667838a",
-                                "uncompressed-sha256": "021553cb1d105d58268df35f5c22f83570a089ce3682936d0789f67e3558d877"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "82a176e85adfa66f0744391e86386f2a65ec8e9352eb41ae649f73a582bdead4",
+                                "uncompressed-sha256": "dfe529c1dc48aa129bcee9014c3f923707def2e0262e1084103c3460ae3dee96"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8a43029696170041ecc7ebb627f2ac087369d959a87c55c3cb02670d722be110",
-                                "uncompressed-sha256": "6165939b223bbe2ac3b762fb87a55fbf7e33ec18afc6c677b8b6d0b1d1050074"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "5c319afe42bd9655adce717d010a4f8e38fa34e825dd41d8d77808a728e3849c",
+                                "uncompressed-sha256": "c0ed3ce62dcf59edbf9ac44331d35847db0ffe156c56d5655adf211495ef470f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "18c757936fad0596007222fee848eb77b6f3f88bf03298c18b519bab3b9f9e8d",
-                                "uncompressed-sha256": "b583fbe6ddc76360de7085f931a18b3fc71849bb4de26a1eeeff7a2ff3f3b85b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "dbf82b76f322b74093366ae91cf81f53af022593716d3f33381098d2901631d7",
+                                "uncompressed-sha256": "62b114a32cecefe0c7a9f92f0ece0b1732a99c8c1f0fe3cdb78a7e77a9e7c8de"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "538554cd3189b223f79de8b388f1cb5c34ea75ebf48aaa719ad1455fda556bb3",
-                                "uncompressed-sha256": "3af10241b57c6bf092e94491758e91b4a5d5f9ebc3ae3eb385a0b2752fa2a2fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a80a783549824b29704e971378084bfe0c5765ae0064584be9ee698510c027f1",
+                                "uncompressed-sha256": "244fbaaf2a419ad06488cc5d7851b9857d4f8a12f45ae6a375008e202bf5a746"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "90d22e119b7d976111b8682b8784c5b7e1a2b3d77a6dabeea32e9bc96754ff4b",
-                                "uncompressed-sha256": "1691ce7ed1098d676cdd361d6b1f26ca482e57f4b50be201dfaa1de926e5863b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "cc333516e59aa426efc4d3024f237e2d3d3aa1d26f5f695afe7a6fb634508058",
+                                "uncompressed-sha256": "3058fb29b032cf4302217a5ab623f025b434c23d87b54dc7aec504484e65d764"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "844a7311e2aeac05a07d309ecb82b823fa892dcfb105f0dee5948f0d36e7ce78",
-                                "uncompressed-sha256": "3d3c63b9ea8fa32bdffa978c7ba8cdb261744b1755cd9257fa63fe1fea9349f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "71c419a56b7447fce2d51bc219451e1f54837c34656cb8603f5a73c5c97f16c3",
+                                "uncompressed-sha256": "edf39846eed4ef28219b588185f0dc58134b73dc1e2aa3c48d7ec5e87ce80d46"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "bebe7d163540f3ae5889dbac56a44430c533e8ac12fb41abe351cf7408f62938"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "bb80b05f940586b2d1bb9bc4a696e40d2d5ed0c24e5ca64342277517cdb68b7c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7df3c4d93ec3f48cacac990ae48dd879beab802946d47f9cdbfcf8f4d37d148d",
-                                "uncompressed-sha256": "548e8c5a202f642045df521dc7d371f1455042271081a1d45e791491ba7399e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "d9b0b1012479666f8808e006e8b62ca2572824795cf588d31462bbd86fd519d3",
+                                "uncompressed-sha256": "3e036667ae711fddbe98e8d57e27677be69fbe12b381863ef2ebb78b9dfbad06"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live.x86_64.iso.sig",
-                                "sha256": "4bebccb0ae402c8378b2dfb687a9625d1cffdb07a9c8ebbcc7d20e4c32b96e39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live.x86_64.iso.sig",
+                                "sha256": "49919c9ad277cbc0deb691b47168910f19f71672a1ee49e57781dde25156a20d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-kernel-x86_64.sig",
-                                "sha256": "297f232fdedaa8dfc5e81b478fb5467536e47da28982cb95051e496576ea6bd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-kernel-x86_64.sig",
+                                "sha256": "684ebbde99ae22641508c8a7440502e07ff75ea2cba59ba93ba8bf8b0a63a9a2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "1423d738964edd7dff9031cb1796d695f600e41c16b3e75c682eb4d1b77071bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "47e8c21a7857280f1737b04d776e1fb309232607003192718a23899209ba570d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6e63bea1a44b03dac09ac42f444294ea56a0dc53ee880ecf04f9d46184413873"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "43a6b31efdb1eb04bf680ee4103643ca64f4dfb7d1c2cca3565060e7c26ef2dd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b5ad8c2045c9415d9ead81e1591a0a5ddb7ecf820380fc07f5dd0c98eef2a467",
-                                "uncompressed-sha256": "dab4451ffeac5ebd7357d3b768c1e5d69a394b91cde2a349ed0bb0a36b1b872f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "4ee235f141c3b66621f0f9622c094f6b0c23fc189c11bbdfe6425fe140bf4b14",
+                                "uncompressed-sha256": "c2102baad0a1bf7cf5dac11ed4740197d4ecab17eb5a678e44e3ef0143d48d69"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "32037badaa051e66155190e9adc7b23414126232c470af581f77dd79d106a13f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "824f2ed21c5ac994aa34ca8291b63d74637cc63d0abfb2b3973eef94b7e57f07"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e1fc606d243e2567573c2bce99a1220f06a1ade4c4670e833dc5835fababff43",
-                                "uncompressed-sha256": "1a04702f066427396827a5ab7c6eeee52bf9ff6072241eddc6de71f8afdb772a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2a7db216248cb6ec4c43b52a9de318128735010e7490431d53e1759b0165eb8c",
+                                "uncompressed-sha256": "1423580b806118228b817561096af3886f296b979e409831971883f22b2f5721"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "36a917412fbcc2e9d921f0c50d2059847fb68915ec4dec523b16d0c7e4c8cbd3",
-                                "uncompressed-sha256": "368611368424460bd0d5f13da97c616944ddc4ba743064bb7c223625043740ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2da64b8c6c4a039fc0b204a1d44c96c1e4f2384544636b80f23c26c939f5c6e2",
+                                "uncompressed-sha256": "98070ae1f7f9ec22f49e02544a0651f92c12612f480ac5d632a320fb11eb5ee5"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "3eced6579c5db3b12220bbfc6ce1be0c9d3a320e509a28d30cdfe18107ee161a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "477d8f72a93faab8ed720e82329a5dd67b0ddc87d6cbb61e0d961dda6139f748"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "e212b687490b01c29c406c7710e7795a3f7ab5f8ba240423033ed6bcda944109"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "1b3e656ff4536c240947206f970c939bb2bc13aa985a352f2d6dc119b779d555"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250315.2.0/x86_64/fedora-coreos-41.20250315.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b1492e15d469bb6abb954f890efa3c951942191b7ea275ec42637527036006b2",
-                                "uncompressed-sha256": "c694040af6d4873074e542d52f12aa837ae02f2b741a36f16feb2d3b786015db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "cb76d6884cd1c36cfbb5c0125a1c56fe276e0e16886099cb5cf62b52e703284a",
+                                "uncompressed-sha256": "65d9bc24cb8eae5f9a3a42af3f8c16c1fa0b4e5c889c78bd35b92b7c883d9469"
                             }
                         }
                     }
@@ -732,145 +732,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0fc2a5b6b171d3de6"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-08b5e670718b907af"
                         },
                         "ap-east-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0f3fea7ec66e15781"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0e9634d3778f3d773"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-06089d7cbb6f126d4"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-031b642f0c78bcca9"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0e02abbf599d17e6e"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0a7a343692dffe4bc"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-02c705fa703154293"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0c7f5206ad82390b5"
                         },
                         "ap-south-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0d3ea7aee8f6b35a2"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-048733129e1add683"
                         },
                         "ap-south-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-08e4cf75443351cbb"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0a18dbd4eb38620a4"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0a025e217e5128832"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0992db59b6d1dbda0"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-07b76b1bc88f5e6ea"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0bb0dd989a4e43125"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-031af5787daf952e4"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0f901e7d01130c7f3"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-00c00db6d996bd06a"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0bd5fb01aacede15a"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0a37cb976c331e73f"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-053fc2da338d5bd6c"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-08ac4c7cf46b26a83"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-08858b7b11ac3ef16"
                         },
                         "ca-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-09e3bf7537265c906"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-024d59eba0f5257c6"
                         },
                         "ca-west-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-026ff7b83d5e29fd3"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0ef873d93ada3026a"
                         },
                         "eu-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-067f1e95dbaf59823"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0fb764c2d0a2f62e7"
                         },
                         "eu-central-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0b1ae2f1c982a345d"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-021e45964c7d85d82"
                         },
                         "eu-north-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0dc9161130988ac5f"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0f14dd2e775f47673"
                         },
                         "eu-south-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0392e23160841996b"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0ea45aa5afc5f24e5"
                         },
                         "eu-south-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-04ea6ca58e92c6b6a"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-05763cbbe76f3eb4e"
                         },
                         "eu-west-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0217931afb736f51f"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0be80ff839f7846ad"
                         },
                         "eu-west-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-09a333ab7f784db46"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0160abc7c59798015"
                         },
                         "eu-west-3": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0fa1c69a6d4c17f60"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0e2ce14f6da600ff6"
                         },
                         "il-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-09c214e6e7f24172b"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0554bb299b6280085"
                         },
                         "me-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-06d9656ebdffc6721"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0c4537ba2942f11f6"
                         },
                         "me-south-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0746801344f5200d7"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-04030416b6d41ad78"
                         },
                         "mx-central-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0ab682ef0dd808ab9"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0a243a1b323465ced"
                         },
                         "sa-east-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0662d4d67a630ee0b"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-041d023b98b6bf1c4"
                         },
                         "us-east-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0339eb2b77966cb50"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-0b311d2524af30f92"
                         },
                         "us-east-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-02a7b49f77278c9db"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-05260403473fc5500"
                         },
                         "us-west-1": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0fc7010a897da1668"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-00e655e179cbd9a41"
                         },
                         "us-west-2": {
-                            "release": "41.20250315.2.0",
-                            "image": "ami-0640bfdc6402889f5"
+                            "release": "41.20250331.2.0",
+                            "image": "ami-000e94fb0a7882d4d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20250315-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250331-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250315.2.0",
+                    "release": "41.20250331.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:274d7a19bdc3677b4a7350be86db9662598ef25a4ae529e1dc80821415a90bf6"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b7a7dc08fef050c50652676c05cb944f4a60d5a5adb08e072edc6be1137dcf0f"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-03-18T13:57:22Z"
+    "last-modified": "2025-04-01T15:04:54Z"
   },
   "releases": [
     {
@@ -127,9 +127,6 @@
     {
       "version": "41.20250302.1.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -139,8 +136,16 @@
       "version": "42.20250316.1.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "42.20250331.1.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1742308200,
+          "start_epoch": 1743523200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-03-18T13:57:21Z"
+    "last-modified": "2025-04-01T15:04:52Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20250302.2.0",
+      "version": "41.20250315.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20250315.2.0",
+      "version": "41.20250331.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1742308200,
+          "start_epoch": 1743523200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).