### PR TITLE
Roll out stable 42.20250410.3.1, testing 42.20250427.2.0, next 42.20250427.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,156 +1,156 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-04-15T14:06:33Z",
+        "last-modified": "2025-04-29T15:47:30Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "1ad03ff42bc526ce4987f3743c2c5aef088909d57176974b5f7265099bc841c9",
-                                "uncompressed-sha256": "ed78505932508e6fc8cd352c0e5babecc80a994b69625d36e2b52d47d9eab189"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "2949b26c38587a73c3b262638635ad09838055e8e9ebb83d1a104d989ad208d8",
+                                "uncompressed-sha256": "65aae4c812ddbe3ca1bc441b48a1908957ccb60085754921e7288add6a41ca0e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "649fc3139cd988548b723246d5799cbfcaf1309c36ee1e1bd2249c480b6cbdd2",
-                                "uncompressed-sha256": "7dfa3beadbbd22bfc12f7bdc783e3b8a762a4dd91705adce28072467ef455702"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "60129b60183e36c41795543e5e9f797d827217b46d7742462859658af71c071d",
+                                "uncompressed-sha256": "5dc2088eff7dcb3ffda1dde8e6fa28e2f74c5440fc55e9918073239de3828d61"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7ed8a8f9d015d51280b023e5a25e14028f9d641b2f7dab173d53b07a43651d62",
-                                "uncompressed-sha256": "10cb1028cf8cd5882010d3fce2d5e07a6b7eb3487bf0629931fc3da5b077bc65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8400bde1d73731302afd47adc1787c84844fa2842a4c900a9059c2dd0889da9c",
+                                "uncompressed-sha256": "d3773aba6b2a9125cd20ed0a3db76cf2a070ffe5177377d226e43d150cfac0e3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "2ace5348772ce93044bc606f3a2f63f27593565c1e0ed4f888d20d4506a4649e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "def92ccfd55b78868aaa47b15e9eaf52ee31fec17dca0d1adc67683f09072962"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "b57500cf1d5186f52f67ce26e2c39b9c16e203c3752ab722226fe95ec7a38f9f",
-                                "uncompressed-sha256": "e7a597173a538098c5e3547cf208a41bff062ccd4e294cb6ad05dc8a465439b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "908723464892c01f8273f37544723a0a82466c9ab753503e36962e5fc55b184e",
+                                "uncompressed-sha256": "cc3400756e4bb93c80126cc1da4de26bd9ec3cb4c13c0b104d7666cbd2e59b79"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "89f8a147374a15a83a5e684a453d30c0b3ce324bcea9216db30a17b93bee516a",
-                                "uncompressed-sha256": "12ab2fbbc125e8a70fb65457b9c69c40496204ba32f6bbb80be67ecb74b33f1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "ac6c66df0403d9b2d614e12eb52e7b62d133822118acd390e8d4235a4b4e1cb6",
+                                "uncompressed-sha256": "a549c731ab36bb3cce68640b1ea85f76627dd8de94b0ee0f4b5771769ec34ed7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ee5f3cd4ddd19f7a3df02422a20af576a70b0d5fb3207f1bc7db18534454b1e2",
-                                "uncompressed-sha256": "7c0693c75b2e513e5590871f99194aa2f4420fcf3068fbf007e769494264d0be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "902c0018fba49a8cfd5d52958b51b83da108b3d82c397ef692ce5f75b0a6de85",
+                                "uncompressed-sha256": "bc5b04790556bac77eb446d76b811d3c548885ad97d041821eb22d6982771a4f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "5675f7287e82b04b6fba238c46c967b59a6dc0899e2869b9601c4352a86087b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live.aarch64.iso.sig",
+                                "sha256": "cd04c49491afe7613e18d45216651da224f3c86302ecd51ad21e67d66d9134e9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-kernel.aarch64.sig",
-                                "sha256": "58f28396356a6377ae67eacb0a0a3e8da84cf075cfae9b808ac92304d66c868a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-kernel-aarch64.sig",
+                                "sha256": "b6b04e199b69d49af1e93f81e40335b8c6a66fffef496714bd009de54cdcc618"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a3a5652af41bedcc183b631973d3cefedccd0238998430339f987639adb43a07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "9aa45bb7b64584da57ea604310d5a44af58f003eb72e21840b5d581b740bb96f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "bcd53b36561f114f2bdf27da8b206ade00e419a62a164936893c250ebff28359"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "e9b552b27271786343b56aa58c990a470bb9d4c2d5986896d84f341889101ebd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "80f16bc7762c49cc1c9708a83a66938fef63a7aaa6fab00256731398b419129f",
-                                "uncompressed-sha256": "902383e099ca207cd6341d8c39c815429c4bc54cab6fe776580301d23b599da4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "f130cd0532494735bc33a4b7af3c81b7e10b4be9412f43e02696959f3dd09223",
+                                "uncompressed-sha256": "2fa8bc2343e076daf2a1880a73087b9ed6878a4111ece82f239fc404768f76fc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "b662e6cb75daa08a7df71de1d31ea5054837d5acd76dadb6bc22d75c51b4c205",
-                                "uncompressed-sha256": "ce3e5ad461efd725e9787366ea7301343a43b5614b87a5a0a09f5518270f70af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "abb3c1e50fd096816e6e94f140292739ecdc8f4f9f25195d8f268d555f5ae8f6",
+                                "uncompressed-sha256": "16e8b0be7d572dffc6f2ef5c9fd2f158c165c8e4ed24adcf615e45924974d15d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/aarch64/fedora-coreos-42.20250414.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "05bf03327aa667b8de2b50457b48fe96efa63ae157d56cbb050fef7b2081aa61",
-                                "uncompressed-sha256": "9206ebbbf220f4555fe5ec8dd2703a93352984406c5a63e2acf1efc8d83b4e3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c1f2d7e7413459b690ece403fca5bdd696d8fa9300bcd1c749f18212f80f7816",
+                                "uncompressed-sha256": "93f689e5da2c34f85822061cce7c36b95a19e3d5efd3ae2edf3cd3bb29345cfe"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-096695df239039d51"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0f157c9c39a11bf62"
                         },
                         "ap-east-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-00c2a8482b4af1579"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-04673db4aabf4ecec"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-063b4ed3fcadb87c8"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0740259a79be1ff7a"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-033bd8393b1d84b88"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0b5f86f77509f1514"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0ce4745062980ed2f"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0132d3c72cf30e907"
                         },
                         "ap-south-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0d64319de95af00c3"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-06cda4195292f8c4a"
                         },
                         "ap-south-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-042825be47a7c481a"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-093da70a86fa30ce7"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-06170930025637661"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-085da3ca5bd6ef4be"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-027269f5a318eb1e9"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-02b95a4e11d111613"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0796f0c90155f2ac2"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-038aa27703e4d2eca"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0b969d18fc4170da2"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0089f4072798cf8e5"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0bbaea676d2af8ed0"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-05388838606785475"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-069dd2a9ea40936f8"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0d80d7c3eee69b092"
                         },
                         "ca-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0ebbeb6fd0b5521d1"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-08f34d647e9bf4e84"
                         },
                         "ca-west-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0a14827eb6685c4f7"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-05b9ae5729018c1d9"
                         },
                         "eu-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-09655398fcc5fe55b"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-09797ff42431963d1"
                         },
                         "eu-central-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0cd7297ee5ad2422f"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0c99492f33ad46989"
                         },
                         "eu-north-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-063b6e5f7577c572b"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-05e1669ba8a9d5c8a"
                         },
                         "eu-south-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0289ce4ed23829350"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0826b588b0a9e2dc4"
                         },
                         "eu-south-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0ce0d4077e5f0770c"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0723e9a01a75ba9c1"
                         },
                         "eu-west-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0af331a27a837dd18"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0bf67b69cf28eb228"
                         },
                         "eu-west-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0fc0e94afba20983b"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0caf747b04ef60ebf"
                         },
                         "eu-west-3": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-03b4190966f409806"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0e5ec3685861ef070"
                         },
                         "il-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-09543d67979280a42"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-07f3d1df388aede61"
                         },
                         "me-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-057141cf1645549bc"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0513f34d819815eca"
                         },
                         "me-south-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0a3b560c5aab153be"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-060dc667db774b2cc"
                         },
                         "mx-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-03425ea3716786dd3"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-09d08ffbb6a4a5f3a"
                         },
                         "sa-east-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0d825b4a5f7df40d1"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-01ab8c9912007e253"
                         },
                         "us-east-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-074af4a5e6aa60b15"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0b9fbd764faccb411"
                         },
                         "us-east-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-03128f58b2ab10058"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-050c33e5f8f5bd61e"
                         },
                         "us-west-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0d2ee6685d2410cdd"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-024a3e9a7f6229ea4"
                         },
                         "us-west-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0f404da9a5441bb5a"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0aa3d736155db0527"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250414-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250427-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "07519a841835d8e369a5bebd3253e1b0ee3603ec07d90a0d0101c312eb95f806",
-                                "uncompressed-sha256": "62856f4626b4287308406423cbe2e548c5078b6fa1dd22d849d7170680ef361f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "1bed0150de47a2750edcc6077315a1111e2e446e53d1f1b6f1f19ca1f396b61b",
+                                "uncompressed-sha256": "a7404bfe947835c3573479c22102d058e1b8285c8de068221931adeaeb981705"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "0227010eb5a1be99bbb9aad4301eb947c9e632386397a7fa026523ded84b636a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live.ppc64le.iso.sig",
+                                "sha256": "1f4a2b63462c7eb11d311c9c4d91438d49fa794c0aabfe93958034ecbe220179"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "1f07b533fbb545fd575b04724bf0af8619d1ccb53be90b1a3ce32120b6d52059"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-kernel-ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-kernel-ppc64le.sig",
+                                "sha256": "0aa34c5f7860ac4f37d199b034d154fd298e9d044ab6994afb02086fde6bacd3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "20a34a33542ca6ea16b67efd33ebf7be6d8963a36cab22da4dbe2ebcd422e1c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "2439d91fc061baf1f8b7c523b22bd6687420aa81554e5e49c16b035ca27dae1a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "5d80328c17d70e914b8c7ffbbc759a4b6aa321b66077c7829613586e220aefc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "3afb51a81344dd2bff0aa03ee9efb30690867b185241c305e4f79dc3629f9c18"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "ebaafc5783bea83d5795cb572949461c3b486a278978ebd02d3761f06fa88491",
-                                "uncompressed-sha256": "090e524948c00f964ee0ee206c75c108519638bfe17af76baa19eb1efed2d3eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "fa06d95a69ed692128934d986a19700c0af82ea533b725c2b39902d92bd21dcc",
+                                "uncompressed-sha256": "e458c6240590f95526ed9062efdcbb537c7a9d41ee80ed9183f5eab135493cdc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "4506a19610c91e189f7e9bec4f3e973959aaf34ad5ad9e8c33519f9d7b180317",
-                                "uncompressed-sha256": "3d00e9db0072f124f4830180b2d8a5078b9279ea27f1e1a9ca4c3d120813bda1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "beca5643900e676c19d6a2ada51dea4a217ffe39539e37558ad0e18a0ae86933",
+                                "uncompressed-sha256": "3aab83f7bb2f4feb407173bd9135473c8fe4b22dbc30f32cbbae40da0a4d53b3"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ea61616692891398f62a5d90113f0c91c858e736d387955ed3e3e8b9a54e687d",
-                                "uncompressed-sha256": "f9934153ef9e83f5f84cc4454caa9278f8accba3a16ca1dfa92d19eecc5da8a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f30d4843a5871872b31702f35a2579aa3bd6fb9ade691a2eaafcd391d50d489a",
+                                "uncompressed-sha256": "51774ebdee05109b8e34042fd6d7a19a129eae3f626de06d9b5d5e5687224cbb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/ppc64le/fedora-coreos-42.20250414.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "47f8de8147c5c707ac764a48497684d89fb53b0be42cb2159b879b694fc9d1ef",
-                                "uncompressed-sha256": "0169ec208dd830200661c5d83d909a3937eb8ae4e52eaa75c8efb2ce94fae9c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "e4a6feb9e5fa8705a4ec186931954b572034e035016a2d3de9fdae1b73c466a4",
+                                "uncompressed-sha256": "8dfe5aab0b2c9f76d5c66b1cf7db97a61e92815c04516d2bddbd919e937919b8"
                             }
                         }
                     }
