### PR TITLE
Roll back next 42.20250331.1.0 stream update

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,143 +1,143 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-04-01T15:04:53Z",
-        "generator": "fedora-coreos-stream-generator v0.2.16"
+        "last-modified": "2025-04-01T19:33:34Z",
+        "generator": "fedora-coreos-stream-generator v0.2.15"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "4c1d97601a064de8999d05e9c70d7e9d714514754ba6390de873f16a422c8174",
-                                "uncompressed-sha256": "8b899034fe919f1304ef6f28ffddf4d52a835b1e16e16809441044109b531c62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "82a9371ccb3994c4133c94bf80ba03419f5ef10516c03775dff8e9a2b29c86e0",
+                                "uncompressed-sha256": "b7c9e147268e5327628b13bde70161cc4c98b7027b6d9cfbed238dbfe6f24a8f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "bae6f579b311f600317d0ac080ec5041ecd88eadf08b449f27e862a04c65e17c",
-                                "uncompressed-sha256": "d9fe33d7d427b7a7907341762b232909134315cb1cb9e90538f2b3c9192da46d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d34333b074725094fd1d48a063f1327d18d4635548b7910ddd214b841d8eaaa7",
+                                "uncompressed-sha256": "e7dce12aeccaf5482b3342d6776297ac4cdd8c41da48ec7db6b37e87e1272473"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "022958e10b096e77e6ef818f9084b2d0492584f745a005e117029ee52df99981",
-                                "uncompressed-sha256": "eb3ce219fd750162865872faaa70a63274993c31bf545fc086a0f69385268a31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b834ed8ccb1ebc421781eca20fa26c9d3843386bc5ab061c51e33bb878f98b8c",
+                                "uncompressed-sha256": "b2aab7ee714e31fc31f20647bad9a79bc6206cb17084314e0704cc819f2c43c1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "e341b624404f3cc457fa8750824a1179f234005d56a403b08aa0e997c0e21179"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "89eacddd0fa7a32ddd6a95740a3cbb454b5a1228b462cecc4d592d8952b49562"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "573d83983fa48a889ef24bf721bcef2d86103c3ceacc52f7632e7234acb1ae9f",
-                                "uncompressed-sha256": "8658a626afe3e7e33cb0b1c57f0ff0eadf8457ae1aece404338dbab0f63b1675"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "d8de206e6a5c27714b90a2886b25995ec25f0ba554f324ac117d805c8f63d0e5",
+                                "uncompressed-sha256": "f1d804a66bc58eb67e8c969e65ccf9a0821685dc85314d5e2f3ea75c5168ee1f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "b8f4e96613653470351c096aa454a43c2779f3783729b2e38b0c03d3cb681e44",
-                                "uncompressed-sha256": "cb0e2b5fcae64fd58583efa57607397fd704d67197e5db15cf6e1f44d20317a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a1cdb445a0ebd0e689d9b48c64c75a590e7305ad98116d38a56d180aeac8d163",
+                                "uncompressed-sha256": "1b6b73c4884e577a68c7a14031ebb8d53d567d18751a9aaee81760f55d763295"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "84e8156650d90ccf19a4f81661a2c7fcebda9a8b385782f6ca50dfcc2b7a38b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "8fa463ca94c617e6c0ab07b296d2f4ee2ae119479e458a6f254598cd53f18956"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-kernel.aarch64.sig",
-                                "sha256": "e249c9d6d365dc640215ab759e18d2a8ff06db2aea29fcb4f4d13e3392f4a25a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-kernel.aarch64.sig",
+                                "sha256": "7d2188a4937cbdf8aa32dc78265689da4263cfd3746629cba0913301ef5a3186"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "471042243300eaf87c13bb6319df9d23abfdb294002a7f6ce426eae51fec7040"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "2adae2e068fbb70c64372eed6deb4820641a3b2cf1267c5938f11e599a06b17d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "f44fee2cacae298067068985b82489bda6df89cce00e45f14cd5103c3dfe0cf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a0b9d549ffea44d5b6a0aaaced6ddc101cd1c196f75ac8347e1ee1c76d6184d4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "293e80b574b1b09e196b22380a6ab46b42386fb4763b469b6953c0bb35351d49",
-                                "uncompressed-sha256": "e2b3c8c60f240b0995c08e5741608a845ed44da9d55771f62ffa8a9cb42bccab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "5c0aadadd59cf6f52ad10f258917f135066e47fe4a671b578e9dec881a6c8381",
+                                "uncompressed-sha256": "57c30ec124fa24812629669277f5b34347d50ef5a16708d3ec6622bdd6f758db"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "563ba00de85d258f3ad90d2d1f0ed4674f1148659c06a1f0c139c89211948af4",
-                                "uncompressed-sha256": "b29b53bc661bab997c91542d6c377b2e1455264642764824213cff7825b365c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "98f98c749f99d9aa051a5eb0d4f6097ac6ca2ed49cfd21064e8afdb1d7d781d0",
+                                "uncompressed-sha256": "da2d358c9c3c3ffcd56460b71bf677a0750bec6464ef4086aa21faec8398ae26"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/aarch64/fedora-coreos-42.20250331.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "514cc4c9950562dd3d1eed4ee91f5a270d3ca84a7c65583ef32e0db519c092a2",
-                                "uncompressed-sha256": "30548963d0ca48c752caef8849a6218904515ecd65c713418b10b2b957bd4ef3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/aarch64/fedora-coreos-42.20250316.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9bc43d31f110a71e795d9558f70706592b3bcf798975851e536159f9161607c7",
+                                "uncompressed-sha256": "170acfc25f13245793385e2f4dfee4973b81d0f68000664174412ccad74040b4"
                             }
                         }
                     }
