### PR TITLE
Roll out stable 42.20250512.3.0, testing 42.20250526.2.0, next 42.20250526.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,156 +1,156 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-05-14T09:25:06Z",
+        "last-modified": "2025-05-28T14:20:15Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "e6eeaf4fd27854015047403ca6ea87e79a834d5781f9fb4ec2aee11d39ef4784",
-                                "uncompressed-sha256": "3f5b05d7e626de7a8eed6f45fc33ff2ca4b997a51ad62ba12522ae451a6b5643"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "2b9444cef669be288cdcbceb22c797d3a283752b7fc61a79bb6351c6b2746416",
+                                "uncompressed-sha256": "7f17820d098e9e6886565596570d6f9c618ddbcc70d6ddf8d1dca977dbeb6ce4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "00fd40dbe072c70f1b6c5bd3b98486476d12cd2fb4981ef534904cb1574a3b4b",
-                                "uncompressed-sha256": "3a73e915ecc13fb917f31767c4ca240335c405e1c47d8dc42c61a47c67d7f46d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "1241012cfd91a04c47dc0e1150b3967d9d576dfa07e5eb7a7b04ceadae6d460f",
+                                "uncompressed-sha256": "08f3b4b0254a72382f5b9ccf88833dbcf96ecc5a6c842feebd6eeb10cd20f276"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "71faa3c334daf9d0b8195c4eff29537683b363811266ef6ad432d8a696f378c4",
-                                "uncompressed-sha256": "4ea1f49e91622791944e57e3e49e681c6da1bb536e2cac787367e1bf132b7e27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "838faad120b9c06f07bd5c3ae5cf1adaac12d5877736cd0339b45c6246b0e6af",
+                                "uncompressed-sha256": "b035ee974830053e09b308ade6dad2c4320b2e7646b3acf32eb79b9ba857da12"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "64a7f6c8f23ed49fae02b756c7c373322c01b6e6ec846a5b71e3b5bbd132b39a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0e1ad5a02b732c811e33620e9cca9e9f7a3b98a6f498d8b66a355cd3f88501b0"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "109234e0a97d29d4747f4d0835c2a1bf160007454158bf5c6b959f46999460cb",
-                                "uncompressed-sha256": "478035203328152bbb67a2e99193643f7d1de7360f239471e171659a5da082aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "369b8255d84676626de8e64636f34d8a08415b47167beaceaf0e431bb548eacb",
+                                "uncompressed-sha256": "7eb221e81118ba981c9bc0e1719ee32f75b2215851589cf862020c632bc245b1"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "a9f6afbe5d05cbf4b0e2c6e008a6589609d44f43f6ad559795a5e36289f45da2",
-                                "uncompressed-sha256": "61b5788c90c8a1e819f6ef0023ecf2c6e61ec85c3a00f7830875f3eca8c9cca2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "3616ea46088f37f6f7fdc33c307f4569e9c1b85e8d3970036456e472c1bba18a",
+                                "uncompressed-sha256": "fcbc883f645491f286d487ffc1cefca86201bd1fdbee58a19706ee4987f1c4b0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f2992b78955a7d59d9e598caadf1a3c79ca03591acd19084f5141732724ee6cc",
-                                "uncompressed-sha256": "4607c5091f1dd7fdbca67c9975adcda86bf196a484fc8f2306562a594e94d825"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "016b77be4ad1cc95c9c17e28cc72c02c687b7656adfa0bbcd1e065494a11f2cc",
+                                "uncompressed-sha256": "7c4cd5eb512d82fe5329d4d87727fcf69e09edf702ee2d30d4da915ac3721320"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "0ff5c18ae76e51e44a5e2706deb18231a0e3c7b8632d5f20bf9feaa7ea20e5f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "5407eeca4abb29c504474b99c968090c8e2417d3ce3253ece6001d7f515db9be"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-kernel.aarch64.sig",
-                                "sha256": "d1e29a6904a85764ad3433262285c757d2009d8db2e5e49f907325bb7eb5846e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-kernel.aarch64.sig",
+                                "sha256": "073c680bc51e149f28b4d4682ad4b021bbcc2e8578aac114ccbcd2ee6f663b5d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1d009129369e30d796a0edb6b80cff73042395d9866a9c2dc463253cf148cad8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "bb401d498f1ac32e7bb31492e5bf6996f00caf67b16e61c2ca8ef2dbe79730f2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "6b9c8d18c86622c2da13c2805c030a65f9168088f9409d189c78c6c3e7bee1ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "646a1cac6d5c689e42111258c631d34af0e34d450b2d004c87f2e9c4f105fbe0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "2fa4614e0675c2adb6362a4fbc7f270b4dc2f9880665c7e79beb0aad3c53825c",
-                                "uncompressed-sha256": "97931d272f534bc2f15c4871b023a3e7a0b6a34d12bbac0e1fd7eae40f596c88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "b792ff90952c31fa3bb0c8da3c7ec46130a5dce7bc48386cb5477314711a275b",
+                                "uncompressed-sha256": "1c9f7f57db9bdb78c5c643440fb0bb7830e076c5897d9ef05cc0fbc004478039"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2a0c6571a746bdc321430a2d5f9fb6bb2378b19a5220c940d52c4d94d929aab9",
-                                "uncompressed-sha256": "7f13b307f50c8ffb4a35581212760597dae8976487998d60fb81c8ff9c145609"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4dc37e94cf15610f84fa4c60bb7d81fd0bf3d8ea8afecb8eaf5d0307813e65b7",
+                                "uncompressed-sha256": "ef5de3e6889764c4053f44de395b144afcfb10a80c19a4a1cb3e584937a191c0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/aarch64/fedora-coreos-42.20250512.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "b2e905eeb3ec9027fc6394a2fc270655aa43ce809f6390f816e8945d999b132b",
-                                "uncompressed-sha256": "946e5c2ebd3fbfb459cbf51dd229c61eef76b0d3cd420b76257a84cf55aae79b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "fbf05da3b1e0524f637f9d4a7b841a583198fd2ededc210235d72b4890388f43",
+                                "uncompressed-sha256": "e93b30b090c6a0b273b9725cd7a965a172d4dd074edc9071610ecabb41b09f7c"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0233f4c942947e324"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-095eab536febab621"
                         },
                         "ap-east-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-08a9364d9c7914351"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0076f412b252b1909"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-042219cbb0e1e5cfb"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-083605f54c28ae515"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0cc75aefe383f525e"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0f5074428c5e50675"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0a0ba4f87292021c8"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0f1908d82d9de5c5e"
                         },
                         "ap-south-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-08e46cfe5f47d00f6"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-081b68d4679705d72"
                         },
                         "ap-south-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0baf4c0f1d10f4ca5"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0a5704d1b74a66064"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0a1a95ef434747b77"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-04ed0e1e69cb74b96"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0f1a5d6ab6a70fdd0"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-060579cd7174b7468"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0ad708c8a212138f3"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0b81b3cf993d72a7d"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0ee10f1e8e7893da8"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0d2d61a1b8d6d2c98"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-05f6d238b88c8bd46"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0b169c17f45414e13"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-01dc5f1c59cdd6770"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-090bd9849423f8dae"
                         },
                         "ca-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0b6fcc34a020b1c0c"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-02c8bf9ce18fd3664"
                         },
                         "ca-west-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-01f9c5c8eda0f4706"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-042fd9c0da63957ce"
                         },
                         "eu-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-016a6286517b50154"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-03aa5a89cb4402846"
                         },
                         "eu-central-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-039c70fc2a0e15b8a"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0effed4e593d2b230"
                         },
                         "eu-north-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0c06e10f4894bca4a"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0672afb107cf9a2a4"
                         },
                         "eu-south-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0d3e3c60ae9cfdcc8"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-027fba7b176e9f9b3"
                         },
                         "eu-south-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0d7aa2d57d68405da"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-08485491a8e8d80b3"
                         },
                         "eu-west-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-030303bf86c088e2b"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0fabaea929048b239"
                         },
                         "eu-west-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0c341319305ff475f"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0780a1c56d712cbe5"
                         },
                         "eu-west-3": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0ff458d518b64174e"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-05ad42feadcb50237"
                         },
                         "il-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-051fa20a8cab3eae2"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-033510385659eb180"
                         },
                         "me-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-00ac2c17489ad949f"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0d9fcdbc69344116f"
                         },
                         "me-south-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0d9c30a04b9d1b64a"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-08f5b5e20644963c3"
                         },
                         "mx-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0213ec2d8cb37a7a9"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0baa76e4af00e01fd"
                         },
                         "sa-east-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0a58d93b068ab0953"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-05d5718fd6ef9a1fc"
                         },
                         "us-east-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-053b15a6cdba0e5c6"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0343cfe0dda1d0fb7"
                         },
                         "us-east-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0f9a4008f287fb482"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-08644e96abc077bcc"
                         },
                         "us-west-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-06c38e94bb5ff481d"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-01b564d3d9055f772"
                         },
                         "us-west-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0731e046b493b5e7f"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0265862095c9fa1f8"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250512-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250526-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "de65cf29d89675c8de29c49d19d416e698ac2f36a4b881e46dfbb0cef4b48004",
-                                "uncompressed-sha256": "a77b3c96fea8838657c9df125883db5b95f67282f227176ab19bebea89686a91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "b7da066cd868d6272d7247fb147f2c9b09e4b1671c16dd567249817d74752421",
+                                "uncompressed-sha256": "665b6d5709b7b47cd80f10cec26d90e1c7f499f4bf2b466cab92536efba11b2b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "1a62c3c303aa650409ae0e6d82eb783e732fdc577210dea5d6892f38a7d84a38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "f569febcd63952ff7c1a2be6f7d286ad5b17790f98770016f49e5cd19d1603bd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "d66a3c81a6244a6ec567f307267df8203cf93ad765fe0e9f3e980b39d8769c2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "fccdb6ed4189dfd27b79c3dcb92da3ba5fb270818cc51a78b6d69860c6315b45"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "0cf704e3d7892f7feb513eea467d9bf6045297c69d579c1fe5bf8458b6212375"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "1baf70d73773acdc8828aff31a8419076d35ae9de5aaf8f233d693ae71db8d4b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "98617d555de7fb7361e073c936bfdb7faf0de541f66677c611e63cce71c34341"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "94c7bd605c94a348f5625f945b514ac1c887a1e569d2ba2656da636ff0396895"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "e47cf780822cdf93f04409a48a3a705db1407165d1b61753535a3dd45f9ac454",
-                                "uncompressed-sha256": "c7058be035586da072392c0240ffe61c66b68a5393cfac1ac1926f24729b4ecf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "f5010676ec4aaa5f4f72b6925f66f26ae58508b7d5d6738ee5ce080b23a07041",
+                                "uncompressed-sha256": "ed1037a209a521e07674c719ab2e2e9bf74eb0b703305247369e8a5f82c1ecd9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "1c995b2e26edd78db328dfe77284a7e3decf0a3681cd3ebb3ad5c7661f7909db",
-                                "uncompressed-sha256": "42bc6e9881d8d48147906d52cada44c227c8f3c36a185782952107f5dfcbc376"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e9ffcff098e89f5475cf07c60ce85a1da7f7530123dc48307a10a0773d84050a",
+                                "uncompressed-sha256": "d5d9ec8524674b9c93fcff6e5f9dd369dba26e444db17744f23ff71a7c27822e"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2a5b9d715e4eb4c9d32c520ce75a51b85051b57fdb7fbaa6e8c1edce9a8f6f48",
-                                "uncompressed-sha256": "cd15c95d0b6c78658c23a603cc21896da9a383287c601ceb344fca070cef3ef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "281af99295787b87a261eec07dee50960165fc766987f90a2fc02ff8d7cd05a8",
+                                "uncompressed-sha256": "7b40c8f380ef944c2b133ce634241fbe522e6362c6fd632f8ab7eabe7eabdfc1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/ppc64le/fedora-coreos-42.20250512.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "694e2668443350d8be385ac5aef33cee6da43855ef6fe900a47e383dd187c84e",
-                                "uncompressed-sha256": "a195af16173bdccc207cbbc134a116b57becf43f9a7f7f63d6e041c65df65c61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "f070de9eb1e8b3d586843e42d47efe10cc2a37992264f79adc2168f04ad03ab6",
+                                "uncompressed-sha256": "6eef32f8ec65f18a3b1db40ecb00551cf509ab74863631eac158dcae940ef1d9"
                             }
                         }
                     }
