### PR TITLE
Roll out stable 42.20250410.3.2

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,156 +1,156 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-04-29T15:47:28Z",
+        "last-modified": "2025-05-01T13:32:39Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "b08d370ce95e0cb424da35f54b2891360eaab2fc8c04d86d03565369b89f89ae",
-                                "uncompressed-sha256": "c7d3694f03db48cf734400a8c86fea1b53ab8269e8b73f1bae223bd0eefef262"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-applehv.aarch64.raw.gz.sig",
+                                "sha256": "1849a1e2d68ccfab033d2d9aa81d127eb32862672d8ed1e58f82e0710debbd3e",
+                                "uncompressed-sha256": "5dd26bb2b9c8245980a92951e411d72ecea7ba10c8fff143a6ff3944a76fac9b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b97aff712a864c206b3d05610f94b943cf87d901dd1f02a09fffe6f9b9f58c1d",
-                                "uncompressed-sha256": "97b885de1476604635f1b0456a57eedd92be2bf88d47a970e98821c10e756d82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "99237485553695eda176d713cac53dfc8499c3a10b13746f364197f8501029fe",
+                                "uncompressed-sha256": "937a8faf2af19155d78b3395814117af8c35f5b805a6e056cbfdfb26408ac9bc"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "239bf67f0787106ebfe49fbd6954644caa9fb370c1dc2286eb2865fab07ae936",
-                                "uncompressed-sha256": "7b608bcde98760e4635709061423d149084392b71d394c364eeecd80714cfc9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c39cb3876bad8733b2c78359151f47d2f749395b9eaf63767cd2d42f5ec9f4fb",
+                                "uncompressed-sha256": "68133ce2264f14157306ade2c8ac57c3a3734297581f82480e344ba3481aa5ad"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "bdcbdcf99d3ba8b16e7041ce8406b0f1c92aac5474d786d313ccf7168d21df77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-gcp.aarch64.tar.gz.sig",
+                                "sha256": "73ffb71b10c84c7a6844673ed011c9b23e72fc6dfb785b8fb163ac6ec488cdee"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "b5d46ba883561ebb7a154326950d7dbacfe8f058ac46b58c061a7b0bf7dd8e06",
-                                "uncompressed-sha256": "c37258945766d5019ae424992c92caaf4b27e137d5cbe22550feda2142d0446d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "ade4918759d95d260d2054b79011b4b0b54141ee33ee5ed20034b7d21d65474a",
+                                "uncompressed-sha256": "90d14fadc8039c9c12b840269d26398193b41e4a496147dd4618326ef6ef11c9"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "03e3f57801ae18858ccc38930cc071c4e99d6dad1775023f425728bcf4f054f3",
-                                "uncompressed-sha256": "f4496b2b8ba888e758e9586cdaa55d8a2a8a4b5d7f93495403c67670e55ecffe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "589aad1839857d04a6a648b846324071d6f12d39e55d05f850f431e3559f96be",
+                                "uncompressed-sha256": "127f3d7cf434f99632ab855ba412e3ab379d7da0a2ff093632dd41aef6962ef3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d39e0b59b5e4eaf7a6f98d5b11c69b4d90fb24ac08b521de2910b292018d6f85",
-                                "uncompressed-sha256": "55a9f0e07725a7a25e8fed92011e1bd019a48dddd1c64f807b5308b94562eb42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f82075ff7b2b0204cac326f59ab9d2499370ae274577aa1fb46a492642ebfebc",
+                                "uncompressed-sha256": "30562a898903f80d550ca8dae4b7fc4a164bf7a045f1914a7ea821124af682a0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "8e4dc658326aeebc0ae599bb435283b2475d196e8f0b8f4337759395bc09f6cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-iso.aarch64.iso.sig",
+                                "sha256": "bd7cf6da83723d110d1e84f7834deda7d909970cc09348ee1525be504d88ee92"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-kernel.aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-kernel.aarch64.sig",
                                 "sha256": "e249c9d6d365dc640215ab759e18d2a8ff06db2aea29fcb4f4d13e3392f4a25a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "e15a4a58bc3f316d7506fc546030d1e794d730a43083aabe33ce097e82e579b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "c7c307bd6bc27978b27536ce5756b1c5086ad4898ace7499395822fb68b6949e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "53b6cb6be7def6b74d2bf0d17b2625f8eda063f65dab5486e1bc12366bf0309a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "3d32c23bfa00137da99ee8f51bc1147c21ea44e7e8dccd4e1497dc002519d4a0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "7b1018f2352b4331a446746e93d4ba95c2145878e1161c44e7f147b2a31a59ff",