@@ -389,85 +389,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "6c9875cf9e7fec7616a2a3908bfb6a6044ff77aabe7c5b49347ffa8e65a9ff09",
-                                "uncompressed-sha256": "ad4e2d6f059ecf2b92bada478a18c8ad8fdf4a2702e1f473f35006fd9a38fc14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b50e5650d4d93e4fdebbdae742ea9013ba2cd2bd791fa8ddddbbe98d89fba8de",
+                                "uncompressed-sha256": "9ff8aa3a9d90556a47c7cbd705363d6f5d6ca47adc72557142a5700b58b81dba"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "607e2f53afbb85fe249e636418a69dc21cb57650d888fa90584e5969d73530cc",
-                                "uncompressed-sha256": "69149051d2c4d187828e0447d61d990743b3e1acc8236001459092e3f2fa6813"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ee36f49d1dbb76e924c2fd1d329ce39171ed97ebeceaef36ac547daaa472086d",
+                                "uncompressed-sha256": "459f04525c86721f74601c2a772c24fe62a3fabec3513ebbf6340d45c0ed5eb2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "7e9243d5044aee21149c99fb6e4d55b01e9def0c226a9de10a83bbf14b09f4bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live.s390x.iso.sig",
+                                "sha256": "f838a8a12469f66556e91f34d9954a08f6fb3a4c637101932f1f663b7442b14d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-kernel.s390x.sig",
-                                "sha256": "a3817890e7949788b9cae8881a4b36c2af42ae3c32f927a981472c78e59fab83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-kernel-s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-kernel-s390x.sig",
+                                "sha256": "47bfcd274f467ba058929e38489b7d383272f37d36326bd91da4b4097fd38698"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "a691a8b17ee020a7323cd5952491df8b63861bebb7b90fa17253c05856d093a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "6cd980c7c2afd2e17c0a9f75a1d0a5148ec3043cc03eee47e8f2a4f3efa0833c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "d59c274170007eaf9507259c8f16232b616edc047fa8f87642405a1994059762"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "21d0380a69b414bffdc2397263b29e3049d5ecf86a70f8c04b15514279e11e34"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "064152ee61ba3e4eec6870b1c367b7ce791ae9bc3b3b85219a63f98b1d1dab5b",
-                                "uncompressed-sha256": "fe51dd7cb69b81ca7a6407d53a48dc0f593baa6914ad28e086d9be8b9b36f978"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e022ed22ec664f5ae10852c2ade1661244ab8e75f44ed6b592b9e97c0c7af81d",
+                                "uncompressed-sha256": "1b0832e3c49fc16cb19eab95a485683764f5200a81557a3864b57d7b8ae89d11"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "3abe1bdd055ad7bfd4874e36eb33e83f09afe75087e32031aa740dce5c589758",
-                                "uncompressed-sha256": "2f43f3ecba3df70e121e2b1485f8f94a3ef7c54d36214a254869aac48d66a825"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9d42405003b8b0082568e940fe11e0946c2c7b9f09e1baefe1000bb0ede1e3cb",
+                                "uncompressed-sha256": "1d15da77844a64349c6719b574aef74dc62a6d4375fec46c202bf80b8b9add26"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/s390x/fedora-coreos-42.20250414.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9cd8767510fe280919cf15de312701ded176a39487783dd242cdd1ab30f0083a",
-                                "uncompressed-sha256": "91e55eb0cf9f6b2e5b2b5f976a48a68f86070efd6bad62b0c18a54fe8645f03b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "a735882d289312c7f9b51fc5405f69a46268c8be4c632a5531950eb5dc64d698",
+                                "uncompressed-sha256": "6ae3a09344f800abcdc0b9cbd1dffefe648ed9e8f426725152afe9fcc0e54532"
                             }
                         }
                     }
@@ -478,275 +478,275 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "fbb00027a0ac13c17526b9db1686ea2b039e4b4a8ee542c288cffb0f7ffb502d",
-                                "uncompressed-sha256": "cd7c262aac3c164166f60c20aa66bb9847ff126c912dc0e720a63b343fd5954f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c3a32fc1732c80f8e264388af3f07b9e43a524b9c0b02d630c83ce8d30d530b3",
+                                "uncompressed-sha256": "0d97e19a25a8c83b7b4c8edf2dadc054672de69d089af937a2ad9362c284edb7"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "42432ba608ea04ed91a81cce4139b161cfcfa0735972e15a0be8ff9065e62cda",
-                                "uncompressed-sha256": "5855b8920157d8409d289d87b6edb74734e4ae9679933c5465e683ddeb633eff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "e4c9df3aece1a495b5be3ce3590969794f25de7eff40559a694b9b8b37e0e8fa",
+                                "uncompressed-sha256": "7989ca69067d57f6b19c9da2a357e78ee00059cd42ea57ede40f77ff1af185eb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "37ecedd3efd8a9410b5f61ebd525243acffb5ffde033f7cfe6c4218d11aafec0",
-                                "uncompressed-sha256": "6e4ea35b77fab550e781e6631f793fa139133105735c5e20bf2c8a0def681706"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "4fa4e3285600248d7a52b93c3fddf6337d0743d2d3618b608de97dd78064650a",
+                                "uncompressed-sha256": "2d3e6e39c4f3f987375c1863da6c6bd81f7a2781807b4f2ca94baec3c6823cf1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ef1f9f9bae2d9647cfe135df43246d0f606a23560f245aa918d8b153bd920b9e",
-                                "uncompressed-sha256": "535180e268d7aeb47f109480cd124fd7f4e0df2c0fd353a975faeb2ee9005f0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "adf26dc4607f1cc79aab343e2a1d039476ef81c31bd19c9ac29dbffec3654890",
+                                "uncompressed-sha256": "dab373f59e0a24dc8b15a61b83ba73608f364673badc638a5b90eecc9c189502"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "123169b7a161a0fafb572bac014e87eb1c3cb6472dba2d962c8a84a1a973683d",
-                                "uncompressed-sha256": "f734c524e36c5534b8ca75825a50e60b4fdbd096bfe252a18083ccf23c0da50f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8f4c44e821af33e4f3d020db3c491d5e6b8430b4db602bb4334ff60b631c0a5d",
+                                "uncompressed-sha256": "658cafc4d8edb40cc051170990fc025e1d22c9afca1573895b6395bc97896b81"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "0d01287063b166c19980efe2f06fc5de79eac81a736e40b41605aafdd4ac7240",
-                                "uncompressed-sha256": "075d39e2ce3dc1ccd8d2c1633b89fe4efbf1632ee0dae99891e72e8e9c148434"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "2d5dcc3fb2e39f45718f0e66d9f0e600355c85b48cb07a6cf926361d955c5bf4",
+                                "uncompressed-sha256": "7703d29b33bfab2494bdf7acaf0abc5a9516078cb1803779b556ad51f7f0818c"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a6c893880cb19885d43290908f31094a03df0bd7f498fab1874e12d6fd8b1a91",
-                                "uncompressed-sha256": "526b55bf9aefe03e36cd6aff25616357496533a9731dfee80544bfb9b145f867"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "79e5db7acc1f7f2c6c8491ebd60b48b384de827c76dd3348f76a21a9b05852da",
+                                "uncompressed-sha256": "9c479ba6911d9af6f9f06d6dc033868ef8e5dae19a4aa914f25bde9b531661b1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "565f91204f22105ae5978c7afed0b448e9df3b91f9ce75e21c6381c6b6c0ba24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "5e90bc9d13b69b1dee735f2212e7b131d604258434fdb11d9b567d405a7081e5"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "a140b093b1ddd2b73119aac7f8a92cf5a6279f3accff8d3e0b08d086ffbfb11c",
-                                "uncompressed-sha256": "b154502e9ebd3e8e118d0352153dc2dea700ad945c0650159250fbc5488983f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "16e51a9e5866fb13f7a237cad41a95580cf61d62ead74c364fd3276410f7bd75",
+                                "uncompressed-sha256": "7ad0549aad4bd561d6852518351a7747985338fca2396cde740479d6dc90d549"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "b3066b0db053425d5f41ee4a4f54b6cb8c69912cc17e5ce3c2dedd7d660509bf",
-                                "uncompressed-sha256": "0acecc48a84b6cbb5b1fb725318d54b3d19203ae4732fc8d35cc07f3933f5f78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "18faa0c594a4998cd271d2d42bba497b1e9243a32492090edf68af825463b478",
+                                "uncompressed-sha256": "2bee17f5244c435085075791c434ad3d6cc90b9d8104ac6898ff281871071e5a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "6497c35555e7b038668cdc51e0df78455fa75b619c0ee89e34fc36ecef1e172f",
-                                "uncompressed-sha256": "b099ff4d1cf8af4c332417db47b12f4679d52699d446e3e80d33fd46a1e910e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4612b8d11d070d4974d4285382326eb12bbabc9c1df8dd9ebce90a6691e88c9f",
+                                "uncompressed-sha256": "313b65d9328a457428f8a76182163e5bcc55f0cfdf892074db76b48d23b62363"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b8d249ecac42bd7299b902d39072b0a64b4b120f1bc66a38ac86acea704f42db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "6aedca36b950f79df10a31529defb633d0f8b19ba1722cd6680b1758ab502de9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "39c2dc7fbd2ae18b5073fb2a2ef563b54b7f349d08e800bff04a3e84fe4b8674",
-                                "uncompressed-sha256": "706bfdc5a4c62d4ea04aa9dd0c10e947172dcf796224f6d5a2357d54c1b9afc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b5ef028eecb34b9c7f4751eb3c65e4fc301f929ed71d2e84b8c8a981636526d9",
+                                "uncompressed-sha256": "c4b04582df41f1ca3c5a300b696d8fa19a2c4a59335a5cf7cdb5cd777513a709"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "16ffe15420fc13c58f89d28cff6018ff2fc48cc762d73731ab8c094d86dabb92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live.x86_64.iso.sig",
+                                "sha256": "53fc2319b5a6446881d1f88e674d3954e2550e54f1561ead4d0cc284bec64250"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-kernel.x86_64.sig",
-                                "sha256": "1eecf8109bb4a6b6125a7923d1f0e6e1ed1c71ab87752f7117baa3fe335b8a1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-kernel-x86_64.sig",
+                                "sha256": "aa30a5cc0328207724fdb75f6b1c9298d5cb979200ebf8c008643ef2f65e8122"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "37a398d3df9eae7343b5b3f0dda1d6623318f27369712c90bd8e5d4aadbf7cfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "351733d4230e5ed1bb96addad6d3361ee3dc104b63fe8c849a2b9d33434d4f03"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "25faf128082c6af73572200114f2c676cbb9fa23c9267716c98a57ad57bf7cc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "3d56dcb262470cb4d17afbced7aa1ba7393031e12cba82a256094c395ba508ef"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "7bb6e336e9d1a16f0b006a22c3441e437a44b941ae7aadcd7b3f44aca4ee6c56",
-                                "uncompressed-sha256": "c732ea6d8dc482a495bd796a24747314f77a5bdea8dfabfb76034e04a7f46edd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "37a0f6d2c7a1944c84b6f2f6554be1595b45d048ec40f0a22d19efb0bb339a59",
+                                "uncompressed-sha256": "27373a255b921aa606710f7da5e8b443cadce81b6ce35f71cc2bf91a395f5b31"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8e2f7cf82df372822f59f18c73659b9ccb40acf38ec72f5eb5558a89dada3156"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "b91a110d7cc0dfc108b8a7804bd901dff8fd705ef37183ecc8c7da83b7511ceb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5cce5901d16efeafb26d0bf5c1771ba895ce77199281ba04d9010a72e2566b5f",
-                                "uncompressed-sha256": "1fa9cd9b1e70340ab4fb84d2ff9a1b7d0a8f47e553732c339cac6a7251ff009a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "abe935874c7280d783676382000509b9fb13094ec9e13546b5138a585b6ff28a",
+                                "uncompressed-sha256": "12dae4547e460676d930a0a948d1540a1b78df7f7eb46bce647888cd1d933a73"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "56d8918670a5a819675c5f90c36aa45018c9b8f057c806f5e7f7d7fa7dcbf790",
-                                "uncompressed-sha256": "334e33ff60f50f8bbfc581a7804f7392e9a60b6830c086bae4e0c8f441e627da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b0cddf3a0eabb31a52e9d4e3a2b042b28bc075a13ed66845173e839eafc1aaf3",
+                                "uncompressed-sha256": "a7077b4fd724ac01e0a9c4c69d309afb0bfec93d41a46885ad119b65f60d43b1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "efafcc041bd39c9dae0138e04bc68ea3b5c31402ea68350e7dc9db1da66a2c73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "57bf96facaef68543c7f7e03c705d7c0024e8e31c9e47245332900c6cdb50294"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "2e2dc469401b6add1888acfdcafe73a50ea0a6f78819cec6f0e512c1cd0db0b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "365eabd53abc39cdfd3fadaf13879b4b9791eb45f93a417f0b37cb04e0e258bd"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250414.1.0/x86_64/fedora-coreos-42.20250414.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7ddaebab9ef1eb4aca3298971d0315c292f4aa4fd470ebe5f2e069f3193ddfce",
-                                "uncompressed-sha256": "8fdb197bbd1eeefd37f3b74407e15182196f6006a70248865a278a8fba287be5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "db966035cd98e4d346b64bf1b5751485a2ead16f7cdad6beb063ffb8bc743d1c",
+                                "uncompressed-sha256": "06e392113616de4730f98a4addfe9a9faa3c5359f909001a553463dfa8bb2745"
                             }
                         }
                     }