@@ -147,225 +147,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0246310c575d6941e"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0d30ea9c1edb16bda"
                         },
                         "ap-east-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-08efc970f74d4c61a"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0c7d9a80b94e607a4"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-037102c844ef28346"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0c60ce39a8ce155ba"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0e55e0d55fde18816"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0b2da3e1e2d85de72"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0c470cc3354334585"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0e4b30f12ee0faf00"
                         },
                         "ap-south-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0abea6f0c050dc23a"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ee232160dfbe40d0"
                         },
                         "ap-south-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0b57d0caed88ed822"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-035188ab4af82215e"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-07520472593ce53cb"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-084cacc4561d9e17b"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0920d4ae7922b6538"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0873d2ee0c2e644c8"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0e6cb02d4e905cb54"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0b706cd3d9ab37fb4"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0a62ecea8b2e388e3"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-088843d6f6cc1f5d2"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0a4b022313e5d36e8"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-02ac7d2c9e427041a"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-02c0cca5c1e8b9836"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-01eb75a37a076de02"
                         },
                         "ca-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0599bd1bc407af645"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0c8f1a2cdfc3eb3dd"
                         },
                         "ca-west-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0b1a7dd376d3f7439"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-03464944bf7eeb5ce"
                         },
                         "eu-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0aa925c72658c05e7"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0652c96e9e98c794f"
                         },
                         "eu-central-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-018e4fda54d622c98"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-03f6877fc9cc97e76"
                         },
                         "eu-north-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0d252f3283d1cb1e4"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-09db7a2362119b7ca"
                         },
                         "eu-south-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0fdc8c5f1fd7c32fb"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ddb68001f52aa11e"
                         },
                         "eu-south-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-047536802eab107f1"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0769a8061f37be723"
                         },
                         "eu-west-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0f83a0c77b00fd85e"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0f55ffa612c4154ab"
                         },
                         "eu-west-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-00045063d75d0fa74"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-00a244bf35803de02"
                         },
                         "eu-west-3": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-057c3ff67055cd430"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0a1d9526df507dab3"
                         },
                         "il-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-013753929a7543c68"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0d561abc387e54aa7"
                         },
                         "me-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0ec6658b41bdadb44"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-079b42ac4ba32bf1f"
                         },
                         "me-south-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-061c6c8f97d8ea01d"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0a06889137554d1d8"
                         },
                         "mx-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0c7412fc5727bc375"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-094000680b76da3d9"
                         },
                         "sa-east-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0de3e465543d01a7e"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-05c52e1cee4371da9"
                         },
                         "us-east-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-034b6435f3e9daaf9"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0dc8687e850bfa269"
                         },
                         "us-east-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-05b0f82cf3859d607"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-052fb57c4ab9bd0c3"
                         },
                         "us-west-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-04d64ac1f0fe76f1f"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-08fd4fddc28c0c56d"
                         },
                         "us-west-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0f0fae32d02e391f4"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0a626e43f4a28175a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250331-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250316-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "dc83f98188d4d58f37b0308ef0c1c6ea55fb0cd41e02a49231cc6e49ba5df493",
