### PR TITLE
Roll out stable 41.20250331.3.0, testing 42.20250410.2.0, next 42.20250414.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,156 +1,156 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-04-11T13:07:22Z",
+        "last-modified": "2025-04-15T14:06:33Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "0d584270f14355474fb11513f404d0c6984df908812da4e3ce48f9a33df99656",
-                                "uncompressed-sha256": "f4bd330c81a2a00de5c400ff85004099bdb09aaeb392bde66b68c42f43516754"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "1ad03ff42bc526ce4987f3743c2c5aef088909d57176974b5f7265099bc841c9",
+                                "uncompressed-sha256": "ed78505932508e6fc8cd352c0e5babecc80a994b69625d36e2b52d47d9eab189"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "6e24a508f0a0d3c9fdfd852ea1361625c61893470112f74bf595177e16f516dc",
-                                "uncompressed-sha256": "d4d8902fb50d5f18e2b86030634ac0b16c1dc81fb121d27360e3c87e01112adc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "649fc3139cd988548b723246d5799cbfcaf1309c36ee1e1bd2249c480b6cbdd2",
+                                "uncompressed-sha256": "7dfa3beadbbd22bfc12f7bdc783e3b8a762a4dd91705adce28072467ef455702"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "32f805e8fb3ad2b1bbf2a2183d0150e136a64e4b843c1cd525a3b00b04033c4f",
-                                "uncompressed-sha256": "e1fc2a78a6be14ed17a849791b09f2e73a9058fbcf4ec075f50eb65c41692371"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7ed8a8f9d015d51280b023e5a25e14028f9d641b2f7dab173d53b07a43651d62",
+                                "uncompressed-sha256": "10cb1028cf8cd5882010d3fce2d5e07a6b7eb3487bf0629931fc3da5b077bc65"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "ec28a7b3add8379a3d7b7650bb9da9e7430d39332f9d1655af59363520e6a62c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "2ace5348772ce93044bc606f3a2f63f27593565c1e0ed4f888d20d4506a4649e"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "ef094f746edfa9a1ae0ade64032d426351f5e31d290091971ca3aa2d3bd1d7c0",
-                                "uncompressed-sha256": "2b4c7a248eb28c847e34b3d8b97362717a697c486a8ab4d0e212901911df81ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "b57500cf1d5186f52f67ce26e2c39b9c16e203c3752ab722226fe95ec7a38f9f",
+                                "uncompressed-sha256": "e7a597173a538098c5e3547cf208a41bff062ccd4e294cb6ad05dc8a465439b4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "e748d724338eab0694dcb0d98e17fbbdfdd3dc2dcd7ce585eecf652833c4bbcc",
-                                "uncompressed-sha256": "2703212073a5203aa111a87baacfa25030a323d79c7d0b5718d06fbff80c1799"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "89f8a147374a15a83a5e684a453d30c0b3ce324bcea9216db30a17b93bee516a",
+                                "uncompressed-sha256": "12ab2fbbc125e8a70fb65457b9c69c40496204ba32f6bbb80be67ecb74b33f1e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "0e48d4837322359c06d8aae5aefe66edc16cc4baceb14dc68a956d1bbddaf41b",
-                                "uncompressed-sha256": "4b4de33b78033e5f1fc96745dd7391f75dd6b643851e5a300cfd6b664ddb94f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ee5f3cd4ddd19f7a3df02422a20af576a70b0d5fb3207f1bc7db18534454b1e2",
+                                "uncompressed-sha256": "7c0693c75b2e513e5590871f99194aa2f4420fcf3068fbf007e769494264d0be"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "72244df5690f325b2f840cc6b2bc7bd666ef60b7179f394c51ba3113b6b16298"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "5675f7287e82b04b6fba238c46c967b59a6dc0899e2869b9601c4352a86087b4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-live-kernel.aarch64.sig",
-                                "sha256": "e249c9d6d365dc640215ab759e18d2a8ff06db2aea29fcb4f4d13e3392f4a25a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-kernel.aarch64.sig",
+                                "sha256": "58f28396356a6377ae67eacb0a0a3e8da84cf075cfae9b808ac92304d66c868a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "52d583231ad1fb3fa3ab742b4814dafd3e555bc34b3560182957a2204ecb3464"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a3a5652af41bedcc183b631973d3cefedccd0238998430339f987639adb43a07"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "a75694fa806c1f315a9154193a2084aa4128b8d582b81e60132beeb10cb5da62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "bcd53b36561f114f2bdf27da8b206ade00e419a62a164936893c250ebff28359"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "6af4785752b897881e12db6ddae8ba4ed91454609f179d1f6a81f58bfda69c00",
-                                "uncompressed-sha256": "c8aa23dc049295340ccb94a575af988b5e02d5f1179743016a8d327adf408df8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "80f16bc7762c49cc1c9708a83a66938fef63a7aaa6fab00256731398b419129f",
+                                "uncompressed-sha256": "902383e099ca207cd6341d8c39c815429c4bc54cab6fe776580301d23b599da4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "fb10bae3f13244aaf7e33374ccedc122d348b824c7a7aa46a3d3c87a92dc099d",
-                                "uncompressed-sha256": "fb4db03c5a9df6c74ffe6fdd982c6102140cd468f32545adf283663f2ee9bf45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b662e6cb75daa08a7df71de1d31ea5054837d5acd76dadb6bc22d75c51b4c205",
+                                "uncompressed-sha256": "ce3e5ad461efd725e9787366ea7301343a43b5614b87a5a0a09f5518270f70af"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/aarch64/fedora-coreos-42.20250410.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "9d735abb6e16d7d0bd07154353d3fb1b3102b074113ddb4b7e128153a2b30fb1",
-                                "uncompressed-sha256": "4ff0eaf808ed015445da74689db7b8c8ba09386dae77b4a0703060fe9306bd30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "05bf03327aa667b8de2b50457b48fe96efa63ae157d56cbb050fef7b2081aa61",
+                                "uncompressed-sha256": "9206ebbbf220f4555fe5ec8dd2703a93352984406c5a63e2acf1efc8d83b4e3b"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0543818781b0fe76b"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-096695df239039d51"
                         },
                         "ap-east-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-038b35dddb943bd99"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-00c2a8482b4af1579"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0fba86b359e95e42c"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-063b4ed3fcadb87c8"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0b9ac0245c1832151"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-033bd8393b1d84b88"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0bc4082a86ad5fba9"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0ce4745062980ed2f"
                         },
                         "ap-south-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-03679b3c7b4128e67"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0d64319de95af00c3"
                         },
                         "ap-south-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0cb78b09502a58e24"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-042825be47a7c481a"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-04d448472a1e5c26a"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-06170930025637661"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0036a436d15aab241"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-027269f5a318eb1e9"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0ab74e6492ec9d333"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0796f0c90155f2ac2"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0fb80b47fccabf526"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0b969d18fc4170da2"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0b304f21057933f04"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0bbaea676d2af8ed0"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-054192e1a940581bf"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-069dd2a9ea40936f8"
                         },
                         "ca-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-062c6dcdac61288cb"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0ebbeb6fd0b5521d1"
                         },
                         "ca-west-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-04b4431cfd700f62b"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0a14827eb6685c4f7"
                         },
                         "eu-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0aca052d04d2c6f11"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-09655398fcc5fe55b"
                         },
                         "eu-central-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0aab24374bef691c1"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0cd7297ee5ad2422f"
                         },
                         "eu-north-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0d0d4479479d0d7b7"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-063b6e5f7577c572b"
                         },
                         "eu-south-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-098dd8305e61f3247"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0289ce4ed23829350"
                         },
                         "eu-south-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0564b90e76f19f620"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0ce0d4077e5f0770c"
                         },
                         "eu-west-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0c51026f68577e481"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0af331a27a837dd18"
                         },
                         "eu-west-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-024078d0058fe21d0"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0fc0e94afba20983b"
                         },
                         "eu-west-3": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0b538c7eaf103377e"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-03b4190966f409806"
                         },
                         "il-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0814a0f2e0e25d74e"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-09543d67979280a42"
                         },
                         "me-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0f62bfa6d9c9d766f"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-057141cf1645549bc"
                         },
                         "me-south-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-01e1c882b414cff5f"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0a3b560c5aab153be"
                         },
                         "mx-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-07dcdfb9fe11b37a8"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-03425ea3716786dd3"
                         },
                         "sa-east-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0983f64333dbbf473"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0d825b4a5f7df40d1"
                         },
                         "us-east-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0174c54c650509b8a"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-074af4a5e6aa60b15"
                         },
                         "us-east-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0635135d3f620265b"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-03128f58b2ab10058"
                         },
                         "us-west-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0d1e480e5da5a583a"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0d2ee6685d2410cdd"
                         },
                         "us-west-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-06d66cc276825194b"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0f404da9a5441bb5a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250410-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250414-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "2c5724760996ffaa340ce13f17553eb3c6e86a4383251c8d0d4c316431033fdf",
-                                "uncompressed-sha256": "d6e32094700d5ceaa8ca46758dca2adbe1fe9c1b1d5f32960ead3aa4107892d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "07519a841835d8e369a5bebd3253e1b0ee3603ec07d90a0d0101c312eb95f806",
+                                "uncompressed-sha256": "62856f4626b4287308406423cbe2e548c5078b6fa1dd22d849d7170680ef361f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "22e0484c98b6c77ed5bc08338d90a403d74e5ab4df97f96711c6edce7b5f204d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "0227010eb5a1be99bbb9aad4301eb947c9e632386397a7fa026523ded84b636a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "4a522a1b85554d5f4f7aa0aa0cee8d1ccf877165c5c4751247956a51d4a1958b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "1f07b533fbb545fd575b04724bf0af8619d1ccb53be90b1a3ce32120b6d52059"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "77f4e090a5da1594886262f48c60e10f0f75a60efab7df9d9ca384ab9f684e5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "20a34a33542ca6ea16b67efd33ebf7be6d8963a36cab22da4dbe2ebcd422e1c8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "f4f169b0f05a6aaec6a743a60256cce8e3ad56f4809c63dfe85a125a2988c279"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "5d80328c17d70e914b8c7ffbbc759a4b6aa321b66077c7829613586e220aefc1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "f4c938aadbffb55b6c39035a24a6bd3033cb19bd79eb673996b6460fbade7931",
-                                "uncompressed-sha256": "48fb2765acfee4c16962155e06092ae797b9ccd085d2dd97fb26c1fcc9bdaf69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "ebaafc5783bea83d5795cb572949461c3b486a278978ebd02d3761f06fa88491",
+                                "uncompressed-sha256": "090e524948c00f964ee0ee206c75c108519638bfe17af76baa19eb1efed2d3eb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "1174895c4514b48afe918b6626b3410f7fe3c89b448d1101a3b43144dcd1ed24",
-                                "uncompressed-sha256": "95afc104ba65d24eb048041e07ef0c81b7ad6fa417132fc80c93fb8ea14ac47f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "4506a19610c91e189f7e9bec4f3e973959aaf34ad5ad9e8c33519f9d7b180317",
+                                "uncompressed-sha256": "3d00e9db0072f124f4830180b2d8a5078b9279ea27f1e1a9ca4c3d120813bda1"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "0fdc721cf1d982e1ec1d841d5058dd7aa256e33d61cf923d13d9db00bb5cef01",
-                                "uncompressed-sha256": "17d7cedcf48faba2bf9740eb76b73775f885196fd71689585befa5ebeddd1968"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ea61616692891398f62a5d90113f0c91c858e736d387955ed3e3e8b9a54e687d",
+                                "uncompressed-sha256": "f9934153ef9e83f5f84cc4454caa9278f8accba3a16ca1dfa92d19eecc5da8a4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/ppc64le/fedora-coreos-42.20250410.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "6eb1fc43b872337f2e4fed856de4a810cfd84c2a7213b77e91ce88666c851af3",
-                                "uncompressed-sha256": "74dc8ccf396a09f1b5dca91ad4f4e378881ee56f4e94894d20a515942a0f976c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "47f8de8147c5c707ac764a48497684d89fb53b0be42cb2159b879b694fc9d1ef",
+                                "uncompressed-sha256": "0169ec208dd830200661c5d83d909a3937eb8ae4e52eaa75c8efb2ce94fae9c0"
                             }
                         }
                     }
