### PR TITLE
Roll out stable 42.20250427.3.0, testing 42.20250512.2.0, next 42.20250512.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,156 +1,156 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-04-29T15:47:30Z",
+        "last-modified": "2025-05-14T09:25:06Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "2949b26c38587a73c3b262638635ad09838055e8e9ebb83d1a104d989ad208d8",
-                                "uncompressed-sha256": "65aae4c812ddbe3ca1bc441b48a1908957ccb60085754921e7288add6a41ca0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "e6eeaf4fd27854015047403ca6ea87e79a834d5781f9fb4ec2aee11d39ef4784",
+                                "uncompressed-sha256": "3f5b05d7e626de7a8eed6f45fc33ff2ca4b997a51ad62ba12522ae451a6b5643"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "60129b60183e36c41795543e5e9f797d827217b46d7742462859658af71c071d",
-                                "uncompressed-sha256": "5dc2088eff7dcb3ffda1dde8e6fa28e2f74c5440fc55e9918073239de3828d61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "00fd40dbe072c70f1b6c5bd3b98486476d12cd2fb4981ef534904cb1574a3b4b",
+                                "uncompressed-sha256": "3a73e915ecc13fb917f31767c4ca240335c405e1c47d8dc42c61a47c67d7f46d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "8400bde1d73731302afd47adc1787c84844fa2842a4c900a9059c2dd0889da9c",
-                                "uncompressed-sha256": "d3773aba6b2a9125cd20ed0a3db76cf2a070ffe5177377d226e43d150cfac0e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "71faa3c334daf9d0b8195c4eff29537683b363811266ef6ad432d8a696f378c4",
+                                "uncompressed-sha256": "4ea1f49e91622791944e57e3e49e681c6da1bb536e2cac787367e1bf132b7e27"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "def92ccfd55b78868aaa47b15e9eaf52ee31fec17dca0d1adc67683f09072962"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "64a7f6c8f23ed49fae02b756c7c373322c01b6e6ec846a5b71e3b5bbd132b39a"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "908723464892c01f8273f37544723a0a82466c9ab753503e36962e5fc55b184e",
-                                "uncompressed-sha256": "cc3400756e4bb93c80126cc1da4de26bd9ec3cb4c13c0b104d7666cbd2e59b79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "109234e0a97d29d4747f4d0835c2a1bf160007454158bf5c6b959f46999460cb",
+                                "uncompressed-sha256": "478035203328152bbb67a2e99193643f7d1de7360f239471e171659a5da082aa"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "ac6c66df0403d9b2d614e12eb52e7b62d133822118acd390e8d4235a4b4e1cb6",
-                                "uncompressed-sha256": "a549c731ab36bb3cce68640b1ea85f76627dd8de94b0ee0f4b5771769ec34ed7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "a9f6afbe5d05cbf4b0e2c6e008a6589609d44f43f6ad559795a5e36289f45da2",
+                                "uncompressed-sha256": "61b5788c90c8a1e819f6ef0023ecf2c6e61ec85c3a00f7830875f3eca8c9cca2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "902c0018fba49a8cfd5d52958b51b83da108b3d82c397ef692ce5f75b0a6de85",
-                                "uncompressed-sha256": "bc5b04790556bac77eb446d76b811d3c548885ad97d041821eb22d6982771a4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f2992b78955a7d59d9e598caadf1a3c79ca03591acd19084f5141732724ee6cc",
+                                "uncompressed-sha256": "4607c5091f1dd7fdbca67c9975adcda86bf196a484fc8f2306562a594e94d825"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live.aarch64.iso.sig",
-                                "sha256": "cd04c49491afe7613e18d45216651da224f3c86302ecd51ad21e67d66d9134e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "0ff5c18ae76e51e44a5e2706deb18231a0e3c7b8632d5f20bf9feaa7ea20e5f9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-kernel-aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-kernel-aarch64.sig",
-                                "sha256": "b6b04e199b69d49af1e93f81e40335b8c6a66fffef496714bd009de54cdcc618"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-kernel.aarch64.sig",
+                                "sha256": "d1e29a6904a85764ad3433262285c757d2009d8db2e5e49f907325bb7eb5846e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "9aa45bb7b64584da57ea604310d5a44af58f003eb72e21840b5d581b740bb96f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "1d009129369e30d796a0edb6b80cff73042395d9866a9c2dc463253cf148cad8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "e9b552b27271786343b56aa58c990a470bb9d4c2d5986896d84f341889101ebd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6b9c8d18c86622c2da13c2805c030a65f9168088f9409d189c78c6c3e7bee1ae"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f130cd0532494735bc33a4b7af3c81b7e10b4be9412f43e02696959f3dd09223",
-                                "uncompressed-sha256": "2fa8bc2343e076daf2a1880a73087b9ed6878a4111ece82f239fc404768f76fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "2fa4614e0675c2adb6362a4fbc7f270b4dc2f9880665c7e79beb0aad3c53825c",
+                                "uncompressed-sha256": "97931d272f534bc2f15c4871b023a3e7a0b6a34d12bbac0e1fd7eae40f596c88"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "abb3c1e50fd096816e6e94f140292739ecdc8f4f9f25195d8f268d555f5ae8f6",
-                                "uncompressed-sha256": "16e8b0be7d572dffc6f2ef5c9fd2f158c165c8e4ed24adcf615e45924974d15d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2a0c6571a746bdc321430a2d5f9fb6bb2378b19a5220c940d52c4d94d929aab9",
+                                "uncompressed-sha256": "7f13b307f50c8ffb4a35581212760597dae8976487998d60fb81c8ff9c145609"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/aarch64/fedora-coreos-42.20250427.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c1f2d7e7413459b690ece403fca5bdd696d8fa9300bcd1c749f18212f80f7816",
-                                "uncompressed-sha256": "93f689e5da2c34f85822061cce7c36b95a19e3d5efd3ae2edf3cd3bb29345cfe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b2e905eeb3ec9027fc6394a2fc270655aa43ce809f6390f816e8945d999b132b",
+                                "uncompressed-sha256": "946e5c2ebd3fbfb459cbf51dd229c61eef76b0d3cd420b76257a84cf55aae79b"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0f157c9c39a11bf62"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0233f4c942947e324"
                         },
                         "ap-east-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-04673db4aabf4ecec"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-08a9364d9c7914351"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0740259a79be1ff7a"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-042219cbb0e1e5cfb"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0b5f86f77509f1514"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0cc75aefe383f525e"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0132d3c72cf30e907"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0a0ba4f87292021c8"
                         },
                         "ap-south-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-06cda4195292f8c4a"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-08e46cfe5f47d00f6"
                         },
                         "ap-south-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-093da70a86fa30ce7"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0baf4c0f1d10f4ca5"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-085da3ca5bd6ef4be"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0a1a95ef434747b77"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-02b95a4e11d111613"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0f1a5d6ab6a70fdd0"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-038aa27703e4d2eca"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0ad708c8a212138f3"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0089f4072798cf8e5"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0ee10f1e8e7893da8"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-05388838606785475"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-05f6d238b88c8bd46"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0d80d7c3eee69b092"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-01dc5f1c59cdd6770"
                         },
                         "ca-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-08f34d647e9bf4e84"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0b6fcc34a020b1c0c"
                         },
                         "ca-west-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-05b9ae5729018c1d9"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-01f9c5c8eda0f4706"
                         },
                         "eu-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-09797ff42431963d1"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-016a6286517b50154"
                         },
                         "eu-central-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0c99492f33ad46989"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-039c70fc2a0e15b8a"
                         },
                         "eu-north-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-05e1669ba8a9d5c8a"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0c06e10f4894bca4a"
                         },
                         "eu-south-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0826b588b0a9e2dc4"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0d3e3c60ae9cfdcc8"
                         },
                         "eu-south-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0723e9a01a75ba9c1"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0d7aa2d57d68405da"
                         },
                         "eu-west-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0bf67b69cf28eb228"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-030303bf86c088e2b"
                         },
                         "eu-west-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0caf747b04ef60ebf"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0c341319305ff475f"
                         },
                         "eu-west-3": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0e5ec3685861ef070"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0ff458d518b64174e"
                         },
                         "il-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-07f3d1df388aede61"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-051fa20a8cab3eae2"
                         },
                         "me-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0513f34d819815eca"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-00ac2c17489ad949f"
                         },
                         "me-south-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-060dc667db774b2cc"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0d9c30a04b9d1b64a"
                         },
                         "mx-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-09d08ffbb6a4a5f3a"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0213ec2d8cb37a7a9"
                         },
                         "sa-east-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-01ab8c9912007e253"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0a58d93b068ab0953"
                         },
                         "us-east-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0b9fbd764faccb411"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-053b15a6cdba0e5c6"
                         },
                         "us-east-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-050c33e5f8f5bd61e"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0f9a4008f287fb482"
                         },
                         "us-west-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-024a3e9a7f6229ea4"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-06c38e94bb5ff481d"
                         },
                         "us-west-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0aa3d736155db0527"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0731e046b493b5e7f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250427-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250512-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "1bed0150de47a2750edcc6077315a1111e2e446e53d1f1b6f1f19ca1f396b61b",
-                                "uncompressed-sha256": "a7404bfe947835c3573479c22102d058e1b8285c8de068221931adeaeb981705"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "de65cf29d89675c8de29c49d19d416e698ac2f36a4b881e46dfbb0cef4b48004",
+                                "uncompressed-sha256": "a77b3c96fea8838657c9df125883db5b95f67282f227176ab19bebea89686a91"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live.ppc64le.iso.sig",
-                                "sha256": "1f4a2b63462c7eb11d311c9c4d91438d49fa794c0aabfe93958034ecbe220179"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "1a62c3c303aa650409ae0e6d82eb783e732fdc577210dea5d6892f38a7d84a38"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-kernel-ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-kernel-ppc64le.sig",
-                                "sha256": "0aa34c5f7860ac4f37d199b034d154fd298e9d044ab6994afb02086fde6bacd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "d66a3c81a6244a6ec567f307267df8203cf93ad765fe0e9f3e980b39d8769c2e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "2439d91fc061baf1f8b7c523b22bd6687420aa81554e5e49c16b035ca27dae1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "0cf704e3d7892f7feb513eea467d9bf6045297c69d579c1fe5bf8458b6212375"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3afb51a81344dd2bff0aa03ee9efb30690867b185241c305e4f79dc3629f9c18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "98617d555de7fb7361e073c936bfdb7faf0de541f66677c611e63cce71c34341"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "fa06d95a69ed692128934d986a19700c0af82ea533b725c2b39902d92bd21dcc",
-                                "uncompressed-sha256": "e458c6240590f95526ed9062efdcbb537c7a9d41ee80ed9183f5eab135493cdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "e47cf780822cdf93f04409a48a3a705db1407165d1b61753535a3dd45f9ac454",
+                                "uncompressed-sha256": "c7058be035586da072392c0240ffe61c66b68a5393cfac1ac1926f24729b4ecf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "beca5643900e676c19d6a2ada51dea4a217ffe39539e37558ad0e18a0ae86933",
-                                "uncompressed-sha256": "3aab83f7bb2f4feb407173bd9135473c8fe4b22dbc30f32cbbae40da0a4d53b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "1c995b2e26edd78db328dfe77284a7e3decf0a3681cd3ebb3ad5c7661f7909db",
+                                "uncompressed-sha256": "42bc6e9881d8d48147906d52cada44c227c8f3c36a185782952107f5dfcbc376"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "f30d4843a5871872b31702f35a2579aa3bd6fb9ade691a2eaafcd391d50d489a",
-                                "uncompressed-sha256": "51774ebdee05109b8e34042fd6d7a19a129eae3f626de06d9b5d5e5687224cbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2a5b9d715e4eb4c9d32c520ce75a51b85051b57fdb7fbaa6e8c1edce9a8f6f48",
+                                "uncompressed-sha256": "cd15c95d0b6c78658c23a603cc21896da9a383287c601ceb344fca070cef3ef6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/ppc64le/fedora-coreos-42.20250427.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "e4a6feb9e5fa8705a4ec186931954b572034e035016a2d3de9fdae1b73c466a4",
-                                "uncompressed-sha256": "8dfe5aab0b2c9f76d5c66b1cf7db97a61e92815c04516d2bddbd919e937919b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "694e2668443350d8be385ac5aef33cee6da43855ef6fe900a47e383dd187c84e",
+                                "uncompressed-sha256": "a195af16173bdccc207cbbc134a116b57becf43f9a7f7f63d6e041c65df65c61"
                             }
                         }
                     }