-                                "uncompressed-sha256": "c3ad509448ef8cc1d4a378d131755701d3cf7519841b0327e1d7cde5e6f3ca85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "fa5545a02ce05125d80be1eb531f588642d2393b7e628667da38d0559a169381",
+                                "uncompressed-sha256": "c0cd48cbe7bdc06f1297f84c31dd6c455b79abf0833c14c75a0f6aec29cbe52e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "f964f0b41fe852c73c51faa6bbc1d4a5d9bed2ba0fdc5c9eb702a2ac9245aaf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "27fe5beb962f6d9982984b1b12c5b7ad695a78d7319aabad71431b71f7422088"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "4a522a1b85554d5f4f7aa0aa0cee8d1ccf877165c5c4751247956a51d4a1958b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "819fb464461cc6d581898b30bffdc91447aa9cdb8c165b440f3612305508b43c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f0d65b6b06a15a2bea77babd60ae81ace0cad17c7bc048abcce768d3006da0df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "47b5615ed6149a6779a6421c25aa82983274e6a099acd5e13a549135a2a2037f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "441398a203cc283d26de363d7532f94c087fe17a04b9b3611973473d894579db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "3e211d203adbd90ced0e8400ac45e91c05fd7b13979a3ba439497121f5fbde40"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "f1f32a668e857350a18e0fb2e1d84dcdbc7f9a095168be5a10606386b090f806",
-                                "uncompressed-sha256": "aa1a34c27425da594a737ff5aa50d681801482624bceb34adb917f6c55e48b98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "49070ef13082eb6b9da159589ce0e59ba9575b19b5428a1020c09a0e41aa077a",
+                                "uncompressed-sha256": "ae289ca7964c4b158f12643ee34b33ffde6400b2b70b0074a35a52b193b51636"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "2d5b3f2a46992cceb74eeaddc2520a9232ea6c45a97e80e7c81c6be9c72d9358",
-                                "uncompressed-sha256": "04a0d75b346dcab5d72a9e1a41ed4779532e42fedd5c2e17c462d72d5f0c1a2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "cdba4188884f4a9269a980cfe70a3317ccaf0cd411fbdb95db95d3663b498d35",
+                                "uncompressed-sha256": "a9181a0a717f1140e49ab6ab28cd2bc2546ba95ffaf232a45e60d04f8110a638"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "0073d6fa0c7c0d0b83f65cf26085692968f94ab0d1a51b4c9da70c8c679a67a1",
-                                "uncompressed-sha256": "05412b88fb7c360e82f59b398e8a8b92d5ea0edc619d8f7827f08c9d20dbce20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "de4ae95d3d32c488becfe71c00b1e6914d6c3bcbe64c124e24525f574cd0b1fc",
+                                "uncompressed-sha256": "495d542d72ad71b675dbd1934259e9fb3c22788f36668476e3f24e76318250ac"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/ppc64le/fedora-coreos-42.20250331.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "a6ef1588e1e344a892c167307fb2bb979ae2f1277a251e35f8776157e3d11398",
-                                "uncompressed-sha256": "214f3f6ea6170ba97c41f8eb8fef5e556aa650b5bcf089250fcf6acd92221371"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/ppc64le/fedora-coreos-42.20250316.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "e0542cbdc1835ec24c93434ac03a1fa3891dcdc63863b3a98385878fc04b31fb",
+                                "uncompressed-sha256": "826d11fa2fd1fa2c5572993253a2ad3ebcb7378a588588c0b11c8c0cb8cf5941"
                             }
                         }
                     }
