### PR TITLE
updates/stable: pause stable rollout

### DIFF
--- a/updates/stable.json
+++ b/updates/stable.json
@@ -126,16 +126,6 @@
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
-    },
-    {
-      "version": "42.20250410.3.1",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1745942400,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
There is a docker networking issue that we are investigating. https://github.com/coreos/fedora-coreos-tracker/issues/1939