@@ -389,364 +389,382 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "bec447774dc3febf531033994523a0abc291cdcca72bbb8b82f00a00047759e0",
-                                "uncompressed-sha256": "debe4f2f8539196d73326ea2e9a39015be82e8a3c03ad499ec3542a628658917"
-                            }
-                        }
-                    }
-                },
-                "metal": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "4k.raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "2d0f94f781002c14fa49fee69a1fa36cfe34f8f889fe01ee5129b6b5a63b3a38",
-                                "uncompressed-sha256": "e8a92931e6190fe215ac1bccdb09c3c4899c232b470220bb04a47dc1027973cc"
-                            }
-                        },
-                        "iso": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "af8143c5117d9bd31aff2ebbf0b725ad4d0f76d68e1caf965c4edaedfbe9eec4"
-                            }
-                        },
-                        "pxe": {
-                            "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-kernel.s390x.sig",
-                                "sha256": "a13d1cec10a9c4fa5851a22c3fc0becd4bf9e716aab4f32f1407ffd1a10ab999"
-                            },
-                            "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "7ab4a83965ad9df45136fccb56a87ee88571056f6f3df849691f40432d2ed4f1"
-                            },
-                            "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "24746f1441a4343bbc062c3f5075747e7c5d424ffb5e57cc2c4be76cb117d1ff"
-                            }
-                        },
-                        "raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "909f5a586cf2d62a3703a69893a235e2ddf2f694a55e4c143001da3197673dd5",
-                                "uncompressed-sha256": "d8abd3ac9f76e714766fddedcc38a921859ff1fcfe94a520133d7aa6373c4237"
-                            }
-                        }
-                    }
-                },
-                "openstack": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "3c47d375bb06ad92961a4adad3c958f84fc6afcc57834c278dec74100432875b",
-                                "uncompressed-sha256": "28eba3efe4773759aa1969c9a00ec392c20bfd11cb3e6ad69e13de3d792f57b4"
-                            }
-                        }
-                    }
-                },
-                "qemu": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/s390x/fedora-coreos-42.20250512.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "dcd949c6ed67e19f439a1eef31ff4a7c87e05b9179efd19a185028e095aa1fca",
-                                "uncompressed-sha256": "323f4f1244e7e792df14ab1a55c6a13bd4576545e4d191e302fad3226a0ff3bd"
-                            }
-                        }
-                    }
-                }
-            },
-            "images": {}
-        },
-        "x86_64": {
-            "artifacts": {
-                "aliyun": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1166e9c60047668d75de89cf0230846601ef0c22a69eeb7663d29c69f7299c1e",
-                                "uncompressed-sha256": "5a988badb3fe4b29d980565a9b2323e459c82a65455b1c188e1939a6a38f6fab"
-                            }
-                        }
-                    }
-                },
-                "applehv": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "raw.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "d0c3157a78b62c0629e16c5e7f0e858d5bb35cc1aab683c38965b8f1f9729546",
-                                "uncompressed-sha256": "43312bd72ecd7017fad07bf72109500642cd8ac2bddff965b62530b126d5fe6f"
-                            }
-                        }
-                    }
-                },
-                "aws": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "vmdk.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1b405decdd3071de3ded08edfaac70db1dd1576b36e21790e6f621d6de1d8b00",
-                                "uncompressed-sha256": "843c16f7be5f23f891a290c3d4a8c2d6ce2f890586a718efc84c2cacf7ea4f33"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1dbf13fecb06bcd9aa207d5adfd91ff90c4551b8330c1d114fcadb43257af61c",
-                                "uncompressed-sha256": "b9bab3fad1563a473d8367f97eb9427911781913a5f8d4b836bd0369c42a3fad"
-                            }
-                        }
-                    }
-                },
-                "azurestack": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "2d2470101c58349c8616c36d6fb01a2c4bcfc7d787576d06a1445ac88f34d05d",
-                                "uncompressed-sha256": "87e9824f083b34f0abd04462379b100706ad19dfb5d3906799e1efd5d964b62b"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "13affbea006bb04c0213812180681b89357c3724e9b24175c0c353394589f594",
-                                "uncompressed-sha256": "c97ac489fbd1f6c2a8cc8f4f126912d88472ab5eacf114e0a1da773ef86a646e"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "78e6fc27148b82331829efb1703a3d724c6fca27167c26cfbed379ec948d2675",
-                                "uncompressed-sha256": "441b8e67b6bbac8d45ffad02586050496be711ed3257b910366243e5c5963104"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ea26fd19d1134464eeaba7205a4b0a7c6f2e3231eb45d768e6573741b951b5cf"
-                            }
-                        }
-                    }
-                },
-                "hetzner": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "f1ff8f1f3c6dc7137a5427ebca6c24d14ae3ea2e4108f4e78fcdbd72fc1e74a9",
-                                "uncompressed-sha256": "a3afe4fa3e581c634a6a8103fa96f3ca0139d49b76a27ba3816f48cf7d2177bd"
-                            }
-                        }
-                    }
-                },
-                "hyperv": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "vhdx.zip": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "701345419f47dafbccb17017735e1e612bae6509752db3c137a122fd17c1f7f9",
-                                "uncompressed-sha256": "cfb4f9392e940627037f3a1bd6001540fbcd5a4a44c414a7b22ed597f88e79f0"
-                            }
-                        }
-                    }
-                },
-                "ibmcloud": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5d8f57d92f46fa7233caf6c0da9a58c0a8430acb1fdbcae8cb0c088e51eddea5",
-                                "uncompressed-sha256": "b5b0e608f14cba04b62743ff2e23153028bef5212f2327a45efd33cb560cbc06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ca4f01c8d7d35f892ff06803e18af46d5010fea4c14eabdb6be102f3e4bf482a",
+                                "uncompressed-sha256": "ea5880a7bce4c831c7fcdd51c318407d9713ca3c75c9f0115d16c16517e3ee61"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "1db430f3120f8390e7efc22fc8abc7a5d045cdac72c0e9ddab91feb75282bd6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "8b3e813bb2deb37dee1705b1949406eacb7dc39380d54c9e53e5955a86d49759"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "55d4562a1923f73f94983e4f2204df3c5fbe13072909822f47eac9b0fce20d03",
-                                "uncompressed-sha256": "42a2e028431a2d10850baa9e6f954cab44c319f0e1d816e429c6d65026173690"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "89fe1de1b3d390100211042dbd2ef6f1c12515f1bbc9c77352c06f394b6c4ac9",
+                                "uncompressed-sha256": "d8304c2a24ce335b2be2772de9f651111d08cc44a7216ac7c0bd9a805b80804f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "5a1115f2ba81e06b64b79cf4d6c89606dcce804af64deb98f3f480f087f9b687"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "6af2be122b47668001071177d489e97dce446517f9bd323d8038178777f5d7af"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-kernel.x86_64.sig",
-                                "sha256": "c56c0ba0d64586a3bfd38d45ae786fecdef86726063ce3ea0ab2a71a4ad5abf1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-kernel.s390x.sig",
+                                "sha256": "7b1c1d363f6c670f8fa15b65329d49d8bc795f73e71bcac2110dbcbf45d40932"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "36fd9e3ccd47cc1a451ee800fef2eab2886697f573ebb49cd9c25371b8cdff42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "2602febeb3dacb21685fbcba31d5c2a77fe07afc32da6372fc76961da922fc13"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "74976a78178e71dfa11f4ce6a7fb612172faa2c9d6cf1ca5d5ade7d7688cec48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f60427288e878610943a3c6511a0ef6615a80f70c21cabccd468087c0c84aa49"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b025e4acc129a77d2c3b603eff8528daec9ae28dd21799ad999a948d6006c5e0",
-                                "uncompressed-sha256": "88fd58e67923b7448565f4ab6135d56243ca12aefd707c5069e28f6a47f51b61"
-                            }
-                        }
-                    }
-                },
-                "nutanix": {
-                    "release": "42.20250512.1.0",
-                    "formats": {
-                        "qcow2": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "99a7e81d6b1da040d5fbf44a15705ac5bac97406fa0b7d679e84b572e3652c22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "f374cc81ad455f9291ea0c9a3fe6c4db2733db6dc8d96aeb3a3a859b3cdc02c5",
+                                "uncompressed-sha256": "d67260522729ad11a0e72340f471163a6517989a782676cb8abd592911aacbaf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9cef8e1a102bc4d1b6affbb598448be998cb80a481342ea91cbdb27ac429255f",
-                                "uncompressed-sha256": "6b75a14ebfc75e91e4ac60ab456ba437e1629f8b1bbaddaf64287d042bb6a935"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "493e4bf9ea9b340959f30a91d3cc57e5ccaaed8f4623172ac175159caa41b970",
+                                "uncompressed-sha256": "a1d70b51e8b57856b9ce137a5840bfff34df4bd2172e61e048a4de16aef864b3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8914d9518552e89cde11c9bf709037544cc9ea0a50d3e3d9d719f999c20c85b1",
-                                "uncompressed-sha256": "2e2b65befe8e09bea35b6ce21e6607c154554c445380a1b2e06e3e6fd3ad7dfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "464a217f3f58dc1fc30bb74dd6e37930b2ab8bc4dacb09f4974f219da7a3f3d7",
+                                "uncompressed-sha256": "4a4e7454569f0b409a5f3703ac0d353728e9fce4a5c3e03c59bb09e73ddeb088"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {
+                "kubevirt": {
+                    "release": "42.20250526.1.0",
+                    "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3e7498255bf21e155e037f0513b13933a42b9ea0f74da0fa271bd47b639ddb63"
+                }
+            }
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "aa183e368f035357d2b08aee54bcb86c8fbe4fe55b7c858feb65dd6b725345ef",
+                                "uncompressed-sha256": "ce12978ba3c0d18dc24744240eb86f9d4f957c8428c7cb505300f97c2fa9b4af"
+                            }
+                        }
+                    }
+                },
+                "applehv": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "cc4daa80d8e48d74b7899e240365664f7e8953882874b60d0bae2b4a0da84add",
+                                "uncompressed-sha256": "f7f5c3c5dd08e080037883780c07b48e10e076f5c1167401e863c79897b1b3e8"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "30540fa75c39f0fd64376754fb84d25b3cf0faa21c1f29a94ae695320477247a",
+                                "uncompressed-sha256": "45b65d3ab94fb709e9e2dc08ef6cf3e200d7fdcc59af61d1fb183fa9bd8c4eab"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "cd41f17a76b9f98d5d38c17f5622ded69ed1c8343da5df8b56baae093cae2ba6",
+                                "uncompressed-sha256": "213bcbbe6e2defc390c5f38abc2b0e5d8e8631da6fe061bf0c945f04b0edcd83"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "bafc1442968f5bd7c176919cb01aadfc2dea4c5375f4f2a8130705831546396e",
+                                "uncompressed-sha256": "1f0e2f35d92d82cdb99a5b4aaf61681ae9625916a8d76781c8fd58adfecb7f94"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "029bb3c15d7db732da4e1b2be80e0943706ff7cc869bcf57651389f286d43ab2",
+                                "uncompressed-sha256": "e87b65655d1945065d3697c76b0c6b703d22910d09513f4e345ed1e9555b95ef"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "1ae0d3624e1f8af04ee736fa3e178f224bec9d0fca7c097efc8449c2320564f6",
+                                "uncompressed-sha256": "d65f5555cd3bc7c6de7e63edfc9db107d38dfc0022e21179dc443cc91ec8f5d7"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c0042d64b38b3a682a87b281a71340dc60ad8ed5780807bc4fdf02af12225f9d"
+                            }
+                        }
+                    }
+                },
+                "hetzner": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "645c33933bec79532d8fab0ae8e91fade20cad5683ee8c0a4851a1dc435cc65b",
+                                "uncompressed-sha256": "5ad1f5b9e808eba1619083485cb0ab392f20b9a7a6a5e9d83ab818cc8713d199"
+                            }
+                        }
+                    }
+                },
+                "hyperv": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "44b39db8dbc29ee63fc5ef4355653a187f2618d3119eb0469cc8d4b7097a174c",
+                                "uncompressed-sha256": "d1aac81ce5924563f2b17df706799d7c5d8b33c84341d2ca9c5a805b5ce9b9f3"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6be5f7729c0c8902cec69552a9ef0c25b6f2527a54b0dd50d72ec00576d80083",
+                                "uncompressed-sha256": "c91786a56969e3377753ad25a761041589f669e11bff083ff816860797c876f8"
+                            }
+                        }
+                    }
+                },
+                "kubevirt": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "ociarchive": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d804901c98827505d56f84f0594c99d58d0326615c39368698e61897a0c1ef28"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4342cf765877dfe7c5c0ab0df711a6674db7d93480fb32df43780d4664578607",
+                                "uncompressed-sha256": "07e9e9099d4878d7d8a9a2a987992c274f12190300b30efc0a18802b4ca809d3"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "b811961697df82cc51b0a2b82c95ebd2aa963661154724b781bc27f6876a9641"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-kernel.x86_64.sig",
+                                "sha256": "9a5ad93c4a15faf067297b23fa62c7db6cf8bbb721210d236c4fb22dd2b543f8"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "72eac2b9f3abd10c927d4670a1d345df260629fc6d959c706045036e3016fc5d"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "77f52f7d4bfec711f7953d17c3a46e63c632e8d251cd76dd9c3d2e17e214b423"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "01838197154f2e74d58f03d222381766c4f1b6a1853bb236dadd48e243c6f177",
+                                "uncompressed-sha256": "3c6d50c3bda1482af0d7538f32bdba0918a9373ef6c9703af9563b38456e63c2"
+                            }
+                        }
+                    }
+                },
+                "nutanix": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "qcow2": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "a9b512f5e7e4dd7ac323c4dbcd2ed0ffef562e9b19b73ca9815d4cc7494715f4"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7c2d1e46d5338b38df7274e6a5bbbd7485e4fe81f1f4dd2e0eaa70cc96885240",
+                                "uncompressed-sha256": "73d45c63bc02f5e621e3e06d80e36b28dc7b332d30606c1dfc40bc50ab9db052"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "42.20250526.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a4276dac463713af5812a9d67f694a8e70fb94d711e41b9f40387dc2dcca3e3a",
+                                "uncompressed-sha256": "f2ceced33043b685f55ccd23d10f1e33354742e8258ee33cb2b056009a612d21"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c3c5d7f01369ace55ec06097baa5b04b701e6d7af45042acf74bd29de1fb86c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c2aca75621b0573a782477ecdb2fd682cf830d47294a10313e32605379936c9e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "5b54fbc975a4434f0157810869a4b538f1489ee84fb0262ef3931e0f982a6511"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "48f2fa8819a4da34871bc9296b476d0b0d7b5a18ec4d182b781b6ae8181e82ed"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250512.1.0/x86_64/fedora-coreos-42.20250512.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d55704b4f26e3d5f1d6bbb6c42d8f822d5750662685c6ea538442435a47652d2",
-                                "uncompressed-sha256": "ade7a0cd5282ed10d1337cf9388ec23ac5480a5622e34bbec2fd4a68eed808ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "583031863a5c864a44b1553934512e5ea7b21606cd8360c07bd22c9b150bbc4c",
+                                "uncompressed-sha256": "adc52a5e5fabbf4ae31461175a5b8d1393e143571e82414a5837e7592899df78"
                             }
                         }
                     }