@@ -756,145 +756,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-03078301977dc50e4"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-09637a3a5ef0a9f3f"
                         },
                         "ap-east-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-07e634b5f3288bfef"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0fefe30705546fbbb"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0ae339eb517bbfbb6"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0506756e7b2d5a1ab"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0e1a61bc98f32f82c"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0e5feb0aa5df83e6d"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0fd78e4b49ad4cfd4"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-030f739f0f31a5982"
                         },
                         "ap-south-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0df666227f3deee59"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-09e504dbf10defdf1"
                         },
                         "ap-south-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0697313588b84cf83"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-00a5d1ce44388dd30"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0e54e221e8f5bab78"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0568699a87af48216"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-093f3d24e4f38e469"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0a589075395e3e578"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0669fb2a9a79c7f07"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0d52d204110364339"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0df5db3d26428364d"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-01d0d15ffc4eaac3b"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-017899f03648e85ef"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-077bf6c1dbc296ddb"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0f70895212caf197e"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-02f6f553e04e52b81"
                         },
                         "ca-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0762816142a702484"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-01a61119aa8a44df6"
                         },
                         "ca-west-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-00645877e8063a835"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-058bf018376bc5f2d"
                         },
                         "eu-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0bd93ee9939c49e44"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0cdb8a6389878a319"
                         },
                         "eu-central-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-056ef9924f97a256c"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0474733f7f239c835"
                         },
                         "eu-north-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0dbbe3614a6651412"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0a86f242459934246"
                         },
                         "eu-south-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0fd2ca36c88668d80"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-07e7039df7e45f608"
                         },
                         "eu-south-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0f5c3087270019381"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0ee06940053a1e16b"
                         },
                         "eu-west-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-04ea931c8d4d17846"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-075f9454aa7c3b527"
                         },
                         "eu-west-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0ab1b9543e0589395"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0cc6517bf93a45930"
                         },
                         "eu-west-3": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-03e62abc2432cbd7b"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0f803d14d13c683eb"
                         },
                         "il-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-001aea7a13624e444"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0ab2f78eedd653281"
                         },
                         "me-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-01d6cd6b331b2caa9"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0c95d6bb048de9f68"
                         },
                         "me-south-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0098dd45124ddfb42"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0b8cffc9db6d26428"
                         },
                         "mx-central-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-0fa96fc95ca1ae589"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-05ed020787e557a5b"
                         },
                         "sa-east-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-07fdef7cdbc2e9905"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-098a306bd6fddc741"
                         },
                         "us-east-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-00eb6f67befe9621d"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0e961ddc1111d5592"
                         },
                         "us-east-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-08756d5ce47971475"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-02f2728c0e2ceca54"
                         },
                         "us-west-1": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-086de5c2f10c55df9"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-04f4a987d03fa98c1"
                         },
                         "us-west-2": {
-                            "release": "42.20250414.1.0",
-                            "image": "ami-00e5281191da7fe15"
+                            "release": "42.20250427.1.0",
+                            "image": "ami-0e4643785a2e82ec4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250414-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250427-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250414.1.0",
+                    "release": "42.20250427.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:926aa2f471792bb9826c17c9629815ef1d4f371fec233c8b933c01c5b1415405"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1afcc809781b91b56eb914497f601c1c9e7a1e80a47fda96b1f47a70981886b2"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,157 +1,156 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-04-15T14:06:30Z",
+        "last-modified": "2025-04-29T15:47:28Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "60cb5a21fb2f2004d61fbaea43fc5da76c4e04be25d9c55d80b752d264f4fdf3",
-                                "uncompressed-sha256": "baaeb7697f88ce0dc993fa3666e242fc7ce4ea024e9f3f9bfd600c63fa64f238"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "b08d370ce95e0cb424da35f54b2891360eaab2fc8c04d86d03565369b89f89ae",
+                                "uncompressed-sha256": "c7d3694f03db48cf734400a8c86fea1b53ab8269e8b73f1bae223bd0eefef262"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "4b34eb2140b7bf181d7fcaa416bfa63cf2386cda48dd9b5095629aceecbd8156",
-                                "uncompressed-sha256": "821726d847c81d3499d56cfdba3d1ef98912a33d7aef0b18e034bc8c824fb4d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b97aff712a864c206b3d05610f94b943cf87d901dd1f02a09fffe6f9b9f58c1d",
+                                "uncompressed-sha256": "97b885de1476604635f1b0456a57eedd92be2bf88d47a970e98821c10e756d82"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "cf3f8d5e3066e6d3fafb7ee0e70c220936b47d463ba43f3b01a3e9f678691052",
-                                "uncompressed-sha256": "5394b055ec1748b0f9c0b4038a7b2c035ff1c9f8a152df6a82160fe08962459c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "239bf67f0787106ebfe49fbd6954644caa9fb370c1dc2286eb2865fab07ae936",
+                                "uncompressed-sha256": "7b608bcde98760e4635709061423d149084392b71d394c364eeecd80714cfc9e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a9e9be52631d189bf9efa8505b5a1cd3c67508b227846014ae7a9f8732506c16",
-                                "uncompressed-sha256": "fb743382d586e70276c5390078ed635fa30c802cdab9d0ceec915d348312bd79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "bdcbdcf99d3ba8b16e7041ce8406b0f1c92aac5474d786d313ccf7168d21df77"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "db4336dbc2e049d2ae83e3e829bdbee25a96811f9fd4fa8ec57cca04fab214e2",
-                                "uncompressed-sha256": "be1198358cc4891ce43bf87da8f0f24c85a893e71bd5cb21f0c694af3455d8fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "b5d46ba883561ebb7a154326950d7dbacfe8f058ac46b58c061a7b0bf7dd8e06",
+                                "uncompressed-sha256": "c37258945766d5019ae424992c92caaf4b27e137d5cbe22550feda2142d0446d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "36e3e1bf22d63f5b815ee1e24a33c2e4ee38a6c536fca023cc49edd173181b10",
-                                "uncompressed-sha256": "482be5d7ce65f7c4b72ec710e74336fde9c2a5d77614ba960f3a09cb412f586d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "03e3f57801ae18858ccc38930cc071c4e99d6dad1775023f425728bcf4f054f3",
+                                "uncompressed-sha256": "f4496b2b8ba888e758e9586cdaa55d8a2a8a4b5d7f93495403c67670e55ecffe"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "8f2f536482ac053b85b35d73fbda0e687ac2d80a1518a0193f01624eae599b84",
-                                "uncompressed-sha256": "175fce8631bfb1322d094060b532bda23941d340ac4127c31c3ec73de8c4e664"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d39e0b59b5e4eaf7a6f98d5b11c69b4d90fb24ac08b521de2910b292018d6f85",
+                                "uncompressed-sha256": "55a9f0e07725a7a25e8fed92011e1bd019a48dddd1c64f807b5308b94562eb42"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live.aarch64.iso.sig",
-                                "sha256": "1ddbef985b1019a4b465ca67fae5e5e4b96e4f3cf1a1e2be1a4d30726dd76ab2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "8e4dc658326aeebc0ae599bb435283b2475d196e8f0b8f4337759395bc09f6cf"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-kernel-aarch64.sig",
-                                "sha256": "194210ba81810e428a4ef7a94ac4202afd87f97b3c038b53111a082ed31660e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-kernel.aarch64.sig",
+                                "sha256": "e249c9d6d365dc640215ab759e18d2a8ff06db2aea29fcb4f4d13e3392f4a25a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "4c54a89b2238d68b185eee497ebf43629da9917a008d6b0cf2cfc74c9f8e57f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "e15a4a58bc3f316d7506fc546030d1e794d730a43083aabe33ce097e82e579b0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "2450129dcb3557a4e9757ae9899131832506fbd90b8956e6b876f15e23474e30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "53b6cb6be7def6b74d2bf0d17b2625f8eda063f65dab5486e1bc12366bf0309a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "75b4a999c19fe9bc7d4bd86a847337578ef5d6126191f84ed88900965e8037f6",
-                                "uncompressed-sha256": "3ab5feb1ce5c4ab294a158d667f080fccdb608eb5a55455c96c6ecff232e86e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "7b1018f2352b4331a446746e93d4ba95c2145878e1161c44e7f147b2a31a59ff",
+                                "uncompressed-sha256": "c805f1956ab0c21f76d4b4cc680183425035e13f2c662c7aa58a321ea9edbd26"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f8a21e53b0d91283aa736d9af03b367f6684945d6dbecfd8a325d59b458bc1d8",
-                                "uncompressed-sha256": "77804825a7cfebc080afe1b1b1512d2eb7b6ecd20ed3c9358d291d1282a3569f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "a51ba431564f31d1f48a3820794cafbdc1d849c84cbb36be373e24f822339c4d",
+                                "uncompressed-sha256": "8c6d1ef031c9759547ea7451796014e6580626856ffc311b6fdb85601b75047b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/aarch64/fedora-coreos-41.20250331.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "314f0a5004e32daeb52a098b9bb4f6160c65eade18af67fbb923233c16e19160",
-                                "uncompressed-sha256": "662cf9639dbc5138c4d196f17a45c75a74746d51a1a90ececb42b3e3912ec213"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e14370c5ef9b7d831462da67f28101d5d81cefcb58516a155cf46489f3c28bf9",
+                                "uncompressed-sha256": "f04761e193574b6ac0f10993145bd3384ae52f2798301b52c636103ca8f8aeae"
                             }
                         }
                     }