@@ -389,85 +389,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "acdaa2ae74f27b9e71d265a0c57f54172fbe13744bdf1854e2c75e9c9ba23263",
-                                "uncompressed-sha256": "c2d0a61f91661be540cb2e5fdf2d6d137435f3b0f89a22bdb7bf4f1451559f30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6c9875cf9e7fec7616a2a3908bfb6a6044ff77aabe7c5b49347ffa8e65a9ff09",
+                                "uncompressed-sha256": "ad4e2d6f059ecf2b92bada478a18c8ad8fdf4a2702e1f473f35006fd9a38fc14"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4dcddb8244276857485ce77236e97fb45ae917a81154c611ac8a2844469eab21",
-                                "uncompressed-sha256": "16a3d37059f495624f3e7cd2f3fee5004cf15656cbbfabdeba61d7f6cf1448d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "607e2f53afbb85fe249e636418a69dc21cb57650d888fa90584e5969d73530cc",
+                                "uncompressed-sha256": "69149051d2c4d187828e0447d61d990743b3e1acc8236001459092e3f2fa6813"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "e156016a3e73b8222a441ef82bd8528aac5fcf137e4deeadf9cfb9fffff8f56b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "7e9243d5044aee21149c99fb6e4d55b01e9def0c226a9de10a83bbf14b09f4bb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-live-kernel.s390x.sig",
-                                "sha256": "1e340eca4d780fbf5ebc94e683060463acd1725ceb437bc0c7e30994701cf835"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-kernel.s390x.sig",
+                                "sha256": "a3817890e7949788b9cae8881a4b36c2af42ae3c32f927a981472c78e59fab83"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "31eeb0bc127569cb6c7e4b2fa70e15236bbddc1b3087dac4ebfac5388e70a37e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "a691a8b17ee020a7323cd5952491df8b63861bebb7b90fa17253c05856d093a5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "5ab90400cbc5b1ff1e41e2ea4acceafde09a7a70e15e3c8a72e5d9429ad02736"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "d59c274170007eaf9507259c8f16232b616edc047fa8f87642405a1994059762"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "f22fde0dd0f5d346fb85a22aa30ce873487a32546bd3fcfa65b4072987b713cc",
-                                "uncompressed-sha256": "8d842b179a0ed388dad17db94c18df1c3f4b94fabe75eced88dafcc84165dfcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "064152ee61ba3e4eec6870b1c367b7ce791ae9bc3b3b85219a63f98b1d1dab5b",
+                                "uncompressed-sha256": "fe51dd7cb69b81ca7a6407d53a48dc0f593baa6914ad28e086d9be8b9b36f978"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "45bf4813ec22b06e65e5a962b5b8346825e94d048b24f20d8a3245ddd8569406",
-                                "uncompressed-sha256": "956f7bbbeb050bff6daa4d9a4caf8ca6d86d9421b3697c206f63820a7836be65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "3abe1bdd055ad7bfd4874e36eb33e83f09afe75087e32031aa740dce5c589758",
+                                "uncompressed-sha256": "2f43f3ecba3df70e121e2b1485f8f94a3ef7c54d36214a254869aac48d66a825"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/s390x/fedora-coreos-42.20250410.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "fb2431acc084fe94e96ef7c500cd4fb7e49df67fc87a95d0f1fd979037d9f071",
-                                "uncompressed-sha256": "8d0ce1789c2efd0ad6883edcc238658e70a6c30521ea7c610b4be4fea6ed51ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9cd8767510fe280919cf15de312701ded176a39487783dd242cdd1ab30f0083a",
+                                "uncompressed-sha256": "91e55eb0cf9f6b2e5b2b5f976a48a68f86070efd6bad62b0c18a54fe8645f03b"
                             }
                         }
                     }
@@ -478,275 +478,275 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "56ea9ca90bc587a203490f235a9566ea43b10d9df8ad620a52bf42103a03c7eb",
-                                "uncompressed-sha256": "76633b0fc0ec5259d18cb6cbe2d4346736ced4f89cb2d12df7e3a888fa8a5011"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "fbb00027a0ac13c17526b9db1686ea2b039e4b4a8ee542c288cffb0f7ffb502d",
+                                "uncompressed-sha256": "cd7c262aac3c164166f60c20aa66bb9847ff126c912dc0e720a63b343fd5954f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "efc49bc9ff055b2e7bdc2e3bb167f04d9240316fefe748e091abbeacaa349d53",
-                                "uncompressed-sha256": "6b01e2aff9448ebe17b23560f63d05c35863f79a44ea3772ba63b3b596ceb00d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "42432ba608ea04ed91a81cce4139b161cfcfa0735972e15a0be8ff9065e62cda",
+                                "uncompressed-sha256": "5855b8920157d8409d289d87b6edb74734e4ae9679933c5465e683ddeb633eff"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b4811da08451021ac1b6d058967519d523a8ecb58d9a1c5a213c533b3bda5b65",
-                                "uncompressed-sha256": "6f0a2af94fd71c8c380a4a03cfc5c6070e874700e4c17c24804307e4fa491ba8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "37ecedd3efd8a9410b5f61ebd525243acffb5ffde033f7cfe6c4218d11aafec0",
+                                "uncompressed-sha256": "6e4ea35b77fab550e781e6631f793fa139133105735c5e20bf2c8a0def681706"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "24264e33c235b782b414652f448c7706d3a8bc99f27cd3e6c7e0a52d88402a08",
-                                "uncompressed-sha256": "abe57a794c464bd2ad463c4a1c42801ec3bcca8e18aaa5aae745b7f3cd0b75c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ef1f9f9bae2d9647cfe135df43246d0f606a23560f245aa918d8b153bd920b9e",
+                                "uncompressed-sha256": "535180e268d7aeb47f109480cd124fd7f4e0df2c0fd353a975faeb2ee9005f0d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "651e283a9246b4ee2c820824c0059a6eb90835f4daf45659a8aef84cdceb92fe",
-                                "uncompressed-sha256": "e4a141853f14e22d67f81267c33c09d4b09e133a5b9002ef63f2c26674a6ebfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "123169b7a161a0fafb572bac014e87eb1c3cb6472dba2d962c8a84a1a973683d",
+                                "uncompressed-sha256": "f734c524e36c5534b8ca75825a50e60b4fdbd096bfe252a18083ccf23c0da50f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "360eb54a5c32fd0030bc3086fe30e5cfbaf23a3b3a9c84aafeede3b0c91ca75f",
-                                "uncompressed-sha256": "02c0eca7c247382d67bb58115038c3f895e6efb1e86ffa33ea863163c806cfbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "0d01287063b166c19980efe2f06fc5de79eac81a736e40b41605aafdd4ac7240",
+                                "uncompressed-sha256": "075d39e2ce3dc1ccd8d2c1633b89fe4efbf1632ee0dae99891e72e8e9c148434"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "fc0e85644bc50ee3d4426513cbafd91d4cbe0c942517a0feffd5fbf1a19ab3bb",
-                                "uncompressed-sha256": "af55fc51837aa663a31608de2540bae46b8e604216c7d0c1ee0d3b50f00bdadd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a6c893880cb19885d43290908f31094a03df0bd7f498fab1874e12d6fd8b1a91",
+                                "uncompressed-sha256": "526b55bf9aefe03e36cd6aff25616357496533a9731dfee80544bfb9b145f867"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3a811c8a09fe49007a8532a0c41ae6938a40847340f58ead7b2abe3108e461c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "565f91204f22105ae5978c7afed0b448e9df3b91f9ce75e21c6381c6b6c0ba24"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "549bfb109765f4b63212b91ee43609902c3c855c191e37c32312c3d3bab464c7",
-                                "uncompressed-sha256": "d7622ebbd2c1cf44fcf242f4e245d91d783836dfcd498bac76d7d82837b3df67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "a140b093b1ddd2b73119aac7f8a92cf5a6279f3accff8d3e0b08d086ffbfb11c",
+                                "uncompressed-sha256": "b154502e9ebd3e8e118d0352153dc2dea700ad945c0650159250fbc5488983f1"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "d8870630eca9954a8fbd5d2bb28654be9a62c88b065c63356b1789bed4773c45",
-                                "uncompressed-sha256": "04b35409f980de30727cb5a275e1a139bd3654b304f57e872d53ce26e9ea927e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "b3066b0db053425d5f41ee4a4f54b6cb8c69912cc17e5ce3c2dedd7d660509bf",
+                                "uncompressed-sha256": "0acecc48a84b6cbb5b1fb725318d54b3d19203ae4732fc8d35cc07f3933f5f78"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5e236ee7895be233052c9943569b2af0b8ce457c8bd092ad7fcc752dd3b645fe",
-                                "uncompressed-sha256": "93665b7de46734d9031a1bf0fcf02db76aa88dc0dedae1313faa944283efd993"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6497c35555e7b038668cdc51e0df78455fa75b619c0ee89e34fc36ecef1e172f",
+                                "uncompressed-sha256": "b099ff4d1cf8af4c332417db47b12f4679d52699d446e3e80d33fd46a1e910e7"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a8e20ad256f36440e1d89d5521adfbac7c46ab33ccc956414ad6fcbf699e8b7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b8d249ecac42bd7299b902d39072b0a64b4b120f1bc66a38ac86acea704f42db"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "765d8fc4f18b5f4351dad4a14a21654ca15705e2a002d08c173695ae78f14ecf",
-                                "uncompressed-sha256": "4c5816820f8c275d35517d10bcb113bfceb1ab81acbf6a8c7fa2c79a6deef17c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "39c2dc7fbd2ae18b5073fb2a2ef563b54b7f349d08e800bff04a3e84fe4b8674",
+                                "uncompressed-sha256": "706bfdc5a4c62d4ea04aa9dd0c10e947172dcf796224f6d5a2357d54c1b9afc8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "c00f5ee4565661bca14dd9b40d8b45bb414d41ac1cbf4210e2e16376f4c672a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "16ffe15420fc13c58f89d28cff6018ff2fc48cc762d73731ab8c094d86dabb92"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-live-kernel.x86_64.sig",
-                                "sha256": "507b2265becc1125b372233c43b044ca68d8cdeba9ed7da2544e1c98529ec289"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-kernel.x86_64.sig",
+                                "sha256": "1eecf8109bb4a6b6125a7923d1f0e6e1ed1c71ab87752f7117baa3fe335b8a1c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "6ca8025bd0866c70d6838943e4e86ce6794e73a0091a88a0efea1f14aa93e16e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "37a398d3df9eae7343b5b3f0dda1d6623318f27369712c90bd8e5d4aadbf7cfb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "dff9a108ec9d69916db412f7353e4c428ce9f27fd40fc4c94f83670fb075f39b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "25faf128082c6af73572200114f2c676cbb9fa23c9267716c98a57ad57bf7cc7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "1edf1330ca21aa62338ce03492ef4ab2e77bba2dbd321ded4281eef2565b7360",
-                                "uncompressed-sha256": "9b74f99ef3e082fb48db0a5e6d53c38e13012b90d297c31adb6487afe5e6aa9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "7bb6e336e9d1a16f0b006a22c3441e437a44b941ae7aadcd7b3f44aca4ee6c56",
+                                "uncompressed-sha256": "c732ea6d8dc482a495bd796a24747314f77a5bdea8dfabfb76034e04a7f46edd"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8083c642b9e3aa75ade253e0988223bbadd0209a02396fcaa8e65bc2c293b26c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "8e2f7cf82df372822f59f18c73659b9ccb40acf38ec72f5eb5558a89dada3156"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f5d5636fd9aeec8affbed2c958cc96773923daf9764246f56d6adba09ddf7f6b",
-                                "uncompressed-sha256": "7777fff915b0fbce6d7a92ffcdf666411b345271954ee3dae97804f9c5f7e062"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "5cce5901d16efeafb26d0bf5c1771ba895ce77199281ba04d9010a72e2566b5f",
+                                "uncompressed-sha256": "1fa9cd9b1e70340ab4fb84d2ff9a1b7d0a8f47e553732c339cac6a7251ff009a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6be157819f3e962de87fe6c1410258a3c72473de0ecbcb898a8dd7f5e00bf2b4",
-                                "uncompressed-sha256": "300d604b47295dfb2ea5fface7b995d393c1e5954b76bf09e8c360c3405a58dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "56d8918670a5a819675c5f90c36aa45018c9b8f057c806f5e7f7d7fa7dcbf790",
+                                "uncompressed-sha256": "334e33ff60f50f8bbfc581a7804f7392e9a60b6830c086bae4e0c8f441e627da"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "3308e01694f2ffd6d2ebc5e20bbda1dc11be6748dcfd6c49e3d20656006f5234"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "efafcc041bd39c9dae0138e04bc68ea3b5c31402ea68350e7dc9db1da66a2c73"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "76596f3e110bacf62ebf546416dcef69b43068aeecd222b0d47713924aa0de9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "2e2dc469401b6add1888acfdcafe73a50ea0a6f78819cec6f0e512c1cd0db0b9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250410.1.1/x86_64/fedora-coreos-42.20250410.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0e49298ec1412207ed63b4976547988c1a1d8588c1d99a23a24a72367efcfc22",
-                                "uncompressed-sha256": "9d006b7a1bfb5f17bf108ad24aeb1ef171c6df298d1f699309c49a65b2dcd7d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7ddaebab9ef1eb4aca3298971d0315c292f4aa4fd470ebe5f2e069f3193ddfce",
+                                "uncompressed-sha256": "8fdb197bbd1eeefd37f3b74407e15182196f6006a70248865a278a8fba287be5"
                             }
                         }
                     }