-                                "uncompressed-sha256": "c805f1956ab0c21f76d4b4cc680183425035e13f2c662c7aa58a321ea9edbd26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "c1d0d0cfb427e5275a15e342c506f99d60d0eff0da41121508f110643c95cba5",
+                                "uncompressed-sha256": "766fa8a3ce6931e7694830b294bae47c5572f2ae368762b82ff7ef001d573c2f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "a51ba431564f31d1f48a3820794cafbdc1d849c84cbb36be373e24f822339c4d",
-                                "uncompressed-sha256": "8c6d1ef031c9759547ea7451796014e6580626856ffc311b6fdb85601b75047b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4a34dfabb5185ae61a37bb0b2c58e9b2d98d192de81165d7d10ed7722271c3e1",
+                                "uncompressed-sha256": "f89855bd35fbbe92207453b27a1ae503caf00d99dadc5a3ec0f3f3a9ece12ab2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/aarch64/fedora-coreos-42.20250410.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e14370c5ef9b7d831462da67f28101d5d81cefcb58516a155cf46489f3c28bf9",
-                                "uncompressed-sha256": "f04761e193574b6ac0f10993145bd3384ae52f2798301b52c636103ca8f8aeae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "7f1ee1a2ccfcdb60e656b39e4b7ae73f2846bf762debcae03f777a9a012e0b38",
+                                "uncompressed-sha256": "12c9db8651fbd1b9d3abe8b0513b27848adefa9e6e72211dc64ecf7d48dcef85"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-02812a2fe826261d7"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-085a04beea25f96a0"
                         },
                         "ap-east-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0d15b89be088559ad"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0c90b2b2593bcb790"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-03d3dff91bcc8d987"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0b568c8d4c7d7460b"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-08392a2befd163421"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0e31dc362c62e711c"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-07fdcbd77a2618a73"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-058f90bde08e43246"
                         },
                         "ap-south-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0edc6de33cdfa311c"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0323004265c1ebe3f"
                         },
                         "ap-south-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-035a28b4195a17066"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0dfaaee1f6237d8a9"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0aec9b53339b8ea8f"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-035dba027aeafa6a1"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0ef27da3475939973"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0ecaf6bc87d3be0a7"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-044c8a3baa14e07d7"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0971f2f760c512ab4"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-013d34f60c14c5d93"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0cab3e68040346a92"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-02523d9b8188bd18e"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-073d802a46b28ae4d"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0f5594a72c995f0c6"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-05f5416547088e7a6"
                         },
                         "ca-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-02ca2d36edd84ba7b"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0e7c6f3ee712c0fc1"
                         },
                         "ca-west-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0b838d29c4cc77416"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0503df3ec2d4c94de"
                         },
                         "eu-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0962a1e06790e90ca"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0ca8a14e4a9f4dc87"
                         },
                         "eu-central-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-00a9733d7dd9aec26"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0dfa66a8479e2c998"
                         },
                         "eu-north-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-027aae6d1e1889554"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0937d9aee9721d044"
                         },
                         "eu-south-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0bfa942366acbca0e"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-03225c7098c46d0df"
                         },
                         "eu-south-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-091ed316a71174448"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-05b63da78618eb9f7"
                         },
                         "eu-west-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0b49f88b4b439d4c1"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-08d49fc79d467fc39"
                         },
                         "eu-west-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-054503f8583d9f7b9"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0c5c707485ccf98cd"
                         },
                         "eu-west-3": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-034cbac8ffed31256"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-07147b66b26ffeb61"
                         },
                         "il-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0876609df3e0887bb"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0e34cb3a0e25adb96"
                         },
                         "me-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0aa65072c47ca6241"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0644f830caea58e8c"
                         },
                         "me-south-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0990089d03cb6a577"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0a1963348a8b580ec"
                         },
                         "mx-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-031964faadd81665f"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-05cc3e1dddb14ccb7"
                         },
                         "sa-east-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-034d3d0a7d8750238"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-08a4ff096aeda80a7"
                         },
                         "us-east-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-06b679a3966888aaf"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0011174d303d30f18"
                         },
                         "us-east-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0ca798832aeffab78"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-06291edfaafc49330"
                         },
                         "us-west-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-042da0166ba744e2b"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-01ece755ed1611f64"
                         },
                         "us-west-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0772c82cda81ccca1"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0fb27392df46d6f35"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250410-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250410-3-2-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "2d87933945136abb6dd965921665f255e175e592aa6916adf7cd7559fc3db6e8",