@@ -756,145 +774,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-018bb36d06aa42d30"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0a23107b0d2c25fc6"
                         },
                         "ap-east-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-076892f4181bfced2"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0bd14f7e9919fe9da"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0ed0e746779dd626b"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-044a9557bc62a3db5"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-025e17343aafa3096"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-03d5245fface880f1"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-052009b10e7e36531"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0adbc976357fa9742"
                         },
                         "ap-south-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-07b7bbe858a6e304d"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-012d344a697c23bcc"
                         },
                         "ap-south-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-04a8d85236f94758b"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-009d04f9025502cba"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-076bc062206e74941"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0283e69393e2a5290"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0964185e98c9b25b7"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0050aef941fd86acd"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0ff69459b6cc09141"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0897806e1f1bf3ee2"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0ceedbfba435290bd"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-015d3821548e18166"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0b77b37adf37d8a46"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-041c6c312213534e1"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0acae43cb3099daf8"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0543bd192449156bb"
                         },
                         "ca-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-04178dfea886d1fe7"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-09a6cd4d34cc72bbd"
                         },
                         "ca-west-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-05acf47efceab829c"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0bfb8d32a2b41d162"
                         },
                         "eu-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-017beec68adc9cc4a"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-05a25539d9183e066"
                         },
                         "eu-central-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-00cbc7b117dd2e2b7"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0a25e7876a08ff50e"
                         },
                         "eu-north-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0053531c54ec07842"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-02723e64b165062bc"
                         },
                         "eu-south-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0cef38f495b45ec7e"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0d2d8a7a0c702fbef"
                         },
                         "eu-south-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-02320168c5bad63c2"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0d68bb987b1d9f25b"
                         },
                         "eu-west-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-06e9cf3b63239f391"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-04e4721ef5c952f90"
                         },
                         "eu-west-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-060e022b327deffd7"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0379238c652faee8a"
                         },
                         "eu-west-3": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0521b0f4f279ad620"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-05110bfa00583d975"
                         },
                         "il-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0ac17fbe9ff0c39c0"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-09f9e92d9ca9126ae"
                         },
                         "me-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-074064e24b06083b8"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-050ebcada0fcdea6f"
                         },
                         "me-south-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0366aa291c20b1184"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0ba2a7788eb14e93c"
                         },
                         "mx-central-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0aafe188a0427a015"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-096b18e7fb640af36"
                         },
                         "sa-east-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0957bd5d1b07c311f"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0a536f903d612b32c"
                         },
                         "us-east-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0fb7542cf80351737"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-038dfb68214993a79"
                         },
                         "us-east-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-090594efb8c9b8a95"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0f076dd7f377e41de"
                         },
                         "us-west-1": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0698470c56c2ba6d0"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0fc96c0e45c8e5b52"
                         },
                         "us-west-2": {
-                            "release": "42.20250512.1.0",
-                            "image": "ami-0118ef59d283e4720"
+                            "release": "42.20250526.1.0",
+                            "image": "ami-0ca7dfccfc9ab873c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250512-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250526-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250512.1.0",
+                    "release": "42.20250526.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:05bf13710223a00e45c1465d31902bfc8e7771fd5b3d82567fcec44b7054892d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:25265d6d3ddb9bcca625d135efe14dd90ee866818da8eba2743bd79d7c9bc4ac"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,156 +1,156 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-05-14T09:25:02Z",
+        "last-modified": "2025-05-28T14:20:11Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "d0e0bd672219c3fae00601eb09772dc1b61039c0b8c913813717ef4f0ee3fe7a",
-                                "uncompressed-sha256": "5c2eaf014e2c7fed1316e4d495e25159f1da0a996c306344fd7fe299f7d5fbf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "10d741a9a53aecfeb3f08030f127531ac6cf1a94c6b320f1bcfa4b2c8dd69ba8",
+                                "uncompressed-sha256": "5a18c5373593e3795b3bc22fca464082b21b76c9a77a0307d7fde2f978b2384f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "1a93c17844e774f46c43254a2788eee432ca925a967bc0d9454a0717d04ec355",
-                                "uncompressed-sha256": "ef53ba0ce6babd5ecbca2c6565d0f9dad526e3567fbe7a8c768a39d4ba43d581"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8f718b2d884f34cda2d424a3dd7c1c9119b60605cc45f44905214dbc5afd63d1",
+                                "uncompressed-sha256": "b2027d67cac2dbce683e1ec24dfd7452b0972c8063e8cf9b57db13258ec7489d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "be2f6a485a08fcc5d694c9502b9d3fd2aff455058f14f9c55b7c32a0e9342ebb",
-                                "uncompressed-sha256": "3637b25901721f9227a749b4542e13421c3ba974646bcfadbcec0c3ccb38893e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "8db836eb3f99ac2230a9f2c9ba62cbd5591779dff4537526de0d9417ee28e824",
+                                "uncompressed-sha256": "189c2059192b9ef46a054aa9635e720fef888262b762904e657ad0a516a1e761"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "2725f9c69037ea77fdce736b9a5db1d630582e3c050a629f3048ab9ce371c3eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "e580979f436fee26b30cc67547bc68edaaebdeee7dcdac1129415f7040d760b2"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "4e9fac7953e6fb5e5660a9ec1bc6f7b1138dc5cad9c62350520cb133360f1fb0",
-                                "uncompressed-sha256": "2295b249e4397ac1d1ab636d5549a3698d10f8759f00be92ffe3518726bd0222"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "35b60387f27391d411df0bc316ae5c6f098440ed52bca7128229fc7b0ae56288",
+                                "uncompressed-sha256": "76b0b536665f34b53e3083ccc6946a316d1b83eff57d78cf98f80fe20054e98f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "7d1bde3e47f1fccff7a67ba5aa96fbc173fde6c193d72c362820d0228f4865b3",
-                                "uncompressed-sha256": "43f14770fedbe4dd2faa577af80234c677a05ff1d1ea989297f3a079aa8a82c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "9493afa054b74a78bce521a2a2fd8c706548a2dab243c4478d448d63ded764c0",
+                                "uncompressed-sha256": "00a874cfdcc235f8de9b3b07aefe4f0f8874b74014bcd6e8f2d580ee3df78bd4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a2e0a2dbc1d659796747691a38a6075fa5047ca88a4280e8c6bff8ef4dae6c41",
-                                "uncompressed-sha256": "5718ba5044c701a383bfb2530a3d14a9e15b8c8d4c90f9613212f978c3615753"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ebef31c830312c23d8cfc8233974d96177b592adc15df925c60510fa75d68b48",
+                                "uncompressed-sha256": "1bee87a5b6a083344692752bf15487b39324833fedab770cda7f5aed2acac2a5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-iso.aarch64.iso.sig",
-                                "sha256": "210b989acafc95e786be451c82b0085907ef4c497836f882bd1fd25ed0877c51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-iso.aarch64.iso.sig",
+                                "sha256": "2b7aa92fb009234f8363315602d42550208073ec80c3fd3ad72f565faeff74ba"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-kernel.aarch64.sig",
-                                "sha256": "b6b04e199b69d49af1e93f81e40335b8c6a66fffef496714bd009de54cdcc618"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-kernel.aarch64.sig",
+                                "sha256": "d1e29a6904a85764ad3433262285c757d2009d8db2e5e49f907325bb7eb5846e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "a2da30c64c890f8e979509caaba4ab2c2de15c0abfa186d72749229ba4388a2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "bdce8b3410db153f91d614eb0fa9f551db43d691ef35d7c72a50f82a7196a5f5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "c5c80bf1dba964ca1eda7ceba181f0677432db057088ebf6a1f310c39afbed46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "3a64aa1d21c410edf8e4bdb9b16bcaf634206fe8660a5984da269106e6eca6bc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "a612614f422583678ce46c1fe0a7c0b6184c1904e8ceb7aecf7b1c80b0c7bcbe",
-                                "uncompressed-sha256": "90bc129cd38951676220a4b16422af97bca4d1103dd7f1732b54f0ed51652e93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "f24a143e8cebea9470bf0763cf7742b4f90a9317252021cd143ca52387a2848e",
+                                "uncompressed-sha256": "172a3319a97ed926afb81b306d50039a01ed1a120a9e02b04c109cbced195d1a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "0b5b3e71f18e68aab9c6dea238ba49c814f62c9650a146174e4afd7996c5cdf3",
-                                "uncompressed-sha256": "d32e8a914ca2b91819b8cea2c0fd25bd903842d6cceb6edb3c17091d1f363aa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "c2949ae2e5e84ecc64078e5c04fce8b0dd1d6451f082050bac72585d6411f420",
+                                "uncompressed-sha256": "d14b1978f468bc1a517cd7c2cd4ceea048aed15de2bf0d2096f2ebfaa64a0bd0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/aarch64/fedora-coreos-42.20250427.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a2946fc5bfece9b133370fede9a542fe4b5c1e5eac65f1d1b6d9488a56f2b639",
-                                "uncompressed-sha256": "b28fe64fcd5d5d08f2e15b05587bc70e5dde399bf99ca8b8d94d78494fa8a2f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "0cdd1c000ce306caf5f1c2fd35fe96c9fc8ea52d7c30d2ff066b69ff484a47b2",
+                                "uncompressed-sha256": "c112225f97f75d54905b234a390e17479faf096558d4de1f87f5d0f0616ac593"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-061eb8b293d69f8a8"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-06c21597b929395af"
                         },
                         "ap-east-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-03f91caf4a87425c2"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0ebde86fc6692d63c"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0d53ab1970065b558"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-083b42ce1a8aaf78d"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0cdbcbbadfd288978"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-01ebcffd9318a48f4"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-055a7ca2ef1182e68"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-08e0469cd8deb86ea"
                         },
                         "ap-south-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0957e8188e10a28e6"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0264e5d03c7a81058"
                         },
                         "ap-south-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0c0c65fd71ada7a6a"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-086285ec3fdf783e8"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-03435cfe50273797c"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0688d8785283fefea"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-060518f0b90e4496b"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0a24c6356e0dbf32c"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0b59ef6654b6b891d"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-09fde1510b3238b37"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0ff84ca35815f15ab"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-06bce9661616669e3"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0fed8eb000e2512e0"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-06af789f55ffff2e4"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0fc8a660c4915d64f"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0a67121f1d3d863dd"
                         },
                         "ca-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-079a3ba93f2c9b466"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0c83067b77f51cc98"
                         },
                         "ca-west-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-07787fe9fc8735a8a"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-060747102b645a119"
                         },
                         "eu-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-049d6f524b6e43c60"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-044c88ddaec3d1a3e"
                         },
                         "eu-central-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-09f2c86418624443c"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-00fcfd598385a77f0"
                         },
                         "eu-north-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0f5d829703338952b"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0d9a1e521e4a73138"
                         },
                         "eu-south-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-072c1a5c5d8175bbd"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0ad3da26d5066077c"
                         },
                         "eu-south-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-084b9d6e47721c02f"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-098184593bbf0689a"
                         },
                         "eu-west-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-03c40e91c70e08584"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-04876bccbff88c486"
                         },
                         "eu-west-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0b04839fa09319739"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-01405349e8015abc5"
                         },
                         "eu-west-3": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-024ee9c2395c95dbe"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-07115ec1116fa599d"
                         },
                         "il-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0c3eede12d4b95899"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-04b48e0f0654e2d17"
                         },
                         "me-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0ecaeb64c29c6d0ad"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0ec043a171a2e7d08"
                         },
                         "me-south-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0b372d482a087b5f6"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-02b0c26d9d785ece0"
                         },
                         "mx-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-03524a7aab045da39"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-06874df852470d567"
                         },
                         "sa-east-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-04f853ddbe35577e2"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-081acbec0f05b0ea4"
                         },
                         "us-east-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0bae55c8b8587ef94"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0d664fefb95c69d45"
                         },
                         "us-east-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0d876ceb7d6f40736"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-008013150e665b1f1"
                         },
                         "us-west-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0d249f0a729b747f3"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-081601269cf3a87e3"
                         },
                         "us-west-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0249a73ba66d307ff"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-03071ec07ca04b21e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250427-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250512-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f59f57a4bc17fbc112406ff4bd2bac5a959570e727b2c85d93c5ede470c06f33",