@@ -161,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-09f41e7e8f178f4a5"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-02812a2fe826261d7"
                         },
                         "ap-east-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-09423eb10c451754b"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0d15b89be088559ad"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0649bc25e1c5e1300"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-03d3dff91bcc8d987"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0a7e64c4c8ca85f20"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-08392a2befd163421"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-03501f52bd108584c"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-07fdcbd77a2618a73"
                         },
                         "ap-south-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-094d2786161d38336"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0edc6de33cdfa311c"
                         },
                         "ap-south-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-05469923a4836aedf"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-035a28b4195a17066"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-010feb714b9b5f824"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0aec9b53339b8ea8f"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0c141e7d596e28464"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0ef27da3475939973"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0ecfe9f27ac3b1c47"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-044c8a3baa14e07d7"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-076e021bcaeb9b2e9"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-013d34f60c14c5d93"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0d4765dbbff8a9478"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-02523d9b8188bd18e"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0c5c436a239f6d143"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0f5594a72c995f0c6"
                         },
                         "ca-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0a6b3f80223401b9a"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-02ca2d36edd84ba7b"
                         },
                         "ca-west-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-012cc3fa9699ff48e"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0b838d29c4cc77416"
                         },
                         "eu-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0f1015c3c915bd776"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0962a1e06790e90ca"
                         },
                         "eu-central-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-00dcd62803aed60b0"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-00a9733d7dd9aec26"
                         },
                         "eu-north-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0c3cc8e7906cc6fd4"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-027aae6d1e1889554"
                         },
                         "eu-south-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0abe734129f81374a"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0bfa942366acbca0e"
                         },
                         "eu-south-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-029bcd01ac5ee4e2a"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-091ed316a71174448"
                         },
                         "eu-west-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0b9e9603911c5b591"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0b49f88b4b439d4c1"
                         },
                         "eu-west-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-03331da64136e38ca"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-054503f8583d9f7b9"
                         },
                         "eu-west-3": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0bab98617d3706459"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-034cbac8ffed31256"
                         },
                         "il-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-05912d48745ba190b"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0876609df3e0887bb"
                         },
                         "me-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-05f7fcf3cbf018c38"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0aa65072c47ca6241"
                         },
                         "me-south-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0ea49666978068acb"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0990089d03cb6a577"
                         },
                         "mx-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0abd3cf98224873ef"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-031964faadd81665f"
                         },
                         "sa-east-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0e93dfd5b32450c3f"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-034d3d0a7d8750238"
                         },
                         "us-east-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-03ec000e1dd3f8d74"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-06b679a3966888aaf"
                         },
                         "us-east-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-06e7abfec8fdf3317"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0ca798832aeffab78"
                         },
                         "us-west-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0e7f0ddd5fa58e88b"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-042da0166ba744e2b"
                         },
                         "us-west-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-07e226750f355296f"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0772c82cda81ccca1"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-41-20250331-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250410-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "5307162cccb4ccfd57c6236feed5bf747c691aac95eb48fef5f4ec43b56c73a5",
-                                "uncompressed-sha256": "87659bb32334b1692353fa0e3794cd22835ca9772f39051a9b3d101a410272a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "2d87933945136abb6dd965921665f255e175e592aa6916adf7cd7559fc3db6e8",
+                                "uncompressed-sha256": "d7e7b1b3c627181f879a4d2296090186dc3c47e4b6e1153d1cfc01725a809204"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live.ppc64le.iso.sig",
-                                "sha256": "0c3d1c0a529974ea9db564ee308307ec698a83aac2cf82f9b20d68539cb6d423"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "276fe0ba25809e4a9e8f00f64c4a84596bdf30e534d37f3f33e61323bd500415"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-kernel-ppc64le.sig",
-                                "sha256": "56fd0720eac7f0f5cc20964eaae934e14b0559c9f6a50e4cce1d4a499f7b9a0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "4a522a1b85554d5f4f7aa0aa0cee8d1ccf877165c5c4751247956a51d4a1958b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5bb65231a1c0a747ba65de067d0f8f074190e9ed684ac8b38eb08c98d1626adc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "c27f2692cb803b140b2c893790531b5abfee5ec7d2bc95c4a9fcc21059754ed8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "404baae9cd0b87e0fa079d6286181990cc8ce9e7ef8d78fa9ea0aab5ef042b5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f0644e15a2797706232cd6995b146f0acb9e4ff7f996af57dbb542fd09630fca"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "40b9bb2678fd62ba8f44567190420af8c1cef1bc38fac2668eae80ee1c29c586",
-                                "uncompressed-sha256": "f1b8abc05a3b27883f181908a0974da7345482bca08c32f6fa9ef17c54ac8287"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "286274cc8bbac392def37ee48c28e88ce52ed5f6a5bb7122890623387f1cfb4f",
+                                "uncompressed-sha256": "a681577a671ad78e47964052b2a450f0a4411997058f832b69737db7d66b6453"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e6135a574d39a1554558b541258e7b47a5d430a197713190d8d0db77cfa84e43",
-                                "uncompressed-sha256": "241247a03971407516429ec0e719a2e74f69f31b1aed49a9a62c7866c778dedd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "633997a3ff290e1a0a94ef0b4cf7c4409d2bd9974297291bbd647f8cd14cada4",
+                                "uncompressed-sha256": "4f74e0708adbc1cb4f0fa40c817b65d1a0ac63927a0bdf6a6f2110cec5c6c4ed"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "e4109b20773c441b37e56c2207c302d6ca4d63a89d0c50eb27fa0dc1288da81f",
-                                "uncompressed-sha256": "c2ee63fd7f29403bced3525d7c6d159f98ec754699906970efbf9ca075b51e15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "edd9d119cc50c3a1bef799c0e9f4f76c656caaefc800bd91047d547ff31917d6",
+                                "uncompressed-sha256": "9fa57bfb406acdd9e4579456c96c247fb66d90d39b3e4b16b55fa65084b33003"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/ppc64le/fedora-coreos-41.20250331.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "6d06324d03409e28bc3c9911fc4774c76ebaead41453fdc31c822c6a97f4de16",
-                                "uncompressed-sha256": "b9cb4ef6a745e7653eabaf9d5edbfe0c81434985ef6d11413ba6c9fb9be5b6d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "60fa595eab25825dfdfc0573c3975daab80b2d598837fc5fc42f533a93bc5e6f",
+                                "uncompressed-sha256": "84206a15a281ff52ebba1d50bd1a45430d7e914d3396422122b71ac838dadd6c"
                             }
                         }
                     }
@@ -390,85 +389,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ea13c8b3659997cda55cd52ff2beb9a4e4e25eb536d8999234672787bd407ef9",
-                                "uncompressed-sha256": "c4ad5f817d273ce4051424576e92ea2c543f523391fe78245dee56458ad3be27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "c7d6da170562c306d551369eacaa8a68d97abe2da059933ca2e88acaea2dcbfe",
+                                "uncompressed-sha256": "7aea5f4abe72c4e4e788bac38a95493969eb55f710cc3a421f32268cbc273b26"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f02ccab47a8a1b92db0a7325929ca2b118e1548eb6ff4ee7e92017cc655f6e0e",
-                                "uncompressed-sha256": "e82062672042ed85ec0d894eb4c667597035036fd25afe19ce829b1c73c12a47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1b3f5c54382d19bbe705543f745d59ac6f3d454d047a0834948f8cb22a46951b",
+                                "uncompressed-sha256": "4d1dca81799eaa09ea37ebd2a87f4324a341e596a4541709c1158f5ec3f7dded"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live.s390x.iso.sig",
-                                "sha256": "5a3ada77912dcb045c2fe9d631819f516ad2cdb7c5d2e0f4d12520c7ee3df376"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "7671b1e77f0ce7a6089ed109fb8e6faaafc3b021b6ac12012cfee0c49c5b2b80"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-kernel-s390x.sig",
-                                "sha256": "275a7b3dc386d98eba56452a04526b1b7e5a68e78f86ec62e2bd7778f0483791"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-kernel.s390x.sig",
+                                "sha256": "1e340eca4d780fbf5ebc94e683060463acd1725ceb437bc0c7e30994701cf835"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "8658db039422e384f557d4125dc9d8948184b07f33b717220e07b36c82009cab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "d60a644c0bbf811185c77d90a95cdbd4fa59c1836b803d7899ecb18c3625f87f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "247cb65b40472db3297a5d844d9aa7ac5d278ec5d01de10b6794ad398511995b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "15bcfa95f3eeb5b7cf84f767711c026f89c4862c48bd0387169f9d2dbf0fbe9f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "21092bd02beba465110bf739f7c1624873bf93b07e55abf309d8247409ba648e",
-                                "uncompressed-sha256": "8a12d4bb2610e51d823002ada1195ae7a430f0065370fcd23cdc8e6f14ed4195"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "ca6079b50a73214ab9c02bb97c868004a49bb1a101ff80346bbe77bc8400e493",
+                                "uncompressed-sha256": "c4cbf7f0c3bbea7eb39ff8ee8418f70d75ce477cea4ecafb4fb7d977c45305ed"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d60edb59d8c318053f914c0e195f3e9faaf73df0f0bb209be91f551a2ca8f9d4",
-                                "uncompressed-sha256": "4d97c82cfd876d75d60958f219ccfaf69eaaf8432e9a5a9c8e036675096f8c70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5a508295de2cfa6823f6de3230f79556619bf867f52b36859a4a267ac7a3376a",
+                                "uncompressed-sha256": "2e313b2184252953e951926de05942c6a9bdf4aba1ef14646d39894405172b22"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/s390x/fedora-coreos-41.20250331.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "3a5ef1cc530ae8b708c3594726e1f17634752a76f11d446fc5b36d78ba54beef",
-                                "uncompressed-sha256": "c9bb864b20d49b56a10a8f08849efc4229bce8b1ceb47a47a118c9af6abcf2ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9737a8aa78c6ad033b7e6a952b2d3189e82a1df4056018818e0b91c657f3d4e4",
+                                "uncompressed-sha256": "b481f4680cc54670587ca0a885cc950b7759dae8ad06e316f33f40d1ee370375"
                             }
                         }
                     }