@@ -389,85 +389,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b50e5650d4d93e4fdebbdae742ea9013ba2cd2bd791fa8ddddbbe98d89fba8de",
-                                "uncompressed-sha256": "9ff8aa3a9d90556a47c7cbd705363d6f5d6ca47adc72557142a5700b58b81dba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "bec447774dc3febf531033994523a0abc291cdcca72bbb8b82f00a00047759e0",
+                                "uncompressed-sha256": "debe4f2f8539196d73326ea2e9a39015be82e8a3c03ad499ec3542a628658917"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ee36f49d1dbb76e924c2fd1d329ce39171ed97ebeceaef36ac547daaa472086d",
-                                "uncompressed-sha256": "459f04525c86721f74601c2a772c24fe62a3fabec3513ebbf6340d45c0ed5eb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "2d0f94f781002c14fa49fee69a1fa36cfe34f8f889fe01ee5129b6b5a63b3a38",
+                                "uncompressed-sha256": "e8a92931e6190fe215ac1bccdb09c3c4899c232b470220bb04a47dc1027973cc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live.s390x.iso.sig",
-                                "sha256": "f838a8a12469f66556e91f34d9954a08f6fb3a4c637101932f1f663b7442b14d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "af8143c5117d9bd31aff2ebbf0b725ad4d0f76d68e1caf965c4edaedfbe9eec4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-kernel-s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-kernel-s390x.sig",
-                                "sha256": "47bfcd274f467ba058929e38489b7d383272f37d36326bd91da4b4097fd38698"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-kernel.s390x.sig",
+                                "sha256": "a13d1cec10a9c4fa5851a22c3fc0becd4bf9e716aab4f32f1407ffd1a10ab999"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "6cd980c7c2afd2e17c0a9f75a1d0a5148ec3043cc03eee47e8f2a4f3efa0833c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "7ab4a83965ad9df45136fccb56a87ee88571056f6f3df849691f40432d2ed4f1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "21d0380a69b414bffdc2397263b29e3049d5ecf86a70f8c04b15514279e11e34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "24746f1441a4343bbc062c3f5075747e7c5d424ffb5e57cc2c4be76cb117d1ff"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "e022ed22ec664f5ae10852c2ade1661244ab8e75f44ed6b592b9e97c0c7af81d",
-                                "uncompressed-sha256": "1b0832e3c49fc16cb19eab95a485683764f5200a81557a3864b57d7b8ae89d11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "909f5a586cf2d62a3703a69893a235e2ddf2f694a55e4c143001da3197673dd5",
+                                "uncompressed-sha256": "d8abd3ac9f76e714766fddedcc38a921859ff1fcfe94a520133d7aa6373c4237"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "9d42405003b8b0082568e940fe11e0946c2c7b9f09e1baefe1000bb0ede1e3cb",
-                                "uncompressed-sha256": "1d15da77844a64349c6719b574aef74dc62a6d4375fec46c202bf80b8b9add26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "3c47d375bb06ad92961a4adad3c958f84fc6afcc57834c278dec74100432875b",
+                                "uncompressed-sha256": "28eba3efe4773759aa1969c9a00ec392c20bfd11cb3e6ad69e13de3d792f57b4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/s390x/fedora-coreos-42.20250427.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "a735882d289312c7f9b51fc5405f69a46268c8be4c632a5531950eb5dc64d698",
-                                "uncompressed-sha256": "6ae3a09344f800abcdc0b9cbd1dffefe648ed9e8f426725152afe9fcc0e54532"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "dcd949c6ed67e19f439a1eef31ff4a7c87e05b9179efd19a185028e095aa1fca",
+                                "uncompressed-sha256": "323f4f1244e7e792df14ab1a55c6a13bd4576545e4d191e302fad3226a0ff3bd"
                             }
                         }
                     }
@@ -478,275 +478,275 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c3a32fc1732c80f8e264388af3f07b9e43a524b9c0b02d630c83ce8d30d530b3",
-                                "uncompressed-sha256": "0d97e19a25a8c83b7b4c8edf2dadc054672de69d089af937a2ad9362c284edb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1166e9c60047668d75de89cf0230846601ef0c22a69eeb7663d29c69f7299c1e",
+                                "uncompressed-sha256": "5a988badb3fe4b29d980565a9b2323e459c82a65455b1c188e1939a6a38f6fab"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "e4c9df3aece1a495b5be3ce3590969794f25de7eff40559a694b9b8b37e0e8fa",
-                                "uncompressed-sha256": "7989ca69067d57f6b19c9da2a357e78ee00059cd42ea57ede40f77ff1af185eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "d0c3157a78b62c0629e16c5e7f0e858d5bb35cc1aab683c38965b8f1f9729546",
+                                "uncompressed-sha256": "43312bd72ecd7017fad07bf72109500642cd8ac2bddff965b62530b126d5fe6f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "4fa4e3285600248d7a52b93c3fddf6337d0743d2d3618b608de97dd78064650a",
-                                "uncompressed-sha256": "2d3e6e39c4f3f987375c1863da6c6bd81f7a2781807b4f2ca94baec3c6823cf1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1b405decdd3071de3ded08edfaac70db1dd1576b36e21790e6f621d6de1d8b00",
+                                "uncompressed-sha256": "843c16f7be5f23f891a290c3d4a8c2d6ce2f890586a718efc84c2cacf7ea4f33"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "adf26dc4607f1cc79aab343e2a1d039476ef81c31bd19c9ac29dbffec3654890",
-                                "uncompressed-sha256": "dab373f59e0a24dc8b15a61b83ba73608f364673badc638a5b90eecc9c189502"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1dbf13fecb06bcd9aa207d5adfd91ff90c4551b8330c1d114fcadb43257af61c",
+                                "uncompressed-sha256": "b9bab3fad1563a473d8367f97eb9427911781913a5f8d4b836bd0369c42a3fad"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8f4c44e821af33e4f3d020db3c491d5e6b8430b4db602bb4334ff60b631c0a5d",
-                                "uncompressed-sha256": "658cafc4d8edb40cc051170990fc025e1d22c9afca1573895b6395bc97896b81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "2d2470101c58349c8616c36d6fb01a2c4bcfc7d787576d06a1445ac88f34d05d",
+                                "uncompressed-sha256": "87e9824f083b34f0abd04462379b100706ad19dfb5d3906799e1efd5d964b62b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2d5dcc3fb2e39f45718f0e66d9f0e600355c85b48cb07a6cf926361d955c5bf4",
-                                "uncompressed-sha256": "7703d29b33bfab2494bdf7acaf0abc5a9516078cb1803779b556ad51f7f0818c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "13affbea006bb04c0213812180681b89357c3724e9b24175c0c353394589f594",
+                                "uncompressed-sha256": "c97ac489fbd1f6c2a8cc8f4f126912d88472ab5eacf114e0a1da773ef86a646e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "79e5db7acc1f7f2c6c8491ebd60b48b384de827c76dd3348f76a21a9b05852da",
-                                "uncompressed-sha256": "9c479ba6911d9af6f9f06d6dc033868ef8e5dae19a4aa914f25bde9b531661b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "78e6fc27148b82331829efb1703a3d724c6fca27167c26cfbed379ec948d2675",
+                                "uncompressed-sha256": "441b8e67b6bbac8d45ffad02586050496be711ed3257b910366243e5c5963104"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "5e90bc9d13b69b1dee735f2212e7b131d604258434fdb11d9b567d405a7081e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ea26fd19d1134464eeaba7205a4b0a7c6f2e3231eb45d768e6573741b951b5cf"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "16e51a9e5866fb13f7a237cad41a95580cf61d62ead74c364fd3276410f7bd75",
-                                "uncompressed-sha256": "7ad0549aad4bd561d6852518351a7747985338fca2396cde740479d6dc90d549"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "f1ff8f1f3c6dc7137a5427ebca6c24d14ae3ea2e4108f4e78fcdbd72fc1e74a9",
+                                "uncompressed-sha256": "a3afe4fa3e581c634a6a8103fa96f3ca0139d49b76a27ba3816f48cf7d2177bd"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "18faa0c594a4998cd271d2d42bba497b1e9243a32492090edf68af825463b478",
-                                "uncompressed-sha256": "2bee17f5244c435085075791c434ad3d6cc90b9d8104ac6898ff281871071e5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "701345419f47dafbccb17017735e1e612bae6509752db3c137a122fd17c1f7f9",
+                                "uncompressed-sha256": "cfb4f9392e940627037f3a1bd6001540fbcd5a4a44c414a7b22ed597f88e79f0"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4612b8d11d070d4974d4285382326eb12bbabc9c1df8dd9ebce90a6691e88c9f",
-                                "uncompressed-sha256": "313b65d9328a457428f8a76182163e5bcc55f0cfdf892074db76b48d23b62363"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5d8f57d92f46fa7233caf6c0da9a58c0a8430acb1fdbcae8cb0c088e51eddea5",
+                                "uncompressed-sha256": "b5b0e608f14cba04b62743ff2e23153028bef5212f2327a45efd33cb560cbc06"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "6aedca36b950f79df10a31529defb633d0f8b19ba1722cd6680b1758ab502de9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "1db430f3120f8390e7efc22fc8abc7a5d045cdac72c0e9ddab91feb75282bd6f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b5ef028eecb34b9c7f4751eb3c65e4fc301f929ed71d2e84b8c8a981636526d9",
-                                "uncompressed-sha256": "c4b04582df41f1ca3c5a300b696d8fa19a2c4a59335a5cf7cdb5cd777513a709"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "55d4562a1923f73f94983e4f2204df3c5fbe13072909822f47eac9b0fce20d03",
+                                "uncompressed-sha256": "42a2e028431a2d10850baa9e6f954cab44c319f0e1d816e429c6d65026173690"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live.x86_64.iso.sig",
-                                "sha256": "53fc2319b5a6446881d1f88e674d3954e2550e54f1561ead4d0cc284bec64250"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "5a1115f2ba81e06b64b79cf4d6c89606dcce804af64deb98f3f480f087f9b687"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-kernel-x86_64.sig",
-                                "sha256": "aa30a5cc0328207724fdb75f6b1c9298d5cb979200ebf8c008643ef2f65e8122"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-kernel.x86_64.sig",
+                                "sha256": "c56c0ba0d64586a3bfd38d45ae786fecdef86726063ce3ea0ab2a71a4ad5abf1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "351733d4230e5ed1bb96addad6d3361ee3dc104b63fe8c849a2b9d33434d4f03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "36fd9e3ccd47cc1a451ee800fef2eab2886697f573ebb49cd9c25371b8cdff42"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "3d56dcb262470cb4d17afbced7aa1ba7393031e12cba82a256094c395ba508ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "74976a78178e71dfa11f4ce6a7fb612172faa2c9d6cf1ca5d5ade7d7688cec48"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "37a0f6d2c7a1944c84b6f2f6554be1595b45d048ec40f0a22d19efb0bb339a59",
-                                "uncompressed-sha256": "27373a255b921aa606710f7da5e8b443cadce81b6ce35f71cc2bf91a395f5b31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b025e4acc129a77d2c3b603eff8528daec9ae28dd21799ad999a948d6006c5e0",
+                                "uncompressed-sha256": "88fd58e67923b7448565f4ab6135d56243ca12aefd707c5069e28f6a47f51b61"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "b91a110d7cc0dfc108b8a7804bd901dff8fd705ef37183ecc8c7da83b7511ceb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "99a7e81d6b1da040d5fbf44a15705ac5bac97406fa0b7d679e84b572e3652c22"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "abe935874c7280d783676382000509b9fb13094ec9e13546b5138a585b6ff28a",
-                                "uncompressed-sha256": "12dae4547e460676d930a0a948d1540a1b78df7f7eb46bce647888cd1d933a73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9cef8e1a102bc4d1b6affbb598448be998cb80a481342ea91cbdb27ac429255f",
+                                "uncompressed-sha256": "6b75a14ebfc75e91e4ac60ab456ba437e1629f8b1bbaddaf64287d042bb6a935"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b0cddf3a0eabb31a52e9d4e3a2b042b28bc075a13ed66845173e839eafc1aaf3",
-                                "uncompressed-sha256": "a7077b4fd724ac01e0a9c4c69d309afb0bfec93d41a46885ad119b65f60d43b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8914d9518552e89cde11c9bf709037544cc9ea0a50d3e3d9d719f999c20c85b1",
+                                "uncompressed-sha256": "2e2b65befe8e09bea35b6ce21e6607c154554c445380a1b2e06e3e6fd3ad7dfa"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "57bf96facaef68543c7f7e03c705d7c0024e8e31c9e47245332900c6cdb50294"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c3c5d7f01369ace55ec06097baa5b04b701e6d7af45042acf74bd29de1fb86c5"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "365eabd53abc39cdfd3fadaf13879b4b9791eb45f93a417f0b37cb04e0e258bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "5b54fbc975a4434f0157810869a4b538f1489ee84fb0262ef3931e0f982a6511"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250427.1.0/x86_64/fedora-coreos-42.20250427.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "db966035cd98e4d346b64bf1b5751485a2ead16f7cdad6beb063ffb8bc743d1c",
-                                "uncompressed-sha256": "06e392113616de4730f98a4addfe9a9faa3c5359f909001a553463dfa8bb2745"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "d55704b4f26e3d5f1d6bbb6c42d8f822d5750662685c6ea538442435a47652d2",
+                                "uncompressed-sha256": "ade7a0cd5282ed10d1337cf9388ec23ac5480a5622e34bbec2fd4a68eed808ff"
                             }
                         }
                     }