-                                "uncompressed-sha256": "d7e7b1b3c627181f879a4d2296090186dc3c47e4b6e1153d1cfc01725a809204"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "02620c448a18bdd1fe7c63da6484c79e233f613cf46fdd25f99b26426bffd8cb",
+                                "uncompressed-sha256": "56ffe600b1d78f7d36891cd5933d4879a8e396cfac7bdf0c07480bf76ed048aa"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "276fe0ba25809e4a9e8f00f64c4a84596bdf30e534d37f3f33e61323bd500415"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-iso.ppc64le.iso.sig",
+                                "sha256": "890a66e1bde2a629c1a37b6fd73373b8dd3d6f02bdcaedc7056efedfdf852e51"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-kernel.ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-kernel.ppc64le.sig",
                                 "sha256": "4a522a1b85554d5f4f7aa0aa0cee8d1ccf877165c5c4751247956a51d4a1958b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "c27f2692cb803b140b2c893790531b5abfee5ec7d2bc95c4a9fcc21059754ed8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-initramfs.ppc64le.img.sig",
+                                "sha256": "feca993045362300c0b0603a0c103fcac42bb0c245f2b4914a12abe48e5d7d20"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "f0644e15a2797706232cd6995b146f0acb9e4ff7f996af57dbb542fd09630fca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-rootfs.ppc64le.img.sig",
+                                "sha256": "b6af5796cb65307c5c0a236e0491917318c6e0421ce51cf83241e9bf66593da1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "286274cc8bbac392def37ee48c28e88ce52ed5f6a5bb7122890623387f1cfb4f",
-                                "uncompressed-sha256": "a681577a671ad78e47964052b2a450f0a4411997058f832b69737db7d66b6453"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-metal.ppc64le.raw.xz.sig",
+                                "sha256": "fe31658957f8d78b24f40ee02b8cfc0c4074657d774d5247565117634658bb8f",
+                                "uncompressed-sha256": "05ae7ef764a222b090c9836c7a2243b9de7a2c715b2455f963fb0aab095bf58d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "633997a3ff290e1a0a94ef0b4cf7c4409d2bd9974297291bbd647f8cd14cada4",
-                                "uncompressed-sha256": "4f74e0708adbc1cb4f0fa40c817b65d1a0ac63927a0bdf6a6f2110cec5c6c4ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "3ed309e489409e3e2774cd1fdd07ba991e704ba1c5c3beda12b1f252df70a62f",
+                                "uncompressed-sha256": "00f509cf2f2eaa85f4b133b81f63665816bccce7079bf09873eb51e98a3dac35"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "edd9d119cc50c3a1bef799c0e9f4f76c656caaefc800bd91047d547ff31917d6",
-                                "uncompressed-sha256": "9fa57bfb406acdd9e4579456c96c247fb66d90d39b3e4b16b55fa65084b33003"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c1b7e19b36349a865310d440d87a0a7048dc9e37311c0fc6b6473f8c1aec12ac",
+                                "uncompressed-sha256": "5576a08c43abb0dc41d892e601441fc244dee9320bb749b28a282b6621747c4b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/ppc64le/fedora-coreos-42.20250410.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "60fa595eab25825dfdfc0573c3975daab80b2d598837fc5fc42f533a93bc5e6f",
-                                "uncompressed-sha256": "84206a15a281ff52ebba1d50bd1a45430d7e914d3396422122b71ac838dadd6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "b7eb8ba48c34bd0896c38c2cabdb6310d316052300484927d67e5c17a5ed5348",
+                                "uncompressed-sha256": "fa6ae323cc3208c6529c3523d50e5b126be5cd9dd80414e4d7de5b105365007e"
                             }
                         }
                     }