@@ -479,276 +478,275 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "47a7aad85081e04f725b9bedf71e8606edaf5da206f0ae8329d0568998dc7861",
-                                "uncompressed-sha256": "12542a3400640a03725f1ee9390679e52e4e3426d3ad93ce83ffbbc180e1eaf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8ce4040e5f5e7df092322092f04ce00e8ed1dfa5c2bd0c7b96641449e2185d5a",
+                                "uncompressed-sha256": "fe478f249160e8c49f401696f3b8333c177724575c4f1dd98c1f014025393e54"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "1b4bf603d5ac4e8b07c4a47ddfe654b0c648d2e6b8d9db0735de60bb5833fcf2",
-                                "uncompressed-sha256": "f5e6a61b88f3dd590c0a0b9564c7431fb7d1428b89da6f984fee4c6d51099c93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "74e84986d87004d2455714802fac472283c5e36d67e95555ebb3c60ba159c33f",
+                                "uncompressed-sha256": "52e639b45b0aa1ff809926d31e6eb57ea03e8208bf21274bf2f8b89968ed935d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b86f52d3db34f94fe41e32d480e1a0561d13605fef5aaf25a7488200d7d4c701",
-                                "uncompressed-sha256": "7f80187b70053170325c5347b3df07466a8135e2d3410ced24e812330d2d4093"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0c56a0bb0cc6f8b286b24db8a39fb29ea1e259d4df05534bdef72b19b163a2de",
+                                "uncompressed-sha256": "2b9036ae280c2db3b774d95728b83095c024a7ba7f82d503e9c560c00d579559"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "772d80d802d742f8f94ec2c61281aeed5e69a2588fd8442aabe61f464f6e182b",
-                                "uncompressed-sha256": "b24e7ed92a074171d9edc165f19646d916e1ebc94afc046b9f27c7feb36c1b2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "241c058611480ee93e8b4b27968955f8fe854f3e1f30f337ead7371cf4f4dfd7",
+                                "uncompressed-sha256": "147304afad63834ecfea0fdbf5414c61dc230f0a73f568dec9b84f76dc2b28d0"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "753a11645fbf3f7feb1c1a6a74b20f54ab90ab610d14bff9d5ed8dd3aea9f4df",
-                                "uncompressed-sha256": "de49d31743764efe92215f18035f5d037991ee37f7b665d810f4760ebb876c0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3abd2f9c5379720d7c29d612e60db669f8e6817edceec58b9aad5cf6869600e7",
+                                "uncompressed-sha256": "5fb3d4e17f88826aa51d114d92d64bd50b4cdbdb53b30eb624c2fe8ae48a123c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f956808cecaa9952bc8cadfb4489b1a76a201d0bf6c3e11f295ca7df0e658649",
-                                "uncompressed-sha256": "f71b58d5f65bfe66dc63f46142ce8ab6188f846be33cc75867a541d7423c4da6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c710cb0e7c1ba97dbd52edb5bf2373dc466f782b92c5e337a22251fb8cf49690",
+                                "uncompressed-sha256": "5cab51505caae2bf0c0facaae1c8cd87813c2465123636e4f8165c0de8221cd3"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "218d24ebb7251fdb004270792e801d6c5d5f442e9ad5c58dae0a0bf62b1f90b8",
-                                "uncompressed-sha256": "645f3ca446a51101d84628d973693fcdba710645e26ce9c1af8bc403ee48359e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "5d9d3eb23820619a760803f7b3a0beadfe29793b8ff499537346e7730ce07776",
+                                "uncompressed-sha256": "9ec15f6a40b2b22cb86c281ae88c71aaabf7cbbe3c2a54edfedf41f4fde4008c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "11f5b16cc814e61150a669f0aceda32be12e46d51a133212fe690f099ecf9db2",
-                                "uncompressed-sha256": "d98be8936c18f3f00431c1af2d09384a51092464390662aecaed5738937ac104"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ee4ca7783b375a9896f05aded26d08bf7edbbb01056b209ebf17016564666e26"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "bf4e9e43fd39b573e156bc2cfa4f447afca8f7c5650e0eee56457730a31983a2",
-                                "uncompressed-sha256": "3384ed7a57ed440aac9d0a83da5efc2e99a774fa469533ba5b04548cd2fe818c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "056c642d973f138dd5f18f09bd7011e6a846aad2a2c062c43da486498beb65c9",
+                                "uncompressed-sha256": "9506773c35a575474ecff665ab1150cfb60e2ad5df7ac30842d85995fee78a4e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "c95133115c15c3cb22824773798ce3f1bb050c9b00e086259405f1aa46da2261",
-                                "uncompressed-sha256": "ae88e8788a1264dc6ebc65ed11214aff3c9facef5d5832322d0c5cb85b061c5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "f99cda4a5d3036f7e66e9498a119665a2a642d7d33ef9a3eee5da49e4aeb411a",
+                                "uncompressed-sha256": "3aa16b2743d2f5b33ff87b2138abd16f729203452d32176cdff2a45bbaca31a4"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "58997590c2e74f43f10dae9e1d2699e8cb88ad9e9802f9ce35368673a2129010",
-                                "uncompressed-sha256": "d288535ab6c7fd7cde8c17aad1257534c602159aa0fa767b3c4cd1b8005a2a57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e020b1d6197f3cf3a327b9b1e7a7dac831b9f4abe0cba9b8f78775b9c713de78",
+                                "uncompressed-sha256": "74e03313f6325adcd34480ced35aa2fcfe6c36a3b41dd0540a644474d76d4de7"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "3e7262bb29d3715f4166bc484820cd48e2ad248046a77a9e417274838f0a6d4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ea712babe4abbc70acaa3e6e4704e5121dcd44890ba6216c934616c575a963a7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "33dd19cc4525e3a5514bc0866ced2469b1860ec2d66b02a4b35051229303dea0",
-                                "uncompressed-sha256": "96d1d6df0918f5627756c2df664065eab3247d63a5262846a2dca524d607bf4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "48efc160ecf6bd5f2d463277eae1b572cb0817ae655f8d64d19947efbc8016a0",
+                                "uncompressed-sha256": "c771c9ddcd0cde53c85689f8171aee8ceefafb2800162d3f5bea3e5dc1c4ccdc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live.x86_64.iso.sig",
-                                "sha256": "1e5557c954ba451a0c0ebe1341e58dd64f3cca3e77cf483c3fd715336e91c429"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "a402f058a5ec013f5e8949d880faa0664220676cb13aa574103192bf1b57fdc8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-kernel-x86_64.sig",
-                                "sha256": "684ebbde99ae22641508c8a7440502e07ff75ea2cba59ba93ba8bf8b0a63a9a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-kernel.x86_64.sig",
+                                "sha256": "507b2265becc1125b372233c43b044ca68d8cdeba9ed7da2544e1c98529ec289"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "0de95cb1f52c20c281563b02e35f1d0291f60b66b3ae32c02e54e5ca0cc61fda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "21778d5d2746c2d48d67c5d54c478fdb35b7792b0cea86886688b91f5ed7879f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3a33e41600a2108eb128e6a4b7481a5a244f8d7514d417e065749f2acdad4cf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "6bed7ea294c9060b9b0d9fa098b634760250384965463395467e9b761aaafa46"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "4dc3796c7fe322f8556d6a3bdc434cbca7fa687297bd2e7bfa0073bcb16f71fc",
-                                "uncompressed-sha256": "2f499a972d4752da8e4cfe137db94db843a55e0c0f4c6f8ed332af553fc2e22f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "cbd7f70bd82ae4646a0f1e491a6b6cdf37d3fbe7d4a5161343cbf1b54d192500",
+                                "uncompressed-sha256": "f93c644db63ca06aede9d1091cbe803889cb51e204a8ca4a22345eed566cd38d"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "1a2375bd0f0052d25d02b14e7db528cea5087efdb8db3aed9c220301eeb063c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "a8e6a8481672ef135279cc62be8b4c0f0dbd4338ca379414d67d38f0a880036f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "6e070e439d19f969ddd6774219cde30efcdb74c60e391c9b319a2816ae79eedf",
-                                "uncompressed-sha256": "6fe0848f6f75fabfa5f6e91b8828c30e8a0281558cba730d37f04a2412f5d834"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a2612e0aa4f5591e9243f46866e12386748419302f857cc8a9ed7e6a3fa59b67",
+                                "uncompressed-sha256": "c945e75559e034633e67256cea67927f70de462cb87dcb52735ffabcd10f8ae5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "4e19fa2181e885a9d8dedd42ae6d04efbfeedae19910e2620d02101aa6da5513",
-                                "uncompressed-sha256": "e29342b2240b2e37aa2e4974fe2cf69168e99bc239c5f31e889fe8ca3895edba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0d61e562e13d1ea42fbe76b5792269fbf1b1ff58765b4f96e82041ef0161be91",
+                                "uncompressed-sha256": "2d9f7bfcbb3e08113918602f816e1c1e82e22d1b926f7be9fae61b3363660bc9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "3cc60efd99c2be9be2212e54acdd15aa041864eb8d37aa1bf97d28c58c533b5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "0e009ce7160512418e4e1e0490d1851c5158fda4bf410d09220a2c1a0a2dd141"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "3870c6c8e6c177d8f335f8ca5b14d9eb183c2892771699de04175f355aee7b13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "9ebbcb7be8ce14e418d6318fca00384351b42a38678bce34ee5319d76afec6c8"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/41.20250331.3.0/x86_64/fedora-coreos-41.20250331.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "8e9762144f931f7c3bdb552813910b4efcc8fff4fc0088d8288f9586cbb5863b",
-                                "uncompressed-sha256": "f8761c284c72dbe36172e609d482f84cd853e52833387f521c0141bb358e5c01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "944c38b564b1c42268a2b6322470a317551b2bf83a901f3116b53ec77cf0fbd0",
+                                "uncompressed-sha256": "15be34aeacff94b9944b4340ca2579698854c13a8ce4f869233f6754b457ad0e"
                             }
                         }
                     }