@@ -756,145 +756,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0e5fe98b4815ba281"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-03078301977dc50e4"
                         },
                         "ap-east-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-049d89c7b7abdec8b"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-07e634b5f3288bfef"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0fba27fc5794add06"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0ae339eb517bbfbb6"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-07990be790bee2de4"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0e1a61bc98f32f82c"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0c755b29375738657"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0fd78e4b49ad4cfd4"
                         },
                         "ap-south-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-058ffb8a959c0f2da"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0df666227f3deee59"
                         },
                         "ap-south-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-022932cafe11b9e25"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0697313588b84cf83"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0dc6088739e837291"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0e54e221e8f5bab78"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0fda658b3f445ce52"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-093f3d24e4f38e469"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-009dc58c5c9f6f20c"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0669fb2a9a79c7f07"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-076160d33714c7768"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0df5db3d26428364d"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-09c1ed3ca2df42df4"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-017899f03648e85ef"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0c3bf27a78fbf9cf8"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0f70895212caf197e"
                         },
                         "ca-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-00aacc66568b56e60"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0762816142a702484"
                         },
                         "ca-west-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0e94a0db093b4710f"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-00645877e8063a835"
                         },
                         "eu-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-01b2fd6e557397765"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0bd93ee9939c49e44"
                         },
                         "eu-central-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-083fe8c274ca55485"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-056ef9924f97a256c"
                         },
                         "eu-north-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-01db2c2cf74a50510"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0dbbe3614a6651412"
                         },
                         "eu-south-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0ee5b11465def94ee"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0fd2ca36c88668d80"
                         },
                         "eu-south-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-073b06311224a9649"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0f5c3087270019381"
                         },
                         "eu-west-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-024487599fa7923e3"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-04ea931c8d4d17846"
                         },
                         "eu-west-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0132eaae7873703a4"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0ab1b9543e0589395"
                         },
                         "eu-west-3": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-00fb73fefa85ae012"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-03e62abc2432cbd7b"
                         },
                         "il-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0fb3aaa70a26e17ee"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-001aea7a13624e444"
                         },
                         "me-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-068cf09fd68f9d5d9"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-01d6cd6b331b2caa9"
                         },
                         "me-south-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-07c2e8ba9ed76c048"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0098dd45124ddfb42"
                         },
                         "mx-central-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-051f9dd729ed2dd8e"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-0fa96fc95ca1ae589"
                         },
                         "sa-east-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-040c6ed19f2c2fe37"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-07fdef7cdbc2e9905"
                         },
                         "us-east-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0396d2c8d548ed111"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-00eb6f67befe9621d"
                         },
                         "us-east-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0a338d02237be9a0e"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-08756d5ce47971475"
                         },
                         "us-west-1": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-0a16c58e1df7d191c"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-086de5c2f10c55df9"
                         },
                         "us-west-2": {
-                            "release": "42.20250410.1.1",
-                            "image": "ami-02be55a77f4e7458d"
+                            "release": "42.20250414.1.0",
+                            "image": "ami-00e5281191da7fe15"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250410-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250414-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250410.1.1",
+                    "release": "42.20250414.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3b3e50391cc13f510a13a0bbdccbc47f7b714399ca8125393e8327be8fd4351a"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:926aa2f471792bb9826c17c9629815ef1d4f371fec233c8b933c01c5b1415405"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,157 +1,157 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-04-02T15:49:56Z",
+        "last-modified": "2025-04-15T14:06:30Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "6fef51318a7e9b69cdd8385f2c3f28c72a0b77c24cfd2ec4c50d16d1f322f729",
-                                "uncompressed-sha256": "ebd51a24f207c10aa09bd6d3ec9d0bd94343b695fc76a756aca22e10c62b54ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "60cb5a21fb2f2004d61fbaea43fc5da76c4e04be25d9c55d80b752d264f4fdf3",
+                                "uncompressed-sha256": "baaeb7697f88ce0dc993fa3666e242fc7ce4ea024e9f3f9bfd600c63fa64f238"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b9982a41094adee306022556d268ff7048ff337706a7349f1b851aab795e1c49",
-                                "uncompressed-sha256": "6b16a5ede52bfe1469c59e82f03e216ae6b187d55dca89593f71e9a7276c91ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4b34eb2140b7bf181d7fcaa416bfa63cf2386cda48dd9b5095629aceecbd8156",
+                                "uncompressed-sha256": "821726d847c81d3499d56cfdba3d1ef98912a33d7aef0b18e034bc8c824fb4d8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "05fd0677c5a22553658361f3c0250ab85e7501a07397cadeedaaf0f82649d3eb",
-                                "uncompressed-sha256": "55598e18fc4dcec86fbabeb8dfdee699704245db4b35da9cdaafadbadcc19309"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "cf3f8d5e3066e6d3fafb7ee0e70c220936b47d463ba43f3b01a3e9f678691052",
+                                "uncompressed-sha256": "5394b055ec1748b0f9c0b4038a7b2c035ff1c9f8a152df6a82160fe08962459c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "ef0e708c0812709c30292c1dd590b4668a5e06203a66f31d1ee3f5a841ee2b1e",
-                                "uncompressed-sha256": "65b521ac5f38a4939d59fad64f8ba2f5e4f30873364fc977f7ffe5e5a25e7f3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a9e9be52631d189bf9efa8505b5a1cd3c67508b227846014ae7a9f8732506c16",
+                                "uncompressed-sha256": "fb743382d586e70276c5390078ed635fa30c802cdab9d0ceec915d348312bd79"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "b2b1ebe85eebe3ed4ceab68b897c826f403fd54f057e3dd0a626af55c24f163e",
-                                "uncompressed-sha256": "88f49e40c9e818c0bd1de87c9168e549ff4e462a4b399636cc10ec3c438c7cac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "db4336dbc2e049d2ae83e3e829bdbee25a96811f9fd4fa8ec57cca04fab214e2",
+                                "uncompressed-sha256": "be1198358cc4891ce43bf87da8f0f24c85a893e71bd5cb21f0c694af3455d8fc"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "415a6ae9993548c7dae7ac0dd2556f3a1ffda07b23fad4f1663e2eecbff114ff",
-                                "uncompressed-sha256": "47782c1f427c752122ec45aee001787f0dd483fd5f981ee6619093a2de21346a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "36e3e1bf22d63f5b815ee1e24a33c2e4ee38a6c536fca023cc49edd173181b10",
+                                "uncompressed-sha256": "482be5d7ce65f7c4b72ec710e74336fde9c2a5d77614ba960f3a09cb412f586d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "fea0b8d583fb31a7c83f3a4ec4443719601303d9bb0c7701dd330255d08a17f4",
-                                "uncompressed-sha256": "86fe690a6f49bb173cb81f70e8e459bc7e2b4738e7c71b52510ec4198fe51885"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "8f2f536482ac053b85b35d73fbda0e687ac2d80a1518a0193f01624eae599b84",
+                                "uncompressed-sha256": "175fce8631bfb1322d094060b532bda23941d340ac4127c31c3ec73de8c4e664"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-live.aarch64.iso.sig",
-                                "sha256": "1297aa51d48a9bdbe815d1a6996806072db111d20996eb3259c28ec076f2522b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live.aarch64.iso.sig",
+                                "sha256": "1ddbef985b1019a4b465ca67fae5e5e4b96e4f3cf1a1e2be1a4d30726dd76ab2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-live-kernel-aarch64.sig",
-                                "sha256": "3f9059fd030ec42582d5e5ad580fe9b94ef10d63bf91d23d14bded40db89b18f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-kernel-aarch64.sig",
+                                "sha256": "194210ba81810e428a4ef7a94ac4202afd87f97b3c038b53111a082ed31660e4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8d34923735d3498f6d723a7aef8ec6b376fecf92abf8d047d88d94ca73b92d00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "4c54a89b2238d68b185eee497ebf43629da9917a008d6b0cf2cfc74c9f8e57f0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "b54068f4deb252a14e95d0c93b4c25a5943d9ccb1d6b5f4fa2e57b4c89d8c3da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "2450129dcb3557a4e9757ae9899131832506fbd90b8956e6b876f15e23474e30"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "9c4123a571d28e1678931a7f1dfcb81a8e2d8b012ae7902194bfe536d94c5673",
-                                "uncompressed-sha256": "87049d700c01a0916f1cc384abd555142e05f2742a6835e66706c17bbed02610"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "75b4a999c19fe9bc7d4bd86a847337578ef5d6126191f84ed88900965e8037f6",
+                                "uncompressed-sha256": "3ab5feb1ce5c4ab294a158d667f080fccdb608eb5a55455c96c6ecff232e86e1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d52110b8fd2d8e7448cb2488ff49c789496abbce3895507c13e786ef3a100119",
-                                "uncompressed-sha256": "95a656d8d15a9c2c188c13f16b243a0746a2d04ba0ac41e1e0ac7a46c0f36e5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "f8a21e53b0d91283aa736d9af03b367f6684945d6dbecfd8a325d59b458bc1d8",
+                                "uncompressed-sha256": "77804825a7cfebc080afe1b1b1512d2eb7b6ecd20ed3c9358d291d1282a3569f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/aarch64/fedora-coreos-41.20250315.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1e6e439f5d4bde53bc428c123c31eab1f395ec92afc1182495df267b12e53b2c",
-                                "uncompressed-sha256": "4ca103f99c927416ee4f2c91d6d1f770c0d5e4d36229d7e0444a6ecc728701df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "314f0a5004e32daeb52a098b9bb4f6160c65eade18af67fbb923233c16e19160",
+                                "uncompressed-sha256": "662cf9639dbc5138c4d196f17a45c75a74746d51a1a90ececb42b3e3912ec213"
                             }
                         }
                     }