@@ -756,145 +756,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-09637a3a5ef0a9f3f"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-018bb36d06aa42d30"
                         },
                         "ap-east-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0fefe30705546fbbb"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-076892f4181bfced2"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0506756e7b2d5a1ab"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0ed0e746779dd626b"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0e5feb0aa5df83e6d"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-025e17343aafa3096"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-030f739f0f31a5982"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-052009b10e7e36531"
                         },
                         "ap-south-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-09e504dbf10defdf1"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-07b7bbe858a6e304d"
                         },
                         "ap-south-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-00a5d1ce44388dd30"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-04a8d85236f94758b"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0568699a87af48216"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-076bc062206e74941"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0a589075395e3e578"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0964185e98c9b25b7"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0d52d204110364339"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0ff69459b6cc09141"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-01d0d15ffc4eaac3b"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0ceedbfba435290bd"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-077bf6c1dbc296ddb"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0b77b37adf37d8a46"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-02f6f553e04e52b81"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0acae43cb3099daf8"
                         },
                         "ca-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-01a61119aa8a44df6"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-04178dfea886d1fe7"
                         },
                         "ca-west-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-058bf018376bc5f2d"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-05acf47efceab829c"
                         },
                         "eu-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0cdb8a6389878a319"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-017beec68adc9cc4a"
                         },
                         "eu-central-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0474733f7f239c835"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-00cbc7b117dd2e2b7"
                         },
                         "eu-north-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0a86f242459934246"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0053531c54ec07842"
                         },
                         "eu-south-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-07e7039df7e45f608"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0cef38f495b45ec7e"
                         },
                         "eu-south-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0ee06940053a1e16b"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-02320168c5bad63c2"
                         },
                         "eu-west-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-075f9454aa7c3b527"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-06e9cf3b63239f391"
                         },
                         "eu-west-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0cc6517bf93a45930"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-060e022b327deffd7"
                         },
                         "eu-west-3": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0f803d14d13c683eb"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0521b0f4f279ad620"
                         },
                         "il-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0ab2f78eedd653281"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0ac17fbe9ff0c39c0"
                         },
                         "me-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0c95d6bb048de9f68"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-074064e24b06083b8"
                         },
                         "me-south-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0b8cffc9db6d26428"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0366aa291c20b1184"
                         },
                         "mx-central-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-05ed020787e557a5b"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0aafe188a0427a015"
                         },
                         "sa-east-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-098a306bd6fddc741"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0957bd5d1b07c311f"
                         },
                         "us-east-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0e961ddc1111d5592"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0fb7542cf80351737"
                         },
                         "us-east-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-02f2728c0e2ceca54"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-090594efb8c9b8a95"
                         },
                         "us-west-1": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-04f4a987d03fa98c1"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0698470c56c2ba6d0"
                         },
                         "us-west-2": {
-                            "release": "42.20250427.1.0",
-                            "image": "ami-0e4643785a2e82ec4"
+                            "release": "42.20250512.1.0",
+                            "image": "ami-0118ef59d283e4720"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250427-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250512-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250427.1.0",
+                    "release": "42.20250512.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1afcc809781b91b56eb914497f601c1c9e7a1e80a47fda96b1f47a70981886b2"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:05bf13710223a00e45c1465d31902bfc8e7771fd5b3d82567fcec44b7054892d"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,156 +1,156 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-05-01T13:32:39Z",
+        "last-modified": "2025-05-14T09:25:02Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-applehv.aarch64.raw.gz.sig",
-                                "sha256": "1849a1e2d68ccfab033d2d9aa81d127eb32862672d8ed1e58f82e0710debbd3e",
-                                "uncompressed-sha256": "5dd26bb2b9c8245980a92951e411d72ecea7ba10c8fff143a6ff3944a76fac9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "d0e0bd672219c3fae00601eb09772dc1b61039c0b8c913813717ef4f0ee3fe7a",
+                                "uncompressed-sha256": "5c2eaf014e2c7fed1316e4d495e25159f1da0a996c306344fd7fe299f7d5fbf6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "99237485553695eda176d713cac53dfc8499c3a10b13746f364197f8501029fe",
-                                "uncompressed-sha256": "937a8faf2af19155d78b3395814117af8c35f5b805a6e056cbfdfb26408ac9bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "1a93c17844e774f46c43254a2788eee432ca925a967bc0d9454a0717d04ec355",
+                                "uncompressed-sha256": "ef53ba0ce6babd5ecbca2c6565d0f9dad526e3567fbe7a8c768a39d4ba43d581"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "c39cb3876bad8733b2c78359151f47d2f749395b9eaf63767cd2d42f5ec9f4fb",
-                                "uncompressed-sha256": "68133ce2264f14157306ade2c8ac57c3a3734297581f82480e344ba3481aa5ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "be2f6a485a08fcc5d694c9502b9d3fd2aff455058f14f9c55b7c32a0e9342ebb",
+                                "uncompressed-sha256": "3637b25901721f9227a749b4542e13421c3ba974646bcfadbcec0c3ccb38893e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-gcp.aarch64.tar.gz.sig",
-                                "sha256": "73ffb71b10c84c7a6844673ed011c9b23e72fc6dfb785b8fb163ac6ec488cdee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "2725f9c69037ea77fdce736b9a5db1d630582e3c050a629f3048ab9ce371c3eb"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "ade4918759d95d260d2054b79011b4b0b54141ee33ee5ed20034b7d21d65474a",
-                                "uncompressed-sha256": "90d14fadc8039c9c12b840269d26398193b41e4a496147dd4618326ef6ef11c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "4e9fac7953e6fb5e5660a9ec1bc6f7b1138dc5cad9c62350520cb133360f1fb0",
+                                "uncompressed-sha256": "2295b249e4397ac1d1ab636d5549a3698d10f8759f00be92ffe3518726bd0222"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "589aad1839857d04a6a648b846324071d6f12d39e55d05f850f431e3559f96be",
-                                "uncompressed-sha256": "127f3d7cf434f99632ab855ba412e3ab379d7da0a2ff093632dd41aef6962ef3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "7d1bde3e47f1fccff7a67ba5aa96fbc173fde6c193d72c362820d0228f4865b3",
+                                "uncompressed-sha256": "43f14770fedbe4dd2faa577af80234c677a05ff1d1ea989297f3a079aa8a82c1"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f82075ff7b2b0204cac326f59ab9d2499370ae274577aa1fb46a492642ebfebc",
-                                "uncompressed-sha256": "30562a898903f80d550ca8dae4b7fc4a164bf7a045f1914a7ea821124af682a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a2e0a2dbc1d659796747691a38a6075fa5047ca88a4280e8c6bff8ef4dae6c41",
+                                "uncompressed-sha256": "5718ba5044c701a383bfb2530a3d14a9e15b8c8d4c90f9613212f978c3615753"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-iso.aarch64.iso.sig",
-                                "sha256": "bd7cf6da83723d110d1e84f7834deda7d909970cc09348ee1525be504d88ee92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-iso.aarch64.iso.sig",
+                                "sha256": "210b989acafc95e786be451c82b0085907ef4c497836f882bd1fd25ed0877c51"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-kernel.aarch64.sig",
-                                "sha256": "e249c9d6d365dc640215ab759e18d2a8ff06db2aea29fcb4f4d13e3392f4a25a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-kernel.aarch64.sig",
+                                "sha256": "b6b04e199b69d49af1e93f81e40335b8c6a66fffef496714bd009de54cdcc618"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "c7c307bd6bc27978b27536ce5756b1c5086ad4898ace7499395822fb68b6949e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "a2da30c64c890f8e979509caaba4ab2c2de15c0abfa186d72749229ba4388a2d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "3d32c23bfa00137da99ee8f51bc1147c21ea44e7e8dccd4e1497dc002519d4a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "c5c80bf1dba964ca1eda7ceba181f0677432db057088ebf6a1f310c39afbed46"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "c1d0d0cfb427e5275a15e342c506f99d60d0eff0da41121508f110643c95cba5",
-                                "uncompressed-sha256": "766fa8a3ce6931e7694830b294bae47c5572f2ae368762b82ff7ef001d573c2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "a612614f422583678ce46c1fe0a7c0b6184c1904e8ceb7aecf7b1c80b0c7bcbe",
+                                "uncompressed-sha256": "90bc129cd38951676220a4b16422af97bca4d1103dd7f1732b54f0ed51652e93"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4a34dfabb5185ae61a37bb0b2c58e9b2d98d192de81165d7d10ed7722271c3e1",
-                                "uncompressed-sha256": "f89855bd35fbbe92207453b27a1ae503caf00d99dadc5a3ec0f3f3a9ece12ab2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "0b5b3e71f18e68aab9c6dea238ba49c814f62c9650a146174e4afd7996c5cdf3",
+                                "uncompressed-sha256": "d32e8a914ca2b91819b8cea2c0fd25bd903842d6cceb6edb3c17091d1f363aa1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/aarch64/fedora-coreos-42.20250410.3.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7f1ee1a2ccfcdb60e656b39e4b7ae73f2846bf762debcae03f777a9a012e0b38",
-                                "uncompressed-sha256": "12c9db8651fbd1b9d3abe8b0513b27848adefa9e6e72211dc64ecf7d48dcef85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a2946fc5bfece9b133370fede9a542fe4b5c1e5eac65f1d1b6d9488a56f2b639",
+                                "uncompressed-sha256": "b28fe64fcd5d5d08f2e15b05587bc70e5dde399bf99ca8b8d94d78494fa8a2f8"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-085a04beea25f96a0"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-061eb8b293d69f8a8"
                         },
                         "ap-east-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0c90b2b2593bcb790"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-03f91caf4a87425c2"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0b568c8d4c7d7460b"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0d53ab1970065b558"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0e31dc362c62e711c"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0cdbcbbadfd288978"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-058f90bde08e43246"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-055a7ca2ef1182e68"
                         },
                         "ap-south-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0323004265c1ebe3f"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0957e8188e10a28e6"
                         },
                         "ap-south-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0dfaaee1f6237d8a9"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0c0c65fd71ada7a6a"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-035dba027aeafa6a1"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-03435cfe50273797c"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0ecaf6bc87d3be0a7"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-060518f0b90e4496b"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0971f2f760c512ab4"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0b59ef6654b6b891d"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0cab3e68040346a92"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0ff84ca35815f15ab"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-073d802a46b28ae4d"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0fed8eb000e2512e0"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-05f5416547088e7a6"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0fc8a660c4915d64f"
                         },
                         "ca-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0e7c6f3ee712c0fc1"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-079a3ba93f2c9b466"
                         },
                         "ca-west-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0503df3ec2d4c94de"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-07787fe9fc8735a8a"
                         },
                         "eu-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0ca8a14e4a9f4dc87"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-049d6f524b6e43c60"
                         },
                         "eu-central-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0dfa66a8479e2c998"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-09f2c86418624443c"
                         },
                         "eu-north-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0937d9aee9721d044"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0f5d829703338952b"
                         },
                         "eu-south-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-03225c7098c46d0df"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-072c1a5c5d8175bbd"
                         },
                         "eu-south-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-05b63da78618eb9f7"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-084b9d6e47721c02f"
                         },
                         "eu-west-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-08d49fc79d467fc39"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-03c40e91c70e08584"
                         },
                         "eu-west-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0c5c707485ccf98cd"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0b04839fa09319739"
                         },
                         "eu-west-3": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-07147b66b26ffeb61"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-024ee9c2395c95dbe"
                         },
                         "il-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0e34cb3a0e25adb96"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0c3eede12d4b95899"
                         },
                         "me-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0644f830caea58e8c"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0ecaeb64c29c6d0ad"
                         },
                         "me-south-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0a1963348a8b580ec"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0b372d482a087b5f6"
                         },
                         "mx-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-05cc3e1dddb14ccb7"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-03524a7aab045da39"
                         },
                         "sa-east-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-08a4ff096aeda80a7"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-04f853ddbe35577e2"
                         },
                         "us-east-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0011174d303d30f18"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0bae55c8b8587ef94"
                         },
                         "us-east-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-06291edfaafc49330"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0d876ceb7d6f40736"
                         },
                         "us-west-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-01ece755ed1611f64"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0d249f0a729b747f3"
                         },
                         "us-west-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0fb27392df46d6f35"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0249a73ba66d307ff"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250410-3-2-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250427-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "02620c448a18bdd1fe7c63da6484c79e233f613cf46fdd25f99b26426bffd8cb",