@@ -376,85 +376,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "44fb6810022554c492c1f339fdce752865f2cb04deb2dd5e3eb2408df44afe1a",
-                                "uncompressed-sha256": "d94c2e0eb44d2b52414194a39f484398eea432e45c72b09ef0dccd35d155e902"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cd1f883dadf76222c7cc8c0c0549f42e451eac1f830c8830de5e5cff7446be5c",
+                                "uncompressed-sha256": "fdae5605cea23ff71d33550d0c46b9b5e9e2d4a80ed699a541fc4666f59ed568"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1ecc0569417dfa29ca92399efbed6fa4b571d6478ea2a74a0b5e0bc3dd124f33",
-                                "uncompressed-sha256": "bcba2e8dd14d8f59461daa11ae8f6920ccc840d3f5c00b18323527ac12dc03a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "5ff6d30e2a4712f24d33c7bfed7801af599be207871795f00ed1b8d91177aa9b",
+                                "uncompressed-sha256": "ed0f7495b2ba0711d43438e87c4854a7489bfaf721591285e633ea856d676582"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "4083aa7e1366401aa83601b903f368ed4865407760cbe1321109cd004b6c9a95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "f989889081beef90d86b07dde01ca944b181a586d606b8393c7148fc7955fe32"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-kernel.s390x.sig",
-                                "sha256": "1e340eca4d780fbf5ebc94e683060463acd1725ceb437bc0c7e30994701cf835"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-kernel.s390x.sig",
+                                "sha256": "8fe769b1d70bd3f210625bf54f651efff53fa2c4ad3e62c70f5a300120ead28a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "95247d152ade3560d029e6db28d2cac86fb2242cbc8831b3ce55e8d9d8d0d894"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "785d40540739a0b6b1b85b6df05d969a490b597f7eabf6bced8bedc5f3063689"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "0496011d6ef1aa5168ef1dc7c049e07b47e7cfdd2e1f7c6489de8b13e6543cd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "9c9ee505fa2d7fdd0ebc9e1fae1915d346c5f4925653e8c7f47c65aec5350850"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "fc95601f60a14c3abe683b207e07baa347a33b93aa91ce5a23a8ddea05307fa6",
-                                "uncompressed-sha256": "18b432c997a13f02445759ae24fd6a2afdc9a4b588b1bcd62a83a61961d6a2dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "86e01dc08f7845f0efcea5bc3930f0ae342bd684e8f3b60b770b188eab0f749a",
+                                "uncompressed-sha256": "467098be3c49ad91f70d00fa687796fe4299951ebfc56f8807a95b04438eb63e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "fdfb5a36bf35ccea6f9b3610f0835c299893e5e395b8cbd61a1ea29a2021a291",
-                                "uncompressed-sha256": "e4eb57bb0f8627c881b7501c26bd2a89f74cf751f186256a030c58822475194f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "7d5abaa4b580a643ab65e87429a0cb19200ab81f50f58cb07d382443f18564d4",
+                                "uncompressed-sha256": "4aa8d90ce0edddac4e15a07bca95c7cde5c0a88b2990c6f60ec0dba0884e9a51"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/s390x/fedora-coreos-42.20250331.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6f7c9da6ef27e3672efd795a2b528904af92656a5c773defbd9782b7f5663154",
-                                "uncompressed-sha256": "f0fbb14bcc749d4275171a385f4a6dccff06289eb8fa097f7192cca594c58ee1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/s390x/fedora-coreos-42.20250316.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4eabb4654b9b7c746abf92b966cc3f55c40a88973aab7aea56ab36a962914ef2",
+                                "uncompressed-sha256": "bfd2a7c91af03d0133a345b1e909af9e1b2f50d80f7bc0dbc690feccdccd132f"
                             }
                         }
                     }