@@ -758,145 +756,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-06dc2cf3d4feb31f9"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0840922d76d6eea63"
                         },
                         "ap-east-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0909776c9b727a1c7"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-03242877b45299750"
                         },
                         "ap-northeast-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0bec5bba1264376f8"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-08af52563b58e2631"
                         },
                         "ap-northeast-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0f21c54e6d5f133ab"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-02c8fed129e051591"
                         },
                         "ap-northeast-3": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0535ca867be42cbad"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-00318bfc82cc8059b"
                         },
                         "ap-south-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0427c83a5e31b42b2"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0b2b6aeab3e51249e"
                         },
                         "ap-south-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-07afbe6594cdfcacb"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0d922ab78df3dac93"
                         },
                         "ap-southeast-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0c7db2c32d74847b9"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0d9312777f2badf20"
                         },
                         "ap-southeast-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-009048d73c2c3fe13"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-018f07da7c6e2fd75"
                         },
                         "ap-southeast-3": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0495cfa6529c0f91c"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-00bcfa5587d58c6b9"
                         },
                         "ap-southeast-4": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-01e95eed4b0bdffa6"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0f8945241defc35f2"
                         },
                         "ap-southeast-5": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0e9d7fc85c299daad"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0093d8c47bd2a7f3f"
                         },
                         "ap-southeast-7": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-095fdf39ec26f2a83"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0bbbe4cc999c7de02"
                         },
                         "ca-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0d550d7d070bf0b32"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-04fec6dab80cdee76"
                         },
                         "ca-west-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0eff9a7171e96f45b"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-024dd65aae9d0da3c"
                         },
                         "eu-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0ca3c87d880208d80"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0998131c618e96f66"
                         },
                         "eu-central-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0fae48b86f1d2d195"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0e56a50fa792f15cb"
                         },
                         "eu-north-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-07c51a21357f8cacd"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-001cf9fa498c91d10"
                         },
                         "eu-south-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0421e5c6631c1b81b"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0d224fa5b3fa4d8a4"
                         },
                         "eu-south-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0a4d7a4962e3b82a6"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0cd891454cb179c42"
                         },
                         "eu-west-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0c0346521e2017d12"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-05fa99f9816e910b2"
                         },
                         "eu-west-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-02ca3cdad06475523"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-04f4245fa55c053a0"
                         },
                         "eu-west-3": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-063a516c93fe77339"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0561e36024ad462f4"
                         },
                         "il-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0a723e4687165b6ef"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0fb3d26829b0d93f0"
                         },
                         "me-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-06159de5ca4dd41ac"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-09f10000bc5a6a309"
                         },
                         "me-south-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0d91889d61d19a4d8"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-02592f13ce42a2096"
                         },
                         "mx-central-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0ee0aaf707cdd00e3"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0dece810838138193"
                         },
                         "sa-east-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0da93b655d1d41b37"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-0a75e028e091a685d"
                         },
                         "us-east-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-03b38f32afb4acd02"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-03a7950d1665eb833"
                         },
                         "us-east-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-041f41ee451858149"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-01770610ac72c32bf"
                         },
                         "us-west-1": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0784bb90bbe65dbbd"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-049e9fe3c53d48bbf"
                         },
                         "us-west-2": {
-                            "release": "41.20250331.3.0",
-                            "image": "ami-0e79f4ebc83cd6e13"
+                            "release": "42.20250410.3.1",
+                            "image": "ami-023fd4649369bff3a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-41-20250331-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250410-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "41.20250331.3.0",
+                    "release": "42.20250410.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2d0ad606533da95ffb130c9a7a1f6b1933e2341a95077efa599c0b8540cad9d0"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8b0482503cef336b4ed4bd6a72b689763e75119d66cbe4227d02e20d03a8d7c5"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,156 +1,156 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-04-23T23:43:15Z",
+        "last-modified": "2025-04-29T15:47:29Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "b9fe72def1dde5ea873ebca5df4fc4d0f3ca762c5df7f508327d16caaad299f6",
-                                "uncompressed-sha256": "63ad0e34fd89a0a9df2887958bf0540a1da7d4d5810eb33f5a8e98af66c5f3d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "0532ce85e31dd797464be2fed42bed77d6ed605beaec15ae47f5df890b829197",
+                                "uncompressed-sha256": "3be0fbc658318dfebce4962bd805903298d1893cfe7cc0c54f98e74cec581d00"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a3124194222f1df7c7cdbb10dcf131e303c9ff62ebbe0e25d998fd872970e1f3",
-                                "uncompressed-sha256": "83ff0335a10ddb804051ab4c73a2130ec0ebd225accc3d63cfbb14f55fe3bc0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "13fda5809101fad4a9e56e37e474304c73508359b51d08e030136c6f448ee66d",
+                                "uncompressed-sha256": "71250a9ff26c1133e77fc72bb84e88188e6a7361bebedc141df4abe533309510"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "3d47c67c80c0f6d75732ba02494adc4787b427dae890fcb8f9508fd563317b95",
-                                "uncompressed-sha256": "3546a869b6d7b7018d8ca04d4fd3fb284958d64a8056ae666506c42fca271888"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "69a3a893d14e4d38ec6d47154e900d69874e6e9b9359dfbf40bc7d13491792fc",
+                                "uncompressed-sha256": "7f4423fab516b3a59677af4ff1d35496e85d2cd7e878e4697dee837b22b1136f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "1aef4549fbc64671ea3da579ea94665f658505ed205238e3f5f21a277014e0cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "3013e39a26b9ea72f387e65b2aee7f75f24c2a5dec342481c048fb4c5c58d1b3"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "15283946402f92a804abee0dc87e9221543e403e90d9aa433e446ffecd281b15",
-                                "uncompressed-sha256": "b2b1aa8a7af70746bbe35de120976bf396502bf6d7eeeb265d828365593bc3bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "d88a4fda12e98fb1509cc367f44ef3ac50476351fba37d72e5405b0c4886fc0b",
+                                "uncompressed-sha256": "2d731688de0912efbb677c65c62dbf4c2faacbc63327e74f5b46e922f2c8c41c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "864c2fdf3a77c0a2bf36020784deb1ebe6c0933b906930d796a2556a85664f5e",
-                                "uncompressed-sha256": "2767781f634d82f876f323167c2b1b1704fabd8c1befb28a728964e81033da04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "844bb937973013834a5d5202fe33044aabcb576795f2eab8d5639b218e7085e9",
+                                "uncompressed-sha256": "e7c63835ac613f0b9090d6fffd8158fba27c69ae64519a4d58139b30d4f7058e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "898804ed048e6d1d26a06020c3ba76e67dd1f3da78717d6a90180aac68fcf97e",
-                                "uncompressed-sha256": "435739ba1b5e37f694372d45806853e896a3e750b476aed5ef8cc7d765409f2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "83586f70f8c877ef36841c58b696601e57f7496b0a6d14198114cfdf9e0ad15e",
+                                "uncompressed-sha256": "d03fb5040a31cca9d50a03e0e7caf481cf8a69ea09357e4fa771113f0ef88778"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "dc20d54fba4449b70f5f53ef05fafd001f626b464400d9c7e83a6b635eb4e5d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "61758f876f65dfb441a8059264d777ed850249891eae1bef77890a14f98347e0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-live-kernel.aarch64.sig",
-                                "sha256": "e249c9d6d365dc640215ab759e18d2a8ff06db2aea29fcb4f4d13e3392f4a25a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-kernel.aarch64.sig",
+                                "sha256": "b6b04e199b69d49af1e93f81e40335b8c6a66fffef496714bd009de54cdcc618"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "487bcb9bd132514f03ad894ece873b8287a9af18e132c38d2bc11c43e8484cbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "8f56d87517b637cca899a739684a6c0b145075e2cd8f987a63c9acbeff3a62f7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "e3a5b1dff59616578158c31fa5f54aec0fc9af2e4b77a8e3e67ccea3d8bd7738"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "2cbb2c35c9e7625e5f61558f9fddf10ef801765ffe9fc83602aeec8c4a615273"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "10affc555e68918c25663f1bee359c7716aff967566ddc79888d37cb2ae7147b",
-                                "uncompressed-sha256": "e4528394038162a6e8fbf4294b51763fbc2a1912ff229c789369c6095d610ac3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "3b36ec6b5cadda1af00e350032afec9082d90ec53b0cd3e0439ff9ca02cdbe91",
+                                "uncompressed-sha256": "3ec8010042fd023a4986b8cb2b7490e9fc21bbccb42f583c7abd6a4247f90c3f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6c7bf4a3843791cb3221cc90352d4062cf77b14d8536321d269252ef08b97248",
-                                "uncompressed-sha256": "7d1a7dcdc99a32ea4ed1a3057159fffcf057c3d15ba2cf6adba889fa704a06d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6b19235998280a04f8137c1c1ca697e948b58296b7836683a54c2a53bfafc7a1",
+                                "uncompressed-sha256": "cd4b9826e8697cabc2e56559a8801f1cab77c4f3f28b67e2732709f8bcd05a81"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/aarch64/fedora-coreos-42.20250410.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "ce49148b593b1bf24cabbac79fea0fa851c4c184c7f8f18873315bc5b02315c9",
-                                "uncompressed-sha256": "e514940b341320a6e2616f6876b9d352d6fa970558294dfcd2790db0dff8c6c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "bb23cd3086ed446c560d6ee839a23af699d2621a2acf5390ee283c0c9966ee38",
+                                "uncompressed-sha256": "8258b2a99cd01bdab4c7442c78e6069b9afd28218d05051821350d1c5b3476e1"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-09f688d7e69ed0645"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-047a7a7abbae2c317"
                         },
                         "ap-east-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-056e2fd7999acf37d"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0f6700db54681a4c5"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-053a1312a6ccf8abf"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-016718a4fdbb485da"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0b996a59c2d817015"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-017a4bf4cb896f88b"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-05a86d0a53dafe0a5"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-06f3fc603f5a67480"
                         },
                         "ap-south-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0f6692b5257fe111b"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0f50939910e31d6fe"
                         },
                         "ap-south-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-01df8efcf10968786"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-02783918585423269"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-096b8fcc936399a11"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-014777f3a420aeab8"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-08378c130815a8474"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-00dceedaac2ebac5c"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0fc33e20a7e52a7ec"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-034a981a761bd49be"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-09c9839720e0066c2"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0938fd0fb391f183e"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0a75454d126ea6b61"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0a6ec29708ad24720"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-03bd1e90eaa26d144"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0272ecf7622172a8a"
                         },
                         "ca-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0a6f9af161ddb8d8b"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-06df06ee126342aad"
                         },
                         "ca-west-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-08e5ad17606eca923"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-045987e82f9f595d6"
                         },
                         "eu-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-07c28c7b2f66a4477"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0ce83bc1e106b938e"
                         },
                         "eu-central-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0edc7d885e2bc1b1f"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-01ddf2029cfde0f19"
                         },
                         "eu-north-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0928ba751dd25417e"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0a88825313ea862c1"
                         },
                         "eu-south-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-05aece0b07035ec31"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-09559d98c5475a0a9"
                         },
                         "eu-south-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0c0bb9dfc8dbd5924"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0f4bd90b19ae07eae"
                         },
                         "eu-west-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-003a59ec00fe8668a"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-070ccb36d679c0fac"
                         },
                         "eu-west-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0661977beefe2f46c"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-09b4da79b2b70ec13"
                         },
                         "eu-west-3": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-06a87f7c323dc14dc"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-038fbc04ae39a52cf"
                         },
                         "il-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0ebf34a9558b413fb"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0605588dbc4a696cb"
                         },
                         "me-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-05742cf63a1176cd7"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0072060e3cd077efa"
                         },
                         "me-south-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-04a7d23ca82519a15"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-010f73b19f56f315f"
                         },
                         "mx-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-00ed0e0e024b8362f"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0407bed0dbef83e33"
                         },
                         "sa-east-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0dfa3b4517a157ee2"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-08d50d098a706803e"
                         },
                         "us-east-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0c15f166773b07369"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0e7896a4e9fe05bf4"
                         },
                         "us-east-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-016e23ed26c3be2aa"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-074209c5a52f8ad5a"
                         },
                         "us-west-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0f93edfc4b60a23f3"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-00c4a89181d228574"
                         },
                         "us-west-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0c371bff7d7621af5"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-083b5b6b4643cb8b6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250410-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250427-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "7356b36625cdf2942b00fcd147497e820472b957f7e80f5af39b82d5a88fde27",