@@ -389,85 +389,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "c7d6da170562c306d551369eacaa8a68d97abe2da059933ca2e88acaea2dcbfe",
-                                "uncompressed-sha256": "7aea5f4abe72c4e4e788bac38a95493969eb55f710cc3a421f32268cbc273b26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9e1d5e80fa3b28f8eb56c85435234e6c6b5f82d082e33a670df1050e528badff",
+                                "uncompressed-sha256": "fc6aafe1d828bcad8ae89574b36464548a4f49889e2456c9843a17144f9ef33f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1b3f5c54382d19bbe705543f745d59ac6f3d454d047a0834948f8cb22a46951b",
-                                "uncompressed-sha256": "4d1dca81799eaa09ea37ebd2a87f4324a341e596a4541709c1158f5ec3f7dded"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "7209c8fb78f65291ac0a53c9b3c27170cc4a1b593652d2eb7a662af090ce8422",
+                                "uncompressed-sha256": "4446750812165cbba7231799574e21dd0dedd122a1be910806732e434042b85b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "7671b1e77f0ce7a6089ed109fb8e6faaafc3b021b6ac12012cfee0c49c5b2b80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-iso.s390x.iso.sig",
+                                "sha256": "4af2a68e7988e455d58cea6a20681200e7d279c1c949f189dff6eb32817b5ee0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-kernel.s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-kernel.s390x.sig",
                                 "sha256": "1e340eca4d780fbf5ebc94e683060463acd1725ceb437bc0c7e30994701cf835"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "d60a644c0bbf811185c77d90a95cdbd4fa59c1836b803d7899ecb18c3625f87f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-initramfs.s390x.img.sig",
+                                "sha256": "da35fc1551135fc1d5d319ed2b1f4d76f622a1f75a91c923a2fc49973d39dc09"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "15bcfa95f3eeb5b7cf84f767711c026f89c4862c48bd0387169f9d2dbf0fbe9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-rootfs.s390x.img.sig",
+                                "sha256": "f852e7268605d709eadf359a27f29d6a4d842ce71b0fabe6fa65a5b18a5acc18"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "ca6079b50a73214ab9c02bb97c868004a49bb1a101ff80346bbe77bc8400e493",
-                                "uncompressed-sha256": "c4cbf7f0c3bbea7eb39ff8ee8418f70d75ce477cea4ecafb4fb7d977c45305ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-metal.s390x.raw.xz.sig",
+                                "sha256": "c7e83055966612bacbc7aeef68ea0adc63bf8b32ddc0cee67aec36c816a7b7a7",
+                                "uncompressed-sha256": "c362918ae7fa42b4bdd65faba560f9fefcbfeae763883c2b374c4ce95ca29d96"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5a508295de2cfa6823f6de3230f79556619bf867f52b36859a4a267ac7a3376a",
-                                "uncompressed-sha256": "2e313b2184252953e951926de05942c6a9bdf4aba1ef14646d39894405172b22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ff0b19c89013f03e0b314b23d395506af8316209810d0acf83b90730bc13ddad",
+                                "uncompressed-sha256": "6ec33f4740a27e634ada5b416d988e4101613eab2ef9d71ff17cd6e93b747745"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/s390x/fedora-coreos-42.20250410.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9737a8aa78c6ad033b7e6a952b2d3189e82a1df4056018818e0b91c657f3d4e4",
-                                "uncompressed-sha256": "b481f4680cc54670587ca0a885cc950b7759dae8ad06e316f33f40d1ee370375"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "70b30a112c46d04fbc1f867721f5eb4405c1187651c6b97259931e3a1310f666",
+                                "uncompressed-sha256": "88316a294aa3f6d4a78b7678bfd6e2f6c1b18e11672f8c715f9e7bfebeaee014"
                             }
                         }
                     }