@@ -465,262 +465,262 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e1ec9fbb6534709b9accf8fd4e1dc6ce7c1121e1e4e0c1cfc028a992ea627e26",
-                                "uncompressed-sha256": "001df0c1d3e4a1b96cbf644cf937de650cc5007073306374d49c1da8241a6f2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "51eb49d26a164a371820d4eb847a7510090bfa86f33d5f7352568274fcf05370",
+                                "uncompressed-sha256": "c4a02e3327358d6112e35f763c46ece62133a0430ef1b48547e9def05beaa184"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "46d0164d4fcb81e8fcbbf5395a317f2287c1903fb57729aa72ee9fcafd9ec6bf",
-                                "uncompressed-sha256": "f3d82f2fbc13202072115b77bf12bb4ccbcd5926833afb386fd3469217e1d421"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "fc4e6fc7050f65aeb50c064d4c06de258a2bf0f49ebd19ece94cc4df18f73a20",
+                                "uncompressed-sha256": "50681a52138545081373f0760cb34e5628b7232ef916568e57e542a25e349ace"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e450d12cd6fcbcf419f4e83f1b60935f4d1983590f87b3f94ac5cb855d1e1030",
-                                "uncompressed-sha256": "f088053a102c367bbd6df8ff29fe74bf2bd8eb260b0095edf66b6470a7b43f78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "48a7f483387fcab3a24f162d88437f4b68db577764105bf244c8b00134085ded",
+                                "uncompressed-sha256": "f7c086a35a176d6d0fe69988e40544a08115e54f7c04d30f9b3a615f5ca15772"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f3d424dcf583ee857fcec386de4ae12bdda48c60a6722670b04d602096a525f6",
-                                "uncompressed-sha256": "46d8aa3eb6b78e47ba2c0a365a0975ddab1442c0925aa4653d773203f6a10d22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a93744cf0ddf237e773b4e2166efb4792cf15fe737726bac1dc4a50f03ab30ae",
+                                "uncompressed-sha256": "21caac9aa538bc3fea0cf99b26002f2ead15d286b23a34dd8461f036f6012e19"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ae1cea2dac784ec71a62c8c732a049684145f26ffed2478eb65d97be5a9412a1",
-                                "uncompressed-sha256": "64ed3ab26d5af8f8374ee50211a64269f4ada1d51c7dec7c235fd85c5fa49b05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d9c075c235bddc6f2f8561b7f5c41d1fb52f8c12afb5177b3b8c4e9b3a77b4ef",
+                                "uncompressed-sha256": "a0b612c9dd996505a9c3504f070194bf75c63ee87664ce2f6b3b4c63ad2813bd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "db288e626833373650d0038c9247e11ad0644a3714da2a432f645cca46df47a4",
-                                "uncompressed-sha256": "c590e25dcce3c034deb5f5f975629322a2d88cdad4cde1f5b32af2c369b8212e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "1d6a692924358df58caf0acd5a184a43e880a9f4b7c6b11e0ff306f03f769c0d",
+                                "uncompressed-sha256": "1362ef748b2fcc205f584059b3774f038387bee930d547456499141c3b62beee"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "0e481d90becb63ad513b75ca4e5937f7188b7ac7b4898917da378c50f17d0ed3",
-                                "uncompressed-sha256": "35643a12db563bd9af5122fd06476874103c30492ef9959b73ac39c418fd23d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c31a0b5678027620f5f1730c69d91ee4f0e590d21cf84e67cef5bab7744ab971",
+                                "uncompressed-sha256": "85b6cecfe30b97e11d836653fbd6845276d199e4a97756d3bfd1b1a156f947ed"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f642c524578419fc1a7efb164cc288cb3981c0916ceeb451a35791c96ca5697a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3a9e1f9b9047fa89e6b4f2203b79b0423bac66a620b10fa1a384e4c7216804c3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "bee3e12340e0fee19987e66a303d3e39fc7baef103716dc9abdab8b04abe8edc",
-                                "uncompressed-sha256": "751e0e2bbac960fccd9c271f71b753b2a292444714e0bd00d91a6adcd1a504c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e35f911ef6941bec3e87a894a1633f9681deeef431d6c1538bfb6366974a4e5c",
+                                "uncompressed-sha256": "4565487a81f82ae3848526f3fc16d47ff131e906faf67baf4d8ad7a0f8fb304d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e7014ed33d9b302a2e4515d72f8cd4c2cc4335de806930db3d94c536292d72e3",
-                                "uncompressed-sha256": "3bf0efa1203d409f0e525108d2d85108c6236580655ba9053220f9630af74321"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "8eaad56b987156521dc7ae89507fffa8839182d48c94339f5c66a343a9d60ba4",
+                                "uncompressed-sha256": "ab3f64fd574e0e80fde07df892512cdc52e187a802226d57e171af1a56e52e69"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "95fb072f9001412bd37dcc90ffb49debfd4a2cfd5055b113a2e92cb9554b37de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "26739d46f0bfd78683b9b555ff8619a30fc1354dd3347e88664fe947e756ccfa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9aa3ba8f8f48a67973f5ed1cb371ada28e72fd718e691cb7dcf377170a47dc37",
-                                "uncompressed-sha256": "3159939841dedee904eaaf6a0a4f611f047f9e4ed2f1de1fa737fed8638f1f37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3b3ffa923da666f422acbc808a58b6364e4427e6213ae499dc913ce92017aee2",
+                                "uncompressed-sha256": "16b319350adb88969764629a9cb68a80b320c4487814a34fd7aca1d8a6b5ba33"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "9dfdfdeea187a45c63a57e38523e60599a61ec7b4ef5f91a0a083ca6b9d0fcce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "d29d7f256e8696ee17742be87420e17b605b16b4c4db6b3dfa3cee91c56418d9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-kernel.x86_64.sig",
-                                "sha256": "507b2265becc1125b372233c43b044ca68d8cdeba9ed7da2544e1c98529ec289"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-kernel.x86_64.sig",
+                                "sha256": "4b77dd608391f5dd945411cb194812e6ca2394b6bfb5eb6e501fb0f87127e41f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "59f3bc7d75523a0826b93210beeb989f1079701709fb9656977f6e883266b879"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3a37d2a88ee232a55063c0b40081c1ffb033dee731689d3bfe188cc16233e1e3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "c306eab01843153e25b7c5e21779b6debfc91aedebe91b955051a8f025bdfce3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "1b74051edb08b37b4c3c250b56c4e29013dd6a6bf8c7d52276429d3449488d40"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c08250d15d44773db3c1c05b7b27faeb9224015649c455e34469dab34758c394",
-                                "uncompressed-sha256": "c136683fbf7bb384604cb852d9af55df3715c6f5db3143ef226292fdaa9837b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1b1ae948cbc27ec66be7603ac44366941e155e35a6a8368eaaf0a8174c75f2ef",
+                                "uncompressed-sha256": "9a66056cc4893314052ef838edf17a53d48acc1daec980303fecb8a51c886ac5"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "928f41d502cf6e4b0102356455346f68c0a234dfd10f62eb486aa368cb250e72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "2a80ed4d9aaf7a604e37477da05705ba48aedfdf44316398116b7bcaf12d4f6f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "67188c00e74cfbbbb7ac83d31571d36468f1018688ffed52162e7b541712a927",
-                                "uncompressed-sha256": "05e51fdf63a9676c13f0b5caa556325747089a2148d4de05c27af21a4b0a9664"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2cade8efd339079f0e2134c3e80897d906d121144937542ea29d3c2b1605f915",
+                                "uncompressed-sha256": "9953b7827096a4d2c5b771a405605d14265daacb3bf6dc9d9b70625bc67c37ef"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3b8a08d07264ebcae0f833362eaddd4f9accae0e80df322032be9fb5bbfad7d1",
-                                "uncompressed-sha256": "1fc506ea1a151a6bb39148c9977ad8c5a353de59d38280b06800644d44e81221"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e2f0189afac145dc2795d6c2a07e6dcb518ebb9455fbf9fc5186a38a13f75fcf",
+                                "uncompressed-sha256": "edafd45d9d54beef8f634b45ecfa5ef68ca529edbab7e3905bbdb40629e0baa7"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "90114916a673e0923c9dfad5cca0b6ffc19ae10476be2569bbe28de2ce82f685"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7c65e3091f6528b8175865f5e8ce7a9ed3f6357c8d914b6d44b4055d19afdd39"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "28b74a8a2f1e61695ddcf7feef701cc1ea1347b7a3c515699e62af8532094e62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "95baf0a3a94fbe6083a11803cf9c64a48d52b3a3e646e23a0b29e2d984aec989"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250331.1.0/x86_64/fedora-coreos-42.20250331.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "16b3acae69189d71e2b776f3bcd8ff97b62f7a029416b62ffe0991a65c32f2f6",
-                                "uncompressed-sha256": "c5aa08ba79a3e582135dcc7c6bc146ff0cd2e9f06c4503333911a13d18ad7ef1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250316.1.0/x86_64/fedora-coreos-42.20250316.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "aefbb554fc7b8c296bdca3127f3fd3b00b545fc404274c63f5b9a183dd2c3a9e",
+                                "uncompressed-sha256": "81ee75abcc93354d670d1a032a43e595477b800ac7b80eaab5c82306b5025b4c"
                             }
                         }
                     }