@@ -161,225 +161,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0afc9fa64365f698d"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-09f41e7e8f178f4a5"
                         },
                         "ap-east-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0df87e5f69452b753"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-09423eb10c451754b"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-08fb98c1bcb9732a2"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0649bc25e1c5e1300"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0938247980e1ba837"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0a7e64c4c8ca85f20"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-05d73e110fd946d14"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-03501f52bd108584c"
                         },
                         "ap-south-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0013c1488ed48736b"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-094d2786161d38336"
                         },
                         "ap-south-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-032244968ae04d446"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-05469923a4836aedf"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-09a280d52ae680685"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-010feb714b9b5f824"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-08a54feb498883ee6"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0c141e7d596e28464"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-095810295dd173e0f"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0ecfe9f27ac3b1c47"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0b8aa9d848667953e"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-076e021bcaeb9b2e9"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-057b717537fcec553"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0d4765dbbff8a9478"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-03267c3e1b8a3a545"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0c5c436a239f6d143"
                         },
                         "ca-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0674e0a967255943c"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0a6b3f80223401b9a"
                         },
                         "ca-west-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-061581af84f4801ac"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-012cc3fa9699ff48e"
                         },
                         "eu-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-01832eb26bde1455c"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0f1015c3c915bd776"
                         },
                         "eu-central-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-04f7050b2573667f8"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-00dcd62803aed60b0"
                         },
                         "eu-north-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-05a0de2b10536227e"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0c3cc8e7906cc6fd4"
                         },
                         "eu-south-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0027685ea6ce21915"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0abe734129f81374a"
                         },
                         "eu-south-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0919b0c1ed0bc46b4"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-029bcd01ac5ee4e2a"
                         },
                         "eu-west-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-051e5ba77346dabc0"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0b9e9603911c5b591"
                         },
                         "eu-west-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0f4cd3168db4503f3"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-03331da64136e38ca"
                         },
                         "eu-west-3": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0b3996b9344d25fe4"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0bab98617d3706459"
                         },
                         "il-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-080260e89cc1c17af"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-05912d48745ba190b"
                         },
                         "me-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-050356ca35ea9edba"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-05f7fcf3cbf018c38"
                         },
                         "me-south-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-049bba695dc40f7f3"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0ea49666978068acb"
                         },
                         "mx-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0bfd02d3ccf25a38f"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0abd3cf98224873ef"
                         },
                         "sa-east-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-041bcdad957e8f43d"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0e93dfd5b32450c3f"
                         },
                         "us-east-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-07a5c713929244919"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-03ec000e1dd3f8d74"
                         },
                         "us-east-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-036fcc97a87a2dbca"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-06e7abfec8fdf3317"
                         },
                         "us-west-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0cb59067d7376f622"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0e7f0ddd5fa58e88b"
                         },
                         "us-west-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-02b7d81fb26367c03"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-07e226750f355296f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20250315-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-41-20250331-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "ef5e4026bc59a9df56d9fdb9a6d021b85b2b4ba70ad5812c21d616cc7c8842e8",
-                                "uncompressed-sha256": "ce2fd8aba0e6cb61d009ac4263729684f956f404338e69ac8149b1e3098473ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "5307162cccb4ccfd57c6236feed5bf747c691aac95eb48fef5f4ec43b56c73a5",
+                                "uncompressed-sha256": "87659bb32334b1692353fa0e3794cd22835ca9772f39051a9b3d101a410272a9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-live.ppc64le.iso.sig",
-                                "sha256": "f5beadcbeb6b1026eaa0c8fc43aa5e47c2f397e01ef830bae0458639ef769b3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live.ppc64le.iso.sig",
+                                "sha256": "0c3d1c0a529974ea9db564ee308307ec698a83aac2cf82f9b20d68539cb6d423"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "66386609d72461f9c442af0cfc014cc0a9eb17cc73b7ed779b64047fc63c217e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-kernel-ppc64le.sig",
+                                "sha256": "56fd0720eac7f0f5cc20964eaae934e14b0559c9f6a50e4cce1d4a499f7b9a0c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "70315d5a8aa72dd6d53b4a5d0484c331a3f04db0b593cf009f13a8b27aecd10e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "5bb65231a1c0a747ba65de067d0f8f074190e9ed684ac8b38eb08c98d1626adc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3c5d9c11f9b49c2025a2fb0b1549e10f116d23eb19d7d5c27de29195b90c09ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "404baae9cd0b87e0fa079d6286181990cc8ce9e7ef8d78fa9ea0aab5ef042b5e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "79e6b137edf56e03f13b20e2b809af8bf9e37543bea8e4923e410b7ad22c5547",
-                                "uncompressed-sha256": "6e00cd51bf69b3c60fdf2e2dfd0b743bbd43b20a91ba7cb2822d4eb64e9db9e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "40b9bb2678fd62ba8f44567190420af8c1cef1bc38fac2668eae80ee1c29c586",
+                                "uncompressed-sha256": "f1b8abc05a3b27883f181908a0974da7345482bca08c32f6fa9ef17c54ac8287"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "8f81f4d47deffe9fb357d9240cf48f95a8109fd1aa49e23af20d971bb50163f2",
-                                "uncompressed-sha256": "8cbdbc42f409d4f0a679dc0a17aee378f9fa1210d97a72e31c30b238be34c4e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e6135a574d39a1554558b541258e7b47a5d430a197713190d8d0db77cfa84e43",
+                                "uncompressed-sha256": "241247a03971407516429ec0e719a2e74f69f31b1aed49a9a62c7866c778dedd"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "36895870355a39d4fd6511929614c43b3a4776c26eacf249381f408344d42087",
-                                "uncompressed-sha256": "0b7162a66311d2f5dec809851e2837c947e13a7f4fb24bbdc6cc9ca35e846d98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "e4109b20773c441b37e56c2207c302d6ca4d63a89d0c50eb27fa0dc1288da81f",
+                                "uncompressed-sha256": "c2ee63fd7f29403bced3525d7c6d159f98ec754699906970efbf9ca075b51e15"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/ppc64le/fedora-coreos-41.20250315.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "7b399281798ff8bbd84dfa8b9efcbc3b27368596568a0fefd2e9943d011b517d",
-                                "uncompressed-sha256": "c85d7ea25b69c02bc3eb8655621967df8c46947f574ca58c1107cb6811aa24c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "6d06324d03409e28bc3c9911fc4774c76ebaead41453fdc31c822c6a97f4de16",
+                                "uncompressed-sha256": "b9cb4ef6a745e7653eabaf9d5edbfe0c81434985ef6d11413ba6c9fb9be5b6d3"
                             }
                         }
                     }
@@ -390,85 +390,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "f8f2562ec6beaf280fd2e517468234674d31964b75d11b28621c3023615710c1",
-                                "uncompressed-sha256": "dbd8003e898ea54e3c80d3b0eb5dffd29bd2d3e5092e4d17023af0f13a9f271f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ea13c8b3659997cda55cd52ff2beb9a4e4e25eb536d8999234672787bd407ef9",
+                                "uncompressed-sha256": "c4ad5f817d273ce4051424576e92ea2c543f523391fe78245dee56458ad3be27"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "8af2ad98c10f706c0dcc96ea1dd53f81f9b27f31a215d29862fb7cb4a546ef0e",
-                                "uncompressed-sha256": "067dfda53688bcceeeeb5a9105c98ed27cf099c8626148bfcbb2d1b97eca413a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "f02ccab47a8a1b92db0a7325929ca2b118e1548eb6ff4ee7e92017cc655f6e0e",
+                                "uncompressed-sha256": "e82062672042ed85ec0d894eb4c667597035036fd25afe19ce829b1c73c12a47"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-live.s390x.iso.sig",
-                                "sha256": "960683f8f38d7181f6a9f797abdd17030cc62ccaf8b0281f91c78f99eed842f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live.s390x.iso.sig",
+                                "sha256": "5a3ada77912dcb045c2fe9d631819f516ad2cdb7c5d2e0f4d12520c7ee3df376"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-live-kernel-s390x.sig",
-                                "sha256": "0e11af135d30cca630bcf0971cc54b8445d2c32a6c5875963c24b661910d1e42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-kernel-s390x.sig",
+                                "sha256": "275a7b3dc386d98eba56452a04526b1b7e5a68e78f86ec62e2bd7778f0483791"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "fe4205fb3c2f8b500c594e6aa2e27aa8c777bf9ebab27b1fcd7730d199b101bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "8658db039422e384f557d4125dc9d8948184b07f33b717220e07b36c82009cab"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "fdc758d92e8db053d078ba9d698208a42d689cf137ab723a7afe1c06ba25250b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "247cb65b40472db3297a5d844d9aa7ac5d278ec5d01de10b6794ad398511995b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4c7b54c79da16c42276c53aad674065aea3df85601eb95f1cdc10350427393e7",
-                                "uncompressed-sha256": "d606c521aff17b8d9507ddfe1229fcb94366ab11ca0ed34bb8e5652ffbb83666"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "21092bd02beba465110bf739f7c1624873bf93b07e55abf309d8247409ba648e",
+                                "uncompressed-sha256": "8a12d4bb2610e51d823002ada1195ae7a430f0065370fcd23cdc8e6f14ed4195"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "02dc20be7d238b4f73f8aebdef859fbf749def12e654627570a020734e19cbb0",
-                                "uncompressed-sha256": "16d1e86bad51bf29809a1bc4bba644c6a2ce00eea6305f5e01595e0cdd1d7719"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "d60edb59d8c318053f914c0e195f3e9faaf73df0f0bb209be91f551a2ca8f9d4",
+                                "uncompressed-sha256": "4d97c82cfd876d75d60958f219ccfaf69eaaf8432e9a5a9c8e036675096f8c70"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/s390x/fedora-coreos-41.20250315.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "e5cb97047d68a1f0cf33b1606a3b082eb97774e37445507983ea540f574ab732",
-                                "uncompressed-sha256": "315e358658ecdfbdf70251274beb89d0042c56ef4684dada559c7e456f067bc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "3a5ef1cc530ae8b708c3594726e1f17634752a76f11d446fc5b36d78ba54beef",
+                                "uncompressed-sha256": "c9bb864b20d49b56a10a8f08849efc4229bce8b1ceb47a47a118c9af6abcf2ef"
                             }
                         }
                     }