-                                "uncompressed-sha256": "fab7564e480aa1cc6296949b4e25d065f1d19c7a3ea303dd8f62271e5ee2453c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "782141afaf96434a8e0daa5faeb0c97b967e0e7870f633c38e894ba7c419b53b",
+                                "uncompressed-sha256": "1ae4bc1d2e6e0f0826619bd75fec41e429aaab784b3583da39439326a5818aa4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "d2d94e2d1b5d6b9410ef1b9ef9d949ee2881d4e858d87011b3d8a9e9a8b29efe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "bb70eb4492ebd6fdb47526a7b3392ce09df79f8a4549b1f6eef0ddb4d2d92585"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-kernel.ppc64le.sig",
-                                "sha256": "0aa34c5f7860ac4f37d199b034d154fd298e9d044ab6994afb02086fde6bacd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-kernel.ppc64le.sig",
+                                "sha256": "d66a3c81a6244a6ec567f307267df8203cf93ad765fe0e9f3e980b39d8769c2e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "486da35c6083b4c742421b24be3956f703808c33ae22ddff505fcbc79d7da726"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "ec4cfdc1c9502e5acbe70b2e08d9b249e0c75286f1381fa0a049f19cfe7545f1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "2c475f6d4fe24c389cbfde3d710103e08175ed2ca1b270a93a5dfa979fd2b23a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "ff04a694cb2bdb52eb7aed9ce170cce6dd78ac873ade9ddbb0cd1b30f5318187"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "b293d853ac12a5a8ff098b51d7ad47f258be198fc04b16c3ca629c1396fd3926",
-                                "uncompressed-sha256": "4bc378cdd40587acaa28288c2da9a0fc5eafd07d7378588866f943a54c2076f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "1e33f51b46dae30d86c102b6b5b69bf81a30b8d5ef31197d2be636070f17e832",
+                                "uncompressed-sha256": "c04d75b276eeb09350de164af1ad64283bb716b2161141d1203bb6d6bd1ec76a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e1b3ad49721f2555a3a1d3af91a544047a6c136917f471e0a135eb9a3da0953f",
-                                "uncompressed-sha256": "7cd14bafc449f753cce1107fc22169d4e8494660b78ac3a3609eff8ec761b0f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "270211ef3da8153a075a87016e707d8bc42ac55074970de997cdb27afcb39a31",
+                                "uncompressed-sha256": "b06097c03f998c3f22443bfa3e8544a02e2d061e1a34ab063019bf2b3f05baf8"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "cf9dd459b03269d57d9de61e08005f9d20e1968d2659122d0d313abb49004d25",
-                                "uncompressed-sha256": "3c55ea4497d55e648959ffdd1d10e6cca98f02ebe36c1bcd94e041c7e4626c8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "79864c449531b586aedff162aea07b881308aacfeb6f11b883daa90ff0a4822b",
+                                "uncompressed-sha256": "6cafd56ac11e84c138f8d8a50a17875528fad70906dd395fd46bdf5ab9b5acd5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/ppc64le/fedora-coreos-42.20250427.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "4c2dd66e3d0aaa7aba9d5d900797a8ae689d49de6972a3af9c7b40fa55e36145",
-                                "uncompressed-sha256": "fbfb12e97b3380cb40c4cd06d20475730783bb17eb70fd9e0c015716d2b00c9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "7f23b5d17253697a0bd72bfdaf9299117f3e75c2d0f174ef7a8f3ee9ad7c9d63",
+                                "uncompressed-sha256": "61b9498f97d0258841c7613dd413a33128d2a5a97948ff0df6607d5cf88ef098"
                             }
                         }
                     }
