### PR TITLE
release-notes: updates for the 2025-04-29 releases

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -1,4 +1,12 @@
 releases:
+  42.20250427.1.0:
+    issues:
+      - text: "Docker Swarm DNS resolution failing in F42"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1933"
+      - text: "Occasional docker crashes on moby-engine-27.5.1-1.fc42"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1918"
+      - text: "No network for moby/docker containers after F42 update"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1939"
   42.20250414.1.0:
     issues: []
   42.20250410.1.1:

--- a/release-notes/stable.yml
+++ b/release-notes/stable.yml
@@ -1,4 +1,24 @@
 releases:
+  42.20250410.3.2:
+    issues:
+      - text: "Docker Swarm DNS resolution failing in F42"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1933"
+      - text: "No network for moby/docker containers after F42 update"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1939"
+  42.20250410.3.1:
+    issues:
+      - text: "Rebase onto Fedora 42"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1851"
+      - text: "Switch live rootfs from squashfs to EROFS"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1852"
+      - text: "Switch to using OSBuild for more cloud artifacts"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1891"
+      - text: "Switch to using OSBuild for the live artifacts"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1725"  
+      - text: "Move from OSTree to OCI for updates of new systems"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1823"
+      - text: "systemd-systemd unmerge + merge results in broken system"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1744"
   41.20250331.3.0:
     issues: []
   41.20250315.3.0:

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -1,8 +1,12 @@
 releases:
-  42.20250410.2.1:
+  42.20250427.2.0:
     issues:
       - text: "Docker Swarm DNS resolution failing in F42"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1933"
+      - text: "No network for moby/docker containers after F42 update"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1939"
+  42.20250410.2.1:
+    issues:
       - text: "Occasional docker crashes on moby-engine-27.5.1-1.fc42"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1918"
   42.20250410.2.0:


### PR DESCRIPTION
- https://github.com/coreos/fedora-coreos-streams/issues/1053
- https://github.com/coreos/fedora-coreos-streams/issues/1055
- https://github.com/coreos/fedora-coreos-streams/issues/1056

release notes are also included for https://github.com/coreos/fedora-coreos-streams/issues/1066, so we might want to wait until it's officially released to merge this.