@@ -479,276 +479,276 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7e1cb630908dce72eebd18744c9472cbfac5c73311af39c5d318fffcf73ae0ee",
-                                "uncompressed-sha256": "a6b1b9f1f5d37326b7ca5ae3f365b9f5d17526b68e8775c3a6ce4411a2fc112b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "47a7aad85081e04f725b9bedf71e8606edaf5da206f0ae8329d0568998dc7861",
+                                "uncompressed-sha256": "12542a3400640a03725f1ee9390679e52e4e3426d3ad93ce83ffbbc180e1eaf2"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "522874f7ad5e757db64ac1b844c8015d4568537b7a8a30d5ed618d10f2fa0ca3",
-                                "uncompressed-sha256": "b782b52a520ffff81b5bf02b9f62da4583d3ed756cbaf267bc73629be9e0c79b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "1b4bf603d5ac4e8b07c4a47ddfe654b0c648d2e6b8d9db0735de60bb5833fcf2",
+                                "uncompressed-sha256": "f5e6a61b88f3dd590c0a0b9564c7431fb7d1428b89da6f984fee4c6d51099c93"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9691fbb9230f67c9dc22c7878fd6697ca3ba37c0e90cbb53d688178cb2a5e1ea",
-                                "uncompressed-sha256": "d2c31cdf97cdaa6642a74d048ffe3176fd30f652cb67dc78419ab98e9e3f4d56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b86f52d3db34f94fe41e32d480e1a0561d13605fef5aaf25a7488200d7d4c701",
+                                "uncompressed-sha256": "7f80187b70053170325c5347b3df07466a8135e2d3410ced24e812330d2d4093"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "88939c0295df930ce929215aaf41d8c2155b406e6d62d234fc7dd3dc1201a4b2",
-                                "uncompressed-sha256": "05d34e254a7316128bebe68f992f9d017b046875af703506f69c5338c5b4029b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "772d80d802d742f8f94ec2c61281aeed5e69a2588fd8442aabe61f464f6e182b",
+                                "uncompressed-sha256": "b24e7ed92a074171d9edc165f19646d916e1ebc94afc046b9f27c7feb36c1b2e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "967ddea2e64abbb8536808e8cf2514b66cef737ca46c8bd34ad9ed85230daf3b",
-                                "uncompressed-sha256": "248fd334c4dd000b181ff6043b234bb058c2edb0eac94a94c1770c020d0d3ca0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "753a11645fbf3f7feb1c1a6a74b20f54ab90ab610d14bff9d5ed8dd3aea9f4df",
+                                "uncompressed-sha256": "de49d31743764efe92215f18035f5d037991ee37f7b665d810f4760ebb876c0b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "88d79b4ca86f4bcaac0fa6727464e86335105be34b01c2b12386e9b01ffc22cc",
-                                "uncompressed-sha256": "9e0592a406acfc4b2d835f077d8581de94c3ce958d2750ab1cc687b1718eb17d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f956808cecaa9952bc8cadfb4489b1a76a201d0bf6c3e11f295ca7df0e658649",
+                                "uncompressed-sha256": "f71b58d5f65bfe66dc63f46142ce8ab6188f846be33cc75867a541d7423c4da6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9721980a0f42600cea51740e55fbbe206fba26a8b42384fedd5aa36076632f49",
-                                "uncompressed-sha256": "64205c156e2b8424396f3ef847e599a222a76d2470b310b44a594c7e12b69f42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "218d24ebb7251fdb004270792e801d6c5d5f442e9ad5c58dae0a0bf62b1f90b8",
+                                "uncompressed-sha256": "645f3ca446a51101d84628d973693fcdba710645e26ce9c1af8bc403ee48359e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "57efb7df8d30a9ceb10b10fa3635d7cc5924e81d7f16e8e25c153766c55593e3",
-                                "uncompressed-sha256": "9fa0aad606238f922ca7da3c190a662b3d61bacbc555e9139c6730fc06df3fad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "11f5b16cc814e61150a669f0aceda32be12e46d51a133212fe690f099ecf9db2",
+                                "uncompressed-sha256": "d98be8936c18f3f00431c1af2d09384a51092464390662aecaed5738937ac104"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "69c294a30457af42b61ff6f50e7bf2dae70eafc6a679acc7780ef673aca1d38b",
-                                "uncompressed-sha256": "8607c5aebc263fdffa61750471792bfa836450cfc05ed31de0e0fcab755a0f2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "bf4e9e43fd39b573e156bc2cfa4f447afca8f7c5650e0eee56457730a31983a2",
+                                "uncompressed-sha256": "3384ed7a57ed440aac9d0a83da5efc2e99a774fa469533ba5b04548cd2fe818c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "bd70bd8127caca1e789531d5afc23483df2fb81eb5e7c8d6d54c916328c66404",
-                                "uncompressed-sha256": "736b265599bd04fa15e6a04b06a17fa9aa72855bc07cd37746e7735e589d3549"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c95133115c15c3cb22824773798ce3f1bb050c9b00e086259405f1aa46da2261",
+                                "uncompressed-sha256": "ae88e8788a1264dc6ebc65ed11214aff3c9facef5d5832322d0c5cb85b061c5e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f1e1b2957c899924c038491c1d52ced91b9452342b8640d9280e702a327a2cb6",
-                                "uncompressed-sha256": "41f81776cc48d04e9ca66143972a3f79f6ba53f884a003cba20341e5f36d5c73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "58997590c2e74f43f10dae9e1d2699e8cb88ad9e9802f9ce35368673a2129010",
+                                "uncompressed-sha256": "d288535ab6c7fd7cde8c17aad1257534c602159aa0fa767b3c4cd1b8005a2a57"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "241626b4b9e260e96e774e9281204fbf05829873a7ed0fe622d7e4aa43cc6eb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "3e7262bb29d3715f4166bc484820cd48e2ad248046a77a9e417274838f0a6d4d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "eab0d71fadd626cfc1cae545465ff78cb59290780639623329baba85035ea264",
-                                "uncompressed-sha256": "18ebd0208970a19603ff077ff3eceb38fe14131870d4d236711cc656e91fdfc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "33dd19cc4525e3a5514bc0866ced2469b1860ec2d66b02a4b35051229303dea0",
+                                "uncompressed-sha256": "96d1d6df0918f5627756c2df664065eab3247d63a5262846a2dca524d607bf4b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-live.x86_64.iso.sig",
-                                "sha256": "ec4deafd55873b4cedeebb7081558e2571c48742a9bcfa126f8f107d8d8f6188"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live.x86_64.iso.sig",
+                                "sha256": "1e5557c954ba451a0c0ebe1341e58dd64f3cca3e77cf483c3fd715336e91c429"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-live-kernel-x86_64.sig",
-                                "sha256": "297f232fdedaa8dfc5e81b478fb5467536e47da28982cb95051e496576ea6bd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-kernel-x86_64.sig",
+                                "sha256": "684ebbde99ae22641508c8a7440502e07ff75ea2cba59ba93ba8bf8b0a63a9a2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8ce8755b6819f42c3620033d58510748b3e22b037dcc9cf3d2d075f45fe12ffd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "0de95cb1f52c20c281563b02e35f1d0291f60b66b3ae32c02e54e5ca0cc61fda"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "b06d5656de02e749269cf49f420c02b5f28b036d4f005abac1fda4d157840e95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3a33e41600a2108eb128e6a4b7481a5a244f8d7514d417e065749f2acdad4cf2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "2c23e0c233235b85af1b83f37df95d1d33e0b6ae3b723bd2103f9597f52b318c",
-                                "uncompressed-sha256": "08c165f3fe2bd1c5beda3008e16fe6ce1c3e3ffe5f37e57777e9cc168fe5014a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "4dc3796c7fe322f8556d6a3bdc434cbca7fa687297bd2e7bfa0073bcb16f71fc",
+                                "uncompressed-sha256": "2f499a972d4752da8e4cfe137db94db843a55e0c0f4c6f8ed332af553fc2e22f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8dfa415c8695991e3a9cd2de202e6b1a46f166f7454415fde84a34a4fcca058d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "1a2375bd0f0052d25d02b14e7db528cea5087efdb8db3aed9c220301eeb063c6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5fc651a267fcc598a34afb0f424e7e5c4d3d7232d1463d27b57edd69c5869b07",
-                                "uncompressed-sha256": "3f803ebd33abddc80b7fb85beb8f59607480049793d426c837205ec3134fd07d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "6e070e439d19f969ddd6774219cde30efcdb74c60e391c9b319a2816ae79eedf",
+                                "uncompressed-sha256": "6fe0848f6f75fabfa5f6e91b8828c30e8a0281558cba730d37f04a2412f5d834"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "78d20c69cdcb75666249966b0149ec400044b29e945bc0cf4a18dbe0b4b70d93",
-                                "uncompressed-sha256": "06f48b92e2b9ebeb772867a5d4b59ad9f44cbbfab0d77a8d437b9f79478c3607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4e19fa2181e885a9d8dedd42ae6d04efbfeedae19910e2620d02101aa6da5513",
+                                "uncompressed-sha256": "e29342b2240b2e37aa2e4974fe2cf69168e99bc239c5f31e889fe8ca3895edba"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "4abeb36808a9c756913bf5a7f0fa2b301723f068f49c519cc9f2e28f0c6cc7ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "3cc60efd99c2be9be2212e54acdd15aa041864eb8d37aa1bf97d28c58c533b5b"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "2365ae1d88fe3e08be5ad1d9e40c47dc44a0e5cac9345d143230678fc4bcce8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "3870c6c8e6c177d8f335f8ca5b14d9eb183c2892771699de04175f355aee7b13"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250315.3.0/x86_64/fedora-coreos-41.20250315.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c9cd946fe2ae6b33ef429a73ba6d0962f3f6fc8da5db81b6739197a7e8ccf5fa",
-                                "uncompressed-sha256": "19c84f28288bd097ecb93bd8aefe0137b089c128c70310a02cac082bbed1dda6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8e9762144f931f7c3bdb552813910b4efcc8fff4fc0088d8288f9586cbb5863b",
+                                "uncompressed-sha256": "f8761c284c72dbe36172e609d482f84cd853e52833387f521c0141bb358e5c01"
                             }
                         }
                     }