@@ -730,145 +730,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0532f7f6ef33d9bfa"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-04b005df2818b8b39"
                         },
                         "ap-east-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-02b1d8dde34ec7b1d"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0eb35ae049f88ee09"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-067461d0a834c2f66"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ce2cf66461f3d7e3"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-05ecd743124a1f0d0"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-095880ebac53e3042"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0acb62ecb05d11f60"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-05f0325bb0116af27"
                         },
                         "ap-south-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0d57e6bf6f14ad568"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ef0fb53db37e430d"
                         },
                         "ap-south-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-07930543d3e8dbdcd"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0971e34f2f11384f4"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-03249d91ec6937f43"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-04dd46cc4b66764bf"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0fb104e02a6a1732a"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-08bea244e091e652c"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-08b2cb5135fcc56c1"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0e26de6228f3c7f9d"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-08424f23ddf49f0b2"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-062b34909652c061f"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0c00efb36b1b726c3"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0aaf30e0de182ecc8"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0c0fdc7abf6a79ef0"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-080e80f906f8b1fa1"
                         },
                         "ca-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-02500d1b588ddd850"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-026884590b8dfec73"
                         },
                         "ca-west-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-035439a11b9c92b71"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0094375aaf2e70ab6"
                         },
                         "eu-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0236798ad8c1a90ff"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ed12e24bf022b8c8"
                         },
                         "eu-central-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-005f0ab3e0d4f4141"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0be547b7ea970029d"
                         },
                         "eu-north-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0cd190fc3eb3999f9"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0815f90acdbdd1aec"
                         },
                         "eu-south-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-02f7a3b3415b15bc2"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-057256c55fc9383cf"
                         },
                         "eu-south-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0e14535b3352323c6"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-04796b6fddd68926c"
                         },
                         "eu-west-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-01e471cf8af8d9e06"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0fa2fde508a63a57b"
                         },
                         "eu-west-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-02e59bcda8311aa75"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0db3fba7cea1722dc"
                         },
                         "eu-west-3": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0bc57efda7e74f1f4"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0d98fe489e616ce90"
                         },
                         "il-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0b1aca02f491b29ca"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0269e075e269af18e"
                         },
                         "me-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0b93dc043df0ae11f"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0ecf8527024d75a24"
                         },
                         "me-south-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-058ed50d20809488b"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0f8aec517ead710d7"
                         },
                         "mx-central-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-07c5538544666cb4f"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0dce0ad062afd150d"
                         },
                         "sa-east-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-0b9ed7d2fe95463c3"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0db2bac4029db54d5"
                         },
                         "us-east-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-08f59037eb8a18a5d"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-072601703af85d2ab"
                         },
                         "us-east-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-06c7775bca03c9b8f"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0acb3168f9c209cbc"
                         },
                         "us-west-1": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-090706e5c4dbb79ea"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-0e721efcbf00e67d6"
                         },
                         "us-west-2": {
-                            "release": "42.20250331.1.0",
-                            "image": "ami-08b869354f43e0dce"
+                            "release": "42.20250316.1.0",
+                            "image": "ami-018e0a0c5c4332bb9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250331-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250316-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250331.1.0",
+                    "release": "42.20250316.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9277b21ef5a0d76030fdf5815efad737df622a59dfa07a9d53281b150d67da38"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bf06bc8f9edd5301a9c003faa63762cedf2fa0522d1eda696c6d553919d52634"
                 }
             }
         }


### PR DESCRIPTION
This is a partial revert of 8661997. Here we are reverting the change that rolls out our boot image bump to the website and stream metadata because we found an issue only with the bootimages.

https://github.com/coreos/fedora-coreos-tracker/issues/1913