### PR TITLE
updates/next: make 42.20250526.1.0 a barrier for OCI migration

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -143,6 +143,9 @@
     {
       "version": "42.20250526.1.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
+        },
         "rollout": {
           "duration_minutes": 2880,
           "start_epoch": 1748448000,


### PR DESCRIPTION
The script for OCI migration first landed in 42.20250526.1.0, so let's make that a barrier even though we'll leave the code in there for now until `testing` and `stable` get migrated.