@@ -758,145 +758,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0038b69c198758f9d"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-06dc2cf3d4feb31f9"
                         },
                         "ap-east-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-02fac5c25546e9196"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0909776c9b727a1c7"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0a2ffb3c97ac52390"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0bec5bba1264376f8"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0b4f260d6416cc33a"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0f21c54e6d5f133ab"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-076eef19d3c06b5e7"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0535ca867be42cbad"
                         },
                         "ap-south-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-06aef27a0f4030e0b"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0427c83a5e31b42b2"
                         },
                         "ap-south-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0b3541c2c69d240bd"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-07afbe6594cdfcacb"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-03f416519163ac5f2"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0c7db2c32d74847b9"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-00af795dab3bb315f"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-009048d73c2c3fe13"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0dc47e32eba3dc3e4"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0495cfa6529c0f91c"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-084209bcc471e839b"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-01e95eed4b0bdffa6"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-041a7e70a9323e047"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0e9d7fc85c299daad"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-05f99745bc6bc7a82"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-095fdf39ec26f2a83"
                         },
                         "ca-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0b3486120e6be925f"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0d550d7d070bf0b32"
                         },
                         "ca-west-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-08286dac1ba4ee244"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0eff9a7171e96f45b"
                         },
                         "eu-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0f7cb51b192cb138b"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0ca3c87d880208d80"
                         },
                         "eu-central-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-081c98540f8eb0ba8"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0fae48b86f1d2d195"
                         },
                         "eu-north-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-04d9f9f56d27e721b"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-07c51a21357f8cacd"
                         },
                         "eu-south-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0afb08c8049e8e1e3"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0421e5c6631c1b81b"
                         },
                         "eu-south-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-09ccef2c6d9f15ddb"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0a4d7a4962e3b82a6"
                         },
                         "eu-west-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-026b96780dd0d7647"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0c0346521e2017d12"
                         },
                         "eu-west-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-036ffffd23ef592b8"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-02ca3cdad06475523"
                         },
                         "eu-west-3": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0f7e1de0487fe011e"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-063a516c93fe77339"
                         },
                         "il-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-060f6cf93d8e9a2c2"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0a723e4687165b6ef"
                         },
                         "me-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0dbca13a83c364997"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-06159de5ca4dd41ac"
                         },
                         "me-south-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-01763865d5052fd80"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0d91889d61d19a4d8"
                         },
                         "mx-central-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-078944b1b0e98c8ec"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0ee0aaf707cdd00e3"
                         },
                         "sa-east-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0219c88456e1daf3d"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0da93b655d1d41b37"
                         },
                         "us-east-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0d31141a7a7e2f2c6"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-03b38f32afb4acd02"
                         },
                         "us-east-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0ab04aa4cd51f99aa"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-041f41ee451858149"
                         },
                         "us-west-1": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-0a46f34b679987949"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0784bb90bbe65dbbd"
                         },
                         "us-west-2": {
-                            "release": "41.20250315.3.0",
-                            "image": "ami-056e576a384119fbd"
+                            "release": "41.20250331.3.0",
+                            "image": "ami-0e79f4ebc83cd6e13"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20250315-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-41-20250331-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250315.3.0",
+                    "release": "41.20250331.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:89de8a9cdd029429c77687752e8fe2724c05889a2d3f89146aa1654b9cd03f3d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2d0ad606533da95ffb130c9a7a1f6b1933e2341a95077efa599c0b8540cad9d0"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,144 +1,156 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-04-01T15:04:51Z",
+        "last-modified": "2025-04-15T14:06:31Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "7d5261b0e971fb9d499f437fb2870af89f0527a6fe1b00918015fdf05fd92902",
-                                "uncompressed-sha256": "d9306c627fb27e6da6274fb03b1b1b6abced80803a1be1967ed94ece4076ae1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "0b8bda23df80c0b20a3436847980d0f7d78678809b7dea4c865a00eb1bc1c889",
+                                "uncompressed-sha256": "e4da250b1789255dcdcc0c485b4ca3c09269c1f495b841e291d669f7fe927078"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8d43c1b72dbd55631d1c53c9c699b86b1d7c68f9375e04b76f906ea9029252f3",
-                                "uncompressed-sha256": "f5c4595c9b6982be24aba0afcc316d7d70cddabc3c36de2bc14c756685bf5622"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "77823e9c7ce5fb1ceac8f9d53d25d80ea65028952c98c47fb0d661a2fd943ce5",
+                                "uncompressed-sha256": "64111893da53650cef3b5a345eadf141eba59a2b3cfb45e084b1d93f5f58e1c2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "5b308e937debbfcc82e3a033c6f31635ad9821f88defddfa10bbe7e88f1f1c6d",
-                                "uncompressed-sha256": "982126def9ab6f2021ccecd438fe2adba2b6bd7702c4efa1c2aeb29c3605992f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5acb18b567c7eaea5c9c675fe2d5f776b1b00ec0d1bb7276a28b70e619735692",
+                                "uncompressed-sha256": "00e472ac3b344934551df00eeb7c40350829855ff0ab536282bd5dda7ef58a4f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "4dfc97b0c67df1a2964ed0bbdf43aa67b81233adcb3c2fb4508d0102e7f3dedb",
-                                "uncompressed-sha256": "3970a81f6d2cb7ca86c5a7d8a330786dd299f7add61ed6e2d92341a0cf8664bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "18eb963ad077bdd1a062fc483745c257c5bf5416c9482701cdbb3762e9ef17c2"
+                            }
+                        }
+                    }
+                },
+                "hetzner": {
+                    "release": "42.20250410.2.0",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "e04600b686b817c2ae4b69aded3760648b1a8d07c7d4604a4561853818bba17b",
+                                "uncompressed-sha256": "615c169ff8caf7c079603bdfee9707b933372ee5ac99e6d793cbf10181b69b6e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "d949b217afb3403be77397d2ae2499629e67935dfccb38639c32d7c25aabd343",
-                                "uncompressed-sha256": "45638d109e93d773e30cee4325026873e26a2859e3bf87eb284b33cd1a4ca205"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "959046c9446fe5bf0bdeaa25b431c1bf8c8a1b61e90ae9c10d1a677f555641cb",
+                                "uncompressed-sha256": "7ae0796a5b0a4d6c105513420fd4580b6db87467176872734d5ae4a046b49418"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "9fcfcb09e954f0705e0ca828acd07c32b9e272573cedb0d46d236d51a8c24d39",
-                                "uncompressed-sha256": "a821368c8b0f7dd2278cd905425af6083d566c0fcd22e49009e88046d3539777"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "0f9df1a50b289207fa4cc316f3df311a304d1d20501511d189f710fedf5cdc3a",
+                                "uncompressed-sha256": "ea0e92f402d828061733a1883514ba19bf4325db8595386be4017166fe13439e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live.aarch64.iso.sig",
-                                "sha256": "a3686235bfd99159389713daf48b5929201b464ca4e671e120ce66a17def2b80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "c44ad5c77255ff50b5f51ae8b8cef1c35adf6b35950a24fccc40fc85cd819a0a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-kernel-aarch64.sig",
-                                "sha256": "194210ba81810e428a4ef7a94ac4202afd87f97b3c038b53111a082ed31660e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-live-kernel.aarch64.sig",
+                                "sha256": "e249c9d6d365dc640215ab759e18d2a8ff06db2aea29fcb4f4d13e3392f4a25a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "4d1955012ecf47a022a80c7db4395d683c485cf3f831af102b9df5992c7dacff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "eac22ab412bd656db8005ac514b83ec1200616d38b116655c7ef052ff483839e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "9cc21ab91db14ac27ab7ae95da429db2df94b331acb762b2dd22db2373a93129"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "4346a1b4025494f6fe1dda89ae4e3f31dab28c1d0e7afa65ce5b884b77cab60d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "fb66c65823d8898ca65c5d9e6abb4d77fd1c0a1eacc3423a0321a736753d40d8",
-                                "uncompressed-sha256": "cd06199f87ddba9d34c30ef0035a6a795c372fc119367ac64659c361a1e180a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "319075a0a88cbce63d9d2487ff1d8af2e68f3761cde62096e81d13f7326af058",
+                                "uncompressed-sha256": "f55082c800258ed8248df911e883871c0e2b910a477787cddd0252a427defd57"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2ef5f3028eeef354f51cc0748da610237e0c56c37630d6fb42bb71dd47eb5bbf",
-                                "uncompressed-sha256": "650ea320a61571a00b2d37b4664f26c7337560f43c2c6bbafeda71f7a1755d20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "a2341b367481fed21f584272e1c7434b260fa318b0eb3b2d97e75087da5317b7",
+                                "uncompressed-sha256": "8e723732b571c13ea242be00e444cadccdb8fe726a023d61b786b88e82523a63"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/aarch64/fedora-coreos-41.20250331.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "655151c943eb6cab4ec4e51c5d1e3155278eadb1ae46bbd72da288c0ad5022e6",
-                                "uncompressed-sha256": "faa861e5dd0797108a441f5430f4d1eb364ba3888c69e9a70d7a20835f5ae872"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/aarch64/fedora-coreos-42.20250410.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "61d6229ccde29bbbb1824909d98ee6e0736a8e0c0c04178e17a7307590c692e7",
+                                "uncompressed-sha256": "108793b338ab5de3c9d0824ce9a482f1ab68f552f2666620fd06d89e648def7e"
                             }
                         }
                     }
@@ -148,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-04bfe078080b91ffb"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0c20687dea57e8a0e"
                         },
                         "ap-east-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-02f8823104ab6a4ce"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0b3a912b48f52d5cd"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0e45085837beed6d8"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0a453658d55c25d5a"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0afc19fcb4867bdac"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0457d20d04b354bd5"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0890bdcf03026bcae"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0edc97cbf5ce6986a"
                         },
                         "ap-south-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0978d84838e95e8ed"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0db7487007b0ae035"
                         },
                         "ap-south-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-01ea403ce75f1c38e"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-01ad1fd70c31fe324"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0bc02e75e4c71b8e3"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-02997dc347eb1b657"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0c15029be3263389e"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0b391b39e99b2c865"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-09f6de1322ce2ac4e"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-070bfa560a9d22575"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0fe982cba4c49f76d"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-011ad35b7a3c972ea"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0600ca9555f376a71"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0798d7280770a3976"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-09c9174bf398a40bd"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-05fe031823c9b804b"
                         },
                         "ca-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-082e4317b1fb90dc7"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-064ee8f6a120c1bff"
                         },
                         "ca-west-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0147eff2fc8ee7bb5"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-04b097e9b83f50118"
                         },
                         "eu-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-04813a459faf297af"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-03d1263eac664e840"
                         },
                         "eu-central-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0540cb7476f440f50"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0bcb5a3a822244e14"
                         },
                         "eu-north-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0720d84f66564a4bd"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-07365009e8d699d4c"
                         },
                         "eu-south-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-06383e6906aec45fd"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-00cf35a16c345df92"
                         },
                         "eu-south-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-05809caa87e81ecc7"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0dfbea2e5131809cc"
                         },
                         "eu-west-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-09f611a2d44448c45"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0e55d5e342c190347"
                         },
                         "eu-west-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-016a67453b9a6e734"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-08679c8989b37732b"
                         },
                         "eu-west-3": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0a9e7f19233262dac"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0745aa29efee3efcf"
                         },
                         "il-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-004ef22e7ae2cd0cc"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0af9c6718872c7e34"
                         },
                         "me-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0da4e76c43e39e5a5"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0826a481522d7c24b"
                         },
                         "me-south-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-04fa3511429ef0ae1"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0fffcacbd82d06493"
                         },
                         "mx-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0f4db3b71af4cef02"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-035faedfb04e80f01"
                         },
                         "sa-east-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0dae54e6ef2ef105b"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-000474b62f368a7d8"
                         },
                         "us-east-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0ef9817fa31fc23ee"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0bf80bdaf15fd2d37"
                         },
                         "us-east-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-057d2d35120fbe0c4"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-00df8cb056e4a62c1"
                         },
                         "us-west-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-05c1fed68ad653cd7"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-073601b6e4a179a01"
                         },
                         "us-west-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0dcfb1bf1f627fc54"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-004f5b885379a4576"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-41-20250331-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250410-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "8f7b6c6e15a0cc5ab38bd5aa7895e0fdbbda7b8c3d193f65216530c61f86d6c1",