-                                "uncompressed-sha256": "56ffe600b1d78f7d36891cd5933d4879a8e396cfac7bdf0c07480bf76ed048aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f59f57a4bc17fbc112406ff4bd2bac5a959570e727b2c85d93c5ede470c06f33",
+                                "uncompressed-sha256": "fab7564e480aa1cc6296949b4e25d065f1d19c7a3ea303dd8f62271e5ee2453c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-iso.ppc64le.iso.sig",
-                                "sha256": "890a66e1bde2a629c1a37b6fd73373b8dd3d6f02bdcaedc7056efedfdf852e51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "d2d94e2d1b5d6b9410ef1b9ef9d949ee2881d4e858d87011b3d8a9e9a8b29efe"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-kernel.ppc64le.sig",
-                                "sha256": "4a522a1b85554d5f4f7aa0aa0cee8d1ccf877165c5c4751247956a51d4a1958b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-kernel.ppc64le.sig",
+                                "sha256": "0aa34c5f7860ac4f37d199b034d154fd298e9d044ab6994afb02086fde6bacd3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-initramfs.ppc64le.img.sig",
-                                "sha256": "feca993045362300c0b0603a0c103fcac42bb0c245f2b4914a12abe48e5d7d20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "486da35c6083b4c742421b24be3956f703808c33ae22ddff505fcbc79d7da726"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b6af5796cb65307c5c0a236e0491917318c6e0421ce51cf83241e9bf66593da1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "2c475f6d4fe24c389cbfde3d710103e08175ed2ca1b270a93a5dfa979fd2b23a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-metal.ppc64le.raw.xz.sig",
-                                "sha256": "fe31658957f8d78b24f40ee02b8cfc0c4074657d774d5247565117634658bb8f",
-                                "uncompressed-sha256": "05ae7ef764a222b090c9836c7a2243b9de7a2c715b2455f963fb0aab095bf58d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "b293d853ac12a5a8ff098b51d7ad47f258be198fc04b16c3ca629c1396fd3926",
+                                "uncompressed-sha256": "4bc378cdd40587acaa28288c2da9a0fc5eafd07d7378588866f943a54c2076f5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "3ed309e489409e3e2774cd1fdd07ba991e704ba1c5c3beda12b1f252df70a62f",
-                                "uncompressed-sha256": "00f509cf2f2eaa85f4b133b81f63665816bccce7079bf09873eb51e98a3dac35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e1b3ad49721f2555a3a1d3af91a544047a6c136917f471e0a135eb9a3da0953f",
+                                "uncompressed-sha256": "7cd14bafc449f753cce1107fc22169d4e8494660b78ac3a3609eff8ec761b0f1"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "c1b7e19b36349a865310d440d87a0a7048dc9e37311c0fc6b6473f8c1aec12ac",
-                                "uncompressed-sha256": "5576a08c43abb0dc41d892e601441fc244dee9320bb749b28a282b6621747c4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "cf9dd459b03269d57d9de61e08005f9d20e1968d2659122d0d313abb49004d25",
+                                "uncompressed-sha256": "3c55ea4497d55e648959ffdd1d10e6cca98f02ebe36c1bcd94e041c7e4626c8e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/ppc64le/fedora-coreos-42.20250410.3.2-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "b7eb8ba48c34bd0896c38c2cabdb6310d316052300484927d67e5c17a5ed5348",
-                                "uncompressed-sha256": "fa6ae323cc3208c6529c3523d50e5b126be5cd9dd80414e4d7de5b105365007e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4c2dd66e3d0aaa7aba9d5d900797a8ae689d49de6972a3af9c7b40fa55e36145",
+                                "uncompressed-sha256": "fbfb12e97b3380cb40c4cd06d20475730783bb17eb70fd9e0c015716d2b00c9d"
                             }
                         }
                     }
@@ -389,85 +389,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9e1d5e80fa3b28f8eb56c85435234e6c6b5f82d082e33a670df1050e528badff",
-                                "uncompressed-sha256": "fc6aafe1d828bcad8ae89574b36464548a4f49889e2456c9843a17144f9ef33f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "51c482a325387962e222579f2001120b20ead7fcec4ec68ab2faef06c028d550",
+                                "uncompressed-sha256": "594545add4f671564d4ea6117fbc4a903c78be7f2361a1a5616ddb51be9fac6a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "7209c8fb78f65291ac0a53c9b3c27170cc4a1b593652d2eb7a662af090ce8422",
-                                "uncompressed-sha256": "4446750812165cbba7231799574e21dd0dedd122a1be910806732e434042b85b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "772fb8656af45d46be93ce80195efd6c7c68864326933a49ccdd61d69882f51f",
+                                "uncompressed-sha256": "5848776787506de828c7c06a8f7c2d55bd8136c881ae000f25154cb516fd9229"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-iso.s390x.iso.sig",
-                                "sha256": "4af2a68e7988e455d58cea6a20681200e7d279c1c949f189dff6eb32817b5ee0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-iso.s390x.iso.sig",
+                                "sha256": "8695c01d2d6051254a6f6a3def7d34cf9788e897bdf459797dd675a864966341"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-kernel.s390x.sig",
-                                "sha256": "1e340eca4d780fbf5ebc94e683060463acd1725ceb437bc0c7e30994701cf835"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-kernel.s390x.sig",
+                                "sha256": "47bfcd274f467ba058929e38489b7d383272f37d36326bd91da4b4097fd38698"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-initramfs.s390x.img.sig",
-                                "sha256": "da35fc1551135fc1d5d319ed2b1f4d76f622a1f75a91c923a2fc49973d39dc09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "d2bb97c3a99244e48d37164a5044fbcbd30ff07e08eaac1d23ede87559e3169d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-live-rootfs.s390x.img.sig",
-                                "sha256": "f852e7268605d709eadf359a27f29d6a4d842ce71b0fabe6fa65a5b18a5acc18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "5beab008e2a5b02793e0e1d5bad1fefb56f323d5e3f0ea80f1edd59feca7f239"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-metal.s390x.raw.xz.sig",
-                                "sha256": "c7e83055966612bacbc7aeef68ea0adc63bf8b32ddc0cee67aec36c816a7b7a7",
-                                "uncompressed-sha256": "c362918ae7fa42b4bdd65faba560f9fefcbfeae763883c2b374c4ce95ca29d96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "9329b857859a4bc783b5f0a161a8544a3b98329d7e442dee786e75aae604937d",
+                                "uncompressed-sha256": "7829be46f1b9c4d27d7646d18c9f9f2229a83cf0879895d12ebbb29357227dd7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ff0b19c89013f03e0b314b23d395506af8316209810d0acf83b90730bc13ddad",
-                                "uncompressed-sha256": "6ec33f4740a27e634ada5b416d988e4101613eab2ef9d71ff17cd6e93b747745"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5f66639066324b9d6198537196fd3878b96698b251d2304c275f8b2b537d602a",
+                                "uncompressed-sha256": "eb535d7b73c4521aa827dd579d57097b8e5e49f67c5691c84ee6a2ea90dd9cc7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/s390x/fedora-coreos-42.20250410.3.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "70b30a112c46d04fbc1f867721f5eb4405c1187651c6b97259931e3a1310f666",
-                                "uncompressed-sha256": "88316a294aa3f6d4a78b7678bfd6e2f6c1b18e11672f8c715f9e7bfebeaee014"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "b232f65730ff2285e0db58f9e78fec6a348cba08c647b227b39fb5d60e9cdcd8",
+                                "uncompressed-sha256": "8ce454580537a45beb15466dc4a0900b0ff363f0d98a2a806337ded46befc49a"
                             }
                         }
                     }