@@ -389,364 +389,382 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "51c482a325387962e222579f2001120b20ead7fcec4ec68ab2faef06c028d550",
-                                "uncompressed-sha256": "594545add4f671564d4ea6117fbc4a903c78be7f2361a1a5616ddb51be9fac6a"
-                            }
-                        }
-                    }
-                },
-                "metal": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "4k.raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "772fb8656af45d46be93ce80195efd6c7c68864326933a49ccdd61d69882f51f",
-                                "uncompressed-sha256": "5848776787506de828c7c06a8f7c2d55bd8136c881ae000f25154cb516fd9229"
-                            }
-                        },
-                        "iso": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-iso.s390x.iso.sig",
-                                "sha256": "8695c01d2d6051254a6f6a3def7d34cf9788e897bdf459797dd675a864966341"
-                            }
-                        },
-                        "pxe": {
-                            "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-kernel.s390x.sig",
-                                "sha256": "47bfcd274f467ba058929e38489b7d383272f37d36326bd91da4b4097fd38698"
-                            },
-                            "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "d2bb97c3a99244e48d37164a5044fbcbd30ff07e08eaac1d23ede87559e3169d"
-                            },
-                            "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "5beab008e2a5b02793e0e1d5bad1fefb56f323d5e3f0ea80f1edd59feca7f239"
-                            }
-                        },
-                        "raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "9329b857859a4bc783b5f0a161a8544a3b98329d7e442dee786e75aae604937d",
-                                "uncompressed-sha256": "7829be46f1b9c4d27d7646d18c9f9f2229a83cf0879895d12ebbb29357227dd7"
-                            }
-                        }
-                    }
-                },
-                "openstack": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5f66639066324b9d6198537196fd3878b96698b251d2304c275f8b2b537d602a",
-                                "uncompressed-sha256": "eb535d7b73c4521aa827dd579d57097b8e5e49f67c5691c84ee6a2ea90dd9cc7"
-                            }
-                        }
-                    }
-                },
-                "qemu": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/s390x/fedora-coreos-42.20250427.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "b232f65730ff2285e0db58f9e78fec6a348cba08c647b227b39fb5d60e9cdcd8",
-                                "uncompressed-sha256": "8ce454580537a45beb15466dc4a0900b0ff363f0d98a2a806337ded46befc49a"
-                            }
-                        }
-                    }
-                }
-            },
-            "images": {}
-        },
-        "x86_64": {
-            "artifacts": {
-                "aliyun": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f5c89c27a3a8b3721cbf6627049e3c2b274238d9be03294a81ab0d9a110e357a",
-                                "uncompressed-sha256": "40c4a6a812e8d41495e1530712e72b2e3bf8e2c60cc4df6aa68e4875e2fe9ccc"
-                            }
-                        }
-                    }
-                },
-                "applehv": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "raw.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "06ee30fd2b5aa200f358e1e1f97937f0efa27569c8c772a6f02cb514caa29c2a",
-                                "uncompressed-sha256": "8b1be65cf56ec7e410319644e606f0a71e6d04d55814066bcc37fd13db1b670d"
-                            }
-                        }
-                    }
-                },
-                "aws": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "vmdk.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "90e4895d413098376c58ac63f3aedc05842d3a0501683ef996c6fbf483b9ca72",
-                                "uncompressed-sha256": "df4bdc5d1e0cd9a2d50e6a30876ea2bf67ded241cd1f8a15c3bb81a9dabc0467"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "4d6de56e10f4a8960aee8fcb56cd70caffbf92c891556c40ebdfd54b9305a477",
-                                "uncompressed-sha256": "db0cb1e169bc46f346bbae469034d971f5d28ea6696071683d09db5af7f229d1"
-                            }
-                        }
-                    }
-                },
-                "azurestack": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "93f9f4ba6bd2a191db433789d119a6713254f4193f2314473e501fc96ef534cd",
-                                "uncompressed-sha256": "5131eca23e0f1ef50e50a0cc0a4e51db27c5b1b6a4448313fac1d8c233f82f8a"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "36de38c84232237146e0aad324b3b2a51d5246501fb57a3e3d47e42aa4d27ed1",
-                                "uncompressed-sha256": "c92adb2257ee961e2f1b4816783a474aa207cfc3da48d9f74f9262380eae9858"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "aab7f6f7fa31ddec80a5e1c4822c600047d1059fe6baf9faec86ecd89afba3a6",
-                                "uncompressed-sha256": "5dd9ce2f861c35aecba2baa0112e490826927cc2338120c97fe467f85eadab1a"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "bc6d2707f37ce9f8ca74937676ab6965a8426d2126538d26f9c0ccf09000cb49"
-                            }
-                        }
-                    }
-                },
-                "hetzner": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "697ab8e68ccdffb639550f211ce25bf5072c8ffdaebecc5dc50dcedb431cf624",
-                                "uncompressed-sha256": "f974961e0eadf04a7930a8984113865db01f5501a180be604f2575bcebaefc1f"
-                            }
-                        }
-                    }
-                },
-                "hyperv": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "vhdx.zip": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "8f17f508b320bcdf5ae91424aff120f6cdd56385a7cf20300fafee03ad93ead4",
-                                "uncompressed-sha256": "d867d7413360b742076ac631e84b4ff37515028d5ff5b7cf5c1cb8a6b05862ba"
-                            }
-                        }
-                    }
-                },
-                "ibmcloud": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4e6b1bca15bb30827df50bdc7d95e43025e69a7f2d3b5709bb4b5744c52050a7",
-                                "uncompressed-sha256": "15930b2e0064aa9b72e69b21a3ebb677d1f2d63a4e41ef22a98e8e6922eb1a7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e6815cc88ec763fe0b0769c127928387491ea3f3acba9cc966cfac06a7625917",
+                                "uncompressed-sha256": "d25eb0661f0d55e7da38678ec5ff86fcc8c7b7b44a5f088839de26f05cabf635"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "f016dcaeecfd572d6e3fbe035d41ec488a38f67dec48c5c0f1243db214940a35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "6b6300afdf2cbd6880deb63dbeec1077f619581cc4a213d75fcbc58f8d985102"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6b8692daf04bdbf890f529f5563cba55f2b09abc8abc36f3882700e4746b8aab",
-                                "uncompressed-sha256": "1e953985ac01922cf75531a1df013f6a3b8707d54bcf5f7d51637b0649269328"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ab703a948b45c85fa55228ed3ca569c7a15ec5c5dcb98f683373c7e8c0b9464c",
+                                "uncompressed-sha256": "b58bdab63112ea5f800a29b5e0ac5bc63bbab10e18f2af51f1805aa1061d4759"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-iso.x86_64.iso.sig",
-                                "sha256": "b6760d7afa58b16221709c20f9ea6f2bd65987137045aaca6984c5113055513e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-iso.s390x.iso.sig",
+                                "sha256": "47d2c491710a4df2fa8f3823f4c22f0474ede08c16dc860e36670874d0ebc902"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-kernel.x86_64.sig",
-                                "sha256": "aa30a5cc0328207724fdb75f6b1c9298d5cb979200ebf8c008643ef2f65e8122"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-kernel.s390x.sig",
+                                "sha256": "a13d1cec10a9c4fa5851a22c3fc0becd4bf9e716aab4f32f1407ffd1a10ab999"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8da8c9b65010a3405b22138e6c5d3a1d619b524d257ccb1e9139354a6e2d939f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "73889ee08512d743a8a0ad99a437063a777554d7f7d7dba48da4543b5b2d34a3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "eb2817ee29cd05df1bc6fc8aab4952ad5946984ef1ef634e5fa60bc6db9a0481"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "e8e8e17c6f8ba4f53784c26fb232472c0c6a4f0293554d6571ebb8cd4a0d537a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "4f2fad606bc3801d0102842c6bb378de2afa4616a624963ab91c318f3c3b63d6",
-                                "uncompressed-sha256": "80845b7778fd5f1a866f2c851d064058260140fc516f4f1416c9c2e5056c3d12"
-                            }
-                        }
-                    }
-                },
-                "nutanix": {
-                    "release": "42.20250427.3.0",
-                    "formats": {
-                        "qcow2": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f6caf9e60e5c1b1715c5f5bc9dbdf4f10040978248ddb2cc07a486ff2eb2379e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "4791f7f33ac1892128b0e15954dccacdf76a6925dc0d4f93645b6c5c21fe597b",
+                                "uncompressed-sha256": "34b84dcdb62cd5f683b0f2425ff4710ca2336018c61c24e7682c734a086e8c0b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "0f60998ce73687de040161c1677448967b5ee1b389cf347933e018869b59d04f",
-                                "uncompressed-sha256": "df13a4f38e4f622ff7072133969b41492609764c6c4e9bd383508d53087c0e11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "f07d27dbe9878529b66c786c42e8b3b92cd0a4dab8f2329a5f278b2e70e5e19e",
+                                "uncompressed-sha256": "7e4624b9a2353047392e5db04788216c1432d39bc4d802e3da2ed01526c434a2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "57f32381c74442f0eb6040ede2775488e339599f66960942756aa9ccb4c1d6e5",
-                                "uncompressed-sha256": "da32e33ae3def0c9c82187b087e80544d38cc6457744c6a69750593c1b0cefa5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "74d03f65b64c24650ea5ed073004af94030b622935ae9bf748ae3655966c227b",
+                                "uncompressed-sha256": "59aa0c1df560dc78bdab2572d9b4c882614f469b1c698558777fe104c22b7583"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {
+                "kubevirt": {
+                    "release": "42.20250512.3.0",
+                    "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bfd6e31a0c0abdae0350a6ca6fa48fe5a162778b15350ffa6aff18b5a092710a"
+                }
+            }
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f5980ef0f28a6e9282a10969f6c0ab05f2fb76491a7520b3a173be3ff76613c4",
+                                "uncompressed-sha256": "07de5fe874ea8c9902b7192089f77729419b2031b1cc31a84ef4dfd5283910fd"
+                            }
+                        }
+                    }
+                },
+                "applehv": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "c352b25dae08628bafd0d05af68bfeb2157de6eecf0b416f944a0f135cd0b28a",
+                                "uncompressed-sha256": "b531b999dd81af8cfe659c3b75fd6d6b5399b7aea7a0ca1700687e588b4e9d00"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "103069068e799bc3ddfc9d0fd27518df4bf11a3513d408b22cc57f4c39bee7b6",
+                                "uncompressed-sha256": "1772bd8538a1ada7483a14d126e114a7bde82cf5a040a7ef08bf7ccb4680e0e2"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b542ed970f7c32e61d89466fe588c169ca6a4af12f9169a251f9b16ca147f741",
+                                "uncompressed-sha256": "f8f1c158a9e8bc4cf26211af612f5b7a3ed3c493a250e8c5c80776064271024d"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "da2c8db116e7420029f247feb8783f0cc3c1e941bc9636112c6c099ae0b38f91",
+                                "uncompressed-sha256": "0037829daf2cd503c0a46a00d38b842bbdc1a3f5b6a65e706c2121b430fd8053"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9ae6afc50cd72daad470f133d6008e22988b13ffa0d04f48859364edb24a76db",
+                                "uncompressed-sha256": "5b4fdcb4021f2e4cdf44983c425b3e7395aa99818af75634208d2e5973fcfeeb"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7d1dd9a4f723571337f92be9963a8416d7ae37de43960f5ddbd46a7392f6bae5",
+                                "uncompressed-sha256": "40088e4f097ac13a8b82d9d4b47686f8a8427e4d8f00b6101448ce29de90cbd6"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "da6dee9ed83a366912aca7ff24da8bc31482cd65f013e44db998a4b7d5a66581"
+                            }
+                        }
+                    }
+                },
+                "hetzner": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "b2aa9cf2636e7ae6de39141a2793314df20625f2a17693c060fbac2eecb8a55c",
+                                "uncompressed-sha256": "fe9e958557cd6719433b859f81c5d9a0b6e08503c0df0f9febe4e3246a72198e"
+                            }
+                        }
+                    }
+                },
+                "hyperv": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e80a7afb3f4a0aaf8cfeffb6746ea63152050014c7390aed5674ede22ecdb89e",
+                                "uncompressed-sha256": "7461d2b0a3fc9eec227d6fdf26ee2e0f91571bd3991747e113f1635c5832a66d"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d88dd0a0b8727749f50dbeb88db9b157ece4671b69d3ddbc6cfb7cfe5e030a9b",
+                                "uncompressed-sha256": "f4ce56971cf7e018fc0ded8b4c387f12c9228ef8a275d355538f31e2509738f3"
+                            }
+                        }
+                    }
+                },
+                "kubevirt": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "ociarchive": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d67ae8621fe1a77856598b2eb21cd9f994d245e4058a2d71ca1f1e55e373e293"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3376b83c73ce1499432af8180727d24cf0b8f7484b1dd4fe564baf237dffd98f",
+                                "uncompressed-sha256": "b1c2cf0918280dde9684576614a603ec71cd5f09c14083f10604b1e955a0f9cb"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-iso.x86_64.iso.sig",
+                                "sha256": "748e2abba89e7fcf24dc7bd5cd6d01118738d2ede9571f500bb5f4162017b990"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-kernel.x86_64.sig",
+                                "sha256": "c56c0ba0d64586a3bfd38d45ae786fecdef86726063ce3ea0ab2a71a4ad5abf1"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "7965d3d0c12054ce4b21d44f554b408644306332c830b8cdc11cf91fa407375e"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e1eba49e7a16d449e11984eb24d04f5ae85570fa20b5021408aa123495015778"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "62baa43bc5bbceb398fbfee1e0780bcc1d11264462da7fa36f35386b48cef402",
+                                "uncompressed-sha256": "acb1325601c0984b80c8559fe24a59d169b390aef8ef649c2d0e91d23bef5e4f"
+                            }
+                        }
+                    }
+                },
+                "nutanix": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "qcow2": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "81ab17c061459e024981f90f1544900b810fbd984374c07ca37780c8de4f5f5e"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "afcd28f431d9f6986a2430dc25f173ef050f4a09d321da009f2e6b2f1775600d",
+                                "uncompressed-sha256": "da368c27885fd7621d145aa6a2334ccf14030c41e43cd6a4f5a62fa7915dd9d7"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "42.20250512.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "963e1c5636d1b684d516dc6143c6e9a6bedf35b1219cc8a1d943d692790e3b0e",
+                                "uncompressed-sha256": "6a216279a382076c070a03a0ada681ada35bf636e8d50079fc8f18153b5ec0f7"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "0ab8401e0432ff9e80722af3732f170c89989805d76c33b7228f7c7f27404deb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "43a187b71760321ef57851294a8cf6629d099a2d413cc0ba6e6b6f9ad088b802"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "6944476326fba928089813f729a13fe7979504ed3cd995934180b50685f1c351"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "f4a47aee96197c38538ed2c01035f1be80994d3e77add2f1abdc09acffb7243c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250427.3.0/x86_64/fedora-coreos-42.20250427.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "57f4c9192ec6e7d7b94182bba3ad66cc7963384e6603d284e29c3d1bba25ba9f",
-                                "uncompressed-sha256": "d210888bab85dfa065cb7ed0d906b9820742408934d0910cf765440ae50172cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7203a325598d0cf61bb92fbd3234fd4a3274aee4a676c5358f0498e24ecd1433",
+                                "uncompressed-sha256": "dc97847bdfab2d0fa8020617370d65ad720cb930f19ea9e9116e6a3ed80ea71c"
                             }
                         }
                     }