-                                "uncompressed-sha256": "fc37158dfaf863d5dcdc0396f972b204fdb7ad703d0d515fa77ba196a0e15c7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "aaa5d7e264dffa4b65f2237aea1c0c857ae7b9c969dcb0d5060d523325716191",
+                                "uncompressed-sha256": "50639cdd34fc3f773b495e7ce98f4d1013a45cdc3ccde969f0fdef6b3825cfc3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live.ppc64le.iso.sig",
-                                "sha256": "06bb7fa1ea46495e06ad7a75346f91212fd00921eeb2b43b1969edb381bd184c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "0a1d7749ad6e2059e7b433cf0cceab0a54406b8a58bea681ed2be1fb02e24f0e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-kernel-ppc64le.sig",
-                                "sha256": "56fd0720eac7f0f5cc20964eaae934e14b0559c9f6a50e4cce1d4a499f7b9a0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "4a522a1b85554d5f4f7aa0aa0cee8d1ccf877165c5c4751247956a51d4a1958b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "816365dee4999ff8bff46442081eea119448c3ee22ee5548d2173cec9804bb13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "c0c89d2f5a71dd7414e6d9d6cd4fae6a4033d3b260b2b58d2eeb3f4c2961d210"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "37e33bfd14ec6da800dfde919ce79605b8b52ef75bc58cffe76cc5d0a58abc89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "0777d1adf535df1a5b290958d7728a6c9475e0fb5a141641f4ef71e54f0c3a86"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "edee3e754ffecdba05856c925625845a2794c7d48ca6dd964f5d7f054d8fa400",
-                                "uncompressed-sha256": "87ff34c1aa4ad285f381dddf8f23969c51aef465bf37864b542c4bbc7289b229"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "b00e95a63b5b236afc157f71103691c7e69183d2452a928ebe4618f1492408a9",
+                                "uncompressed-sha256": "e5b41c69566f3603adc8f8873fe746f4e08e6aae4f8f0a483011efb28034a750"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "dd46491924a33cf813eaebdd9a693b84950f2a7d9b6f2a6d7efc8b44394024a0",
-                                "uncompressed-sha256": "eb8a63d3c7b42644f82aca2f737eed0712c964dacfa444b0562255ffa8bad9c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e43a7ac884aef64c67ac9c46e1da96fd0ac9e00cf36e3951117fa55e4f2ede23",
+                                "uncompressed-sha256": "e9d765c6fc40edf0466e67280cd8398c09da1265d59c5f30691ca5120c8c553a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "f1ca0040105813d58de54ae1dbbb3e04344f26d253184353ed9748a6138d8115",
-                                "uncompressed-sha256": "eac4bf44ff27eef1451eaa04616be4ac12f5c421e6721607571373cb807a4e84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "9744b73d639bd24b0124dfc830e7850f4636cca724d66001473fb84d4eddfc6a",
+                                "uncompressed-sha256": "4af177cecc482e6396f5b85804a4eb4b4b0079ea210eb9e1f2b14662d3b4752a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/ppc64le/fedora-coreos-41.20250331.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "2c450da9475c2c971f3ef0bd0cd5507e0140a59ce0f50faa174440dbefa21594",
-                                "uncompressed-sha256": "b4ccb6e95dc3fd6c7c6fd49fa92b92ace9f60b864a906ddf95278fdebc629756"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/ppc64le/fedora-coreos-42.20250410.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "ad78c10381e0582f8780dd369145d93dc7477592676d17bfb8ede13bf923b20d",
+                                "uncompressed-sha256": "703c71529f065213d3285e8f94b6da2600a191de169b8dbf955b784307c2012b"
                             }
                         }
                     }
@@ -377,85 +389,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "5e84651657ac39602c527fd834d63adc26f1af67a873f7806fb88cb2af0b3363",
-                                "uncompressed-sha256": "9fe3a3f258ce76fabc63c41ec0d232a2992d64960b2d4a5b5c1023fdd949c28d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "040988b6b40da8684aa46bf39905ac8fcb2710f1a258302d52b9465610a06b88",
+                                "uncompressed-sha256": "9635b90740d1f670da86da98c3d75f76f330e802ae923b24362d310db8e193cc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ad554ec032809660d730d33b6527c518cd3147eb9c26e444600e6a7b9c94bee9",
-                                "uncompressed-sha256": "5a0c6e4d9fbde33b2f3893a5f91929cfe5561626657b2b3c914127fc5020267f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "310eac1155064fe8aaf838c3741e8cfd714c8e4e5e39c850cc33ddb9ed09c59f",
+                                "uncompressed-sha256": "b63563ba85f366237190c9b75259c463a117f54173cae04dd3fa08c397a54da7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live.s390x.iso.sig",
-                                "sha256": "7c07d392d38f5da12da08e9abb35d81affad37580f71c3b5c9f204fb7031543b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "6f8d80e5bf24e12ab839b9bf04e48b4c764d05154e9f96b0abe798f646e3a8e4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-kernel-s390x.sig",
-                                "sha256": "275a7b3dc386d98eba56452a04526b1b7e5a68e78f86ec62e2bd7778f0483791"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-live-kernel.s390x.sig",
+                                "sha256": "1e340eca4d780fbf5ebc94e683060463acd1725ceb437bc0c7e30994701cf835"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "0562a8140ed3047b1726f56fd1d9bfa0afcc7a20b4a316e835e570985a32600a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "62e620f3be1aa4ccf949463ebbfd3baa1b277ff4f0dcd5f9daa948d506def5a8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "4267bedc3a87c70633167f959cfb66c3512321df2f0d742b65e1391073754a5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f75ea16b0ec694297d64cadaf7d2d93dff88769c63a43e7ba635e01b2a11bc1e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "a7deb8c397e603569ae5e440a34aa8bdcc3bf5ce5f7f4a28b9e85deb757cb0b2",
-                                "uncompressed-sha256": "7337479dfebdce9b1cde93ad80f535759545a0c64876843a369badfeaad6bb34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "0836b657c899b0d0004852a7e065113e20e1fe6079c1709fcc6913f8b4a5d1eb",
+                                "uncompressed-sha256": "33330913a2f7cf0f87189dce269828a020283e7f4cc0dedbc2fb8a10f29bba15"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "916d9fac6202cf96165c347fadf57eb8b1cc877c4697f7f8a9098e182987b85d",
-                                "uncompressed-sha256": "784c4d6552bc82739613b7b413c9f7d2fc4c26b19bc1cf22dbba376164a30aab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "25084dd6b396c3f15bd2ce7e218d086a63ec7c0e26dfff54aad24a47f336fe7a",
+                                "uncompressed-sha256": "113bf9a996a2993c5f8213adee9ffc63b59d0d3510bbfc4611b043aaecc359ce"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/s390x/fedora-coreos-41.20250331.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "0b79ce146a32028d5c4691fd86ef65bdd8159b8f4035c983228b301fdc76b4f8",
-                                "uncompressed-sha256": "cde57cbd065eae30742b08e0d6723aa27957062e7d62b75fc3727b2b4cb336f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/s390x/fedora-coreos-42.20250410.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ea153abf0c622f0aadf575a9eb55b7505e010f3dc9592fb4fc1a064e6b0b0854",
+                                "uncompressed-sha256": "eac502988b7226594926080a6bb4c8a51e8b11ec71c3ce48bea2491f38456b98"
                             }
                         }
                     }