@@ -478,275 +478,275 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "7221b04bb55545a3d5d5d90ad1134787c7ab263706fbddd13f231479db50dd6f",
-                                "uncompressed-sha256": "6aec4157a5d2538622ac7e2970d3d9b9f35046309b1e57b7e641cbe41c43deb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f5c89c27a3a8b3721cbf6627049e3c2b274238d9be03294a81ab0d9a110e357a",
+                                "uncompressed-sha256": "40c4a6a812e8d41495e1530712e72b2e3bf8e2c60cc4df6aa68e4875e2fe9ccc"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-applehv.x86_64.raw.gz.sig",
-                                "sha256": "e88a91154c1bbfa8f1a1ccea59d924c30808efd061c06b94ff00fe6dc0ed76f1",
-                                "uncompressed-sha256": "734e58bd4c9ef6cfc8fd0ca4096b1c43b4dce96fd79c0168c12fd336de789527"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "06ee30fd2b5aa200f358e1e1f97937f0efa27569c8c772a6f02cb514caa29c2a",
+                                "uncompressed-sha256": "8b1be65cf56ec7e410319644e606f0a71e6d04d55814066bcc37fd13db1b670d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "32dc7a11dc61d8a7a8ead62082f9896ed8f1f3061e194d420262bc0413a872c2",
-                                "uncompressed-sha256": "e40a919d7cad8021d250f4ffec1a67dfc78f272e443dd33fe74eca025189b016"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "90e4895d413098376c58ac63f3aedc05842d3a0501683ef996c6fbf483b9ca72",
+                                "uncompressed-sha256": "df4bdc5d1e0cd9a2d50e6a30876ea2bf67ded241cd1f8a15c3bb81a9dabc0467"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c3bce9cf157bdffb8d664098c9090fa0ceba5f3fef23c94d78ac4f36ee53a8f1",
-                                "uncompressed-sha256": "78bff430fdee603e633356d3192e7a0ec0fa591b95997708de76b0e38ddcf8da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4d6de56e10f4a8960aee8fcb56cd70caffbf92c891556c40ebdfd54b9305a477",
+                                "uncompressed-sha256": "db0cb1e169bc46f346bbae469034d971f5d28ea6696071683d09db5af7f229d1"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "2ddedeb4306b1e7fa4de52b8ba2e08d58c8ea8a49aa9d6b914fad192c20534f0",
-                                "uncompressed-sha256": "9189d63c7ef8b2d4af891a81aec2d825a4565a68449dba5a17bfe5aa0e860a99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "93f9f4ba6bd2a191db433789d119a6713254f4193f2314473e501fc96ef534cd",
+                                "uncompressed-sha256": "5131eca23e0f1ef50e50a0cc0a4e51db27c5b1b6a4448313fac1d8c233f82f8a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4f3685ffd72c8c5afeaf620e56968dfa1a69286a2696a1c0da3c3386f9450f1e",
-                                "uncompressed-sha256": "21bb357e44a5e9b3f6d5f42604869f64fa5221b83020df9414108608d17692dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "36de38c84232237146e0aad324b3b2a51d5246501fb57a3e3d47e42aa4d27ed1",
+                                "uncompressed-sha256": "c92adb2257ee961e2f1b4816783a474aa207cfc3da48d9f74f9262380eae9858"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "feac443deec50393c0c02e34776c455aa555cc2c6f519d8992100b8a04d8aa7c",
-                                "uncompressed-sha256": "85b214e827ef9cc3f945283c7fe1a256039a2a927661f27e952d70d951257ca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "aab7f6f7fa31ddec80a5e1c4822c600047d1059fe6baf9faec86ecd89afba3a6",
+                                "uncompressed-sha256": "5dd9ce2f861c35aecba2baa0112e490826927cc2338120c97fe467f85eadab1a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "225b134a54f6e8e59cca4f74cc4ffd9864d960644e165bc37ecdac8a8f4a26c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "bc6d2707f37ce9f8ca74937676ab6965a8426d2126538d26f9c0ccf09000cb49"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "be253502dc206376c30bb4540705020ee4bdd114651641f34877dd35d37bdba5",
-                                "uncompressed-sha256": "53d10a4de1bf188402e7c1c9724b11a41a18ce372d3945dfb5ad929658414b51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "697ab8e68ccdffb639550f211ce25bf5072c8ffdaebecc5dc50dcedb431cf624",
+                                "uncompressed-sha256": "f974961e0eadf04a7930a8984113865db01f5501a180be604f2575bcebaefc1f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "2ed8a7baa399164c2afc514efd2f1a6af6a041c34a8b460aa1d8a3b51d648841",
-                                "uncompressed-sha256": "bf21fbb5fcb0994f498253fc8fc443932dd30cce5611e033fa5401e152439c44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "8f17f508b320bcdf5ae91424aff120f6cdd56385a7cf20300fafee03ad93ead4",
+                                "uncompressed-sha256": "d867d7413360b742076ac631e84b4ff37515028d5ff5b7cf5c1cb8a6b05862ba"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "dfbff97f6d85e2c6473a8a383b4cad47f5462a4e68251aa235175ed54abf9bb4",
-                                "uncompressed-sha256": "09e0d61c081908e0d700166f2a780ac395319c23d5fc79050379d0ae04570d21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4e6b1bca15bb30827df50bdc7d95e43025e69a7f2d3b5709bb4b5744c52050a7",
+                                "uncompressed-sha256": "15930b2e0064aa9b72e69b21a3ebb677d1f2d63a4e41ef22a98e8e6922eb1a7a"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "6ca5a70fb07c6f33bde202ea0ce00c12e2d7e4a5c21125dc29937ae4ff9c0c19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "f016dcaeecfd572d6e3fbe035d41ec488a38f67dec48c5c0f1243db214940a35"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "70782a1441e9f1a46aba4f5cf64043743808d99d2ed9e71de10582f5d7a55d71",
-                                "uncompressed-sha256": "a28a7ea0d534a723849aa057d4833b712ad7ff674fa31fbb0bd1dd648cc0133e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6b8692daf04bdbf890f529f5563cba55f2b09abc8abc36f3882700e4746b8aab",
+                                "uncompressed-sha256": "1e953985ac01922cf75531a1df013f6a3b8707d54bcf5f7d51637b0649269328"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-iso.x86_64.iso.sig",
-                                "sha256": "35a370954880471e8dbc11784161ffe67d72e0cbd18bf8feaec1ef71effec90f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-iso.x86_64.iso.sig",
+                                "sha256": "b6760d7afa58b16221709c20f9ea6f2bd65987137045aaca6984c5113055513e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-kernel.x86_64.sig",
-                                "sha256": "507b2265becc1125b372233c43b044ca68d8cdeba9ed7da2544e1c98529ec289"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-kernel.x86_64.sig",
+                                "sha256": "aa30a5cc0328207724fdb75f6b1c9298d5cb979200ebf8c008643ef2f65e8122"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "c4cdbe17dbb8b1c0dfd41924fa4958e134a326f45affdf7b16a7b85216b41e1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "8da8c9b65010a3405b22138e6c5d3a1d619b524d257ccb1e9139354a6e2d939f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "e88b873ca033fc418d88ef0fc02e28c72741129b534e2c60b4a6a4256cbe8248"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "eb2817ee29cd05df1bc6fc8aab4952ad5946984ef1ef634e5fa60bc6db9a0481"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "e6a9b1a48c68ce60259ad57b31a83101d3533acfbe9051901693809723777848",
-                                "uncompressed-sha256": "6712e61506cd04d163b9a588790625049575aeef14db23e2d07bd4070aa3390c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "4f2fad606bc3801d0102842c6bb378de2afa4616a624963ab91c318f3c3b63d6",
+                                "uncompressed-sha256": "80845b7778fd5f1a866f2c851d064058260140fc516f4f1416c9c2e5056c3d12"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "06a292f6769fd554d38e0463e1d5d7404699be4278ca23f9bfafaae5d3178e32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f6caf9e60e5c1b1715c5f5bc9dbdf4f10040978248ddb2cc07a486ff2eb2379e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0caba28a281fb4c164e66269114d2eeb1d661d04749ae753d94b229a118959b9",
-                                "uncompressed-sha256": "1afd250c94ab449c4f0fa885f5af0decb6fc6df0b1436af883e670482d577e21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "0f60998ce73687de040161c1677448967b5ee1b389cf347933e018869b59d04f",
+                                "uncompressed-sha256": "df13a4f38e4f622ff7072133969b41492609764c6c4e9bd383508d53087c0e11"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1ba3e12b204bacd1e478f2c0efde6091712e7db80f971268e802f1b8fa1d4bef",
-                                "uncompressed-sha256": "c6c7ac4873267b4af93a2f760b4794f79706860efa046340c32ff6b1ada6dd04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "57f32381c74442f0eb6040ede2775488e339599f66960942756aa9ccb4c1d6e5",
+                                "uncompressed-sha256": "da32e33ae3def0c9c82187b087e80544d38cc6457744c6a69750593c1b0cefa5"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "5d9ad87cf0a3fb1c9469d958146533154b12bdfb11fcdbe53c470547f61c7a36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "0ab8401e0432ff9e80722af3732f170c89989805d76c33b7228f7c7f27404deb"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-vmware.x86_64.ova.sig",
-                                "sha256": "7501ecee04794a6f0d438ae4d1e6c620085c2a730e263e2588d07a8393a04241"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "6944476326fba928089813f729a13fe7979504ed3cd995934180b50685f1c351"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250410.3.2/x86_64/fedora-coreos-42.20250410.3.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a222d9d0ff46a8d919f44e214ae384c988172f0627609f1c66cef021b5e42f82",
-                                "uncompressed-sha256": "5358285843f8bc0fe10ae3b23abc9ec49317d635e11099ab83298cd52ac8d1fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "57f4c9192ec6e7d7b94182bba3ad66cc7963384e6603d284e29c3d1bba25ba9f",
+                                "uncompressed-sha256": "d210888bab85dfa065cb7ed0d906b9820742408934d0910cf765440ae50172cb"
                             }
                         }
                     }