-                                "uncompressed-sha256": "af38d6436367ee8e7d81b5c5acc3f511e5118ccdbcedede6b060d1cf7499ffe6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "8ebf7303a687610c057a95f963be17e305e3e94962ccca5ed03f41c683b950d2",
+                                "uncompressed-sha256": "27fc5c04d25a3f381c9de20b87a6033f43a45b05511f39fa3fa1cec3f535f1d4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "62c5f6a20abd7ee0ab7f95cafb92b55eac559e05bc5b14453841fbe48ed3d0d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "ccf58657d3f5ccfc7c9eee44ea61892675c520fab805873ee051527586ec9bd9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "4a522a1b85554d5f4f7aa0aa0cee8d1ccf877165c5c4751247956a51d4a1958b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "0aa34c5f7860ac4f37d199b034d154fd298e9d044ab6994afb02086fde6bacd3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5b576a12525497ca0273c26be43e75f25ebd1646128f79f132fcb7e40ab62e79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "c6ebfe731bdc0567f50ad642474c99a4e131cf1cac5ef690338a930c74822227"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "16c1cd63eafc179a3587271bbaebbc9feb012597e778427087cb3a47c2917e48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "18ae9f9d3a20fd80d2152ad8b89e6d9b31b5a448a0955dbdda6b75ac479ebebc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "469a4a9bebf7af5061307b3263cd9d1fdb5731264c3d8971ec3ff43bf8860007",
-                                "uncompressed-sha256": "d62d084eb2fb18b1ec8496fb2b52a86784ffee93b53eead932761066b2141f4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "5e29d7a6d60a077bf976a574dfefbba029d0c75ccae7d88309c1c3470b6fa16f",
+                                "uncompressed-sha256": "d07541f63a63386cf0c1947c21cd6407a4f345dbe6134f0db2395b9a05992add"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a3f16a270d711f461badd6203762cfda8b036baa279f4f5cf33b5de1b798b57a",
-                                "uncompressed-sha256": "1a7c05540e1f5f883ef12ba1fed2e199a418a14f0e6929ce22b302f72a8ab359"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "cc0db19d78c83d27924a5ab8d611bca97127595ad27ec5b15b6c972acf7de8ff",
+                                "uncompressed-sha256": "c23a5dbd8088ed73f43806513096f76f75c64fe094ab09e660d89fb5b5c6a0cd"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "e5334f4824ade1a5d2ffbb74dabd09887ab39da3e58fab65e840db2adb056930",
-                                "uncompressed-sha256": "26a943482f0ce06d17c92de553562206d20c5cd1d79e664772cdfef6d6c660ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "58fc8389a3c798435e292a1693fde6e9c352e6ab397e13347acd0700b72dbed2",
+                                "uncompressed-sha256": "a179238cd3a2805380b4043892c14f730d461288117a78bcc5bc0dbd5355a492"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/ppc64le/fedora-coreos-42.20250410.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "070a6063304b3835b9030e569acb99df87baf79c548dce43bf70594b52e6a5e3",
-                                "uncompressed-sha256": "b32b8c0652d62b1e5e6c611ecf5987b30f3f72d3f054990d7027cd8833b0874b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "364a8f6dae7ec0784e6679c7053977c507b2de7f5756e10b2bc15260ac47dac8",
+                                "uncompressed-sha256": "d4eb505cd91c51f778426917bf0510464131c37007c6fee03e4f5a1df23cf715"
                             }
                         }
                     }
@@ -389,85 +389,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4ca88902bfcf970a54583d326bf122dbc0db9acc56910b076bda467875062b61",
-                                "uncompressed-sha256": "e5981aeccc9282edcbb956a60f8fdd903528c040698392ad299e3726a5f4e68e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9a1d8f5e2c50bc0a61e2a2dc108652eed0d9935682259c8b03fac843ebccf6fa",
+                                "uncompressed-sha256": "50f96fc3a2bd6f870f51c4728bd8395f7b1932e6dce5d87471b20dad89289e22"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1503ea65454a7c9fc08035b48292fb239baa29bf35e7c90f85eaa2c9efbe5020",
-                                "uncompressed-sha256": "4b7dc36f8280309a9363c2e9f8f5356a7a76dc362caf70b0d09a5d131648987b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4a026979ec4db2cc1dd91410f998122fbcd4d1731a3e6281243a86552d625547",
+                                "uncompressed-sha256": "eb7b3d7d36e41bb42573e931910726c9d1b0370d13ed17054b085ae339585c76"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "3cb2678620bbfe91bf184b2b04a2ff4f5593d0bf63d80598d123a62552b4b9fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "10470b46ce87d5fe71241c80d3f6ff8c30688b478d34817773a7f67b40c908a9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-live-kernel.s390x.sig",
-                                "sha256": "1e340eca4d780fbf5ebc94e683060463acd1725ceb437bc0c7e30994701cf835"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-kernel.s390x.sig",
+                                "sha256": "47bfcd274f467ba058929e38489b7d383272f37d36326bd91da4b4097fd38698"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "d88dbb4035ecbcd38f45b7446bfd1bd337017f35b015d0dbbf4a118d238553ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "fa55b85babbf0065efcb13ca2c1a8a361e91dc1274c972e29948572cf19eccce"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "e28e2d15f40f22b5ac9dec404d5f7ab9612998c5f9ac5cdb57315bbb33a6ad0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "973f8e13ede2121ab2918d4cf1046e090b7c8ff3c0c8430bf1270404bf2aecc4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "143963c301b8650172a67382be59e6c1582f498bfe3ad24fc7f59d78fab40633",
-                                "uncompressed-sha256": "88b795de2f4b08cd5281e11d694ef96bdff6764f66c32a5241f9793d07920680"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "d8a6ddd2c37051302759b4d5d39e4e416f355616817f03b5ce52b14c799315f4",
+                                "uncompressed-sha256": "e9bc72563b3efc667abc952250ae14a0ae03e81297c43dc392909465b63bf759"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "553c6a001c2b2af9b834b12bffdf8454f16edb22987477616b18852355459200",
-                                "uncompressed-sha256": "f81032b80e196979b6d0d3982a4a83386be1f9a304c3005c8f5729ae8f6ac2ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "414ca6f0e15f4d5569ccfe3c0804857b058154a72eb2cef5f586264eacf56622",
+                                "uncompressed-sha256": "83a47871ce5fdfab9d4e6f8806891b991ee1cc28b5d407bcd7b5c1761bbadb46"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/s390x/fedora-coreos-42.20250410.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "619bcb5710580c0a2997375f95ea0e35befad0095fc709fd3529481b1e6f9fab",
-                                "uncompressed-sha256": "13cf3dbb4d9f4c5a262d1bf48e4c6c4fa8d9b058b770d17a0d7ac48e061f248b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "8eaf1e0ce9b51774f70e853c2630dcf9d8fbb934bfd8785f852e29b4bb3e7ff6",
+                                "uncompressed-sha256": "da1b3b29199c8776dc07543c3e14ff281d2e16bba186d04fdb3013078c2700ad"
                             }
                         }
                     }