@@ -478,275 +478,275 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8ce4040e5f5e7df092322092f04ce00e8ed1dfa5c2bd0c7b96641449e2185d5a",
-                                "uncompressed-sha256": "fe478f249160e8c49f401696f3b8333c177724575c4f1dd98c1f014025393e54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "7221b04bb55545a3d5d5d90ad1134787c7ab263706fbddd13f231479db50dd6f",
+                                "uncompressed-sha256": "6aec4157a5d2538622ac7e2970d3d9b9f35046309b1e57b7e641cbe41c43deb2"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "74e84986d87004d2455714802fac472283c5e36d67e95555ebb3c60ba159c33f",
-                                "uncompressed-sha256": "52e639b45b0aa1ff809926d31e6eb57ea03e8208bf21274bf2f8b89968ed935d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-applehv.x86_64.raw.gz.sig",
+                                "sha256": "e88a91154c1bbfa8f1a1ccea59d924c30808efd061c06b94ff00fe6dc0ed76f1",
+                                "uncompressed-sha256": "734e58bd4c9ef6cfc8fd0ca4096b1c43b4dce96fd79c0168c12fd336de789527"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0c56a0bb0cc6f8b286b24db8a39fb29ea1e259d4df05534bdef72b19b163a2de",
-                                "uncompressed-sha256": "2b9036ae280c2db3b774d95728b83095c024a7ba7f82d503e9c560c00d579559"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "32dc7a11dc61d8a7a8ead62082f9896ed8f1f3061e194d420262bc0413a872c2",
+                                "uncompressed-sha256": "e40a919d7cad8021d250f4ffec1a67dfc78f272e443dd33fe74eca025189b016"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "241c058611480ee93e8b4b27968955f8fe854f3e1f30f337ead7371cf4f4dfd7",
-                                "uncompressed-sha256": "147304afad63834ecfea0fdbf5414c61dc230f0a73f568dec9b84f76dc2b28d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c3bce9cf157bdffb8d664098c9090fa0ceba5f3fef23c94d78ac4f36ee53a8f1",
+                                "uncompressed-sha256": "78bff430fdee603e633356d3192e7a0ec0fa591b95997708de76b0e38ddcf8da"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "3abd2f9c5379720d7c29d612e60db669f8e6817edceec58b9aad5cf6869600e7",
-                                "uncompressed-sha256": "5fb3d4e17f88826aa51d114d92d64bd50b4cdbdb53b30eb624c2fe8ae48a123c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "2ddedeb4306b1e7fa4de52b8ba2e08d58c8ea8a49aa9d6b914fad192c20534f0",
+                                "uncompressed-sha256": "9189d63c7ef8b2d4af891a81aec2d825a4565a68449dba5a17bfe5aa0e860a99"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c710cb0e7c1ba97dbd52edb5bf2373dc466f782b92c5e337a22251fb8cf49690",
-                                "uncompressed-sha256": "5cab51505caae2bf0c0facaae1c8cd87813c2465123636e4f8165c0de8221cd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4f3685ffd72c8c5afeaf620e56968dfa1a69286a2696a1c0da3c3386f9450f1e",
+                                "uncompressed-sha256": "21bb357e44a5e9b3f6d5f42604869f64fa5221b83020df9414108608d17692dc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "5d9d3eb23820619a760803f7b3a0beadfe29793b8ff499537346e7730ce07776",
-                                "uncompressed-sha256": "9ec15f6a40b2b22cb86c281ae88c71aaabf7cbbe3c2a54edfedf41f4fde4008c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "feac443deec50393c0c02e34776c455aa555cc2c6f519d8992100b8a04d8aa7c",
+                                "uncompressed-sha256": "85b214e827ef9cc3f945283c7fe1a256039a2a927661f27e952d70d951257ca7"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ee4ca7783b375a9896f05aded26d08bf7edbbb01056b209ebf17016564666e26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "225b134a54f6e8e59cca4f74cc4ffd9864d960644e165bc37ecdac8a8f4a26c6"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "056c642d973f138dd5f18f09bd7011e6a846aad2a2c062c43da486498beb65c9",
-                                "uncompressed-sha256": "9506773c35a575474ecff665ab1150cfb60e2ad5df7ac30842d85995fee78a4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "be253502dc206376c30bb4540705020ee4bdd114651641f34877dd35d37bdba5",
+                                "uncompressed-sha256": "53d10a4de1bf188402e7c1c9724b11a41a18ce372d3945dfb5ad929658414b51"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "f99cda4a5d3036f7e66e9498a119665a2a642d7d33ef9a3eee5da49e4aeb411a",
-                                "uncompressed-sha256": "3aa16b2743d2f5b33ff87b2138abd16f729203452d32176cdff2a45bbaca31a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2ed8a7baa399164c2afc514efd2f1a6af6a041c34a8b460aa1d8a3b51d648841",
+                                "uncompressed-sha256": "bf21fbb5fcb0994f498253fc8fc443932dd30cce5611e033fa5401e152439c44"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e020b1d6197f3cf3a327b9b1e7a7dac831b9f4abe0cba9b8f78775b9c713de78",
-                                "uncompressed-sha256": "74e03313f6325adcd34480ced35aa2fcfe6c36a3b41dd0540a644474d76d4de7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "dfbff97f6d85e2c6473a8a383b4cad47f5462a4e68251aa235175ed54abf9bb4",
+                                "uncompressed-sha256": "09e0d61c081908e0d700166f2a780ac395319c23d5fc79050379d0ae04570d21"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ea712babe4abbc70acaa3e6e4704e5121dcd44890ba6216c934616c575a963a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "6ca5a70fb07c6f33bde202ea0ce00c12e2d7e4a5c21125dc29937ae4ff9c0c19"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "48efc160ecf6bd5f2d463277eae1b572cb0817ae655f8d64d19947efbc8016a0",
-                                "uncompressed-sha256": "c771c9ddcd0cde53c85689f8171aee8ceefafb2800162d3f5bea3e5dc1c4ccdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "70782a1441e9f1a46aba4f5cf64043743808d99d2ed9e71de10582f5d7a55d71",
+                                "uncompressed-sha256": "a28a7ea0d534a723849aa057d4833b712ad7ff674fa31fbb0bd1dd648cc0133e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "a402f058a5ec013f5e8949d880faa0664220676cb13aa574103192bf1b57fdc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-iso.x86_64.iso.sig",
+                                "sha256": "35a370954880471e8dbc11784161ffe67d72e0cbd18bf8feaec1ef71effec90f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-kernel.x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-kernel.x86_64.sig",
                                 "sha256": "507b2265becc1125b372233c43b044ca68d8cdeba9ed7da2544e1c98529ec289"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "21778d5d2746c2d48d67c5d54c478fdb35b7792b0cea86886688b91f5ed7879f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "c4cdbe17dbb8b1c0dfd41924fa4958e134a326f45affdf7b16a7b85216b41e1a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "6bed7ea294c9060b9b0d9fa098b634760250384965463395467e9b761aaafa46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "e88b873ca033fc418d88ef0fc02e28c72741129b534e2c60b4a6a4256cbe8248"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "cbd7f70bd82ae4646a0f1e491a6b6cdf37d3fbe7d4a5161343cbf1b54d192500",