@@ -756,145 +756,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-04864dde81b389554"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-03b1d027a533e5d1e"
                         },
                         "ap-east-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0f008ce8de8e6a332"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-069fbb16aae225314"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-04b6c87646ad00bda"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0465ef21c44702b9c"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-057ae6ec8f6d33ae9"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-09623635923446f12"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0b00ccc07ebc1fe6a"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0b3ddae99c1ed6e32"
                         },
                         "ap-south-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-02702987f5d4c22c0"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-023b855284bccbbe2"
                         },
                         "ap-south-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0db5c3a506eaae29b"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0d96a4479b323a229"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-010e38db4a40aa986"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0651fb1504eb505ee"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0efd686cf411e4ef6"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0d96548460e40f984"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0765de9665cbaed33"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0d1ef2e7327a430bd"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-03beab6ec1e1d102e"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-026dfd2e240177e51"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0491810769063560f"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0247b47fcddb23aa5"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-01cacdad81059e3a9"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-04958d76b45d7dcf9"
                         },
                         "ca-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0b66c767ff1bd9a24"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-025fadf576148b7a0"
                         },
                         "ca-west-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-00ea714daf77a32b7"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-07d3ed90b34a4a64a"
                         },
                         "eu-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0c3ad5b862967b4f1"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-04ccb2a894d4c893a"
                         },
                         "eu-central-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0225a9f6095dfdb71"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0e4ea4655289d0408"
                         },
                         "eu-north-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0adedfad833d68c0c"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0f882da8265457d5d"
                         },
                         "eu-south-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-07ec459041845c687"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0d47881dd55fc99b7"
                         },
                         "eu-south-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0fd964ab51ce34f81"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-03f75e9047b998b88"
                         },
                         "eu-west-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0b26a2b0a0e45446f"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0897993acbe1c5b5f"
                         },
                         "eu-west-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-05dde7fce133faf9d"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0bb33da219e202306"
                         },
                         "eu-west-3": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0ec8746e55855855c"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-076469fc123368c7a"
                         },
                         "il-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-00f78f7b2ab8bcafb"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0f027816402bda079"
                         },
                         "me-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-059377625365e5a6c"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0f7d57d2b61b9edc8"
                         },
                         "me-south-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-00725e9dad94b672d"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-009780ed583b498e2"
                         },
                         "mx-central-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-086c66771bba95ec6"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0801dff62cb332a85"
                         },
                         "sa-east-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0d9f49468645e1b98"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-069fa30c0f56a8377"
                         },
                         "us-east-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0032387128c80f1b5"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-036f0a8106be1efa0"
                         },
                         "us-east-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-00c8f2bf79c8de60a"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-04fe1d85da76cf2a3"
                         },
                         "us-west-1": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-0065b9c48430af458"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-0e0f4f008ecfbab7e"
                         },
                         "us-west-2": {
-                            "release": "42.20250410.3.2",
-                            "image": "ami-019b6dc2e29fd814f"
+                            "release": "42.20250427.3.0",
+                            "image": "ami-01cc09feb65063eb3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250410-3-2-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250427-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250410.3.2",
+                    "release": "42.20250427.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4339c55b5a8ddab41eaf69c888d2bf46c43a08ca8c93a8887208624ae152b501"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:312d87f36cd129b7f75f1e74bea62415549b4d965d666c305a8b90c000a2c1dc"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,156 +1,156 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-04-29T15:47:29Z",
+        "last-modified": "2025-05-14T09:25:04Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "0532ce85e31dd797464be2fed42bed77d6ed605beaec15ae47f5df890b829197",
-                                "uncompressed-sha256": "3be0fbc658318dfebce4962bd805903298d1893cfe7cc0c54f98e74cec581d00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "04a50bdab89a403ac606084ef56bd614c9759b986af9524f22e68dd56c096820",
+                                "uncompressed-sha256": "7b26bd2f7df8d3388d589ab984998c8781af72a35089ed3509187286415849f7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "13fda5809101fad4a9e56e37e474304c73508359b51d08e030136c6f448ee66d",
-                                "uncompressed-sha256": "71250a9ff26c1133e77fc72bb84e88188e6a7361bebedc141df4abe533309510"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "751b873cf71dc136f624c8f90cc3f96e3b818973edae9c8c57428c26c5e008c6",
+                                "uncompressed-sha256": "60a5c7f299b5f2d9e25babb8e0878db0edf33dfbdedc599746dbe2b0fc753889"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "69a3a893d14e4d38ec6d47154e900d69874e6e9b9359dfbf40bc7d13491792fc",
-                                "uncompressed-sha256": "7f4423fab516b3a59677af4ff1d35496e85d2cd7e878e4697dee837b22b1136f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "e485cd5fa22406f8009133e8080e85599bf61c5fbbf45f17ae3a09214538f940",
+                                "uncompressed-sha256": "9d8d0a65e4980d93c1579c791b8df574c0e461397953969f384fe6d37898a8a0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3013e39a26b9ea72f387e65b2aee7f75f24c2a5dec342481c048fb4c5c58d1b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0e8503b64225162e4c96de170bf8ac223716dd329a6b308c656deb40a98d5a92"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "d88a4fda12e98fb1509cc367f44ef3ac50476351fba37d72e5405b0c4886fc0b",
-                                "uncompressed-sha256": "2d731688de0912efbb677c65c62dbf4c2faacbc63327e74f5b46e922f2c8c41c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "2f0f24392e3581777c906b8fcaedb4e0f2451505273017c2ed1041f6090ee187",
+                                "uncompressed-sha256": "cf97159e1a14d5e6b7ef3093ee9bfce5bee545c3a27abd013aa32436fc433458"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "844bb937973013834a5d5202fe33044aabcb576795f2eab8d5639b218e7085e9",
-                                "uncompressed-sha256": "e7c63835ac613f0b9090d6fffd8158fba27c69ae64519a4d58139b30d4f7058e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "f1ec2a5f563bab14231c491bbe05702f841da35266e5d24ab67dfb47c2291e6c",
+                                "uncompressed-sha256": "21421b9227e43b8e0434e821a901d10ca037a3f9766f2360722dafa6fb8738a5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "83586f70f8c877ef36841c58b696601e57f7496b0a6d14198114cfdf9e0ad15e",
-                                "uncompressed-sha256": "d03fb5040a31cca9d50a03e0e7caf481cf8a69ea09357e4fa771113f0ef88778"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d65d739032a58bcaf0240c7e9f2ee8b5025d06bda8de513a02a5d75134226a05",
+                                "uncompressed-sha256": "c72a2cb2d1b077b0d6cd26a77b6a16efe1dc98d1e6ed2cbf9aaf6f6095285615"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-iso.aarch64.iso.sig",
-                                "sha256": "61758f876f65dfb441a8059264d777ed850249891eae1bef77890a14f98347e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "49f02fbd1ddec0ad70f89ce4eb571980081dca04860c90c4aced78e54f624c91"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-kernel.aarch64.sig",
-                                "sha256": "b6b04e199b69d49af1e93f81e40335b8c6a66fffef496714bd009de54cdcc618"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-kernel.aarch64.sig",
+                                "sha256": "d1e29a6904a85764ad3433262285c757d2009d8db2e5e49f907325bb7eb5846e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "8f56d87517b637cca899a739684a6c0b145075e2cd8f987a63c9acbeff3a62f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "100290218ff25b8ba824220e40b049945a1ca5ced074831b8d98a7b9719b8d78"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "2cbb2c35c9e7625e5f61558f9fddf10ef801765ffe9fc83602aeec8c4a615273"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "6cd12e7d7828f8a45dfda7a05b5e283b9574e428b7572d2e20158174211af56d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "3b36ec6b5cadda1af00e350032afec9082d90ec53b0cd3e0439ff9ca02cdbe91",
-                                "uncompressed-sha256": "3ec8010042fd023a4986b8cb2b7490e9fc21bbccb42f583c7abd6a4247f90c3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "d1fe6dfceba7e81dce2583838f1fd2117fe22f95b45e0081d5b56e17670f4892",
+                                "uncompressed-sha256": "425f672d1ee5d31c5af869c4ecd6d8f1d757e42f1b2dc39b7055c5194cb5a800"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6b19235998280a04f8137c1c1ca697e948b58296b7836683a54c2a53bfafc7a1",
-                                "uncompressed-sha256": "cd4b9826e8697cabc2e56559a8801f1cab77c4f3f28b67e2732709f8bcd05a81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5957e30e1b898ffdadfae74dda3a62d7f50eaabb834d331dca4b9b8c8942a337",
+                                "uncompressed-sha256": "5bfa5c52763bca6ba8e822f8dd3177a3445009ccad7f2a11e3b887fc3bdfd422"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/aarch64/fedora-coreos-42.20250427.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "bb23cd3086ed446c560d6ee839a23af699d2621a2acf5390ee283c0c9966ee38",
-                                "uncompressed-sha256": "8258b2a99cd01bdab4c7442c78e6069b9afd28218d05051821350d1c5b3476e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "630e9700cb698773c42a33216cfd8481ef19d0dd0062959853b721e88e876398",
+                                "uncompressed-sha256": "4d2b0fa2e2e5bc0fe9810ad0e7a6343f56caac4dd356af5141d03e6cee3bc974"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-047a7a7abbae2c317"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-01ee5b82406138a36"
                         },
                         "ap-east-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0f6700db54681a4c5"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-01569137987e6d45e"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-016718a4fdbb485da"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-05c5f4843daea748f"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-017a4bf4cb896f88b"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-007daed21084c1826"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-06f3fc603f5a67480"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-033725c96bdb7bbf2"
                         },
                         "ap-south-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0f50939910e31d6fe"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0de33979bb614b41f"
                         },
                         "ap-south-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-02783918585423269"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0d9cff14467440a08"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-014777f3a420aeab8"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0d87ed73622954553"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-00dceedaac2ebac5c"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0ce89569efb7c8b6a"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-034a981a761bd49be"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0cb29bf50e91557ab"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0938fd0fb391f183e"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-02128147055a877d7"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0a6ec29708ad24720"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0c188998e9a678fac"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0272ecf7622172a8a"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-05ab3577fd8a48f44"
                         },
                         "ca-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-06df06ee126342aad"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-036b54892dbae05c1"
                         },
                         "ca-west-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-045987e82f9f595d6"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0cea3d6388e3b0f9e"
                         },
                         "eu-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0ce83bc1e106b938e"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0c9601590f062b49c"
                         },
                         "eu-central-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-01ddf2029cfde0f19"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0ddb4196e2e4ac66f"
                         },
                         "eu-north-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0a88825313ea862c1"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-02165debd6806a4d4"
                         },
                         "eu-south-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-09559d98c5475a0a9"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-05f12a2dde1abfe31"
                         },
                         "eu-south-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0f4bd90b19ae07eae"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-07a7fc62fa1f9f014"
                         },
                         "eu-west-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-070ccb36d679c0fac"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0e06697f30e39d5d0"
                         },
                         "eu-west-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-09b4da79b2b70ec13"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-040fae4e146262262"
                         },
                         "eu-west-3": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-038fbc04ae39a52cf"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0dd04834e65acf240"
                         },
                         "il-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0605588dbc4a696cb"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-01f37bf5c4089ae1f"
                         },
                         "me-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0072060e3cd077efa"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0d0bebe5b646f52a1"
                         },
                         "me-south-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-010f73b19f56f315f"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0643faf5f5f1ddc2b"
                         },
                         "mx-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0407bed0dbef83e33"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-06778e2fc19f1a6cb"
                         },
                         "sa-east-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-08d50d098a706803e"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0521016e0f2d97e4c"
                         },
                         "us-east-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0e7896a4e9fe05bf4"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-07492a364cb89ea44"
                         },
                         "us-east-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-074209c5a52f8ad5a"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0d0df0b82a1ed6ceb"
                         },
                         "us-west-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-00c4a89181d228574"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0abf46ae585269d44"
                         },
                         "us-west-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-083b5b6b4643cb8b6"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-013511e058ab9aca9"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250427-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250512-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "8ebf7303a687610c057a95f963be17e305e3e94962ccca5ed03f41c683b950d2",