@@ -756,145 +774,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-03b1d027a533e5d1e"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-021fdd0329042d53f"
                         },
                         "ap-east-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-069fbb16aae225314"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0aa30007493ba02fe"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0465ef21c44702b9c"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0cab67f4cedae781f"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-09623635923446f12"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0d2509b88c7cf8e7b"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0b3ddae99c1ed6e32"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0e3da3ed92d8676ad"
                         },
                         "ap-south-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-023b855284bccbbe2"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-06542f94b7c883a70"
                         },
                         "ap-south-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0d96a4479b323a229"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-062ef13e36d0a8131"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0651fb1504eb505ee"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0c1b684441ccf1ca5"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0d96548460e40f984"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0e6ea5f9946bb3c73"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0d1ef2e7327a430bd"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0b812e03734645c61"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-026dfd2e240177e51"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0423a7a9418b4c288"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0247b47fcddb23aa5"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-096199ad21179441e"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-04958d76b45d7dcf9"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0b11c77440e05dbfe"
                         },
                         "ca-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-025fadf576148b7a0"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-028e3e212abffddb9"
                         },
                         "ca-west-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-07d3ed90b34a4a64a"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-09f09d19a96f75feb"
                         },
                         "eu-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-04ccb2a894d4c893a"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0a98b5f222a0d2396"
                         },
                         "eu-central-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0e4ea4655289d0408"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0c12681baad1c7923"
                         },
                         "eu-north-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0f882da8265457d5d"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-03318173cd159e1eb"
                         },
                         "eu-south-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0d47881dd55fc99b7"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-04b2c3819bfbabb77"
                         },
                         "eu-south-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-03f75e9047b998b88"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0d1e5523cf70b934d"
                         },
                         "eu-west-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0897993acbe1c5b5f"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-014fde6f6f7a74c74"
                         },
                         "eu-west-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0bb33da219e202306"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-00d852f9e11ba57c5"
                         },
                         "eu-west-3": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-076469fc123368c7a"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-04232151322d288d3"
                         },
                         "il-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0f027816402bda079"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-0927e18f9a8f87b71"
                         },
                         "me-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0f7d57d2b61b9edc8"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-083f41d19819c6e91"
                         },
                         "me-south-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-009780ed583b498e2"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-036d6350cba3acfe4"
                         },
                         "mx-central-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0801dff62cb332a85"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-02cbc2895507611e5"
                         },
                         "sa-east-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-069fa30c0f56a8377"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-032b577faa7b0c384"
                         },
                         "us-east-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-036f0a8106be1efa0"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-09614d9d7c2f96d00"
                         },
                         "us-east-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-04fe1d85da76cf2a3"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-09410b5b6c34dcdd3"
                         },
                         "us-west-1": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-0e0f4f008ecfbab7e"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-05fd4b86367f3a4b9"
                         },
                         "us-west-2": {
-                            "release": "42.20250427.3.0",
-                            "image": "ami-01cc09feb65063eb3"
+                            "release": "42.20250512.3.0",
+                            "image": "ami-085af0bd4fd5ba3da"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250427-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250512-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250427.3.0",
+                    "release": "42.20250512.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:312d87f36cd129b7f75f1e74bea62415549b4d965d666c305a8b90c000a2c1dc"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:647c877361c9e3224491d5994522f41f58d6d7be2e41eea4cede0be133cfc9e2"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,156 +1,156 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-05-14T09:25:04Z",
+        "last-modified": "2025-05-28T14:20:13Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "04a50bdab89a403ac606084ef56bd614c9759b986af9524f22e68dd56c096820",
-                                "uncompressed-sha256": "7b26bd2f7df8d3388d589ab984998c8781af72a35089ed3509187286415849f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "345b03740c90b1f99409f82a39c4b6fdb932717a118590ae7b718ddf1d520d82",
+                                "uncompressed-sha256": "dac17d2a07dc2a6a8c8ecbbefc7e8e19bb6bbbc62577244aeebf86d5801c1e23"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "751b873cf71dc136f624c8f90cc3f96e3b818973edae9c8c57428c26c5e008c6",
-                                "uncompressed-sha256": "60a5c7f299b5f2d9e25babb8e0878db0edf33dfbdedc599746dbe2b0fc753889"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "afa86e79dd2205028248431ea2814b1148f178157c7bc0e1ea7ee9b9e5232f46",
+                                "uncompressed-sha256": "c6240c559a1416e30fe8ed8cb5ce0ee3de5f3ef277b7a6697317277d817c8bd6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "e485cd5fa22406f8009133e8080e85599bf61c5fbbf45f17ae3a09214538f940",
-                                "uncompressed-sha256": "9d8d0a65e4980d93c1579c791b8df574c0e461397953969f384fe6d37898a8a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9680fa97817e7516bb910e74579fa7b6b501d8c5a83934344b45bac0ba2c7969",
+                                "uncompressed-sha256": "25b6a19a6d50bd285516ad53a487a6632c1fd8d5634209169193da41ec44cf50"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0e8503b64225162e4c96de170bf8ac223716dd329a6b308c656deb40a98d5a92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "ca13b41aacd41a7b7b587d09c973e33a1bf2291035f148aad059bd4f89ee4012"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "2f0f24392e3581777c906b8fcaedb4e0f2451505273017c2ed1041f6090ee187",
-                                "uncompressed-sha256": "cf97159e1a14d5e6b7ef3093ee9bfce5bee545c3a27abd013aa32436fc433458"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "41003ab2baa4319571d9993dfbe7aaa6b75fecff942ea0873e008b87236df996",
+                                "uncompressed-sha256": "78c5ac02fd1a7008306f2c4b077f6f9275462d16eb5d30e14bcada1367de8461"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "f1ec2a5f563bab14231c491bbe05702f841da35266e5d24ab67dfb47c2291e6c",
-                                "uncompressed-sha256": "21421b9227e43b8e0434e821a901d10ca037a3f9766f2360722dafa6fb8738a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "1540806f906aa6c80e9702d7c4995ea9333949cf7382d6dada459d224e495484",
+                                "uncompressed-sha256": "6a47e4ddfd447ce9d04ff3989bfd30018313903f48003128c8f35b75d7aa3643"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d65d739032a58bcaf0240c7e9f2ee8b5025d06bda8de513a02a5d75134226a05",
-                                "uncompressed-sha256": "c72a2cb2d1b077b0d6cd26a77b6a16efe1dc98d1e6ed2cbf9aaf6f6095285615"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "711c8c7e336f0744ee6e67bbc0a76f1702cb7caf5ed66296108d5d3f95b6ba81",
+                                "uncompressed-sha256": "2681d8fee94c9be90823b64e0ebcc5fa6a084fce002492c6ab089f99271b2b47"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-iso.aarch64.iso.sig",
-                                "sha256": "49f02fbd1ddec0ad70f89ce4eb571980081dca04860c90c4aced78e54f624c91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "25d70e6bab764ab2dcfb832d786ddc19091947add424b8f1f3c84296c8d3aff1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-kernel.aarch64.sig",
-                                "sha256": "d1e29a6904a85764ad3433262285c757d2009d8db2e5e49f907325bb7eb5846e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-kernel.aarch64.sig",
+                                "sha256": "073c680bc51e149f28b4d4682ad4b021bbcc2e8578aac114ccbcd2ee6f663b5d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "100290218ff25b8ba824220e40b049945a1ca5ced074831b8d98a7b9719b8d78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "729ebedb6e198fd245a906a38c471f86519983964bc9192a9016e082f3736e97"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "6cd12e7d7828f8a45dfda7a05b5e283b9574e428b7572d2e20158174211af56d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "9eb0b29030077d20fbc2320e882a1c3d6961e51af1580a2741ebd43ce234cd64"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "d1fe6dfceba7e81dce2583838f1fd2117fe22f95b45e0081d5b56e17670f4892",
-                                "uncompressed-sha256": "425f672d1ee5d31c5af869c4ecd6d8f1d757e42f1b2dc39b7055c5194cb5a800"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "064ec9cce656a5f88014bd38bd63ce51b5ed15180fede8b94c405bfc79d939a5",
+                                "uncompressed-sha256": "94f2502cd097aa9933ae9014f918fa99cc2922dfa4c12f9a99956aa6b136c1dd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5957e30e1b898ffdadfae74dda3a62d7f50eaabb834d331dca4b9b8c8942a337",
-                                "uncompressed-sha256": "5bfa5c52763bca6ba8e822f8dd3177a3445009ccad7f2a11e3b887fc3bdfd422"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2982349458c40696f41f1f95e10a6f9b2dde4f59eac1e482a182b8d9dc9aad6e",
+                                "uncompressed-sha256": "67b5c06a77caa24eb8ebf02e28af9b0cdd833b338a6a15f34d1c6f4a2608cae6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/aarch64/fedora-coreos-42.20250512.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "630e9700cb698773c42a33216cfd8481ef19d0dd0062959853b721e88e876398",
-                                "uncompressed-sha256": "4d2b0fa2e2e5bc0fe9810ad0e7a6343f56caac4dd356af5141d03e6cee3bc974"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "db3ae34bd4db59e78d2144a460b93a8784ab9bfde64230e11296052925a3c42b",
+                                "uncompressed-sha256": "e7460db84b788afda7bf212131dd4041a43a5fea03e3aae039743acc331db91e"
                             }
                         }
                     }
@@ -160,225 +160,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-01ee5b82406138a36"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-04e28b715d06c78a4"
                         },
                         "ap-east-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-01569137987e6d45e"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-016a87d70f13a8a32"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-05c5f4843daea748f"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-09efebf9df2f9a789"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-007daed21084c1826"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0b540b2dff50ca5d9"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-033725c96bdb7bbf2"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-05c1035173f9dc9f3"
                         },
                         "ap-south-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0de33979bb614b41f"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-01c94c9cadb083b5a"
                         },
                         "ap-south-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0d9cff14467440a08"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0312843406a226773"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0d87ed73622954553"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-002d8ccc7ed4ff5f9"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0ce89569efb7c8b6a"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-05e7fa413f52655ff"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0cb29bf50e91557ab"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-035ef8b200282cf3f"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-02128147055a877d7"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0dc219868a5e03d44"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0c188998e9a678fac"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-01dc3fa2b9e15494b"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-05ab3577fd8a48f44"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-01e6e0e7a3ead4277"
                         },
                         "ca-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-036b54892dbae05c1"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0fe5d43513aa69ff7"
                         },
                         "ca-west-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0cea3d6388e3b0f9e"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0ae1c65592d2bee21"
                         },
                         "eu-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0c9601590f062b49c"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0faeeb0f1a3c458f9"
                         },
                         "eu-central-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0ddb4196e2e4ac66f"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-01163913e24454d17"
                         },
                         "eu-north-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-02165debd6806a4d4"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0b45800d39016e2dd"
                         },
                         "eu-south-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-05f12a2dde1abfe31"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-02305858a56f277e3"
                         },
                         "eu-south-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-07a7fc62fa1f9f014"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0a88017075747fc45"
                         },
                         "eu-west-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0e06697f30e39d5d0"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0d3f0a0179c2154c8"
                         },
                         "eu-west-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-040fae4e146262262"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-089ef738df353927f"
                         },
                         "eu-west-3": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0dd04834e65acf240"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0d10874cd8c3987b1"
                         },
                         "il-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-01f37bf5c4089ae1f"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-01072ff91078b6273"
                         },
                         "me-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0d0bebe5b646f52a1"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0d37cec1e533ec20c"
                         },
                         "me-south-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0643faf5f5f1ddc2b"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0d93908bf997e6cb7"
                         },
                         "mx-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-06778e2fc19f1a6cb"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0a737a7a8b232d6c2"
                         },
                         "sa-east-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0521016e0f2d97e4c"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0e6b1afff1ea7a3b4"
                         },
                         "us-east-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-07492a364cb89ea44"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0483b6462a65bb2be"
                         },
                         "us-east-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0d0df0b82a1ed6ceb"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0321223a7d9d75558"
                         },
                         "us-west-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0abf46ae585269d44"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-02022b5ffc69cafcf"
                         },
                         "us-west-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-013511e058ab9aca9"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-00c615bbc9e4c832a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250512-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250526-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "595b9282df70995eeafc3d608a1591543deed4c377e9c3d6c6ea8f7af74024aa",