@@ -466,263 +478,275 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "777f89379b11a47b8d38230dbe045e3b6810f1e9b87eaba603d3823f8978bb59",
-                                "uncompressed-sha256": "2e962b611d33d9164db5ec333290c6b7b6e83dc9aa072b0af5e0419cbbcf6898"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8ec7150b8064b7db14c7a7b4e0aa6c2499443333cf87c20934f5117664602d46",
+                                "uncompressed-sha256": "ea6a6409b95d5b1c5721b055a31a9573f1c93aaebc58c161fd977d255ae1cef3"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "a9f1b2df0e61c9b85f1a4b05d179ee8e9a050d4a95140d79d0fb6f95fe9a7aae",
-                                "uncompressed-sha256": "b92224b7c07cf81a69de71b397f982c859ab376f781b68126c1a09ff3fc78208"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "6ae63e5d0433a77cab7144b2757fd9c5a6c2efea33b6fa911f55fc8972e923da",
+                                "uncompressed-sha256": "5bd20d8202bdb1fdd131c2efa8c3182b4da015630881c68ba047e3874acb5bdc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "77068c14d41a57ebba97d6cda007492829f25df93c0a7407b78d88a9b23dffb5",
-                                "uncompressed-sha256": "9768a124bc192bffa9e6cd382dd423ec02f8fab0f1ae9530ee1f4d29d6c17c35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "66914c3d7609ef4af4dd6a03c3aba6e538b32b356c637ae1eebe7c231d6721cf",
+                                "uncompressed-sha256": "f00ff2b9793da1e7fd9efe16aec9fc2318f8b163d7c0a11cb987dfc630391177"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "13229b28e78ff0cbdee50a1bd3c914f63dbc4e38bfb5d995f75d43f613949116",
-                                "uncompressed-sha256": "d82ff7940f4b63aa34a8a3ea60e3f9bca1861358a68d238425ede160c808cfab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "cd290666e9f4fcb863f517af32d8089141f7ea756a2a5e9501952c88a5d1c7ad",
+                                "uncompressed-sha256": "cb057fb1c470f32e8d908f303f1743ec55ad51d57ed38187f7312b71a6e0906c"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "82a176e85adfa66f0744391e86386f2a65ec8e9352eb41ae649f73a582bdead4",
-                                "uncompressed-sha256": "dfe529c1dc48aa129bcee9014c3f923707def2e0262e1084103c3460ae3dee96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "16dbab67d75a54fcc5cd29821aa30774e38b2d5d48febd5b9e5249283eb88ce9",
+                                "uncompressed-sha256": "7248e3eac026067fc7d345ef421f7d64f5bbcb81bb8e66c3a3437ae34df78ed6"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "5c319afe42bd9655adce717d010a4f8e38fa34e825dd41d8d77808a728e3849c",
-                                "uncompressed-sha256": "c0ed3ce62dcf59edbf9ac44331d35847db0ffe156c56d5655adf211495ef470f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "a13ccd4a5a420ae3941ec18b5ae837bae939cec71f93cf22f54c22a40b7bb12b",
+                                "uncompressed-sha256": "3867f61530dfd421c163e2fef3125252d0603c3dc846404d1861c7bc212b7957"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "dbf82b76f322b74093366ae91cf81f53af022593716d3f33381098d2901631d7",
-                                "uncompressed-sha256": "62b114a32cecefe0c7a9f92f0ece0b1732a99c8c1f0fe3cdb78a7e77a9e7c8de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3b77aad783d5a05d8323445c8b181413f6dc3078ce5f42b1aabb10431e3f34b0",
+                                "uncompressed-sha256": "d04c7868ca56b605ca34c576b37b7b38002fc6f58190ba800be88507d1feba35"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a80a783549824b29704e971378084bfe0c5765ae0064584be9ee698510c027f1",
-                                "uncompressed-sha256": "244fbaaf2a419ad06488cc5d7851b9857d4f8a12f45ae6a375008e202bf5a746"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d81aaf2914af3c00737a9709d824e4cb2cb2f7b5adedd630230386bc5b58629d"
+                            }
+                        }
+                    }
+                },
+                "hetzner": {
+                    "release": "42.20250410.2.0",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "581ee9ba36b612cdc7d3d0841a0f4fe07502b55b5fb1fe44cff9b4ef3fb13567",
+                                "uncompressed-sha256": "1836b219bf3396796bcecc9dd2ee8dd79fe7bfb4329c1879f32e0e5aca0bb239"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "cc333516e59aa426efc4d3024f237e2d3d3aa1d26f5f695afe7a6fb634508058",
-                                "uncompressed-sha256": "3058fb29b032cf4302217a5ab623f025b434c23d87b54dc7aec504484e65d764"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "b66ee2d2ca4e1ae6caa3275ca4bc37cea7383f37cd0bbcec3ddae55d6ab30d48",
+                                "uncompressed-sha256": "6c15738b25c41ada4cae02f8a07474924f4c503b3f302146fb92011171d4c7ba"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "71c419a56b7447fce2d51bc219451e1f54837c34656cb8603f5a73c5c97f16c3",
-                                "uncompressed-sha256": "edf39846eed4ef28219b588185f0dc58134b73dc1e2aa3c48d7ec5e87ce80d46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "548794f6aa1401113fab7e73f5d28a5d1153aa278928665106e61fbef50609f7",
+                                "uncompressed-sha256": "0c9bd80159c4cf158efba5495c365a162c0f3ed74eaea70869cbf2be1439db04"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "bb80b05f940586b2d1bb9bc4a696e40d2d5ed0c24e5ca64342277517cdb68b7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "542153cc366030ac12cabe1985192b678fa31d1bc72ffe8a9993122acfe1a467"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "d9b0b1012479666f8808e006e8b62ca2572824795cf588d31462bbd86fd519d3",
-                                "uncompressed-sha256": "3e036667ae711fddbe98e8d57e27677be69fbe12b381863ef2ebb78b9dfbad06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "41c6eb3f09ca24f3c8e154b5e1cb335bf2c3f142eeb73af4aa17a92f36e52708",
+                                "uncompressed-sha256": "0e1e8aaaaf1d066f7f03da65b4200e4c662aa570547b09d4a5b75c691b6e59cc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live.x86_64.iso.sig",
-                                "sha256": "49919c9ad277cbc0deb691b47168910f19f71672a1ee49e57781dde25156a20d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "51ef5619d12cb5ef735f701a639f0b9994793be7bdb8855a7f316be1db6bb52c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-kernel-x86_64.sig",
-                                "sha256": "684ebbde99ae22641508c8a7440502e07ff75ea2cba59ba93ba8bf8b0a63a9a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-live-kernel.x86_64.sig",
+                                "sha256": "507b2265becc1125b372233c43b044ca68d8cdeba9ed7da2544e1c98529ec289"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "47e8c21a7857280f1737b04d776e1fb309232607003192718a23899209ba570d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3adc811e1e45d7c1c56f62bea9669710d0bbd741e88a7bc0a80b20113457b77a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "43a6b31efdb1eb04bf680ee4103643ca64f4dfb7d1c2cca3565060e7c26ef2dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "646f3cd901229ab070212429c28cf865248c9ab187db7346ee9acd07a8a6c4b8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "4ee235f141c3b66621f0f9622c094f6b0c23fc189c11bbdfe6425fe140bf4b14",
-                                "uncompressed-sha256": "c2102baad0a1bf7cf5dac11ed4740197d4ecab17eb5a678e44e3ef0143d48d69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "3d8aa7883e2d4c80af2d14f36fc97698d744ca0a0ed5434f1e66de9717db52b1",
+                                "uncompressed-sha256": "f71472db1c90492056a3dfd8617f919956caa365fa0ead9e26ca38146cd14d09"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "824f2ed21c5ac994aa34ca8291b63d74637cc63d0abfb2b3973eef94b7e57f07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e4a8b28ca8769509804a490114647552952b6bf3b1e17e56951c2d4fde222fda"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2a7db216248cb6ec4c43b52a9de318128735010e7490431d53e1759b0165eb8c",
-                                "uncompressed-sha256": "1423580b806118228b817561096af3886f296b979e409831971883f22b2f5721"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "dfeaf23db1582732c3babfe44da3c071db6e86752701bdd28697b7efafd2f157",
+                                "uncompressed-sha256": "c236c04e81e755aefdd1afe026690b5b842f59c2a12bd95be6fe4e837db09028"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2da64b8c6c4a039fc0b204a1d44c96c1e4f2384544636b80f23c26c939f5c6e2",
-                                "uncompressed-sha256": "98070ae1f7f9ec22f49e02544a0651f92c12612f480ac5d632a320fb11eb5ee5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "93a1fc66990a737547913b104222f2899993c8b5e5f735473faea55d36b5bc97",
+                                "uncompressed-sha256": "c7295e9075053bbe1068c16d2e7cacb5f0ad17fc1c6e29db7ff589be9168552e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "477d8f72a93faab8ed720e82329a5dd67b0ddc87d6cbb61e0d961dda6139f748"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "3765d488e138ca050a5cceac86d262ca6cfa5a586620accae28585b1a944aa51"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "1b3e656ff4536c240947206f970c939bb2bc13aa985a352f2d6dc119b779d555"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "cddb4d9cc1dd91a63265c608df71cabf63623348c31ad47157082f1e426ccdce"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/41.20250331.2.0/x86_64/fedora-coreos-41.20250331.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "cb76d6884cd1c36cfbb5c0125a1c56fe276e0e16886099cb5cf62b52e703284a",
-                                "uncompressed-sha256": "65d9bc24cb8eae5f9a3a42af3f8c16c1fa0b4e5c889c78bd35b92b7c883d9469"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.0/x86_64/fedora-coreos-42.20250410.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0cd1e629db103038c287a0b4569e7b81827760607990fb35d3e90238f7fad14b",
+                                "uncompressed-sha256": "685161826add1789a51bae214c53f4c3b0b194e7b96b24929de64bb8a37aadcc"
                             }
                         }
                     }
@@ -732,145 +756,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-08b5e670718b907af"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-00b82fa39cd8db531"
                         },
                         "ap-east-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0e9634d3778f3d773"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-063fb59a295e74773"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-031b642f0c78bcca9"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-030882219389af53b"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0a7a343692dffe4bc"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0e23e8675bbcfb09d"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0c7f5206ad82390b5"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-06eed28ed4a03744d"
                         },
                         "ap-south-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-048733129e1add683"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-001ec80797788a44f"
                         },
                         "ap-south-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0a18dbd4eb38620a4"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0bf8e6a63715c2c99"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0992db59b6d1dbda0"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-036b7173d8572064a"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0bb0dd989a4e43125"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0aa434119e2442400"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0f901e7d01130c7f3"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0edd78632ff378a5e"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0bd5fb01aacede15a"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-04beb06bb5c9d426f"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-053fc2da338d5bd6c"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0371ff099f3999374"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-08858b7b11ac3ef16"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0e3bb58067dda5f03"
                         },
                         "ca-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-024d59eba0f5257c6"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-013e310b507752d91"
                         },
                         "ca-west-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0ef873d93ada3026a"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-08acb790237bfd2fb"
                         },
                         "eu-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0fb764c2d0a2f62e7"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0c61c318519c2b2fd"
                         },
                         "eu-central-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-021e45964c7d85d82"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-07f3ad50bfb226655"
                         },
                         "eu-north-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0f14dd2e775f47673"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-08981bc3a6e7af6a5"
                         },
                         "eu-south-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0ea45aa5afc5f24e5"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-00d3a38bfb5e6fea2"
                         },
                         "eu-south-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-05763cbbe76f3eb4e"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0d4ea34a31347fab1"
                         },
                         "eu-west-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0be80ff839f7846ad"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-098f31cf05cd6523c"
                         },
                         "eu-west-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0160abc7c59798015"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-09a706c241b7fea36"
                         },
                         "eu-west-3": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0e2ce14f6da600ff6"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-05bd8ba9f8a559cb7"
                         },
                         "il-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0554bb299b6280085"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0028ef834ea0382af"
                         },
                         "me-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0c4537ba2942f11f6"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-08d5591a3e4e30779"
                         },
                         "me-south-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-04030416b6d41ad78"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-065519412d7904f10"
                         },
                         "mx-central-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0a243a1b323465ced"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-098e8ffd5ed5155ac"
                         },
                         "sa-east-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-041d023b98b6bf1c4"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0003ca3cb56e09b46"
                         },
                         "us-east-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-0b311d2524af30f92"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-0a885cd55ffdb09bd"
                         },
                         "us-east-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-05260403473fc5500"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-08ac9e6de78d54c5b"
                         },
                         "us-west-1": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-00e655e179cbd9a41"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-03703c603a9015485"
                         },
                         "us-west-2": {
-                            "release": "41.20250331.2.0",
-                            "image": "ami-000e94fb0a7882d4d"
+                            "release": "42.20250410.2.0",
+                            "image": "ami-01a7368289efdc5c6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-41-20250331-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250410-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250331.2.0",
+                    "release": "42.20250410.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b7a7dc08fef050c50652676c05cb944f4a60d5a5adb08e072edc6be1137dcf0f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:266dcc26521c10ddc09de4400813cb0f43abf2a64d889e93284497eead3672d3"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-04-11T13:07:22Z"
+    "last-modified": "2025-04-15T14:06:34Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "42.20250407.1.0",
+      "version": "42.20250410.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "42.20250410.1.1",
+      "version": "42.20250414.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 1440,
-          "start_epoch": 1744378200,
+          "start_epoch": 1744727400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-04-02T15:49:57Z"
+    "last-modified": "2025-04-15T14:06:31Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "41.20250302.3.2",
+      "version": "41.20250315.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "41.20250315.3.0",
+      "version": "41.20250331.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1743613200,
+          "duration_minutes": 1440,
+          "start_epoch": 1744727400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -137,6 +137,9 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-04-01T15:04:52Z"
+    "last-modified": "2025-04-15T14:06:32Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "41.20250315.2.0",
+      "version": "41.20250331.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "41.20250331.2.0",
+      "version": "42.20250410.2.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1743523200,
+          "duration_minutes": 1440,
+          "start_epoch": 1744727400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).