-                                "uncompressed-sha256": "27fc5c04d25a3f381c9de20b87a6033f43a45b05511f39fa3fa1cec3f535f1d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "595b9282df70995eeafc3d608a1591543deed4c377e9c3d6c6ea8f7af74024aa",
+                                "uncompressed-sha256": "690b40c66dae00bbd5a6ae234495a698381f2282c5def3d6f4e3c3d19482cd5a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "ccf58657d3f5ccfc7c9eee44ea61892675c520fab805873ee051527586ec9bd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "80aa9e46354a40cdd03b4d280221d53324f33ecc5c8682076c6273e00ca65e5c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-kernel.ppc64le.sig",
-                                "sha256": "0aa34c5f7860ac4f37d199b034d154fd298e9d044ab6994afb02086fde6bacd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "d66a3c81a6244a6ec567f307267df8203cf93ad765fe0e9f3e980b39d8769c2e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "c6ebfe731bdc0567f50ad642474c99a4e131cf1cac5ef690338a930c74822227"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "8958bc8c59b1377d50fb39c66e172a39089cbdc79d711f4ec5488ed8fd907cc7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "18ae9f9d3a20fd80d2152ad8b89e6d9b31b5a448a0955dbdda6b75ac479ebebc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "9b1604d4b8be15ea1195f17828c55edf5384fcb07f8d1589196ae8aaf4c0a08c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "5e29d7a6d60a077bf976a574dfefbba029d0c75ccae7d88309c1c3470b6fa16f",
-                                "uncompressed-sha256": "d07541f63a63386cf0c1947c21cd6407a4f345dbe6134f0db2395b9a05992add"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "10de1faac7532b03bea1aae61c684495a0a5e68bd96c41c1d40f1dfe31f963c6",
+                                "uncompressed-sha256": "fe7eb91c8b8de18de4a96412c2d40dfcf7332fbee421557c10f63cf7f21c57ba"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "cc0db19d78c83d27924a5ab8d611bca97127595ad27ec5b15b6c972acf7de8ff",
-                                "uncompressed-sha256": "c23a5dbd8088ed73f43806513096f76f75c64fe094ab09e660d89fb5b5c6a0cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f00371489c99a5dd8807f281be02407182eb88b140b919f57d146eb9c3768adc",
+                                "uncompressed-sha256": "35f0c9512482d75a2ef01806712ce94fe2c83f47fea9759499241e9fecf3614c"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "58fc8389a3c798435e292a1693fde6e9c352e6ab397e13347acd0700b72dbed2",
-                                "uncompressed-sha256": "a179238cd3a2805380b4043892c14f730d461288117a78bcc5bc0dbd5355a492"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "4c0dcb54b6de2584d32f3a6c37a1120eab81e85fd052e529f730c875ece2285c",
+                                "uncompressed-sha256": "edb16fbab174a757e8edf72f36a6b603bc145a3cd0396fe439bd4c45c4c2e7df"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/ppc64le/fedora-coreos-42.20250427.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "364a8f6dae7ec0784e6679c7053977c507b2de7f5756e10b2bc15260ac47dac8",
-                                "uncompressed-sha256": "d4eb505cd91c51f778426917bf0510464131c37007c6fee03e4f5a1df23cf715"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "d4f06aad5c9562e2b67e2f8740d4633f98dd8d8f1324ec3d6d76492a44b8554a",
+                                "uncompressed-sha256": "be3c796e4618fb22a46c1fd3b86188a51e7a0ee14c6c6ac0349941f4ffccb083"
                             }
                         }
                     }
@@ -389,85 +389,85 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9a1d8f5e2c50bc0a61e2a2dc108652eed0d9935682259c8b03fac843ebccf6fa",
-                                "uncompressed-sha256": "50f96fc3a2bd6f870f51c4728bd8395f7b1932e6dce5d87471b20dad89289e22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a8a65446fb4125aaf4782355bd5163e1123d3938bd8ab009f548bcb27647d815",
+                                "uncompressed-sha256": "46891f4a06e097cd759437ca255982c493f5b1ab74bb93521ee9fecf14950186"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4a026979ec4db2cc1dd91410f998122fbcd4d1731a3e6281243a86552d625547",
-                                "uncompressed-sha256": "eb7b3d7d36e41bb42573e931910726c9d1b0370d13ed17054b085ae339585c76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "06b25cc3688975248a2d78841e00a251ec90ecebb5d1cb7078b02a3afe86b1d3",
+                                "uncompressed-sha256": "07f1081522dffce7e6126446c32d2c55c9ea0aca93338a3ba1bb6ba3cbc2fe28"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-iso.s390x.iso.sig",
-                                "sha256": "10470b46ce87d5fe71241c80d3f6ff8c30688b478d34817773a7f67b40c908a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "1b0e128a0fa649547120940d390f93a2fc830bdfc5093674a101ef9da9c4acc4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-kernel.s390x.sig",
-                                "sha256": "47bfcd274f467ba058929e38489b7d383272f37d36326bd91da4b4097fd38698"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-kernel.s390x.sig",
+                                "sha256": "a13d1cec10a9c4fa5851a22c3fc0becd4bf9e716aab4f32f1407ffd1a10ab999"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "fa55b85babbf0065efcb13ca2c1a8a361e91dc1274c972e29948572cf19eccce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "a822d8cdc305f28c2b89a6ae6ef4017d2419bc27dd26fd325c1b54576a2a34a1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "973f8e13ede2121ab2918d4cf1046e090b7c8ff3c0c8430bf1270404bf2aecc4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "2ca3982181bb347208db6bb44fbb44dd6cbf534625692c98925cd660d5af782e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "d8a6ddd2c37051302759b4d5d39e4e416f355616817f03b5ce52b14c799315f4",
-                                "uncompressed-sha256": "e9bc72563b3efc667abc952250ae14a0ae03e81297c43dc392909465b63bf759"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "5dae9cb03ce3e2276e5d39b50c02170e231d670f3a501aadecd8e0d642f851d7",
+                                "uncompressed-sha256": "fd758d451f35c0df5d4874b0f48d64d6b880aee263b86a51331fcba687ddff72"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "414ca6f0e15f4d5569ccfe3c0804857b058154a72eb2cef5f586264eacf56622",
-                                "uncompressed-sha256": "83a47871ce5fdfab9d4e6f8806891b991ee1cc28b5d407bcd7b5c1761bbadb46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e56edd984accdb40b32a14609272ce05b2320224047fd4352206437c9d90fe9d",
+                                "uncompressed-sha256": "131695ea1a03ab51ff2098f90deaf7322a097046b1f1b2c9bfe2316b5907dffe"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/s390x/fedora-coreos-42.20250427.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "8eaf1e0ce9b51774f70e853c2630dcf9d8fbb934bfd8785f852e29b4bb3e7ff6",
-                                "uncompressed-sha256": "da1b3b29199c8776dc07543c3e14ff281d2e16bba186d04fdb3013078c2700ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f3b6d6cadc0f61983742f4bd36c262202d92e6a5777c7db61c32ec3b72ab2f96",
+                                "uncompressed-sha256": "bb1dd7f2d2ac8261f2c9f2f98bf9ee64c8bb827d5b9c1a77e7a3741b69e744eb"
                             }
                         }
                     }