-                                "uncompressed-sha256": "690b40c66dae00bbd5a6ae234495a698381f2282c5def3d6f4e3c3d19482cd5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "a19e74d5344319470b59ce492e58b0e9ea7b3b5014dbab9864a7fc54aa04c4af",
+                                "uncompressed-sha256": "989be7737ea40f5d11ac9b8bfa231ef8271cdfbf1b2b6442ab8fcc52ce957f6e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "80aa9e46354a40cdd03b4d280221d53324f33ecc5c8682076c6273e00ca65e5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "9e222530ecc0ac62dc96d0a40a33c1bd3b3c086801baeed912af0b17f545382e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-kernel.ppc64le.sig",
-                                "sha256": "d66a3c81a6244a6ec567f307267df8203cf93ad765fe0e9f3e980b39d8769c2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "fccdb6ed4189dfd27b79c3dcb92da3ba5fb270818cc51a78b6d69860c6315b45"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "8958bc8c59b1377d50fb39c66e172a39089cbdc79d711f4ec5488ed8fd907cc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "3241ad8c9b1aa877e7005c6992b1f71de52fc770e52b77bd3e5c55ecb4bf0b79"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "9b1604d4b8be15ea1195f17828c55edf5384fcb07f8d1589196ae8aaf4c0a08c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "631eacde044ba297fed2ab318f9a94ed3e405470551b0f5f9e898acaf1af2fb9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "10de1faac7532b03bea1aae61c684495a0a5e68bd96c41c1d40f1dfe31f963c6",
-                                "uncompressed-sha256": "fe7eb91c8b8de18de4a96412c2d40dfcf7332fbee421557c10f63cf7f21c57ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "6737f2853720e132176b10477d5dccb459db6ba405e83667dabab557d09d6dac",
+                                "uncompressed-sha256": "41927664a2abecc1e0c01be5e8e64d1b0b57a17d3c8c2f0ef9b3180231f1abbb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "f00371489c99a5dd8807f281be02407182eb88b140b919f57d146eb9c3768adc",
-                                "uncompressed-sha256": "35f0c9512482d75a2ef01806712ce94fe2c83f47fea9759499241e9fecf3614c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "650d128c81b0bcde28b7bc95cf73f5a353a0bbfa32a261cd6b927aa8b5135037",
+                                "uncompressed-sha256": "3c687dff6176849b6a61d1e5e40fe182be5f4b4bbd2aaeb651d9fb0c9629b635"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "4c0dcb54b6de2584d32f3a6c37a1120eab81e85fd052e529f730c875ece2285c",
-                                "uncompressed-sha256": "edb16fbab174a757e8edf72f36a6b603bc145a3cd0396fe439bd4c45c4c2e7df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "86dfb193a04ef121fc668d3f24008eb7c178b6375f4e9b5ae5b7db37a345cdba",
+                                "uncompressed-sha256": "f0beb656541b514b1f5e43377477198082be59594a5aa9bf0e8d566861d56d25"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/ppc64le/fedora-coreos-42.20250512.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "d4f06aad5c9562e2b67e2f8740d4633f98dd8d8f1324ec3d6d76492a44b8554a",
-                                "uncompressed-sha256": "be3c796e4618fb22a46c1fd3b86188a51e7a0ee14c6c6ac0349941f4ffccb083"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "431ea70ed1234f640683df6965948f24d4efd1fc329658f6760da0f7d9128ab8",
+                                "uncompressed-sha256": "ad07aa6f09aa72cfb5613edc4016720c2cb9020762ee57ed5d7881284296301f"
                             }
                         }
                     }
@@ -389,364 +389,382 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a8a65446fb4125aaf4782355bd5163e1123d3938bd8ab009f548bcb27647d815",
-                                "uncompressed-sha256": "46891f4a06e097cd759437ca255982c493f5b1ab74bb93521ee9fecf14950186"
-                            }
-                        }
-                    }
-                },
-                "metal": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "4k.raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "06b25cc3688975248a2d78841e00a251ec90ecebb5d1cb7078b02a3afe86b1d3",
-                                "uncompressed-sha256": "07f1081522dffce7e6126446c32d2c55c9ea0aca93338a3ba1bb6ba3cbc2fe28"
-                            }
-                        },
-                        "iso": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-iso.s390x.iso.sig",
-                                "sha256": "1b0e128a0fa649547120940d390f93a2fc830bdfc5093674a101ef9da9c4acc4"
-                            }
-                        },
-                        "pxe": {
-                            "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-kernel.s390x.sig",
-                                "sha256": "a13d1cec10a9c4fa5851a22c3fc0becd4bf9e716aab4f32f1407ffd1a10ab999"
-                            },
-                            "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "a822d8cdc305f28c2b89a6ae6ef4017d2419bc27dd26fd325c1b54576a2a34a1"
-                            },
-                            "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "2ca3982181bb347208db6bb44fbb44dd6cbf534625692c98925cd660d5af782e"
-                            }
-                        },
-                        "raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "5dae9cb03ce3e2276e5d39b50c02170e231d670f3a501aadecd8e0d642f851d7",
-                                "uncompressed-sha256": "fd758d451f35c0df5d4874b0f48d64d6b880aee263b86a51331fcba687ddff72"
-                            }
-                        }
-                    }
-                },
-                "openstack": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "e56edd984accdb40b32a14609272ce05b2320224047fd4352206437c9d90fe9d",
-                                "uncompressed-sha256": "131695ea1a03ab51ff2098f90deaf7322a097046b1f1b2c9bfe2316b5907dffe"
-                            }
-                        }
-                    }
-                },
-                "qemu": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/s390x/fedora-coreos-42.20250512.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f3b6d6cadc0f61983742f4bd36c262202d92e6a5777c7db61c32ec3b72ab2f96",
-                                "uncompressed-sha256": "bb1dd7f2d2ac8261f2c9f2f98bf9ee64c8bb827d5b9c1a77e7a3741b69e744eb"
-                            }
-                        }
-                    }
-                }
-            },
-            "images": {}
-        },
-        "x86_64": {
-            "artifacts": {
-                "aliyun": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "111a5fb967455a0dc79c2dde108bd1c459f4b2020418671ce9b986427872dab8",
-                                "uncompressed-sha256": "8f21b903e19e245217f6939f000fc90579a8e1233a51a868280b90fa8ef876ac"
-                            }
-                        }
-                    }
-                },
-                "applehv": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "raw.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "9c9e304e5eed96100e12dd23a87a2dcdf407ad678fa8665dd2412198fcd9408c",
-                                "uncompressed-sha256": "b6b237a9951f6a8ea79a9d1551af5533eddadeec46a330ca3a272bd1032fe946"
-                            }
-                        }
-                    }
-                },
-                "aws": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "vmdk.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "77583c4a0cb4e20abe1937e4e1f29ac3027ff3f1dd2f51e3aeb8749e0e86866a",
-                                "uncompressed-sha256": "5225585ca65397733dee1180cfefd6172dd045ff71691050a654a92705e3acff"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9259292b25d74d7e8e95b83db45cc8b7b527dbaf6f4da4f60f83118d70bd79d4",
-                                "uncompressed-sha256": "ab1dc543940f601bacc467d292ac6c48af9419675a97591a05b8f36fcceb6ef3"
-                            }
-                        }
-                    }
-                },
-                "azurestack": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "888f7ca3a0fca3cfb54d0c8c00032cbec0d713990b7bc250341a05159d4897f8",
-                                "uncompressed-sha256": "77ead75edcb6afb7571775b5c6a2e276a9da2978a75e8d608ee363fd6feabfb2"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4b0d8d4b4418bf8e06f238123c7b141476d5331fbd4e0339c2d29986ff265dec",
-                                "uncompressed-sha256": "d5049842bf1981a17772bd10a95805d51b4853db3e448b02ca27472c4c7b94b5"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "22ddd082f7fe1e118504565b20c25ed2cef30a8019194f5da439abad234768e0",
-                                "uncompressed-sha256": "375cfe7c1b36c045b7c409ec3c4f4aef95e1984065a16c2bb45f0877498b2278"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "32d47bdc663143eaf88735edfacaab9b93c393290bff3d036dc55debb4100076"
-                            }
-                        }
-                    }
-                },
-                "hetzner": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "e37f9f9365cecb211a983e0bed9396c1e3bb5d29ac340fdaacbbf206e3b8492f",
-                                "uncompressed-sha256": "3cf5245a01ce56a8c27a991072f727e9a79641fbde7dfdf95285b1dffbfcab8a"
-                            }
-                        }
-                    }
-                },
-                "hyperv": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "vhdx.zip": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "0bc63f6f040e43f084d5d35b0716f14d4dd40e7d6ca3805016e03b646ee4d5ac",
-                                "uncompressed-sha256": "b93b7e6a6bd9f227d9a83219639ffb81a7af7c04f856d27439d5e51fb8789c6d"
-                            }
-                        }
-                    }
-                },
-                "ibmcloud": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3d6639b103c697944d95172b08edacbdda154fe334fe54522e3db89e174fb0a8",
-                                "uncompressed-sha256": "447e80f53609e7e0e1463d8f62549701f72b0d32fd9d4691eaf5bd6bea7da13c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "44086e140b0db9440ecd413094ca3d29279592dd021ef49250b7ba81d3b1d551",
+                                "uncompressed-sha256": "0b79e0ea7dd23c678a13e8271f1f9fdd1389b27505b8aa3613256081c0540c41"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c8eabc5ab3610562a3adb791978f1deb497902e8b01c500dce61ad5672150bb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "3a59f1ed9907855bde40aba9a077eff05c91405b6c6e58208e5a0d41e956a92a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ed66fb9a6e9db427f168ba2e34c4a5108ce1b355c74edbf19431a0bce787cb33",
-                                "uncompressed-sha256": "fa9ed2a81b0a1c5323ef06ded4cc33475efabc6f8d08828e34ec58f5f2dff198"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "0a398e5ca1d7e9252c7bb705ee32c392210b3fe34cc1a9d4c9e53b9de3d2ab90",
+                                "uncompressed-sha256": "10277f89931d24d320acfd72a4130e76fca7b422ac34b49b46882bc7955cac23"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-iso.x86_64.iso.sig",
-                                "sha256": "2a4033f5e05da1e521de0626dc0fa0ec980c2349ae037ebd688bc871482630dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "ba583de79e372f50b72e1c3d0ce19a00709d57df63535cbfb76453c5cb928cd5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-kernel.x86_64.sig",
-                                "sha256": "c56c0ba0d64586a3bfd38d45ae786fecdef86726063ce3ea0ab2a71a4ad5abf1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-kernel.s390x.sig",
+                                "sha256": "7b1c1d363f6c670f8fa15b65329d49d8bc795f73e71bcac2110dbcbf45d40932"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "af430bb515de7cbd63cc3c20d9afebefe1db31d0d5ba3fa5566b0da9d26e11c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "7eff8604ca5b098b4b0d07738a12426b9609a280d8c3a03a7ee394a34b0381c7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "dc010472ed55e747047d5287575667e4b06fb2394d108e408d210dd5ef257524"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "96094104fc2d711fb3930e6178fafe886a4b269732f02b804b465f54feebda9c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "78449bd22f0fac33cbc268675f2bd268b834a04af0b73c59529e628afe14575d",
-                                "uncompressed-sha256": "cd480e3c0f1f51b37893fdafca91f3193a162c1bc001dbd7b55ba30b6b598237"
-                            }
-                        }
-                    }
-                },
-                "nutanix": {
-                    "release": "42.20250512.2.0",
-                    "formats": {
-                        "qcow2": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f1191a3b33521a116fa32480fa11b32933f7a0d11406671750e1e35577204244"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "991d257da78206e299849a613591b540758949979d0f2b805e25e15e2330c488",
+                                "uncompressed-sha256": "ba58130795bb0e5692710e328d22f79c795516cbc7de278d716e7a21d2b7320f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "15f758d027a4212b5999357dc543b12893d0a055a728ac6d700c89de2555e556",
-                                "uncompressed-sha256": "039c5d4474b5ea8dccd710483fd9a6b91bb2fcfc28190540ace65b054ae2723c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2f123725b18d811d20f6f3f861f25f7c37596de35aecd18488736f10851a7054",
+                                "uncompressed-sha256": "bceddcace06ab9c2193c7fd6cb19dfbab6d7738e00e996f932ec3e40972a9f7a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "4acc045a365cc839a4a7fe68b32906fd9ca01a06e1315b4057b2f49cda69b2b0",
-                                "uncompressed-sha256": "574bc83822f2bc8622e2c099e4c72aa16ea09208773b52d93caa81fd66480c98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "507be77f0419e083e50e5415e2f43b5093e3f4580a1a2b75728ebcddca7752a7",
+                                "uncompressed-sha256": "4d0d617531d3f2dd39d227db3fa27b8a8fcca6a73f127d4616423c5ecbd6408f"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {
+                "kubevirt": {
+                    "release": "42.20250526.2.0",
+                    "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1eb80a7ea0cfcd4d86035ab2b58d7a001c8b33ecd5da485f8239358ba8313cef"
+                }
+            }
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8d8111a3b19dd8fe9d7ab5726e366726b6a37172cb8ec282be2bff363e47fda8",
+                                "uncompressed-sha256": "732cfef8c9abfdc08ca0b81dc0779ab806a9aa95ca412a82d6109b1f84ef8a50"
+                            }
+                        }
+                    }
+                },
+                "applehv": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "raw.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "426381a03a11883c6fe635049395e95a00660c0ff9a7fa1c5912829e608d2f1c",
+                                "uncompressed-sha256": "29ae4e28415d54b8fab080638cfd58f14f8a13fb0ad1521fb4bf22e1c0fb2d5d"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a43fb6c7ffa15a72cff4bbaa87ac2cc161fa71952a6f380fb7db8910ab74af8f",
+                                "uncompressed-sha256": "525702f6dab062fe90559c7d9911913784adaffdd968864d6d7fcd93edd2d101"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7890258e69aa06e0ae1376756b10b960657f122e3a3160ad5f14975eeb7b9a09",
+                                "uncompressed-sha256": "c8016ac583cc434ca555d827b88d0bda95400eb29e3446519046817044fc4c09"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "37632fa7df3be5be2377a2ae59a8cc786afd04025cc8ceef63539d7743d583ce",
+                                "uncompressed-sha256": "05c0d95e8b26c3c708f09bc28b0a089e3551015f988b9fb745be2d7fdddfed1d"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d72b23645ce6513b0cebe6754341e6951409236a4e3f0a9464f0094a80ff893c",
+                                "uncompressed-sha256": "db4fa22b2d210839684558a8be36450137f95d14686b8276d65e9034a306e09b"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "417411cd3ab27718577d41c393fb89917ab99212d243e1383db765d75d8f3353",
+                                "uncompressed-sha256": "92763d8aa7a882d5b74201779eb838d70777561c49800e543c35bd668e2bb2d8"
+                            }
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4290c35c4cc7a10131d2aafaeef8fb47fc73013aefd2e33fa944703a5c1a06d4"
+                            }
+                        }
+                    }
+                },
+                "hetzner": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "6377e7e19b3c0871dad56138ab0cab67352e4e9f550d60db8624a17a9a738fed",
+                                "uncompressed-sha256": "711de5d30b6c710fed4c8a8786e050967ddd97153d3769b710f1150c62f077bd"
+                            }
+                        }
+                    }
+                },
+                "hyperv": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "vhdx.zip": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "8c2bf873ae91a11bb4ffc2b2551422e5c5be513fca2f335f6b75c187fd6b025d",
+                                "uncompressed-sha256": "f1e56af0a9ad1a59d6365d5e1428f55c8a79bd753065a9ce791737d380695ca2"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ee23b7a8c7e140e160aad6000042a5d89bd73ccad67b3650e35b999aff8cdcdf",
+                                "uncompressed-sha256": "58242666259a29c79cdc0ef7a6faad0f63d6176ccdfcd6912b1d3bc12cd61a00"
+                            }
+                        }
+                    }
+                },
+                "kubevirt": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "ociarchive": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a82d91f1161a01cc2df93fa190ecbddc08f4a97fc9a1cf3b4a0c7300d38585bd"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4fbab1b88ee507afdbcb2664f5edb031a2591fa9b336985584e2dc384e745cb8",
+                                "uncompressed-sha256": "f78be5c275cb99eaa6f420c238a3fddb9acff07c044bd589fceabaec87f4786b"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "7113ed70a07d43966dd67ecb50b621ac568ac7d84375607196b911255cacc588"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-kernel.x86_64.sig",
+                                "sha256": "9a5ad93c4a15faf067297b23fa62c7db6cf8bbb721210d236c4fb22dd2b543f8"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "db3704cfc6856f6404cc4c28c727f9fda6edb960561684280ec9d492a6ce81f5"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "2784bb930e70aeb5f1448d8e24e9815e1c8987341885c7d4846083e092afc263"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "9f95cdcdcb0ecd66e52c1ebf468dc86233cc5e294794ca3cdc6f1602ec6e9844",
+                                "uncompressed-sha256": "2ff4b944779881538335d3e1af5e3713f0dcf26040f9579d9456a25a02b53fac"
+                            }
+                        }
+                    }
+                },
+                "nutanix": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "qcow2": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "93e1b9b94d086b69d3c29d210fd6f66fdec0cca822d8256c4674d00e64919ce0"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "30ae09b9007089ce953a67249376fb9333d232b1f1ccca2e47b652c5d729749d",
+                                "uncompressed-sha256": "94fd24cceb6e6ccb622133a5ae492dd9288d22338797bb96081a1c6ade1881b0"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "42.20250526.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2b3ba0d02b3d48b3d487eb4e5b67897ac215704b772b02ee69d0a55c07fe7901",
+                                "uncompressed-sha256": "b80b5600ee7aca931825dc062048059b8a4422e175ae99ee34f1e6cf78991194"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "175e221abfe614ed752c73a03e5291a66e6cfa395049ece79f4f51b5282e3520"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "bab9a3dee51331b76b196822f174626acf7ea453a4c913f94818f2d2d977e605"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "dd0816c02746adb27137da612483978cb6c1b1717629e67091c63527d567f436"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "1f944c35db0d8d76cdd9061dfbe37ce638e2a8d3f039a2392959b3e026bed69c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250512.2.0/x86_64/fedora-coreos-42.20250512.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "ae292fb1257c167924aee2b2d0f46403c255b571817bf3fb5a5653e4edf982da",
-                                "uncompressed-sha256": "ce8a42dd302de283be1ecaeb3524ee1aa4a20a3cb42be0293b4c5bbf0bc8cff5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "e46081666861ec7e9ce1b6de1491f2a4d79e4c5909dd94f779b8c1c1026fbdbd",
+                                "uncompressed-sha256": "5f4bac5fb8c4936e9e49c06f411959ddd7721b63c0a3f02e9433ee73d19f1fe8"
                             }
                         }
                     }