-                                "uncompressed-sha256": "f93c644db63ca06aede9d1091cbe803889cb51e204a8ca4a22345eed566cd38d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "e6a9b1a48c68ce60259ad57b31a83101d3533acfbe9051901693809723777848",
+                                "uncompressed-sha256": "6712e61506cd04d163b9a588790625049575aeef14db23e2d07bd4070aa3390c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "a8e6a8481672ef135279cc62be8b4c0f0dbd4338ca379414d67d38f0a880036f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "06a292f6769fd554d38e0463e1d5d7404699be4278ca23f9bfafaae5d3178e32"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a2612e0aa4f5591e9243f46866e12386748419302f857cc8a9ed7e6a3fa59b67",
-                                "uncompressed-sha256": "c945e75559e034633e67256cea67927f70de462cb87dcb52735ffabcd10f8ae5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0caba28a281fb4c164e66269114d2eeb1d661d04749ae753d94b229a118959b9",
+                                "uncompressed-sha256": "1afd250c94ab449c4f0fa885f5af0decb6fc6df0b1436af883e670482d577e21"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0d61e562e13d1ea42fbe76b5792269fbf1b1ff58765b4f96e82041ef0161be91",
-                                "uncompressed-sha256": "2d9f7bfcbb3e08113918602f816e1c1e82e22d1b926f7be9fae61b3363660bc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1ba3e12b204bacd1e478f2c0efde6091712e7db80f971268e802f1b8fa1d4bef",
+                                "uncompressed-sha256": "c6c7ac4873267b4af93a2f760b4794f79706860efa046340c32ff6b1ada6dd04"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "0e009ce7160512418e4e1e0490d1851c5158fda4bf410d09220a2c1a0a2dd141"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "5d9ad87cf0a3fb1c9469d958146533154b12bdfb11fcdbe53c470547f61c7a36"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "9ebbcb7be8ce14e418d6318fca00384351b42a38678bce34ee5319d76afec6c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-vmware.x86_64.ova.sig",
+                                "sha256": "7501ecee04794a6f0d438ae4d1e6c620085c2a730e263e2588d07a8393a04241"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.1/x86_64/fedora-coreos-42.20250410.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "944c38b564b1c42268a2b6322470a317551b2bf83a901f3116b53ec77cf0fbd0",
-                                "uncompressed-sha256": "15be34aeacff94b9944b4340ca2579698854c13a8ce4f869233f6754b457ad0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a222d9d0ff46a8d919f44e214ae384c988172f0627609f1c66cef021b5e42f82",
+                                "uncompressed-sha256": "5358285843f8bc0fe10ae3b23abc9ec49317d635e11099ab83298cd52ac8d1fd"
                             }
                         }
                     }