@@ -478,275 +478,275 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b523d96a028ca5d1ac6b5cd4d4576d82733f5cd5796aa54cf47ff4ad552a6153",
-                                "uncompressed-sha256": "deaccdcc3d15e1bb0ba92108a43e3ccba4f26a6a127d5cc0a535a7d07c31f3e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2e183250f38c75494ef7ef621c0ab61825d5d652f6186e2f97513d0e88049115",
+                                "uncompressed-sha256": "db01819fd95161c86dd564a126ed58fc9ba4f594ad8836b58aea725bee64452b"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "2e6bd570e667cbb13675d9acd334fdc77a196da4a4d6070ab8a0f42274be2539",
-                                "uncompressed-sha256": "1047c7ab86d2a3047be648e328f11a936f084dee950f253221bccf3e862706e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "23e601188d8604a7cc882324db0dedbe6e5b59e2eb6d7e8ddf37e637a21f9bf0",
+                                "uncompressed-sha256": "a4162b48dbdf8272ffbdc281327c7d110ec99a7d263fdd3dbe2d4f9c5e37cb9e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c62f3accbada8060e9db8306e01435bc71a3e6bcdb7d504c94960540aa2a2a75",
-                                "uncompressed-sha256": "256f32a3ceaf6c113d11f51bf92f761fb6f62c67d2ae729789b71b3544323a23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "dd229ca50910a0fc9fc2bfe941a16138a18b25a730ca791beff500c472936370",
+                                "uncompressed-sha256": "96a06ad88e1f955ef4c697ea72a80bc90a531bbb071658ab959ebebeba0664f4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9dc0598b2bfc64a8f4c1c30cccc329dc6a9b04bde46ed6b4484f2eef052ed42a",
-                                "uncompressed-sha256": "2d720dc9de93b86dc47b3d2c24b3fa138e50b9fbd9e99d6dd4fbfb522257895d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "18669681287afbcf489ed3b7651f31545712eacd7eb14829b1318f0cecde154a",
+                                "uncompressed-sha256": "3279f688f86afca8f9741ffd2e2bd7d8ccf93a9aa9fd5beef7ecca45ca3d3951"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f4439531b4ca4ed42477bfcb27d159295f6f670b9813e3c087888a68df157c86",
-                                "uncompressed-sha256": "e3ebf0ce46c5ad09a382343bb6573a694758e8ee166b104b9cfcc800fe345889"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "52ad31773df18ad09aa321cd183bc1d6bd276814ed2ee7f5c9482d617fbc23df",
+                                "uncompressed-sha256": "ee9006b49f5f11e207ba1aaee7341325555162b749130758694ff7501d23c96d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8d446696d86be9794f8ec98dae5ca0fd1c28adf2f3a58011c6cf8c58b0cdf098",
-                                "uncompressed-sha256": "387ebfef6220cf27cfd15b88a1a25dd4ea7079503082bcf54460bcabeea49aa0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c638b6cd4cc37ba0035bda91a945695a3787522a08daa935b79beb37e4ebdc56",
+                                "uncompressed-sha256": "2c6a5009daa612b08f02e42146daf38d0c65061ea68cc9ffd07e3f38270d0c61"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "83afbc18d0faaaf0601c2bbe8ecccf104a571ed5fa4d48728f66682a66e04319",
-                                "uncompressed-sha256": "fbfdd1121958850db1afe3ed6477de424cd13230821281b99685fb5116c1db5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4dacb42c157883c2e618f0c4a3c90b0ef54e94bd504d5198e998a5505e7ff53e",
+                                "uncompressed-sha256": "1e608a84147964e0bc1b4a58cd13777caf80508ce98f3977489ae88661efa1ec"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3c0e138e36625e8c2e32b3d063b2c30777a9b68d6f109b5db80c2a827b08fd06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "7799091e74b82b5b85bae1e206662615ae2ed04c3cb1cc43b64c8a0a9f342ac9"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "5cfe1eb36ac5ba08a225b94bd1e2363c8714b60f4a364243d0ca77c5123f31d8",
-                                "uncompressed-sha256": "bf2f65393d24f7dab6c97df090707e6df03414b05b7ebaaf3456edce73bdcdc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "f73c32769cf20c9054026494319b7c11fafa4b8050fe3d979b008fdfec254931",
+                                "uncompressed-sha256": "038247b15b8e3756a718ff1be086c8cae3d896216a429b07d8fd05b66ddd7cce"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "89d3b99d48cb3d037304989c2a95cf4f718c36714739275e030ba0103bcfd3d4",
-                                "uncompressed-sha256": "894d55605fc7287aa6db5fea2a1a8689e195d5daddb898aff45e3f61dcf8bd1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "58b2a9fea2c5242b9c360ef76bb5b5610621dce79d8c133016798f1380f13d8e",
+                                "uncompressed-sha256": "b7111176fb6eba3d56e320bfbff01c8fa1b28142442cb0fa2eb32b639b17a639"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "db7aaa765efe9ee7e86904470563bc3af001fab925fcb400e37f6dae8c0e0777",
-                                "uncompressed-sha256": "7baab094ee930920c775ee4affccf9b6eb87ed20b135b12d161fb4e65fd3f0f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "bc8c70993d22eb3e827a3f717299ab8a40d376ff1dcd979f3f737f470934c1ce",
+                                "uncompressed-sha256": "3ce60b12ffc14eb8f90ef16ff6b01fd67236436a81a7c06683da045c3a07b676"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "50eb2d128e2c3dbda36a8942f844878352f9a9603863b049619e6535798e84b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "35b8b4f48302d01abda66b5e44e20170e09148511c54be23c89e7bd03c6251b4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9a0ef0a9da19673575a3972a6d1718a875d225fcf1f4af95a1e059a444719d95",
-                                "uncompressed-sha256": "c3a60fd6d2f8ad2a2089415012161ffc35266af6a8afcbd045a90bdea6e9fda0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4a83ed7ae5702dcf781df3b544351a944d013967dfa36812e49dc446f248fb60",
+                                "uncompressed-sha256": "9f182fcd86b14acecb02c907c72862a1c50d30b9d5c06b2836f7c080d064bc02"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "c57c2b38fa92b26e55ac2c588611e7264285dd07712a59bc68511952146c928c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "bbd2e4254c77df778b664185639ca17ed5af5090cf2d7d2a2b65b0ccae9266f1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-live-kernel.x86_64.sig",
-                                "sha256": "507b2265becc1125b372233c43b044ca68d8cdeba9ed7da2544e1c98529ec289"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-kernel.x86_64.sig",
+                                "sha256": "aa30a5cc0328207724fdb75f6b1c9298d5cb979200ebf8c008643ef2f65e8122"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "42457f8d430687c55c06e1d129144f4230b4d6933958dc33c690ca59d2dcab45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "6dc59922da68c581ea9a7b94fb42e8c024c10833e0b3e2d6487b32f1b83235fc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "1803b70a64ca1d3eca77977236e9337f9d34936adf496141d48a40ffd3e12633"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6e83fc879cf938dfccae5a7f3eda77b453d472fc76549f153c12466e31895d03"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "d6ffe8edbab2f0dd7cdb53c543183f73ca50c4414f70809b1074d5db4f65aa2d",
-                                "uncompressed-sha256": "c90f793e42da48738d7449e520529b525f2ee12f4669680e2d7b71807d8f82d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b250aade0f899af4e8f728431d7d48e18350999a26e47a91a2cb75dc7a7c250d",
+                                "uncompressed-sha256": "04027a88bf921bc2b23d7ba88d0a74219027738bf791b02305827d6b2f0a08c8"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "49dfa2a328feafd0574a076205c373036829500410631f15723a5309c93da0a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "3729c7b27e60c112f5f88f2b605ccd28299a74a7430e21f9e58906e91ab2cdf7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "34d2b0fcab6120e4c9580542cdeb9858406a804efcb1f709c547295855aae5dd",
-                                "uncompressed-sha256": "d6ac735ec549401bed95709403e0b7c260cd0c066271441b2a259436fd89a2a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "308a040992e67463a7b99455403d69a8fb5e6a45007025a686a689e1ca52abdf",
+                                "uncompressed-sha256": "428be1fd958c11f010d5c891e2b5a63105368c96ee436c6e5f8a4c8dee7bcd69"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "cf51ee090c575e78769fe25598e0dbad15269217aa1d0dd5c49ad7cff495fcc5",
-                                "uncompressed-sha256": "79b119c22b77cf7f42945912cff9f7b6e36c6c2c0d2ff3a280be71ad689cb2cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3f0d1bd5827c05151009d29147e3f385d0b83c43ee6c678d0dcc49a3807e51ee",
+                                "uncompressed-sha256": "02570f854a239ae36457672256ed51dfb884844cb8c912aa3d7dd0f31ef68a2e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "5c9bb3722eda8d1aad7584534bc1e04355d1f879359d1f8a4efe3f8048c896c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "5b668908a1060a68069ce47d07c8992aeb85bc284616ef182a502d616583c619"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "7cd426d61eb9bd7b1b3a7920ade9cb19cbbd3ab130da63d80f32cabf6bc3962f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "5d821bd72777525ec55ebeaa57e3d888187848ade62b05a4902e566572e25642"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250410.2.1/x86_64/fedora-coreos-42.20250410.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "093674634922441f435d7a3fd4c5f8b040b791dce248a43d6a4bca635f0993e0",
-                                "uncompressed-sha256": "42d6d8e9f02abb35e795bcfcdf65a3224c9aa35d0b37e5b51e88f7dc7c4e7a8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c7a0cf83b13da4fa3162309049dfc5bcabef9720d7cda22070e3030fe2cbcf31",
+                                "uncompressed-sha256": "21bcc663aaaff4f62ad6089f58b1a265163d51885c8433e22adb37296a55bac9"
                             }
                         }
                     }
@@ -756,145 +756,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0c29a6aff323ddd4a"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0d606c80217e45709"
                         },
                         "ap-east-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0827e32ae71550fc6"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-048c32ac281edfa3d"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0b72586e6a87f63cb"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0cae5b701ab14b1dc"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-06fc9e0c655ac6a4d"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0c3d1b273df5d0446"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0a96fc2729ec8a1a0"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0bdff18c2ddac87ab"
                         },
                         "ap-south-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0d0401ea992d053a5"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-094320f183aa52071"
                         },
                         "ap-south-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-063a68dcc9ab8a9e5"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-04300bb8c5e665e94"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0397a016f032e5cb9"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-060882626a42941c7"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-06d204f195d8f0b95"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-06ae1b17af6a78ce9"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0f313d71c661da97f"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-075dc660657ad5c0c"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-02ad1ce899cd63dbc"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0859a026fe47bc4c8"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-042b2be874b1f4538"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0a57118fc22917be0"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0bb74477546c5b089"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0241916285e23af1a"
                         },
                         "ca-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0f301c3b0f7fba353"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0a5be937f3822b2f6"
                         },
                         "ca-west-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0e96156d18fc3509a"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0bf825759c956f098"
                         },
                         "eu-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-009aafb6a635274dd"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0e85684681bd0ffc0"
                         },
                         "eu-central-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-003f3873f8739606e"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-012c7b3f66e47d009"
                         },
                         "eu-north-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0c436372597ed3d2d"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0cd04cd3ca8c10b3a"
                         },
                         "eu-south-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-08647b4d9e2b7ad20"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0c16cddb733c69906"
                         },
                         "eu-south-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0b7b0163f40962464"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0c8b80687bb224f76"
                         },
                         "eu-west-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0c5b47ae0e65e56eb"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0e1034687765e2032"
                         },
                         "eu-west-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0106ee458701af166"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-03fddb966fba18316"
                         },
                         "eu-west-3": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0844b29c63eb9528e"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-029771d45deefe4cd"
                         },
                         "il-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-01513203918f27610"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0f762210bc8f5262f"
                         },
                         "me-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0dd29bc7cbddab34b"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-01cf8c41357ebb9a7"
                         },
                         "me-south-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-037f8446aca53bb44"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-05797316d3978ef15"
                         },
                         "mx-central-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-06fc125651ca9c1bf"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0687ecc981cbc5bfd"
                         },
                         "sa-east-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-07eced2a4959f9c37"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0b9552a0d79ba947f"
                         },
                         "us-east-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-056eb29e44db75a4b"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-044e139e2a8622c02"
                         },
                         "us-east-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-03d26a9425686fc9c"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0405b958901ad225a"
                         },
                         "us-west-1": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-08f83aed6312854db"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-0016182663a2c2274"
                         },
                         "us-west-2": {
-                            "release": "42.20250410.2.1",
-                            "image": "ami-0d3e791c567925a11"
+                            "release": "42.20250427.2.0",
+                            "image": "ami-07023572e2cf19d6d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250410-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250427-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250410.2.1",
+                    "release": "42.20250427.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:783a6bcc860bbe8df8d1084192d3c2a6473c9cb54a5a1e72375f12551cab99db"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:67d973a8e77f7cd10abb8bd8cec1eaeeed26c5cad4632a90085e95e31d0014eb"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-04-15T14:06:34Z"
+    "last-modified": "2025-04-29T15:47:30Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "42.20250410.1.1",
+      "version": "42.20250414.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "42.20250414.1.0",
+      "version": "42.20250427.1.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1744727400,
+          "duration_minutes": 2880,
+          "start_epoch": 1745942400,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -121,6 +121,9 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-04-15T14:06:31Z"
+    "last-modified": "2025-04-29T15:47:29Z"
   },
   "releases": [
     {
@@ -117,7 +117,7 @@
       }
     },
     {
-      "version": "41.20250315.3.0",
+      "version": "41.20250331.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -125,11 +125,11 @@
       }
     },
     {
-      "version": "41.20250331.3.0",
+      "version": "42.20250410.3.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1744727400,
+          "duration_minutes": 2880,
+          "start_epoch": 1745942400,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-04-23T23:43:16Z"
+    "last-modified": "2025-04-29T15:47:30Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250410.2.0",
+      "version": "42.20250410.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250410.2.1",
+      "version": "42.20250427.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1745503200,
+          "start_epoch": 1745942400,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).