@@ -478,275 +478,275 @@
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2e183250f38c75494ef7ef621c0ab61825d5d652f6186e2f97513d0e88049115",
-                                "uncompressed-sha256": "db01819fd95161c86dd564a126ed58fc9ba4f594ad8836b58aea725bee64452b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "111a5fb967455a0dc79c2dde108bd1c459f4b2020418671ce9b986427872dab8",
+                                "uncompressed-sha256": "8f21b903e19e245217f6939f000fc90579a8e1233a51a868280b90fa8ef876ac"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "23e601188d8604a7cc882324db0dedbe6e5b59e2eb6d7e8ddf37e637a21f9bf0",
-                                "uncompressed-sha256": "a4162b48dbdf8272ffbdc281327c7d110ec99a7d263fdd3dbe2d4f9c5e37cb9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "9c9e304e5eed96100e12dd23a87a2dcdf407ad678fa8665dd2412198fcd9408c",
+                                "uncompressed-sha256": "b6b237a9951f6a8ea79a9d1551af5533eddadeec46a330ca3a272bd1032fe946"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "dd229ca50910a0fc9fc2bfe941a16138a18b25a730ca791beff500c472936370",
-                                "uncompressed-sha256": "96a06ad88e1f955ef4c697ea72a80bc90a531bbb071658ab959ebebeba0664f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "77583c4a0cb4e20abe1937e4e1f29ac3027ff3f1dd2f51e3aeb8749e0e86866a",
+                                "uncompressed-sha256": "5225585ca65397733dee1180cfefd6172dd045ff71691050a654a92705e3acff"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "18669681287afbcf489ed3b7651f31545712eacd7eb14829b1318f0cecde154a",
-                                "uncompressed-sha256": "3279f688f86afca8f9741ffd2e2bd7d8ccf93a9aa9fd5beef7ecca45ca3d3951"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9259292b25d74d7e8e95b83db45cc8b7b527dbaf6f4da4f60f83118d70bd79d4",
+                                "uncompressed-sha256": "ab1dc543940f601bacc467d292ac6c48af9419675a97591a05b8f36fcceb6ef3"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "52ad31773df18ad09aa321cd183bc1d6bd276814ed2ee7f5c9482d617fbc23df",
-                                "uncompressed-sha256": "ee9006b49f5f11e207ba1aaee7341325555162b749130758694ff7501d23c96d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "888f7ca3a0fca3cfb54d0c8c00032cbec0d713990b7bc250341a05159d4897f8",
+                                "uncompressed-sha256": "77ead75edcb6afb7571775b5c6a2e276a9da2978a75e8d608ee363fd6feabfb2"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c638b6cd4cc37ba0035bda91a945695a3787522a08daa935b79beb37e4ebdc56",
-                                "uncompressed-sha256": "2c6a5009daa612b08f02e42146daf38d0c65061ea68cc9ffd07e3f38270d0c61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4b0d8d4b4418bf8e06f238123c7b141476d5331fbd4e0339c2d29986ff265dec",
+                                "uncompressed-sha256": "d5049842bf1981a17772bd10a95805d51b4853db3e448b02ca27472c4c7b94b5"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "4dacb42c157883c2e618f0c4a3c90b0ef54e94bd504d5198e998a5505e7ff53e",
-                                "uncompressed-sha256": "1e608a84147964e0bc1b4a58cd13777caf80508ce98f3977489ae88661efa1ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "22ddd082f7fe1e118504565b20c25ed2cef30a8019194f5da439abad234768e0",
+                                "uncompressed-sha256": "375cfe7c1b36c045b7c409ec3c4f4aef95e1984065a16c2bb45f0877498b2278"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "7799091e74b82b5b85bae1e206662615ae2ed04c3cb1cc43b64c8a0a9f342ac9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "32d47bdc663143eaf88735edfacaab9b93c393290bff3d036dc55debb4100076"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "f73c32769cf20c9054026494319b7c11fafa4b8050fe3d979b008fdfec254931",
-                                "uncompressed-sha256": "038247b15b8e3756a718ff1be086c8cae3d896216a429b07d8fd05b66ddd7cce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "e37f9f9365cecb211a983e0bed9396c1e3bb5d29ac340fdaacbbf206e3b8492f",
+                                "uncompressed-sha256": "3cf5245a01ce56a8c27a991072f727e9a79641fbde7dfdf95285b1dffbfcab8a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "58b2a9fea2c5242b9c360ef76bb5b5610621dce79d8c133016798f1380f13d8e",
-                                "uncompressed-sha256": "b7111176fb6eba3d56e320bfbff01c8fa1b28142442cb0fa2eb32b639b17a639"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0bc63f6f040e43f084d5d35b0716f14d4dd40e7d6ca3805016e03b646ee4d5ac",
+                                "uncompressed-sha256": "b93b7e6a6bd9f227d9a83219639ffb81a7af7c04f856d27439d5e51fb8789c6d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "bc8c70993d22eb3e827a3f717299ab8a40d376ff1dcd979f3f737f470934c1ce",
-                                "uncompressed-sha256": "3ce60b12ffc14eb8f90ef16ff6b01fd67236436a81a7c06683da045c3a07b676"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3d6639b103c697944d95172b08edacbdda154fe334fe54522e3db89e174fb0a8",
+                                "uncompressed-sha256": "447e80f53609e7e0e1463d8f62549701f72b0d32fd9d4691eaf5bd6bea7da13c"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "35b8b4f48302d01abda66b5e44e20170e09148511c54be23c89e7bd03c6251b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c8eabc5ab3610562a3adb791978f1deb497902e8b01c500dce61ad5672150bb6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4a83ed7ae5702dcf781df3b544351a944d013967dfa36812e49dc446f248fb60",
-                                "uncompressed-sha256": "9f182fcd86b14acecb02c907c72862a1c50d30b9d5c06b2836f7c080d064bc02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "ed66fb9a6e9db427f168ba2e34c4a5108ce1b355c74edbf19431a0bce787cb33",
+                                "uncompressed-sha256": "fa9ed2a81b0a1c5323ef06ded4cc33475efabc6f8d08828e34ec58f5f2dff198"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-iso.x86_64.iso.sig",
-                                "sha256": "bbd2e4254c77df778b664185639ca17ed5af5090cf2d7d2a2b65b0ccae9266f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "2a4033f5e05da1e521de0626dc0fa0ec980c2349ae037ebd688bc871482630dc"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-kernel.x86_64.sig",
-                                "sha256": "aa30a5cc0328207724fdb75f6b1c9298d5cb979200ebf8c008643ef2f65e8122"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-kernel.x86_64.sig",
+                                "sha256": "c56c0ba0d64586a3bfd38d45ae786fecdef86726063ce3ea0ab2a71a4ad5abf1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "6dc59922da68c581ea9a7b94fb42e8c024c10833e0b3e2d6487b32f1b83235fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "af430bb515de7cbd63cc3c20d9afebefe1db31d0d5ba3fa5566b0da9d26e11c5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6e83fc879cf938dfccae5a7f3eda77b453d472fc76549f153c12466e31895d03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "dc010472ed55e747047d5287575667e4b06fb2394d108e408d210dd5ef257524"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b250aade0f899af4e8f728431d7d48e18350999a26e47a91a2cb75dc7a7c250d",
-                                "uncompressed-sha256": "04027a88bf921bc2b23d7ba88d0a74219027738bf791b02305827d6b2f0a08c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "78449bd22f0fac33cbc268675f2bd268b834a04af0b73c59529e628afe14575d",
+                                "uncompressed-sha256": "cd480e3c0f1f51b37893fdafca91f3193a162c1bc001dbd7b55ba30b6b598237"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "3729c7b27e60c112f5f88f2b605ccd28299a74a7430e21f9e58906e91ab2cdf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f1191a3b33521a116fa32480fa11b32933f7a0d11406671750e1e35577204244"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "308a040992e67463a7b99455403d69a8fb5e6a45007025a686a689e1ca52abdf",
-                                "uncompressed-sha256": "428be1fd958c11f010d5c891e2b5a63105368c96ee436c6e5f8a4c8dee7bcd69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "15f758d027a4212b5999357dc543b12893d0a055a728ac6d700c89de2555e556",
+                                "uncompressed-sha256": "039c5d4474b5ea8dccd710483fd9a6b91bb2fcfc28190540ace65b054ae2723c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3f0d1bd5827c05151009d29147e3f385d0b83c43ee6c678d0dcc49a3807e51ee",
-                                "uncompressed-sha256": "02570f854a239ae36457672256ed51dfb884844cb8c912aa3d7dd0f31ef68a2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4acc045a365cc839a4a7fe68b32906fd9ca01a06e1315b4057b2f49cda69b2b0",
+                                "uncompressed-sha256": "574bc83822f2bc8622e2c099e4c72aa16ea09208773b52d93caa81fd66480c98"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "5b668908a1060a68069ce47d07c8992aeb85bc284616ef182a502d616583c619"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "175e221abfe614ed752c73a03e5291a66e6cfa395049ece79f4f51b5282e3520"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "5d821bd72777525ec55ebeaa57e3d888187848ade62b05a4902e566572e25642"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "dd0816c02746adb27137da612483978cb6c1b1717629e67091c63527d567f436"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250427.2.0/x86_64/fedora-coreos-42.20250427.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c7a0cf83b13da4fa3162309049dfc5bcabef9720d7cda22070e3030fe2cbcf31",
-                                "uncompressed-sha256": "21bcc663aaaff4f62ad6089f58b1a265163d51885c8433e22adb37296a55bac9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ae292fb1257c167924aee2b2d0f46403c255b571817bf3fb5a5653e4edf982da",
+                                "uncompressed-sha256": "ce8a42dd302de283be1ecaeb3524ee1aa4a20a3cb42be0293b4c5bbf0bc8cff5"
                             }
                         }
                     }
@@ -756,145 +756,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0d606c80217e45709"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-02d2b91963285cd4d"
                         },
                         "ap-east-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-048c32ac281edfa3d"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0d17e0835c36fe026"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0cae5b701ab14b1dc"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0ef600a3892242fef"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0c3d1b273df5d0446"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-05abad4fce373b7c1"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0bdff18c2ddac87ab"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0e8de226f91bb077c"
                         },
                         "ap-south-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-094320f183aa52071"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-06fd9b67b01d084b6"
                         },
                         "ap-south-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-04300bb8c5e665e94"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-08b7a872c418ae304"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-060882626a42941c7"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0c0d5eb53639e7a74"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-06ae1b17af6a78ce9"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0977ef07f48b8cbf9"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-075dc660657ad5c0c"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-054ac4baa0587420b"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0859a026fe47bc4c8"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-09c8108b16d53a749"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0a57118fc22917be0"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0140602ce10efbfe3"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0241916285e23af1a"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-003deb82461c02471"
                         },
                         "ca-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0a5be937f3822b2f6"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-052acca8ed99172ec"
                         },
                         "ca-west-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0bf825759c956f098"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0ae6ed36699828cc9"
                         },
                         "eu-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0e85684681bd0ffc0"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-053b6c2b0b305b69e"
                         },
                         "eu-central-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-012c7b3f66e47d009"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-01240482e7e36dfc6"
                         },
                         "eu-north-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0cd04cd3ca8c10b3a"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-04e13904a567861ab"
                         },
                         "eu-south-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0c16cddb733c69906"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0f0d358cba63edae4"
                         },
                         "eu-south-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0c8b80687bb224f76"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-05e23597458d3c7ce"
                         },
                         "eu-west-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0e1034687765e2032"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0f16bc3b290ff144d"
                         },
                         "eu-west-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-03fddb966fba18316"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-03290be5cf1b6519e"
                         },
                         "eu-west-3": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-029771d45deefe4cd"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-051986421a4cb84f8"
                         },
                         "il-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0f762210bc8f5262f"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0bc61fae62ec889b9"
                         },
                         "me-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-01cf8c41357ebb9a7"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0bcdcb0cbc40b390f"
                         },
                         "me-south-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-05797316d3978ef15"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0c0c6459e73f9760c"
                         },
                         "mx-central-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0687ecc981cbc5bfd"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-08cc4c796df44eb68"
                         },
                         "sa-east-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0b9552a0d79ba947f"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0dae0b01a4a8b50c4"
                         },
                         "us-east-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-044e139e2a8622c02"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-067b5bcba2aa6b552"
                         },
                         "us-east-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0405b958901ad225a"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0ce7ab345bc1e1efc"
                         },
                         "us-west-1": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-0016182663a2c2274"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-0a247c57858bcb608"
                         },
                         "us-west-2": {
-                            "release": "42.20250427.2.0",
-                            "image": "ami-07023572e2cf19d6d"
+                            "release": "42.20250512.2.0",
+                            "image": "ami-080e7e1fccf93f4b7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250427-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250512-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250427.2.0",
+                    "release": "42.20250512.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:67d973a8e77f7cd10abb8bd8cec1eaeeed26c5cad4632a90085e95e31d0014eb"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5309870d1e72764b9dc3aee81fe6d4dd26cc95ed8e35d3055ecccf4d5e1bd1c5"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-04-29T15:47:30Z"
+    "last-modified": "2025-05-14T09:25:06Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "42.20250414.1.0",
+      "version": "42.20250427.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "42.20250427.1.0",
+      "version": "42.20250512.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1745942400,
+          "start_epoch": 1747217700,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-05-01T13:32:40Z"
+    "last-modified": "2025-05-14T09:25:03Z"
   },
   "releases": [
     {
@@ -119,9 +119,6 @@
     {
       "version": "41.20250331.3.0",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -131,8 +128,16 @@
       "version": "42.20250410.3.2",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1800,
-          "start_epoch": 1746108000,
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "42.20250427.3.0",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 2880,
+          "start_epoch": 1747217700,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-04-29T15:47:30Z"
+    "last-modified": "2025-05-14T09:25:05Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250410.2.1",
+      "version": "42.20250427.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250427.2.0",
+      "version": "42.20250512.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1745942400,
+          "start_epoch": 1747217700,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).