@@ -756,145 +756,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0840922d76d6eea63"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-04864dde81b389554"
                         },
                         "ap-east-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-03242877b45299750"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0f008ce8de8e6a332"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-08af52563b58e2631"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-04b6c87646ad00bda"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-02c8fed129e051591"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-057ae6ec8f6d33ae9"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-00318bfc82cc8059b"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0b00ccc07ebc1fe6a"
                         },
                         "ap-south-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0b2b6aeab3e51249e"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-02702987f5d4c22c0"
                         },
                         "ap-south-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0d922ab78df3dac93"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0db5c3a506eaae29b"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0d9312777f2badf20"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-010e38db4a40aa986"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-018f07da7c6e2fd75"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0efd686cf411e4ef6"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-00bcfa5587d58c6b9"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0765de9665cbaed33"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0f8945241defc35f2"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-03beab6ec1e1d102e"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0093d8c47bd2a7f3f"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0491810769063560f"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0bbbe4cc999c7de02"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-01cacdad81059e3a9"
                         },
                         "ca-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-04fec6dab80cdee76"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0b66c767ff1bd9a24"
                         },
                         "ca-west-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-024dd65aae9d0da3c"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-00ea714daf77a32b7"
                         },
                         "eu-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0998131c618e96f66"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0c3ad5b862967b4f1"
                         },
                         "eu-central-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0e56a50fa792f15cb"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0225a9f6095dfdb71"
                         },
                         "eu-north-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-001cf9fa498c91d10"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0adedfad833d68c0c"
                         },
                         "eu-south-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0d224fa5b3fa4d8a4"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-07ec459041845c687"
                         },
                         "eu-south-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0cd891454cb179c42"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0fd964ab51ce34f81"
                         },
                         "eu-west-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-05fa99f9816e910b2"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0b26a2b0a0e45446f"
                         },
                         "eu-west-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-04f4245fa55c053a0"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-05dde7fce133faf9d"
                         },
                         "eu-west-3": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0561e36024ad462f4"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0ec8746e55855855c"
                         },
                         "il-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0fb3d26829b0d93f0"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-00f78f7b2ab8bcafb"
                         },
                         "me-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-09f10000bc5a6a309"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-059377625365e5a6c"
                         },
                         "me-south-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-02592f13ce42a2096"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-00725e9dad94b672d"
                         },
                         "mx-central-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0dece810838138193"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-086c66771bba95ec6"
                         },
                         "sa-east-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-0a75e028e091a685d"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0d9f49468645e1b98"
                         },
                         "us-east-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-03a7950d1665eb833"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0032387128c80f1b5"
                         },
                         "us-east-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-01770610ac72c32bf"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-00c8f2bf79c8de60a"
                         },
                         "us-west-1": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-049e9fe3c53d48bbf"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-0065b9c48430af458"
                         },
                         "us-west-2": {
-                            "release": "42.20250410.3.1",
-                            "image": "ami-023fd4649369bff3a"
+                            "release": "42.20250410.3.2",
+                            "image": "ami-019b6dc2e29fd814f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250410-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250410-3-2-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250410.3.1",
+                    "release": "42.20250410.3.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8b0482503cef336b4ed4bd6a72b689763e75119d66cbe4227d02e20d03a8d7c5"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4339c55b5a8ddab41eaf69c888d2bf46c43a08ca8c93a8887208624ae152b501"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-04-29T15:47:29Z"
+    "last-modified": "2025-05-01T13:32:40Z"
   },
   "releases": [
     {
@@ -124,6 +124,16 @@
         },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+        }
+      }
+    },
+    {
+      "version": "42.20250410.3.2",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 1800,
+          "start_epoch": 1746108000,
+          "start_percentage": 0.0
         }
       }
     }


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).