@@ -756,145 +774,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-02d2b91963285cd4d"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0a4c7c88e8ea42e7b"
                         },
                         "ap-east-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0d17e0835c36fe026"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-020e9931a92d76675"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0ef600a3892242fef"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0b1f97dd4d2d5bb59"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-05abad4fce373b7c1"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0152d5ef7e6084a27"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0e8de226f91bb077c"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0dafe82ed80c018ef"
                         },
                         "ap-south-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-06fd9b67b01d084b6"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-06d5a645d1fb0f9f9"
                         },
                         "ap-south-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-08b7a872c418ae304"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0b83877ff7776e389"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0c0d5eb53639e7a74"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0abb3599bd62a6056"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0977ef07f48b8cbf9"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-06dea3c4adae11277"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-054ac4baa0587420b"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0dd0ec3a5be7e3eee"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-09c8108b16d53a749"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-07858d278bb0f047b"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0140602ce10efbfe3"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0920ee77339b8db50"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-003deb82461c02471"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-06f2ea90703d9545e"
                         },
                         "ca-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-052acca8ed99172ec"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0fc6cb627d13e6981"
                         },
                         "ca-west-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0ae6ed36699828cc9"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-08da3998445de48dd"
                         },
                         "eu-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-053b6c2b0b305b69e"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0b66024079d25259c"
                         },
                         "eu-central-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-01240482e7e36dfc6"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0aaa8f4565aa1f352"
                         },
                         "eu-north-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-04e13904a567861ab"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-06cef9051c8db7c74"
                         },
                         "eu-south-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0f0d358cba63edae4"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-09757c8055711adca"
                         },
                         "eu-south-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-05e23597458d3c7ce"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0a517860e31709a98"
                         },
                         "eu-west-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0f16bc3b290ff144d"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-05bd89df4bd9d42f3"
                         },
                         "eu-west-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-03290be5cf1b6519e"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0a720ced54b1b0886"
                         },
                         "eu-west-3": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-051986421a4cb84f8"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0eb2630fab36f6b09"
                         },
                         "il-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0bc61fae62ec889b9"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-08807858e30015de0"
                         },
                         "me-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0bcdcb0cbc40b390f"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0fdbd29e57e4b574e"
                         },
                         "me-south-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0c0c6459e73f9760c"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-071201b03de094ea8"
                         },
                         "mx-central-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-08cc4c796df44eb68"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0e6d4980e4c888903"
                         },
                         "sa-east-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0dae0b01a4a8b50c4"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-023f4043903839045"
                         },
                         "us-east-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-067b5bcba2aa6b552"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-08b43761885a5da02"
                         },
                         "us-east-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0ce7ab345bc1e1efc"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0a245e85d93d558f4"
                         },
                         "us-west-1": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-0a247c57858bcb608"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0f18577b690725c41"
                         },
                         "us-west-2": {
-                            "release": "42.20250512.2.0",
-                            "image": "ami-080e7e1fccf93f4b7"
+                            "release": "42.20250526.2.0",
+                            "image": "ami-0f5fbd3aab94f9ae4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250512-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250526-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250512.2.0",
+                    "release": "42.20250526.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5309870d1e72764b9dc3aee81fe6d4dd26cc95ed8e35d3055ecccf4d5e1bd1c5"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:948d0c2adc9d9380287968fe8ab66e8fca42d2face51f6037af9da7979973a80"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-05-14T09:25:06Z"
+    "last-modified": "2025-05-28T14:20:16Z"
   },
   "releases": [
     {
@@ -133,7 +133,7 @@
       }
     },
     {
-      "version": "42.20250427.1.0",
+      "version": "42.20250512.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -141,11 +141,11 @@
       }
     },
     {
-      "version": "42.20250512.1.0",
+      "version": "42.20250526.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1747217700,
+          "start_epoch": 1748448000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-05-14T09:25:03Z"
+    "last-modified": "2025-05-28T14:20:12Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "42.20250410.3.2",
+      "version": "42.20250427.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "42.20250427.3.0",
+      "version": "42.20250512.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1747217700,
+          "start_epoch": 1748448000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-05-14T09:25:05Z"
+    "last-modified": "2025-05-28T14:20:14Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250427.2.0",
+      "version": "42.20250512.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250512.2.0",
+      "version": "42.20250526.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1747217700,
+          "start_epoch": 1748448000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).