### PR TITLE
Roll out stable 42.20250526.3.0, testing 42.20250609.2.0, next 42.20250609.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,156 +1,156 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-05-28T14:20:15Z",
+        "last-modified": "2025-06-11T04:42:51Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "2b9444cef669be288cdcbceb22c797d3a283752b7fc61a79bb6351c6b2746416",
-                                "uncompressed-sha256": "7f17820d098e9e6886565596570d6f9c618ddbcc70d6ddf8d1dca977dbeb6ce4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "84b0989ba090c4ec7ceaa050f68aca2d3fca9dc51551597ced60027006976313",
+                                "uncompressed-sha256": "c196125db05c124c457b9a7f1e3afabae19067f53f336042a3aea1a62c99f93e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "1241012cfd91a04c47dc0e1150b3967d9d576dfa07e5eb7a7b04ceadae6d460f",
-                                "uncompressed-sha256": "08f3b4b0254a72382f5b9ccf88833dbcf96ecc5a6c842feebd6eeb10cd20f276"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "83c253302aa2fe33f2cf064940ada42e4bddb46fad78830bf26a3e9d02647a28",
+                                "uncompressed-sha256": "b266001a9faa2f351682414fab6067c294a12cb9c1802d91d0640f0e52edb1da"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "838faad120b9c06f07bd5c3ae5cf1adaac12d5877736cd0339b45c6246b0e6af",
-                                "uncompressed-sha256": "b035ee974830053e09b308ade6dad2c4320b2e7646b3acf32eb79b9ba857da12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c46629c3abf4779bff0bff067d3999e8b7a159030f0e80cfe7cbb7647f55c231",
+                                "uncompressed-sha256": "80dfc4d7266dfb20ca23797edb28b3056dbea2545ab43282faf8c5347ded4db0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0e1ad5a02b732c811e33620e9cca9e9f7a3b98a6f498d8b66a355cd3f88501b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "730732ff0d421b4bbc384f36c7eefc6e05ab8181741fe48d710591af5aa352f0"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "369b8255d84676626de8e64636f34d8a08415b47167beaceaf0e431bb548eacb",
-                                "uncompressed-sha256": "7eb221e81118ba981c9bc0e1719ee32f75b2215851589cf862020c632bc245b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "ab79ed2de6b6d6e712f3d9e22d907183144d6b41a358c690a54768aa426b0b9e",
+                                "uncompressed-sha256": "29cc15da3665ccf1e8050ff3613d9345c35adb7c0afb9d1abf0391cac172cf25"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "3616ea46088f37f6f7fdc33c307f4569e9c1b85e8d3970036456e472c1bba18a",
-                                "uncompressed-sha256": "fcbc883f645491f286d487ffc1cefca86201bd1fdbee58a19706ee4987f1c4b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "0d974451705b01520431ff14351403908ce6953a594b407ad04b12cdb5e6f29f",
+                                "uncompressed-sha256": "b1199d346744410c089c90b5200c865e3312e9f1c72c7167609e812009d74049"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "016b77be4ad1cc95c9c17e28cc72c02c687b7656adfa0bbcd1e065494a11f2cc",
-                                "uncompressed-sha256": "7c4cd5eb512d82fe5329d4d87727fcf69e09edf702ee2d30d4da915ac3721320"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f6277376e21c89ea69f95e2e7d1bf185a7da76c8ed46a4c8990f1296db9aec0f",
+                                "uncompressed-sha256": "e5688633138c3ceb80bb50ddfecbf67d46e8116b1863fbea4d13b1a51d308638"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "5407eeca4abb29c504474b99c968090c8e2417d3ce3253ece6001d7f515db9be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "45feee59dbc7037e0a9dfda5f6b09526656cfbb66eb4a15b94c0ccfaf18ca51f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-kernel.aarch64.sig",
-                                "sha256": "073c680bc51e149f28b4d4682ad4b021bbcc2e8578aac114ccbcd2ee6f663b5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-live-kernel.aarch64.sig",
+                                "sha256": "3ef35a83566af12288a6531618c542e8da857c2353359673edc4a6a63503b318"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "bb401d498f1ac32e7bb31492e5bf6996f00caf67b16e61c2ca8ef2dbe79730f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "51c22802a99f32f3dfb04da84add65b1e5ecb19ffd663db6d8164f71c471f0f0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "646a1cac6d5c689e42111258c631d34af0e34d450b2d004c87f2e9c4f105fbe0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "9e4ea72fbe0ebfad24b8450e00ac979a724ed8c543c67429f1d6cde278fb6a3b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "b792ff90952c31fa3bb0c8da3c7ec46130a5dce7bc48386cb5477314711a275b",
-                                "uncompressed-sha256": "1c9f7f57db9bdb78c5c643440fb0bb7830e076c5897d9ef05cc0fbc004478039"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "e65ebd138337c515d3dc37bf0cfb9e971d0e0564fd9cd84b5bba1ad67904a440",
+                                "uncompressed-sha256": "4207dcc4556c4057a8991b99d3a928f5cd2ec84b747626f93d00c4888f41f3fc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4dc37e94cf15610f84fa4c60bb7d81fd0bf3d8ea8afecb8eaf5d0307813e65b7",
-                                "uncompressed-sha256": "ef5de3e6889764c4053f44de395b144afcfb10a80c19a4a1cb3e584937a191c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "51be02b24c729ff7aba470a800f684848f3bb126a3a6aa86be31f7bd2af081de",
+                                "uncompressed-sha256": "b8839dc8ae19b25c545191b6e33dfc19089a061fec3fcdb24c9efabb3d90f5dd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/aarch64/fedora-coreos-42.20250526.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "fbf05da3b1e0524f637f9d4a7b841a583198fd2ededc210235d72b4890388f43",
-                                "uncompressed-sha256": "e93b30b090c6a0b273b9725cd7a965a172d4dd074edc9071610ecabb41b09f7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/aarch64/fedora-coreos-42.20250609.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1c30930681224555d7085a4d56ed3da120f8701ab124124bda0ee8636869ffcc",
+                                "uncompressed-sha256": "068a830c1c6b77a3857a72bbe0c3e194a0996ff2735b7f9e4fd62d0318a63280"
                             }
                         }
                     }
@@ -160,225 +160,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-095eab536febab621"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-04d14e59e56885108"
                         },
                         "ap-east-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0076f412b252b1909"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0c93faf206bcdace3"
+                        },
+                        "ap-east-2": {
+                            "release": "42.20250609.1.0",
+                            "image": "ami-08cbca050e181475e"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-083605f54c28ae515"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-00f01fc7e177407cb"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0f5074428c5e50675"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-099a51a96493e5bbf"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0f1908d82d9de5c5e"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-05411883c2972de4b"
                         },
                         "ap-south-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-081b68d4679705d72"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0dec95af3b11c7313"
                         },
                         "ap-south-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0a5704d1b74a66064"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0288797e735059a2c"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-04ed0e1e69cb74b96"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-038f2a71fafce7cc2"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-060579cd7174b7468"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0868ff653d310986a"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0b81b3cf993d72a7d"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0f46fcc58582df0a1"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0d2d61a1b8d6d2c98"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0879655f0ccb45915"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0b169c17f45414e13"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0d661e2655970be78"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-090bd9849423f8dae"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-053ed33acca769767"
                         },
                         "ca-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-02c8bf9ce18fd3664"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0714c2f70b0602ce3"
                         },
                         "ca-west-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-042fd9c0da63957ce"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0d313ba2a7c30440e"
                         },
                         "eu-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-03aa5a89cb4402846"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0bfc7a4bf44f4185b"
                         },
                         "eu-central-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0effed4e593d2b230"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-030fab24c8480d77d"
                         },
                         "eu-north-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0672afb107cf9a2a4"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0676d1e487f6d7c28"
                         },
                         "eu-south-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-027fba7b176e9f9b3"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0c568e02bf83b9692"
                         },
                         "eu-south-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-08485491a8e8d80b3"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-07f55cbad32eb9456"
                         },
                         "eu-west-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0fabaea929048b239"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-09e2126ebc0d4f751"
                         },
                         "eu-west-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0780a1c56d712cbe5"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-08b839cbdf93e10eb"
                         },
                         "eu-west-3": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-05ad42feadcb50237"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0e0156d0b64a25fa3"
                         },
                         "il-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-033510385659eb180"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-08ca119b036c5c497"
                         },
                         "me-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0d9fcdbc69344116f"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0c586cdc2b4e30d32"
                         },
                         "me-south-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-08f5b5e20644963c3"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-072b3be594b8bbd5f"
                         },
                         "mx-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0baa76e4af00e01fd"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-02ce9fda180d576ed"
                         },
                         "sa-east-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-05d5718fd6ef9a1fc"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0dc65e8a6b41768d7"
                         },
                         "us-east-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0343cfe0dda1d0fb7"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0ca48919383cbe027"
                         },
                         "us-east-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-08644e96abc077bcc"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0e179a4e8480f1c8f"
                         },
                         "us-west-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-01b564d3d9055f772"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0006a7c67d18022ad"
                         },
                         "us-west-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0265862095c9fa1f8"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0b27e6b4b5cc50b6e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250526-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250609-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "b7da066cd868d6272d7247fb147f2c9b09e4b1671c16dd567249817d74752421",
-                                "uncompressed-sha256": "665b6d5709b7b47cd80f10cec26d90e1c7f499f4bf2b466cab92536efba11b2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "7fa0ff3b1811559c28b31991b3f33370490ddb75bb7b68e373b6659a2b219116",
+                                "uncompressed-sha256": "afc0867ebf8637a328ce3b370706d50c181ddfab57ec61969d374e027202f1dd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "f569febcd63952ff7c1a2be6f7d286ad5b17790f98770016f49e5cd19d1603bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "334d0d209a1430a2513eb739fa566115f8d70fd4e09986479d916eb6373d2af0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "fccdb6ed4189dfd27b79c3dcb92da3ba5fb270818cc51a78b6d69860c6315b45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "4e4b98927b4ce1ba730da001e33521304ea0f5d2ea57ee24845c62bbcf1ee36d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "1baf70d73773acdc8828aff31a8419076d35ae9de5aaf8f233d693ae71db8d4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b9858725ad2213d0946295f732c620439e63e9cecd142eefbd92d6dab35b8389"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "94c7bd605c94a348f5625f945b514ac1c887a1e569d2ba2656da636ff0396895"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "7cb6a1d87ddb657d57cb29cd95893f338eada3445876c6f881a1dbbfe0eec267"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "f5010676ec4aaa5f4f72b6925f66f26ae58508b7d5d6738ee5ce080b23a07041",
-                                "uncompressed-sha256": "ed1037a209a521e07674c719ab2e2e9bf74eb0b703305247369e8a5f82c1ecd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "bd8bc78c7cae511ed7d87263f80c8841e4d1016cee9324f36c286b1107dd2fa2",
+                                "uncompressed-sha256": "641c13e473bba61119108f65ca127daebb6b72607fcc8c9562a3557693f15c6f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e9ffcff098e89f5475cf07c60ce85a1da7f7530123dc48307a10a0773d84050a",
-                                "uncompressed-sha256": "d5d9ec8524674b9c93fcff6e5f9dd369dba26e444db17744f23ff71a7c27822e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "054f072e20266fe1b9834ac1197ec42d11e6e4d27acd5e501ade2255caa21f80",
+                                "uncompressed-sha256": "2a57b02958c38c51bf9348d9841ca5ee676f256ed18986a20b0b5e85c9cd399d"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "281af99295787b87a261eec07dee50960165fc766987f90a2fc02ff8d7cd05a8",
-                                "uncompressed-sha256": "7b40c8f380ef944c2b133ce634241fbe522e6362c6fd632f8ab7eabe7eabdfc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "e25329c4594a07494a48e1aeb816ec7fbfd1ba644546e8c3e1c2031af8dd967d",
+                                "uncompressed-sha256": "2b1516d8e4690b847ff402ed3f0b083785dbbd92be89f9c54a112097cbbf654d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/ppc64le/fedora-coreos-42.20250526.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "f070de9eb1e8b3d586843e42d47efe10cc2a37992264f79adc2168f04ad03ab6",
-                                "uncompressed-sha256": "6eef32f8ec65f18a3b1db40ecb00551cf509ab74863631eac158dcae940ef1d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/ppc64le/fedora-coreos-42.20250609.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "b47b66849b4def9d41391b08324c9d2c9bdfc9f2fc6f121c32898d7f53c2ee70",
+                                "uncompressed-sha256": "d24fbe426fea88500092950350f06f512b7b23307dd5677272cb501b765c5c84"
                             }
                         }
                     }
@@ -389,97 +393,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ca4f01c8d7d35f892ff06803e18af46d5010fea4c14eabdb6be102f3e4bf482a",
-                                "uncompressed-sha256": "ea5880a7bce4c831c7fcdd51c318407d9713ca3c75c9f0115d16c16517e3ee61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6c29823a5aa3d9f632140e4103499ba9c25947bd01babc8954f2022d51dc30f6",
+                                "uncompressed-sha256": "1562f23dc55a16f1efc49f3d0d7394ac6018c5d36e9c5ace9ed25a492c31c932"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "8b3e813bb2deb37dee1705b1949406eacb7dc39380d54c9e53e5955a86d49759"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "0f8b35004d3504272a91682231a2e45e27b6417ab3447d34578da78d68e86686"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "89fe1de1b3d390100211042dbd2ef6f1c12515f1bbc9c77352c06f394b6c4ac9",
-                                "uncompressed-sha256": "d8304c2a24ce335b2be2772de9f651111d08cc44a7216ac7c0bd9a805b80804f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "d11714dfbaf1f8477f2d005d681eb7b2fdd66e2aff89a60100b91c1351156e61",
+                                "uncompressed-sha256": "13b97a5c4be7fe3b0d40f6cd0d9d2a66548a2b6e6ec33f370b98797cb6e6d384"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "6af2be122b47668001071177d489e97dce446517f9bd323d8038178777f5d7af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "844b9a84f110ca1d048f037381b35cc8597acd48405f3ec5e3f9a80b5ecb6917"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-kernel.s390x.sig",
-                                "sha256": "7b1c1d363f6c670f8fa15b65329d49d8bc795f73e71bcac2110dbcbf45d40932"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-live-kernel.s390x.sig",
+                                "sha256": "454c813d03e7323a0d8cf603a3f10e6ace02aba7d204f4de55ae15c7b65d409f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "2602febeb3dacb21685fbcba31d5c2a77fe07afc32da6372fc76961da922fc13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "bd325415b70fffaf6e83375f7d4b46aa1098d36a08a2559ac0593e6d1ce9aae0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "f60427288e878610943a3c6511a0ef6615a80f70c21cabccd468087c0c84aa49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "c12bad04a5dd0441864f483d1bb89091a1678644f2ab79b9d697d2c395a0fdaa"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "f374cc81ad455f9291ea0c9a3fe6c4db2733db6dc8d96aeb3a3a859b3cdc02c5",
-                                "uncompressed-sha256": "d67260522729ad11a0e72340f471163a6517989a782676cb8abd592911aacbaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "be4dd45bc664efa337d1f198115f81987261efca63a2c8ba10212d7bf38ed5b2",
+                                "uncompressed-sha256": "7a073d0130653610338883fe6085c4e27064f9ac5a9531405a932f8185e6f4aa"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "493e4bf9ea9b340959f30a91d3cc57e5ccaaed8f4623172ac175159caa41b970",
-                                "uncompressed-sha256": "a1d70b51e8b57856b9ce137a5840bfff34df4bd2172e61e048a4de16aef864b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "dc6ae043812ec21e73a0598a694a9321fc8723bcb084e871ce1747879c560f2d",
+                                "uncompressed-sha256": "da6baa16a4b0797ad2e26cfa864613a8fbdef6a181aca07a6467fccfdd63545a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/s390x/fedora-coreos-42.20250526.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "464a217f3f58dc1fc30bb74dd6e37930b2ab8bc4dacb09f4974f219da7a3f3d7",
-                                "uncompressed-sha256": "4a4e7454569f0b409a5f3703ac0d353728e9fce4a5c3e03c59bb09e73ddeb088"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/s390x/fedora-coreos-42.20250609.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "57db8000af8792e499133a7e251cd83b6b397679827a1c9910cc5ff6fdd2fdf8",
+                                "uncompressed-sha256": "df5e9b6acec1e2e0bb7dae9c92e7c6893a6f44308f9103c66260c81b1691b6e8"
                             }
                         }
                     }
@@ -487,284 +491,284 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3e7498255bf21e155e037f0513b13933a42b9ea0f74da0fa271bd47b639ddb63"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f18c97e36a8bbe55040b9464c4fecb636061c4476e5abccb5e6afcbf8e009027"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "aa183e368f035357d2b08aee54bcb86c8fbe4fe55b7c858feb65dd6b725345ef",
-                                "uncompressed-sha256": "ce12978ba3c0d18dc24744240eb86f9d4f957c8428c7cb505300f97c2fa9b4af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6f3609eb82d924e00507c428199e8d2ce806fe7efcdcbe71d20e380b1153a1d4",
+                                "uncompressed-sha256": "68b9ea8e06d697b9c3e6ad41f04af01746d1db25f4f4382155a3da9242e73ec5"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "cc4daa80d8e48d74b7899e240365664f7e8953882874b60d0bae2b4a0da84add",
-                                "uncompressed-sha256": "f7f5c3c5dd08e080037883780c07b48e10e076f5c1167401e863c79897b1b3e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "bd545df0c24ae3107ceb62827ee0b1f7f50685c1c92b0267cad3dca317b30b56",
+                                "uncompressed-sha256": "9016d9cd254a03d526f5902c9f28d05853336fd60fbc260f77cea18d5fe4fbda"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "30540fa75c39f0fd64376754fb84d25b3cf0faa21c1f29a94ae695320477247a",
-                                "uncompressed-sha256": "45b65d3ab94fb709e9e2dc08ef6cf3e200d7fdcc59af61d1fb183fa9bd8c4eab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1cc751360b1cfaeabb827594d9144d9c5773dc1ceeacf6ebffd869aa9ef913b7",
+                                "uncompressed-sha256": "61563e4b791483c4e2ab9a578f76b8cccf4371d8a0b6af28879fa78533677d75"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "cd41f17a76b9f98d5d38c17f5622ded69ed1c8343da5df8b56baae093cae2ba6",
-                                "uncompressed-sha256": "213bcbbe6e2defc390c5f38abc2b0e5d8e8631da6fe061bf0c945f04b0edcd83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c27e5a1bf37d188346886345855b3aac0de553b3090f24be21829b0d6e381c4e",
+                                "uncompressed-sha256": "7235a6d9b4faa2ef46666ebf85c5cb0d2013360c0c1464e5ea908fa06a4d68ae"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "bafc1442968f5bd7c176919cb01aadfc2dea4c5375f4f2a8130705831546396e",
-                                "uncompressed-sha256": "1f0e2f35d92d82cdb99a5b4aaf61681ae9625916a8d76781c8fd58adfecb7f94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "110ed2db7133743bec2de748d94dbd47783726640ca473b3a21d8b83fd8b62ec",
+                                "uncompressed-sha256": "3b0d464deaa86345f75f4946077a977386db03a997c2ee3b4ef4168e162b6d93"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "029bb3c15d7db732da4e1b2be80e0943706ff7cc869bcf57651389f286d43ab2",
-                                "uncompressed-sha256": "e87b65655d1945065d3697c76b0c6b703d22910d09513f4e345ed1e9555b95ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "643ef6cec644df7e576270ba1bdcb2a5e5a52ef8fb55d4e958d2a1649b393fd7",
+                                "uncompressed-sha256": "f81194193e20b1e9e3fb1c29ae9feb98cddcb9b418412d75a9c4bf3e3909fa5f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1ae0d3624e1f8af04ee736fa3e178f224bec9d0fca7c097efc8449c2320564f6",
-                                "uncompressed-sha256": "d65f5555cd3bc7c6de7e63edfc9db107d38dfc0022e21179dc443cc91ec8f5d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f381c727293817746dc2379e23d365e9677b31c691fd1aa8afa64b95f9154fce",
+                                "uncompressed-sha256": "c6ea51a6550b580305e2c2ac15d19fd8239024ef149cde6795c481cf4207e489"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c0042d64b38b3a682a87b281a71340dc60ad8ed5780807bc4fdf02af12225f9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "28a4c1f930cb4c0346f28b1d5a6e9792d1c787e5ad6830dfd5ccdce0aeae9951"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "645c33933bec79532d8fab0ae8e91fade20cad5683ee8c0a4851a1dc435cc65b",
-                                "uncompressed-sha256": "5ad1f5b9e808eba1619083485cb0ab392f20b9a7a6a5e9d83ab818cc8713d199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "85092e6994a5155d0c8a13b65c561dc5597dcc4aae8229fbf37ce312ec559615",
+                                "uncompressed-sha256": "49a04bd8087fcc61d098b9da41c5efe14209df4419aec16fec74dbd65176dd02"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "44b39db8dbc29ee63fc5ef4355653a187f2618d3119eb0469cc8d4b7097a174c",
-                                "uncompressed-sha256": "d1aac81ce5924563f2b17df706799d7c5d8b33c84341d2ca9c5a805b5ce9b9f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "88e2cf69535826a0b9529a27758b9b6ae3fc6f2dfa1aafd3766c16f83bb313a2",
+                                "uncompressed-sha256": "59179bcff33e040f41cfc01f0e7327ff5c5635a89bb60b309e546c5291c96070"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "6be5f7729c0c8902cec69552a9ef0c25b6f2527a54b0dd50d72ec00576d80083",
-                                "uncompressed-sha256": "c91786a56969e3377753ad25a761041589f669e11bff083ff816860797c876f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e650efae4369edd30a394cec7031bd69f11d82b5b660b7d87519c97eb5b0cad1",
+                                "uncompressed-sha256": "f9326421838d61724637e1c7834a6ddd8f6916f14a1dba2b476e49087524b5d8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d804901c98827505d56f84f0594c99d58d0326615c39368698e61897a0c1ef28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "02ff09f4d136ff4b80d759ebb8053ed73424a4165e1c3b7d1c37e827e1f2bd51"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4342cf765877dfe7c5c0ab0df711a6674db7d93480fb32df43780d4664578607",
-                                "uncompressed-sha256": "07e9e9099d4878d7d8a9a2a987992c274f12190300b30efc0a18802b4ca809d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "d45e5cac6c89601ff06c6552847292e4ad436c984246020d8091c2ad2d5d7c46",
+                                "uncompressed-sha256": "bcc6c05b1c96f9d660f4eeeaa2bcb1504f6dc63979974ec094b2d8ef65205d57"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "b811961697df82cc51b0a2b82c95ebd2aa963661154724b781bc27f6876a9641"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "da5e8eaf030baba8f554043405ce9caab9c7590a814f0609349751dc028302e9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-kernel.x86_64.sig",
-                                "sha256": "9a5ad93c4a15faf067297b23fa62c7db6cf8bbb721210d236c4fb22dd2b543f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-live-kernel.x86_64.sig",
+                                "sha256": "2f045da62edfc39f6f85a1da7d81416873c5a5451f25b08000e2d817523a9967"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "72eac2b9f3abd10c927d4670a1d345df260629fc6d959c706045036e3016fc5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "e5e16844b359094d71166bcf53ed13429a9ca580542104c1b0499b25fdf9aa52"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "77f52f7d4bfec711f7953d17c3a46e63c632e8d251cd76dd9c3d2e17e214b423"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "065a83d0274cc492954d244c5fc5f1bed896828bf023b43fb306d28d9b647872"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "01838197154f2e74d58f03d222381766c4f1b6a1853bb236dadd48e243c6f177",
-                                "uncompressed-sha256": "3c6d50c3bda1482af0d7538f32bdba0918a9373ef6c9703af9563b38456e63c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "a7f65169c589dc8bc12f0b97babc43671c79bf888cca2d7bf7f15bf685b500c9",
+                                "uncompressed-sha256": "68c6c78bdbe467c03f0c405b6b3e143bfbe21718fc3c6d4f5bfbd6c550b342d6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "a9b512f5e7e4dd7ac323c4dbcd2ed0ffef562e9b19b73ca9815d4cc7494715f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "a6e209aea58a3d741ce7004e0a6057caa83926fb5dcb88107acd9855ec07cc9d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7c2d1e46d5338b38df7274e6a5bbbd7485e4fe81f1f4dd2e0eaa70cc96885240",
-                                "uncompressed-sha256": "73d45c63bc02f5e621e3e06d80e36b28dc7b332d30606c1dfc40bc50ab9db052"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "574010f936664324b24ac21505522d25a5a72cf4f86e2d1a1d01a9bb852a7b92",
+                                "uncompressed-sha256": "b43b556f7e3def7949320d5997d913d5f0465514154397a5b23228c9870b2d4f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a4276dac463713af5812a9d67f694a8e70fb94d711e41b9f40387dc2dcca3e3a",
-                                "uncompressed-sha256": "f2ceced33043b685f55ccd23d10f1e33354742e8258ee33cb2b056009a612d21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4377fe913a9584ef9a8eb8cd1788e7baf09fcbbeb9f7ea19b7728bc597519520",
+                                "uncompressed-sha256": "0908db100d13a81642141c628d12a8f866ef3079b19242797514dea6a8ce75f0"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c2aca75621b0573a782477ecdb2fd682cf830d47294a10313e32605379936c9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "d691ab77026698299bfba1681cbfc2dbfd1e601f26ff5db1e45b489f3e703f72"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "48f2fa8819a4da34871bc9296b476d0b0d7b5a18ec4d182b781b6ae8181e82ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "15751f90de579cd5486ca485727a624b0921bd9f6cf0f698bf23ff43028ce0e0"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250526.1.0/x86_64/fedora-coreos-42.20250526.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "583031863a5c864a44b1553934512e5ea7b21606cd8360c07bd22c9b150bbc4c",
-                                "uncompressed-sha256": "adc52a5e5fabbf4ae31461175a5b8d1393e143571e82414a5837e7592899df78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250609.1.0/x86_64/fedora-coreos-42.20250609.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5f8245772813a3167130fcac452cd979924d4fb10659bce01d956508b9f2ad00",
+                                "uncompressed-sha256": "2d39272381b58d61c51ace9ff50a69627a1f45d63ad46ac6c5371881064e6447"
                             }
                         }
                     }
@@ -774,145 +778,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0a23107b0d2c25fc6"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0b60ade1d03774fa2"
                         },
                         "ap-east-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0bd14f7e9919fe9da"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-043866b8771c57dea"
+                        },
+                        "ap-east-2": {
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0fbeb67f07330ee88"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-044a9557bc62a3db5"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0eb2955eb700efcf6"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-03d5245fface880f1"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0d440af8fcc2492a1"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0adbc976357fa9742"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-09350571fccd907ed"
                         },
                         "ap-south-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-012d344a697c23bcc"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-08bb703d5aacebada"
                         },
                         "ap-south-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-009d04f9025502cba"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0ee4c58665107510f"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0283e69393e2a5290"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0fbc88132e1c51371"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0050aef941fd86acd"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-016aa5dc39347c0c6"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0897806e1f1bf3ee2"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0a08d1c47df758cf2"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-015d3821548e18166"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0d91756155777df3b"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-041c6c312213534e1"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0b2a4e88f97c7e491"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0543bd192449156bb"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-02d8a83d6184388c9"
                         },
                         "ca-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-09a6cd4d34cc72bbd"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0dcea08d41a3e0d6f"
                         },
                         "ca-west-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0bfb8d32a2b41d162"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0da87b1629cf92b34"
                         },
                         "eu-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-05a25539d9183e066"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0a2f0f67780f3857d"
                         },
                         "eu-central-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0a25e7876a08ff50e"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-08b12e1e59333bbc4"
                         },
                         "eu-north-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-02723e64b165062bc"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-057b605846d09b670"
                         },
                         "eu-south-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0d2d8a7a0c702fbef"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0102df80e971523de"
                         },
                         "eu-south-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0d68bb987b1d9f25b"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0d1e11df415258133"
                         },
                         "eu-west-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-04e4721ef5c952f90"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0f60151cbd8d8a9d4"
                         },
                         "eu-west-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0379238c652faee8a"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0e0b80e4a2fb638a6"
                         },
                         "eu-west-3": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-05110bfa00583d975"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-041b78f5ebbdd03ad"
                         },
                         "il-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-09f9e92d9ca9126ae"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0f4aa11a7e62c211c"
                         },
                         "me-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-050ebcada0fcdea6f"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-04cae438541f5116a"
                         },
                         "me-south-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0ba2a7788eb14e93c"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-02a8c591f5a9569f9"
                         },
                         "mx-central-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-096b18e7fb640af36"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0ec3b1cb2bf95b13d"
                         },
                         "sa-east-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0a536f903d612b32c"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0ee80639e1f137a62"
                         },
                         "us-east-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-038dfb68214993a79"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-04ae17043bfda6b9a"
                         },
                         "us-east-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0f076dd7f377e41de"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0e1ad603b2dfa3f50"
                         },
                         "us-west-1": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0fc96c0e45c8e5b52"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-0604a6fd486f715b6"
                         },
                         "us-west-2": {
-                            "release": "42.20250526.1.0",
-                            "image": "ami-0ca7dfccfc9ab873c"
+                            "release": "42.20250609.1.0",
+                            "image": "ami-05362722dd31ebcd2"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250526-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250609-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250526.1.0",
+                    "release": "42.20250609.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:25265d6d3ddb9bcca625d135efe14dd90ee866818da8eba2743bd79d7c9bc4ac"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a22c96066b6b63ec0049bafe061d81ec8d569e496fb662f5ed71bb48533876c6"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,156 +1,156 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-05-28T14:20:11Z",
+        "last-modified": "2025-06-11T04:42:48Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "10d741a9a53aecfeb3f08030f127531ac6cf1a94c6b320f1bcfa4b2c8dd69ba8",
-                                "uncompressed-sha256": "5a18c5373593e3795b3bc22fca464082b21b76c9a77a0307d7fde2f978b2384f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f7321617ce810da1ae7df69d39ce0e226dbf0dfb796e9adc4f7c174c84447e6c",
+                                "uncompressed-sha256": "108bac6e1d4a53b7f246d57e05ad5e1b4be651503c58cfdfc9766dffc1ceff0b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8f718b2d884f34cda2d424a3dd7c1c9119b60605cc45f44905214dbc5afd63d1",
-                                "uncompressed-sha256": "b2027d67cac2dbce683e1ec24dfd7452b0972c8063e8cf9b57db13258ec7489d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5db2eb95d19e13f3b8ba908b2e66cad58a9635b74806eaf9e264e4c6cce6d176",
+                                "uncompressed-sha256": "9cf1b1744b8fc338956b2250531de7ca2881a307f62094813f8da2eac94eda41"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "8db836eb3f99ac2230a9f2c9ba62cbd5591779dff4537526de0d9417ee28e824",
-                                "uncompressed-sha256": "189c2059192b9ef46a054aa9635e720fef888262b762904e657ad0a516a1e761"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ee8b54d8bcc068e8f8eaa2279f2c172f05edb0ac29b25356db409dc0c4a53cde",
+                                "uncompressed-sha256": "98c17b60813a2263b438d1f76fb7b42f344a5e6e7d1ff9c6437575d90c456754"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "e580979f436fee26b30cc67547bc68edaaebdeee7dcdac1129415f7040d760b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "1ecebb32ae227a7008afe9e125058875a7809365ce4feb4bdc56891cac9b1452"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "35b60387f27391d411df0bc316ae5c6f098440ed52bca7128229fc7b0ae56288",
-                                "uncompressed-sha256": "76b0b536665f34b53e3083ccc6946a316d1b83eff57d78cf98f80fe20054e98f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "c7a8f363009b461d862307748457ea572b938e538d88b87e78c9101d9ef4f1f5",
+                                "uncompressed-sha256": "4f52d583b3c4c3aa21011dadb83e30c3084d750375e1ebed7a01da19a44090ba"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "9493afa054b74a78bce521a2a2fd8c706548a2dab243c4478d448d63ded764c0",
-                                "uncompressed-sha256": "00a874cfdcc235f8de9b3b07aefe4f0f8874b74014bcd6e8f2d580ee3df78bd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "5a61190234267980c148676da9dba7a43e4f30d2e06f4fb2429222350bb24de0",
+                                "uncompressed-sha256": "0b5cc96ca629abf66f3663a90e3500b7bd0131cd56b489c585916cef1f19fa39"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ebef31c830312c23d8cfc8233974d96177b592adc15df925c60510fa75d68b48",
-                                "uncompressed-sha256": "1bee87a5b6a083344692752bf15487b39324833fedab770cda7f5aed2acac2a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a5f602da1c753d9f35815ada8b364dc6cf0fbc317eca6812ad7a107a8af189c8",
+                                "uncompressed-sha256": "ac9d07cd7320553a4e9835acbeb1a478a2661aeaf855f3bf2d5839de38d54fc8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-iso.aarch64.iso.sig",
-                                "sha256": "2b7aa92fb009234f8363315602d42550208073ec80c3fd3ad72f565faeff74ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-live-iso.aarch64.iso.sig",
+                                "sha256": "c6a5a80a98bca3f2f274b23605794be2e66581edc1ea4feceba83e835f3669d9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-kernel.aarch64.sig",
-                                "sha256": "d1e29a6904a85764ad3433262285c757d2009d8db2e5e49f907325bb7eb5846e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-live-kernel.aarch64.sig",
+                                "sha256": "073c680bc51e149f28b4d4682ad4b021bbcc2e8578aac114ccbcd2ee6f663b5d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "bdce8b3410db153f91d614eb0fa9f551db43d691ef35d7c72a50f82a7196a5f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "14afe2aadb0fd3dfe153ee1f54ac3fc426d6f610225ffe2a9430cad1918fd6a7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "3a64aa1d21c410edf8e4bdb9b16bcaf634206fe8660a5984da269106e6eca6bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "de05f8b20a77e42ea01ff19031b5f2f3ff7302c78e763c2da484887d464449b7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f24a143e8cebea9470bf0763cf7742b4f90a9317252021cd143ca52387a2848e",
-                                "uncompressed-sha256": "172a3319a97ed926afb81b306d50039a01ed1a120a9e02b04c109cbced195d1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "d48e2ed9f48664fb0be9ee0fc291f43a505012c005df2a0c455db208ab63ce4f",
+                                "uncompressed-sha256": "dc647ddee42ec68cb7fe3b4cd228df2818cfc29e59332c77d2e2283b640bf952"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "c2949ae2e5e84ecc64078e5c04fce8b0dd1d6451f082050bac72585d6411f420",
-                                "uncompressed-sha256": "d14b1978f468bc1a517cd7c2cd4ceea048aed15de2bf0d2096f2ebfaa64a0bd0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "62ac7f5f567f75a2bea2107cc5118ac69cb836ca53e2813e5e1b1bbc6bc08a17",
+                                "uncompressed-sha256": "a4b3b3eabc57b53bb1a1729cd27d42d06e7ec58b463f51fa52e2fd0e124182b1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/aarch64/fedora-coreos-42.20250512.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "0cdd1c000ce306caf5f1c2fd35fe96c9fc8ea52d7c30d2ff066b69ff484a47b2",
-                                "uncompressed-sha256": "c112225f97f75d54905b234a390e17479faf096558d4de1f87f5d0f0616ac593"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/aarch64/fedora-coreos-42.20250526.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "312150fb1d09db900f91d511984b8ed1a56d25ed791e15d398a8037aa5792636",
+                                "uncompressed-sha256": "6b048cc881e9d3a48548f9c58fc9dc305b353cd9f681f1e4304f242574ed5e76"
                             }
                         }
                     }
@@ -160,225 +160,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-06c21597b929395af"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0081d5c77efea3645"
                         },
                         "ap-east-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0ebde86fc6692d63c"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0ba49c676ee65d73e"
+                        },
+                        "ap-east-2": {
+                            "release": "42.20250526.3.0",
+                            "image": "ami-041bbf98c86f5eb9a"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-083b42ce1a8aaf78d"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-09f9bb28c9cb7d5c6"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-01ebcffd9318a48f4"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-023ae32b0b58f025b"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-08e0469cd8deb86ea"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-02f4e9a4eaf8683d7"
                         },
                         "ap-south-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0264e5d03c7a81058"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0cbf26cb5ae8085d5"
                         },
                         "ap-south-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-086285ec3fdf783e8"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-00a2ad49240c2cfbc"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0688d8785283fefea"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0ad76ccc4dd66bea9"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0a24c6356e0dbf32c"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0070d9f3b0733a0e5"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-09fde1510b3238b37"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-081b91c7c233a2f75"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-06bce9661616669e3"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-07ca16594df874cfa"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-06af789f55ffff2e4"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-03fa948311a88547a"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0a67121f1d3d863dd"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-05bdb37cc02bb420c"
                         },
                         "ca-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0c83067b77f51cc98"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0d3ceb3dcfa1476e4"
                         },
                         "ca-west-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-060747102b645a119"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0f3483fd755002cdb"
                         },
                         "eu-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-044c88ddaec3d1a3e"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-000593dec3029de9d"
                         },
                         "eu-central-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-00fcfd598385a77f0"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-09971b6dc726bc1ea"
                         },
                         "eu-north-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0d9a1e521e4a73138"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-082c4460c10cebfad"
                         },
                         "eu-south-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0ad3da26d5066077c"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0f100b2f4fa2eaf55"
                         },
                         "eu-south-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-098184593bbf0689a"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-047c5ce89379b20e3"
                         },
                         "eu-west-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-04876bccbff88c486"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-057ede26c6556dc97"
                         },
                         "eu-west-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-01405349e8015abc5"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-07c84ebb089ad9e9f"
                         },
                         "eu-west-3": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-07115ec1116fa599d"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0d91e5fbf1678cb9c"
                         },
                         "il-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-04b48e0f0654e2d17"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0d5434434c40e9e13"
                         },
                         "me-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0ec043a171a2e7d08"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0791ea7f1ce98e96a"
                         },
                         "me-south-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-02b0c26d9d785ece0"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-039bf899f149fc050"
                         },
                         "mx-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-06874df852470d567"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0db22f2b75d6a3dc4"
                         },
                         "sa-east-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-081acbec0f05b0ea4"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-040e6538b3d7ba266"
                         },
                         "us-east-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0d664fefb95c69d45"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0276db09b5b232af4"
                         },
                         "us-east-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-008013150e665b1f1"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0dd3e617db35d4e8a"
                         },
                         "us-west-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-081601269cf3a87e3"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-07880248eb49c76c3"
                         },
                         "us-west-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-03071ec07ca04b21e"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0b00b2816f48e0601"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250512-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250526-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "782141afaf96434a8e0daa5faeb0c97b967e0e7870f633c38e894ba7c419b53b",
-                                "uncompressed-sha256": "1ae4bc1d2e6e0f0826619bd75fec41e429aaab784b3583da39439326a5818aa4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "2868428b60541ba0cc82fa31610a4af2e2bb08cfc9038dd1fa49931fb79d03d4",
+                                "uncompressed-sha256": "7e8139302da0831434f4927cc78de047e69c83654e4c8839269520c12a62f69c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "bb70eb4492ebd6fdb47526a7b3392ce09df79f8a4549b1f6eef0ddb4d2d92585"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "2cbd5938cf26cc2a9d3c5db649cdd6bd8fd65e245ea5a746bad42bbaef66d907"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-kernel.ppc64le.sig",
-                                "sha256": "d66a3c81a6244a6ec567f307267df8203cf93ad765fe0e9f3e980b39d8769c2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-live-kernel.ppc64le.sig",
+                                "sha256": "fccdb6ed4189dfd27b79c3dcb92da3ba5fb270818cc51a78b6d69860c6315b45"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "ec4cfdc1c9502e5acbe70b2e08d9b249e0c75286f1381fa0a049f19cfe7545f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "6d059d90075848881952b5781598f1133a8b828b7027814e6f77c39a11f8d0fb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "ff04a694cb2bdb52eb7aed9ce170cce6dd78ac873ade9ddbb0cd1b30f5318187"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "b82fff3d22b0dc4472b4f5a8a7c2f07356642ebef367ff7fc0506d2d843c7018"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "1e33f51b46dae30d86c102b6b5b69bf81a30b8d5ef31197d2be636070f17e832",
-                                "uncompressed-sha256": "c04d75b276eeb09350de164af1ad64283bb716b2161141d1203bb6d6bd1ec76a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "aed1ea1b6f6024a3066405d059f4c4c73c7e46dbb5123e2244f3b1da1b7182cd",
+                                "uncompressed-sha256": "e1f6a934fc7ac90581b240fb9970467741b760a192a6c4d7295664271710e73c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "270211ef3da8153a075a87016e707d8bc42ac55074970de997cdb27afcb39a31",
-                                "uncompressed-sha256": "b06097c03f998c3f22443bfa3e8544a02e2d061e1a34ab063019bf2b3f05baf8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2d9945253ae1bc9efa85054b239f95a27e92cf0a05c8b279822ec7b08621c47b",
+                                "uncompressed-sha256": "f9c8a951aa8a54cd6ac6480d4986fd26d8adc8fa558e8840418f5727780b1352"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "79864c449531b586aedff162aea07b881308aacfeb6f11b883daa90ff0a4822b",
-                                "uncompressed-sha256": "6cafd56ac11e84c138f8d8a50a17875528fad70906dd395fd46bdf5ab9b5acd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "27613c967d882a3574642c7bf970eab456fa18da67488a95f690f58c7558a65b",
+                                "uncompressed-sha256": "137e62e559d39c00437c43ef5d7dbdb98b6aa16acb1903ddc475c17845312096"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/ppc64le/fedora-coreos-42.20250512.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "7f23b5d17253697a0bd72bfdaf9299117f3e75c2d0f174ef7a8f3ee9ad7c9d63",
-                                "uncompressed-sha256": "61b9498f97d0258841c7613dd413a33128d2a5a97948ff0df6607d5cf88ef098"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/ppc64le/fedora-coreos-42.20250526.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "63141513f5567097f649130fb2f48f9dfe0fd90a45a9a6033d611872eb2a8cc4",
+                                "uncompressed-sha256": "b31d032022d03289cbcdc74398c534249014fe3ad00a2bf21ec574609d3454c8"
                             }
                         }
                     }
@@ -389,97 +393,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e6815cc88ec763fe0b0769c127928387491ea3f3acba9cc966cfac06a7625917",
-                                "uncompressed-sha256": "d25eb0661f0d55e7da38678ec5ff86fcc8c7b7b44a5f088839de26f05cabf635"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "78cc1a6091ea9de3b907322f427f7db9ea565f24a0c21c7d3de5f8fff231e414",
+                                "uncompressed-sha256": "a3f2d8b4922939c3f90f0b4378c61632797dbd0394476198c9283211f19651db"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "6b6300afdf2cbd6880deb63dbeec1077f619581cc4a213d75fcbc58f8d985102"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "c3af1b12d814a11daea734ff02154a31dcd35c132c81219ae00a89aae0345c7c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ab703a948b45c85fa55228ed3ca569c7a15ec5c5dcb98f683373c7e8c0b9464c",
-                                "uncompressed-sha256": "b58bdab63112ea5f800a29b5e0ac5bc63bbab10e18f2af51f1805aa1061d4759"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "554c71f0cc3489a6e1f3f987b00e8cb1d71ce484aee6e4bf5e6180d81c2d351a",
+                                "uncompressed-sha256": "726a98cd341e6ed04dcaef979a9888c01ac36ff4b7d1c9691f886d3a3cf8ea81"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-iso.s390x.iso.sig",
-                                "sha256": "47d2c491710a4df2fa8f3823f4c22f0474ede08c16dc860e36670874d0ebc902"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-live-iso.s390x.iso.sig",
+                                "sha256": "daea031cc26d26a66de2a8ce9b058435471de1c7a04b4288c2926d56b3b031a5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-kernel.s390x.sig",
-                                "sha256": "a13d1cec10a9c4fa5851a22c3fc0becd4bf9e716aab4f32f1407ffd1a10ab999"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-live-kernel.s390x.sig",
+                                "sha256": "7b1c1d363f6c670f8fa15b65329d49d8bc795f73e71bcac2110dbcbf45d40932"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "73889ee08512d743a8a0ad99a437063a777554d7f7d7dba48da4543b5b2d34a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ba91d852f2da984ab7cc39587fc3719810a5dc4e03e80f4c08544724bd3e7d1a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e8e8e17c6f8ba4f53784c26fb232472c0c6a4f0293554d6571ebb8cd4a0d537a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "7273c10c3f48e1fc60d03f59940c3fdfc14ee0cb1fe33c3f4ceeaeb1a156b0fd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4791f7f33ac1892128b0e15954dccacdf76a6925dc0d4f93645b6c5c21fe597b",
-                                "uncompressed-sha256": "34b84dcdb62cd5f683b0f2425ff4710ca2336018c61c24e7682c734a086e8c0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "b995c3b6438f1455c019887dc83f3c0cbc3ec8aca2a87241f65e4207ac03e64a",
+                                "uncompressed-sha256": "1e7d9144674ac30943bcdef6a45f426de2746c875aef0f0b1b44bdb2672bea20"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f07d27dbe9878529b66c786c42e8b3b92cd0a4dab8f2329a5f278b2e70e5e19e",
-                                "uncompressed-sha256": "7e4624b9a2353047392e5db04788216c1432d39bc4d802e3da2ed01526c434a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "7c74b319373bb97ec59c744641113943e1a616399aa8254e83e07aa749d09fc4",
+                                "uncompressed-sha256": "0a830aea545eacf40d16aa506b3f84e46432313548d5881846089aa8acc0c4cd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/s390x/fedora-coreos-42.20250512.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "74d03f65b64c24650ea5ed073004af94030b622935ae9bf748ae3655966c227b",
-                                "uncompressed-sha256": "59aa0c1df560dc78bdab2572d9b4c882614f469b1c698558777fe104c22b7583"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/s390x/fedora-coreos-42.20250526.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "8faf413bff13e212968920fd7fe9621898a10996591c875fbb9d92eb6956957b",
+                                "uncompressed-sha256": "a67efbdabdc7cd82f206c061da3d9579270acf78e8cacd494a4591d64586091e"
                             }
                         }
                     }
@@ -487,284 +491,284 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bfd6e31a0c0abdae0350a6ca6fa48fe5a162778b15350ffa6aff18b5a092710a"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3cf6558ae2bd4ba83ea1fab00f0fba063d120a694efc710e7983b291c231d0e6"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f5980ef0f28a6e9282a10969f6c0ab05f2fb76491a7520b3a173be3ff76613c4",
-                                "uncompressed-sha256": "07de5fe874ea8c9902b7192089f77729419b2031b1cc31a84ef4dfd5283910fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "e908476fcce0f45cd8d186dd63eb1cd3f28ad119f2f293b3a6f53d3438d58a4a",
+                                "uncompressed-sha256": "0e0dd9e3b4d577e76ab18909c7b0c0c498d2196c1103d6b728cbcb5d5a2dc06c"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "c352b25dae08628bafd0d05af68bfeb2157de6eecf0b416f944a0f135cd0b28a",
-                                "uncompressed-sha256": "b531b999dd81af8cfe659c3b75fd6d6b5399b7aea7a0ca1700687e588b4e9d00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "85e7d38f0459297cb602dfc9c6211dadeeae529c13fae677c3ce0002cbfb24de",
+                                "uncompressed-sha256": "3d612019750227b2a94d7ab2a73603aa36b05a03f9411ef409b99a14f34f6286"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "103069068e799bc3ddfc9d0fd27518df4bf11a3513d408b22cc57f4c39bee7b6",
-                                "uncompressed-sha256": "1772bd8538a1ada7483a14d126e114a7bde82cf5a040a7ef08bf7ccb4680e0e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3f63e6f90ae5b32acde51a8d3ead1542ecec31b996f8428747509216e00102ce",
+                                "uncompressed-sha256": "d4872f0e8fcd1b0c5ccc94f7ceb6c4e35aa6a0604c2c886fe836cb0e549c821e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b542ed970f7c32e61d89466fe588c169ca6a4af12f9169a251f9b16ca147f741",
-                                "uncompressed-sha256": "f8f1c158a9e8bc4cf26211af612f5b7a3ed3c493a250e8c5c80776064271024d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "75f5d4e64f0083619e1d2fcd5bd44225241167fa503eae1bff6e63ad53991418",
+                                "uncompressed-sha256": "a0effc6e8aa989e646867af15c24e3e80e8ba44187bde5ee2e1d0ae24969d1b4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "da2c8db116e7420029f247feb8783f0cc3c1e941bc9636112c6c099ae0b38f91",
-                                "uncompressed-sha256": "0037829daf2cd503c0a46a00d38b842bbdc1a3f5b6a65e706c2121b430fd8053"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7e24a10f94d33d3be5cd391385956fb85fdd36d1a3b005914a7b2e774f4e08c2",
+                                "uncompressed-sha256": "ddb5f6939b0fe5f2a7de8157c7e2857dc127b6495e0f6e771f8f6250b628031a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9ae6afc50cd72daad470f133d6008e22988b13ffa0d04f48859364edb24a76db",
-                                "uncompressed-sha256": "5b4fdcb4021f2e4cdf44983c425b3e7395aa99818af75634208d2e5973fcfeeb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "d948414a998062bdd229c1079e095ec7951d5a22755f249008f4d89d73f1f23d",
+                                "uncompressed-sha256": "db9ee343538540dd2c1328b824018b902a51809e7102a6377b564021b39fe55a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7d1dd9a4f723571337f92be9963a8416d7ae37de43960f5ddbd46a7392f6bae5",
-                                "uncompressed-sha256": "40088e4f097ac13a8b82d9d4b47686f8a8427e4d8f00b6101448ce29de90cbd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c1e60beb5bba2e6576590fa6b28e0b5aff7b89aa0a1fa0ada148996927d3c541",
+                                "uncompressed-sha256": "a31748ac51832ab3827680541383b6c6221c40de837d8ed7604773f50da5fed8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "da6dee9ed83a366912aca7ff24da8bc31482cd65f013e44db998a4b7d5a66581"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ef3cafcf08a4b590894d4a02b11eef30272fc0c9097cd98444359cb0dc471327"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "b2aa9cf2636e7ae6de39141a2793314df20625f2a17693c060fbac2eecb8a55c",
-                                "uncompressed-sha256": "fe9e958557cd6719433b859f81c5d9a0b6e08503c0df0f9febe4e3246a72198e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "120a116bc89ee8b4bfe202cdc470e19f88fff4f0299c097aa3a46cb3de19bf8e",
+                                "uncompressed-sha256": "18862d3b22a6b2c5030802362fea0ab45697e0a51daf737da135a34d56acf2fb"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e80a7afb3f4a0aaf8cfeffb6746ea63152050014c7390aed5674ede22ecdb89e",
-                                "uncompressed-sha256": "7461d2b0a3fc9eec227d6fdf26ee2e0f91571bd3991747e113f1635c5832a66d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "55b3dde1d6c635596e9c07ff2dc3143f7e2e5c7d0064310a91594a292aabb13e",
+                                "uncompressed-sha256": "6ea176f5193154d41931425270d76fd886480092e3afe7acc62f167856b761d5"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d88dd0a0b8727749f50dbeb88db9b157ece4671b69d3ddbc6cfb7cfe5e030a9b",
-                                "uncompressed-sha256": "f4ce56971cf7e018fc0ded8b4c387f12c9228ef8a275d355538f31e2509738f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2ea28be35d6dc055744ddca30056f81a9759eaa7276ad95b65227f5446648183",
+                                "uncompressed-sha256": "ec3975ec2f65d34cecf5893de5718c09e73f4e170387a3822f9f95cce589c74a"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d67ae8621fe1a77856598b2eb21cd9f994d245e4058a2d71ca1f1e55e373e293"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "99bc72eea03d5b158f5af1546318d6044c9383a1f9d8d42277eac0f7e6f097df"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3376b83c73ce1499432af8180727d24cf0b8f7484b1dd4fe564baf237dffd98f",
-                                "uncompressed-sha256": "b1c2cf0918280dde9684576614a603ec71cd5f09c14083f10604b1e955a0f9cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "d11a1b76b5508ea70a7efecca241f165304d444c906050eb205f362674180495",
+                                "uncompressed-sha256": "79b1de5ccd612f7926e27293af5c8a34b7d827d0cc1f49653da6b859082e797e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-iso.x86_64.iso.sig",
-                                "sha256": "748e2abba89e7fcf24dc7bd5cd6d01118738d2ede9571f500bb5f4162017b990"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-live-iso.x86_64.iso.sig",
+                                "sha256": "6911f57cd519289ce63a347599a5cb363cb3dbbc9e8b840c4e30639993455296"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-kernel.x86_64.sig",
-                                "sha256": "c56c0ba0d64586a3bfd38d45ae786fecdef86726063ce3ea0ab2a71a4ad5abf1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-live-kernel.x86_64.sig",
+                                "sha256": "9a5ad93c4a15faf067297b23fa62c7db6cf8bbb721210d236c4fb22dd2b543f8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7965d3d0c12054ce4b21d44f554b408644306332c830b8cdc11cf91fa407375e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "83f2a254c1845f07f0be89281a80d80c4d70909022dd2977a780645e719183ce"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e1eba49e7a16d449e11984eb24d04f5ae85570fa20b5021408aa123495015778"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "dae6c2fea8a393aa9ebaac35b6ab6df03e440379d54461768b4424c9d42e36bf"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "62baa43bc5bbceb398fbfee1e0780bcc1d11264462da7fa36f35386b48cef402",
-                                "uncompressed-sha256": "acb1325601c0984b80c8559fe24a59d169b390aef8ef649c2d0e91d23bef5e4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "8fa390891357df8f100a3d01a0082c853b91d2d6d9e3bd569b599460eb300aee",
+                                "uncompressed-sha256": "c12943978bbd92662c6b3f583c4e0f64693c807f676a42ba9685c125ec826f68"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "81ab17c061459e024981f90f1544900b810fbd984374c07ca37780c8de4f5f5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "daaf9c2123240f9e7d7fa815e3ef00db32add810dcfc882ae78ba166b29386ea"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "afcd28f431d9f6986a2430dc25f173ef050f4a09d321da009f2e6b2f1775600d",
-                                "uncompressed-sha256": "da368c27885fd7621d145aa6a2334ccf14030c41e43cd6a4f5a62fa7915dd9d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8fe1822a48f5d15884bf59deab09341c607d6d715e5c2c91733a739c4615ad38",
+                                "uncompressed-sha256": "8329395e1c758d5eef786e140a1aeadefbb547bb4f2fbb7a0a20488c37f3b3ac"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "963e1c5636d1b684d516dc6143c6e9a6bedf35b1219cc8a1d943d692790e3b0e",
-                                "uncompressed-sha256": "6a216279a382076c070a03a0ada681ada35bf636e8d50079fc8f18153b5ec0f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "aea91b44dc1397174bc00f438c0f908d9dea585171ba05cbd1c4dca4c439e986",
+                                "uncompressed-sha256": "d915e72af7074c833d3017e81b6467609839fe875c6a6f84549f5bd484b025b7"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "43a187b71760321ef57851294a8cf6629d099a2d413cc0ba6e6b6f9ad088b802"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b5acc00c5f9dc33f917ec41a9b1cc77a71a8ca06ed32dada2089a6424cffafc4"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "f4a47aee96197c38538ed2c01035f1be80994d3e77add2f1abdc09acffb7243c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "9abe177990894e7935970db07a67217bc622f2212151cd2cf9b062b9a7e2d795"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250512.3.0/x86_64/fedora-coreos-42.20250512.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7203a325598d0cf61bb92fbd3234fd4a3274aee4a676c5358f0498e24ecd1433",
-                                "uncompressed-sha256": "dc97847bdfab2d0fa8020617370d65ad720cb930f19ea9e9116e6a3ed80ea71c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250526.3.0/x86_64/fedora-coreos-42.20250526.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "966db02bf82998c6ed6b45ea23b414a8413684e1f8e25164db877c3a42404131",
+                                "uncompressed-sha256": "9057a95ed11a3b27d505fb0e808921a38dc2527dc8617b549cd2e73c4c765464"
                             }
                         }
                     }
@@ -774,145 +778,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-021fdd0329042d53f"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0daf05e14807b1aba"
                         },
                         "ap-east-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0aa30007493ba02fe"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0392eb90980849ebd"
+                        },
+                        "ap-east-2": {
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0c64e465bbee9e94b"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0cab67f4cedae781f"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-089972ecdb2af21f1"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0d2509b88c7cf8e7b"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0d07aa69c8531ef67"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0e3da3ed92d8676ad"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-088b6170ca789effb"
                         },
                         "ap-south-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-06542f94b7c883a70"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0ccf425b99b595c0b"
                         },
                         "ap-south-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-062ef13e36d0a8131"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0c642f92162d0c276"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0c1b684441ccf1ca5"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-09ef51473bbee01f0"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0e6ea5f9946bb3c73"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-04dbd4c9331e5e9f1"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0b812e03734645c61"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0e7a14f8088cb0ea4"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0423a7a9418b4c288"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0b2d006155b6b7570"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-096199ad21179441e"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0a03400183bb6b516"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0b11c77440e05dbfe"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-03b9638d8f44ab4fa"
                         },
                         "ca-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-028e3e212abffddb9"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-05ac4fd56f03d4e22"
                         },
                         "ca-west-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-09f09d19a96f75feb"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0388cbcabc90bcea1"
                         },
                         "eu-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0a98b5f222a0d2396"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-015464857f03fd3dd"
                         },
                         "eu-central-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0c12681baad1c7923"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0789e83fea5fe005e"
                         },
                         "eu-north-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-03318173cd159e1eb"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0be3fd1b6da7a02bd"
                         },
                         "eu-south-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-04b2c3819bfbabb77"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0811b41a0a4ea0e63"
                         },
                         "eu-south-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0d1e5523cf70b934d"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0b610ae1a995b16f2"
                         },
                         "eu-west-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-014fde6f6f7a74c74"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-008ca214c02a4be7b"
                         },
                         "eu-west-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-00d852f9e11ba57c5"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-08d248efe66b9d028"
                         },
                         "eu-west-3": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-04232151322d288d3"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0dc806fcd9aaa66e5"
                         },
                         "il-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-0927e18f9a8f87b71"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0c5e4477dfee4c4c9"
                         },
                         "me-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-083f41d19819c6e91"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0d52ce048604c8435"
                         },
                         "me-south-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-036d6350cba3acfe4"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0c1701fe996d2a2b6"
                         },
                         "mx-central-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-02cbc2895507611e5"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-02df09f1f131ba8cc"
                         },
                         "sa-east-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-032b577faa7b0c384"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0d4d0c3d82bbafc6b"
                         },
                         "us-east-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-09614d9d7c2f96d00"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0b44aca10796b4db4"
                         },
                         "us-east-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-09410b5b6c34dcdd3"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-00a036d9d0b152627"
                         },
                         "us-west-1": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-05fd4b86367f3a4b9"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-00d1bf6feac51bd36"
                         },
                         "us-west-2": {
-                            "release": "42.20250512.3.0",
-                            "image": "ami-085af0bd4fd5ba3da"
+                            "release": "42.20250526.3.0",
+                            "image": "ami-0c908b579ea2a4391"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250512-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250526-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250512.3.0",
+                    "release": "42.20250526.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:647c877361c9e3224491d5994522f41f58d6d7be2e41eea4cede0be133cfc9e2"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e9384fdfc4feaa7bf7f12ffbcd0a7306d41b2552bc9cdd6962feb290be445ccb"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,156 +1,156 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-05-28T14:20:13Z",
+        "last-modified": "2025-06-11T04:42:50Z",
         "generator": "fedora-coreos-stream-generator v0.2.16"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "345b03740c90b1f99409f82a39c4b6fdb932717a118590ae7b718ddf1d520d82",
-                                "uncompressed-sha256": "dac17d2a07dc2a6a8c8ecbbefc7e8e19bb6bbbc62577244aeebf86d5801c1e23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f9a8e5cc46738d0663e3b6dce344d11465e74a331f3f61ee81f3f69f5bfd0a08",
+                                "uncompressed-sha256": "caec31c9962c2c168a29aeca33f8a4f3e7d1824487eaee0fa63d4cbad9a31136"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "afa86e79dd2205028248431ea2814b1148f178157c7bc0e1ea7ee9b9e5232f46",
-                                "uncompressed-sha256": "c6240c559a1416e30fe8ed8cb5ce0ee3de5f3ef277b7a6697317277d817c8bd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "904436e2b824d691ea45e0ce54527d4216d2f823f00be16df1b8b29cbb5678d5",
+                                "uncompressed-sha256": "0dd69c298354caecfd68f4b4e53c81872bccd7137b70a179d9d5e1d5698f51ee"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "9680fa97817e7516bb910e74579fa7b6b501d8c5a83934344b45bac0ba2c7969",
-                                "uncompressed-sha256": "25b6a19a6d50bd285516ad53a487a6632c1fd8d5634209169193da41ec44cf50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "68c3e6eccb8b4a86b74b0ac55bd4fe0db07c68f1d7354c0bfbf0cfb518328dba",
+                                "uncompressed-sha256": "87b1d97d42da397d54b9821fd0e3cfa8cc763e883611b03cf16216029698c3d2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "ca13b41aacd41a7b7b587d09c973e33a1bf2291035f148aad059bd4f89ee4012"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "53753b105d7e1d58dc2c6a45fb8fb72a8b556db095c495f9c96aeb548cb8ad87"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "41003ab2baa4319571d9993dfbe7aaa6b75fecff942ea0873e008b87236df996",
-                                "uncompressed-sha256": "78c5ac02fd1a7008306f2c4b077f6f9275462d16eb5d30e14bcada1367de8461"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "e64694e28d962a91bc21de3c6e2e4844190e572e013f409d228461255d28c662",
+                                "uncompressed-sha256": "a0951194b3cc44273e74c7b6206f1fc17572beb10c01cf9a25276a7bad8f06b6"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "1540806f906aa6c80e9702d7c4995ea9333949cf7382d6dada459d224e495484",
-                                "uncompressed-sha256": "6a47e4ddfd447ce9d04ff3989bfd30018313903f48003128c8f35b75d7aa3643"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "1862ff6c9738aa6e01286d8599bffb6f6575eac75822dd5aa81e9100d9c1ef75",
+                                "uncompressed-sha256": "aebd30edd4033f25afef7c4073ef911cd45ff2c1e4714b6985305ac6ca5c25ee"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "711c8c7e336f0744ee6e67bbc0a76f1702cb7caf5ed66296108d5d3f95b6ba81",
-                                "uncompressed-sha256": "2681d8fee94c9be90823b64e0ebcc5fa6a084fce002492c6ab089f99271b2b47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "27a695257e6e06be6389eca3917a6a5e63e9c3c83e25c30118eaf1e5b6b38bb9",
+                                "uncompressed-sha256": "cbd77b7a61a0097f55153ddf01c38feeff462f4abc5074ce02198bc5e74bd287"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-iso.aarch64.iso.sig",
-                                "sha256": "25d70e6bab764ab2dcfb832d786ddc19091947add424b8f1f3c84296c8d3aff1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "85a65863c6818e2a94be0869ce4cacb2358968a2af8e42ae363bf88b289d544c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-kernel.aarch64.sig",
-                                "sha256": "073c680bc51e149f28b4d4682ad4b021bbcc2e8578aac114ccbcd2ee6f663b5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-live-kernel.aarch64.sig",
+                                "sha256": "3ef35a83566af12288a6531618c542e8da857c2353359673edc4a6a63503b318"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "729ebedb6e198fd245a906a38c471f86519983964bc9192a9016e082f3736e97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "2abd42c16a1167cca02b4456b7af7e587637237f147833159776a030b6e1ca49"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "9eb0b29030077d20fbc2320e882a1c3d6961e51af1580a2741ebd43ce234cd64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "0dad637de111c5f4e48dae97c617a9d35ebd9afe3a2267f61e0759035e6189eb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "064ec9cce656a5f88014bd38bd63ce51b5ed15180fede8b94c405bfc79d939a5",
-                                "uncompressed-sha256": "94f2502cd097aa9933ae9014f918fa99cc2922dfa4c12f9a99956aa6b136c1dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "1b528424a24fbc102cc9ba919d8e183f8e44ffb49e46e50aeeaf13f280fe9966",
+                                "uncompressed-sha256": "c83fc3a3f3dbcddd9c4d4fef0a6d1c29e6f7cca015605dd253867183cd0f0464"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2982349458c40696f41f1f95e10a6f9b2dde4f59eac1e482a182b8d9dc9aad6e",
-                                "uncompressed-sha256": "67b5c06a77caa24eb8ebf02e28af9b0cdd833b338a6a15f34d1c6f4a2608cae6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "1a026d5d638904cf73777e72f4d1998d11e53aad5962c5b559db0db4ce6636f3",
+                                "uncompressed-sha256": "0178bee1f38de3e45c1e842e5d7eb47b8b1a8408e86526ee6286c85d568e50c5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/aarch64/fedora-coreos-42.20250526.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "db3ae34bd4db59e78d2144a460b93a8784ab9bfde64230e11296052925a3c42b",
-                                "uncompressed-sha256": "e7460db84b788afda7bf212131dd4041a43a5fea03e3aae039743acc331db91e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/aarch64/fedora-coreos-42.20250609.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e7535dfd36e6db866ed64be1ed02c6a900fb035a806b4587ea263d27f7a6aaf1",
+                                "uncompressed-sha256": "45b11af61d9708ec4f372f52c8acb424bf82f6f8a4eb81677b3082f1e353eb0b"
                             }
                         }
                     }
@@ -160,225 +160,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-04e28b715d06c78a4"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-09bab8c210d55a0fb"
                         },
                         "ap-east-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-016a87d70f13a8a32"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-02fa6e4e0274a5907"
+                        },
+                        "ap-east-2": {
+                            "release": "42.20250609.2.0",
+                            "image": "ami-059b12aec68c37fd4"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-09efebf9df2f9a789"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0618b02b4c398a6ae"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0b540b2dff50ca5d9"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0147c34aa8030ae01"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-05c1035173f9dc9f3"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-07b53c1f5deb4fb5f"
                         },
                         "ap-south-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-01c94c9cadb083b5a"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-07151d017f564afa2"
                         },
                         "ap-south-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0312843406a226773"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-06f538748470e2773"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-002d8ccc7ed4ff5f9"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0b57466025353bad4"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-05e7fa413f52655ff"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0ae7e7f08f44f1680"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-035ef8b200282cf3f"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-045f00719b2da1ed9"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0dc219868a5e03d44"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-00a18ceee3a10a09f"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-01dc3fa2b9e15494b"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0dacfb1b9fa2e8018"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-01e6e0e7a3ead4277"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-04cbb2a47596ae353"
                         },
                         "ca-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0fe5d43513aa69ff7"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0ced0fdd6c1d6d6ee"
                         },
                         "ca-west-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0ae1c65592d2bee21"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0caf25f79459791fc"
                         },
                         "eu-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0faeeb0f1a3c458f9"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-09a3092bb2dff907d"
                         },
                         "eu-central-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-01163913e24454d17"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-08425e8d98fd70b28"
                         },
                         "eu-north-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0b45800d39016e2dd"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0bb88bd787e72e2b3"
                         },
                         "eu-south-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-02305858a56f277e3"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-02b1161d868738403"
                         },
                         "eu-south-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0a88017075747fc45"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-04e782cc9b2a6085d"
                         },
                         "eu-west-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0d3f0a0179c2154c8"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0263ef2329cb91cee"
                         },
                         "eu-west-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-089ef738df353927f"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0b5e24163e022e41c"
                         },
                         "eu-west-3": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0d10874cd8c3987b1"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0be4a1426f36a7c35"
                         },
                         "il-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-01072ff91078b6273"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0b4280bbcb0707d9b"
                         },
                         "me-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0d37cec1e533ec20c"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0a7d79f8fb047284f"
                         },
                         "me-south-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0d93908bf997e6cb7"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-09d71ef2eebf5f147"
                         },
                         "mx-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0a737a7a8b232d6c2"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0660bf18ccd8464ad"
                         },
                         "sa-east-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0e6b1afff1ea7a3b4"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-05b709348faff2cc4"
                         },
                         "us-east-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0483b6462a65bb2be"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0fa48cd3787244ebe"
                         },
                         "us-east-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0321223a7d9d75558"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-08a521059bf0b198f"
                         },
                         "us-west-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-02022b5ffc69cafcf"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-014da27a252aad643"
                         },
                         "us-west-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-00c615bbc9e4c832a"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0aa3338062290f430"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250526-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250609-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a19e74d5344319470b59ce492e58b0e9ea7b3b5014dbab9864a7fc54aa04c4af",
-                                "uncompressed-sha256": "989be7737ea40f5d11ac9b8bfa231ef8271cdfbf1b2b6442ab8fcc52ce957f6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "026610dd851510e17ff9f976dbd16f2b9ce146014cfc0d13decd496544a7a06e",
+                                "uncompressed-sha256": "7c90125898f4ce8e1b9da47c5caad1d4447ce44a1c1906199be27e6cc680194d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "9e222530ecc0ac62dc96d0a40a33c1bd3b3c086801baeed912af0b17f545382e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "3f758c3aa6a929202587314318cfe039867edd318dc1ab43744fa58102327ce3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-kernel.ppc64le.sig",
-                                "sha256": "fccdb6ed4189dfd27b79c3dcb92da3ba5fb270818cc51a78b6d69860c6315b45"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "4e4b98927b4ce1ba730da001e33521304ea0f5d2ea57ee24845c62bbcf1ee36d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "3241ad8c9b1aa877e7005c6992b1f71de52fc770e52b77bd3e5c55ecb4bf0b79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "4852bb92a46e186c99357debfc69a0ecfde6be8d877e770d6095e10d4aca729e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "631eacde044ba297fed2ab318f9a94ed3e405470551b0f5f9e898acaf1af2fb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "777efa7997f86f9cc33ac75480d473c56898d6ab4df3077339831ddd39b4620e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6737f2853720e132176b10477d5dccb459db6ba405e83667dabab557d09d6dac",
-                                "uncompressed-sha256": "41927664a2abecc1e0c01be5e8e64d1b0b57a17d3c8c2f0ef9b3180231f1abbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "207fdf148c21ffad20408fa94455379151606b4e0b266ff8e1bd97abae0129f6",
+                                "uncompressed-sha256": "05f275db0b0a592e90c0ba77a9e65b09a667a60e268baee0400c19c5e0c7cbf3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "650d128c81b0bcde28b7bc95cf73f5a353a0bbfa32a261cd6b927aa8b5135037",
-                                "uncompressed-sha256": "3c687dff6176849b6a61d1e5e40fe182be5f4b4bbd2aaeb651d9fb0c9629b635"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "fda5513451a38ab4400b24efbc49f63571e748b9e579658d9bebad4f98105c41",
+                                "uncompressed-sha256": "b6917ba110df991f8e5252b88c289bb0e8fd935c91a0fc359188d932377ae21c"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "86dfb193a04ef121fc668d3f24008eb7c178b6375f4e9b5ae5b7db37a345cdba",
-                                "uncompressed-sha256": "f0beb656541b514b1f5e43377477198082be59594a5aa9bf0e8d566861d56d25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "9a37a91c466466d287e77d923ae6faf8137c503f5b86115e8ea02004b375b32f",
+                                "uncompressed-sha256": "132222089cf302b0faf1cb675f3d98810f16072f947daeb1f6fbdf7b7f84a146"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/ppc64le/fedora-coreos-42.20250526.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "431ea70ed1234f640683df6965948f24d4efd1fc329658f6760da0f7d9128ab8",
-                                "uncompressed-sha256": "ad07aa6f09aa72cfb5613edc4016720c2cb9020762ee57ed5d7881284296301f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/ppc64le/fedora-coreos-42.20250609.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "247987a7c3c5a3e7593ad980350e2d408a549f6f0acfe40c981a6d54049698f4",
+                                "uncompressed-sha256": "3c1bcf1262a95b78d22f8ea736d46f673c7a6a5fd656a48ca31cf057e077e35b"
                             }
                         }
                     }
@@ -389,97 +393,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "44086e140b0db9440ecd413094ca3d29279592dd021ef49250b7ba81d3b1d551",
-                                "uncompressed-sha256": "0b79e0ea7dd23c678a13e8271f1f9fdd1389b27505b8aa3613256081c0540c41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "608c38c9b5dd09d917abc9ec1d63d76c2dfbc7379039b30b5ca51b71dc34216c",
+                                "uncompressed-sha256": "71edc2a4588afdbd161599704a578bc8695e336388c8007f01ab07dad4aee91d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "3a59f1ed9907855bde40aba9a077eff05c91405b6c6e58208e5a0d41e956a92a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "4c0ae50640118e931d088af257f7f649f46a7ba52d511fe31457cc1c052b62a5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "0a398e5ca1d7e9252c7bb705ee32c392210b3fe34cc1a9d4c9e53b9de3d2ab90",
-                                "uncompressed-sha256": "10277f89931d24d320acfd72a4130e76fca7b422ac34b49b46882bc7955cac23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "7f05ace639b7eef3d0d3eda0668c4537ab97870c981fb6d0a7ae539aa5ef35e2",
+                                "uncompressed-sha256": "44cfcb62d8977bf095902ac524d7d84c6ea1a73ee4689d9f922a9874eef8cd48"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-iso.s390x.iso.sig",
-                                "sha256": "ba583de79e372f50b72e1c3d0ce19a00709d57df63535cbfb76453c5cb928cd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "dafc1b0a70ea3e5785a70c4c27a484fbcf728bb83c47f4f669745b23b7281ec0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-kernel.s390x.sig",
-                                "sha256": "7b1c1d363f6c670f8fa15b65329d49d8bc795f73e71bcac2110dbcbf45d40932"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-live-kernel.s390x.sig",
+                                "sha256": "454c813d03e7323a0d8cf603a3f10e6ace02aba7d204f4de55ae15c7b65d409f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "7eff8604ca5b098b4b0d07738a12426b9609a280d8c3a03a7ee394a34b0381c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b25ac9786a2b178287ad456de16b55ec546884ba7385de5eb91b6d5d4e1e196d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "96094104fc2d711fb3930e6178fafe886a4b269732f02b804b465f54feebda9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "44a17c41a39968a49a08da2b9b93655c20de74b21e84559f5f7f20351829b85f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "991d257da78206e299849a613591b540758949979d0f2b805e25e15e2330c488",
-                                "uncompressed-sha256": "ba58130795bb0e5692710e328d22f79c795516cbc7de278d716e7a21d2b7320f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "fcaa03d781204b28762708bed7f46f44088c85f02a12dd112719c7067c0ff6e4",
+                                "uncompressed-sha256": "f47e6b9a9df14f6ca529758461c4ea08a8b9cebe8d8f4476cf3d948391283cfb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2f123725b18d811d20f6f3f861f25f7c37596de35aecd18488736f10851a7054",
-                                "uncompressed-sha256": "bceddcace06ab9c2193c7fd6cb19dfbab6d7738e00e996f932ec3e40972a9f7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "75cb11dfcdbf6dea7669e6b10e68a8e3c46f16a3ed572c80d322e3f0df5d14bd",
+                                "uncompressed-sha256": "f6c5701c7ed9425422fad3d396c43600be208e934119c5daeb62e5a771e419bc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/s390x/fedora-coreos-42.20250526.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "507be77f0419e083e50e5415e2f43b5093e3f4580a1a2b75728ebcddca7752a7",
-                                "uncompressed-sha256": "4d0d617531d3f2dd39d227db3fa27b8a8fcca6a73f127d4616423c5ecbd6408f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/s390x/fedora-coreos-42.20250609.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "e46bc07fd1efad1a0c556c806d8eda7b25f9f05583f59f28c080bd6fd5c19deb",
+                                "uncompressed-sha256": "b7aecd227e51196453b7ccee119ca04d15ab52990d8e01d88993c8edbf2d8dcf"
                             }
                         }
                     }
@@ -487,284 +491,284 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1eb80a7ea0cfcd4d86035ab2b58d7a001c8b33ecd5da485f8239358ba8313cef"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1437edd05b3f1a19fd2166b9b1e7d5b3a0fc2c66d0e43ab07f213ea9dafbcd96"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8d8111a3b19dd8fe9d7ab5726e366726b6a37172cb8ec282be2bff363e47fda8",
-                                "uncompressed-sha256": "732cfef8c9abfdc08ca0b81dc0779ab806a9aa95ca412a82d6109b1f84ef8a50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2259e12d7b2e4f62dad0601ab70619e48286621eb0ed7e86b03d68dbfbe53357",
+                                "uncompressed-sha256": "4edc84373d3c55ce4e7ce5025e284fee79c86d84fedfceec75b47ad9503126ac"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "426381a03a11883c6fe635049395e95a00660c0ff9a7fa1c5912829e608d2f1c",
-                                "uncompressed-sha256": "29ae4e28415d54b8fab080638cfd58f14f8a13fb0ad1521fb4bf22e1c0fb2d5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "aa8e04b29170baae2a61f1071cae80bc80e89f6a7c056136554f6e9fcc9fd62c",
+                                "uncompressed-sha256": "80684aa50f3f9d217aac64db0f78fa50938999931d713881a40c823299848f7c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a43fb6c7ffa15a72cff4bbaa87ac2cc161fa71952a6f380fb7db8910ab74af8f",
-                                "uncompressed-sha256": "525702f6dab062fe90559c7d9911913784adaffdd968864d6d7fcd93edd2d101"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "da5fe8a87dc6f5bb5378be474bda0870694bb72bf68af35e97d66bf579e27fdd",
+                                "uncompressed-sha256": "a92a710beda3e15f36710eae20c8be0bc4cc98dd324e5da8417e4c3ba4e5531c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7890258e69aa06e0ae1376756b10b960657f122e3a3160ad5f14975eeb7b9a09",
-                                "uncompressed-sha256": "c8016ac583cc434ca555d827b88d0bda95400eb29e3446519046817044fc4c09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "91e66b2ffac61fad2011044ed618ec3e428d6c226c1561ffb3d3d125435cf55e",
+                                "uncompressed-sha256": "1213878dbe64352e4fe8b6fce366fe3bc78744b7102e2a0ac7d9055d7c4a9758"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "37632fa7df3be5be2377a2ae59a8cc786afd04025cc8ceef63539d7743d583ce",
-                                "uncompressed-sha256": "05c0d95e8b26c3c708f09bc28b0a089e3551015f988b9fb745be2d7fdddfed1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "07cc020b52821e3283eeafa03dee59b326db24b1c168fbd88da45803a497403e",
+                                "uncompressed-sha256": "f27624e8d909bab4b15e24f5cbe005e1ab14188a1bde35f9d392a3c3a9929633"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "d72b23645ce6513b0cebe6754341e6951409236a4e3f0a9464f0094a80ff893c",
-                                "uncompressed-sha256": "db4fa22b2d210839684558a8be36450137f95d14686b8276d65e9034a306e09b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "27ae0083ea9a9d13582a2b19e6abf261a638841f66d0ae8537cdad23dd974512",
+                                "uncompressed-sha256": "fbe722d1c4bb89bcd322371349ebebeb1dadc2a2203c870260fbcfe2fdda5dbd"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "417411cd3ab27718577d41c393fb89917ab99212d243e1383db765d75d8f3353",
-                                "uncompressed-sha256": "92763d8aa7a882d5b74201779eb838d70777561c49800e543c35bd668e2bb2d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "653e204f33c7f87ac4b3078cbe559df8e0ec0ae108daa623a3096633fb164cd6",
+                                "uncompressed-sha256": "e9fec3cfba126008fc49e3e5c1035d603d7c426de1bb7f9b85b30ee0d14e79a9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4290c35c4cc7a10131d2aafaeef8fb47fc73013aefd2e33fa944703a5c1a06d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b294dd88a97214dfff110500187e3d8dfb3f472e8097fdec00bad724bcf8a99d"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "6377e7e19b3c0871dad56138ab0cab67352e4e9f550d60db8624a17a9a738fed",
-                                "uncompressed-sha256": "711de5d30b6c710fed4c8a8786e050967ddd97153d3769b710f1150c62f077bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "1f5c13b15d48656cd182010254107fb68ab53b5aff39d6fc30e90e2629c5a569",
+                                "uncompressed-sha256": "7ac9491b8445f6f47224a20528f35c67cda7e996de8887950f0a22fd5df14e04"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "8c2bf873ae91a11bb4ffc2b2551422e5c5be513fca2f335f6b75c187fd6b025d",
-                                "uncompressed-sha256": "f1e56af0a9ad1a59d6365d5e1428f55c8a79bd753065a9ce791737d380695ca2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "1cfefad3396bccf2e34c70017f50e8202c7d528a26ae1950ebeb6b336089100d",
+                                "uncompressed-sha256": "e5391cb79b6e5d1ef51644cce54549f8418197245ae6ba9ccede236dfa11f13e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ee23b7a8c7e140e160aad6000042a5d89bd73ccad67b3650e35b999aff8cdcdf",
-                                "uncompressed-sha256": "58242666259a29c79cdc0ef7a6faad0f63d6176ccdfcd6912b1d3bc12cd61a00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ce403ec085ff80e57dacb0870aabb3812882ec549985f4ffac47db0e2637082f",
+                                "uncompressed-sha256": "08b960b72a785bb0fc64f0c14bcda8d45d069a2544b75a98bf5ca2a29aeb6fcb"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a82d91f1161a01cc2df93fa190ecbddc08f4a97fc9a1cf3b4a0c7300d38585bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b7f43ea2407c09bcd73602ec2b9ecd69e4b38e226c9aa922d42913fe55e8c86d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4fbab1b88ee507afdbcb2664f5edb031a2591fa9b336985584e2dc384e745cb8",
-                                "uncompressed-sha256": "f78be5c275cb99eaa6f420c238a3fddb9acff07c044bd589fceabaec87f4786b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "83ce36f69fb9bc14aa809256fe27ac69266816a5a3f8face1c2a559803ca73b2",
+                                "uncompressed-sha256": "320023746fd2acd9693ae83d9952cf49ec732434e40acbbb813a5eb521aad90e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-iso.x86_64.iso.sig",
-                                "sha256": "7113ed70a07d43966dd67ecb50b621ac568ac7d84375607196b911255cacc588"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "adffd597ab551cd3e9bd63448a208ca10a52100108b350b247c820067df854f3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-kernel.x86_64.sig",
-                                "sha256": "9a5ad93c4a15faf067297b23fa62c7db6cf8bbb721210d236c4fb22dd2b543f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-live-kernel.x86_64.sig",
+                                "sha256": "2f045da62edfc39f6f85a1da7d81416873c5a5451f25b08000e2d817523a9967"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "db3704cfc6856f6404cc4c28c727f9fda6edb960561684280ec9d492a6ce81f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "883e4b74dc3f90f0e4f55640c7eeb06f12590124f14efada36916fabd455997d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "2784bb930e70aeb5f1448d8e24e9815e1c8987341885c7d4846083e092afc263"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "420e5bee69539367b9738a3f5561cc09dc83540fb263c78b0d9c930c28d7e41f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "9f95cdcdcb0ecd66e52c1ebf468dc86233cc5e294794ca3cdc6f1602ec6e9844",
-                                "uncompressed-sha256": "2ff4b944779881538335d3e1af5e3713f0dcf26040f9579d9456a25a02b53fac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "4a08701e1fcb8390d6a76ac40b7ce3b0e44e8b11279d15ab19e354c4c0a14793",
+                                "uncompressed-sha256": "61c5acde6c6d18caf9ba87f7ba19b4fab76f5cf5a71b87c75c48116ad93a9a4b"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "93e1b9b94d086b69d3c29d210fd6f66fdec0cca822d8256c4674d00e64919ce0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "249f7fba509dd02ce4382752e875e5330af93d5fbd283a62186ec3dfbb6714a8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "30ae09b9007089ce953a67249376fb9333d232b1f1ccca2e47b652c5d729749d",
-                                "uncompressed-sha256": "94fd24cceb6e6ccb622133a5ae492dd9288d22338797bb96081a1c6ade1881b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ece761280504c0d59f6b805b7dbaf520559d71d90fc49bb12cc1124079524524",
+                                "uncompressed-sha256": "1a237f475a7c199605b475f55b9f220c4dab5691e9cd8146d4290f11ff7a3fc9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2b3ba0d02b3d48b3d487eb4e5b67897ac215704b772b02ee69d0a55c07fe7901",
-                                "uncompressed-sha256": "b80b5600ee7aca931825dc062048059b8a4422e175ae99ee34f1e6cf78991194"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9bf5dff9ad6176bdc5e38d2b7ca794b8ac1b6e5fa8f6bfaef44b72db9d7d7cb6",
+                                "uncompressed-sha256": "0fb8110cf719080b8edcb2d1a9d97d8206cfc6f40cbb6644db830c1d7cba5841"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "bab9a3dee51331b76b196822f174626acf7ea453a4c913f94818f2d2d977e605"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "4aaeec6ef1187d9237cc9fcef8337936bd00e7078fec8d9473d7a5eff0fac002"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "1f944c35db0d8d76cdd9061dfbe37ce638e2a8d3f039a2392959b3e026bed69c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "766289a74eb2d39b9a94fea27f5e22ccbfac2c3a0603df1a9eaad4c0a47c8152"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250526.2.0/x86_64/fedora-coreos-42.20250526.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "e46081666861ec7e9ce1b6de1491f2a4d79e4c5909dd94f779b8c1c1026fbdbd",
-                                "uncompressed-sha256": "5f4bac5fb8c4936e9e49c06f411959ddd7721b63c0a3f02e9433ee73d19f1fe8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250609.2.0/x86_64/fedora-coreos-42.20250609.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "dc73aaa4df7132185bc24fa33d43ab9192eb4a53f3637828286519665bf430be",
+                                "uncompressed-sha256": "67734d7d5dc0876428bfcbd83402a3624e3093a001d86aada433f8b7e9ed2fb7"
                             }
                         }
                     }
@@ -774,145 +778,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0a4c7c88e8ea42e7b"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0bfd4b5997251a34f"
                         },
                         "ap-east-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-020e9931a92d76675"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-074a2ad1a043f8d15"
+                        },
+                        "ap-east-2": {
+                            "release": "42.20250609.2.0",
+                            "image": "ami-03cb387e9f3e25bca"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0b1f97dd4d2d5bb59"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-06b88b52782c9b307"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0152d5ef7e6084a27"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-074a82d50bf9c19af"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0dafe82ed80c018ef"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0dbda8d6a4b9d453a"
                         },
                         "ap-south-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-06d5a645d1fb0f9f9"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0e9bc4bc7da34a053"
                         },
                         "ap-south-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0b83877ff7776e389"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0aba4f1693aeb0e55"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0abb3599bd62a6056"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-026b9eaea932e1bcf"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-06dea3c4adae11277"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-01c8c57b0b8570eb5"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0dd0ec3a5be7e3eee"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0064ed1d90402aa72"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-07858d278bb0f047b"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-06389fd28d8c68a21"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0920ee77339b8db50"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-08a8aa2461a979597"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-06f2ea90703d9545e"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-03ed7fb4290b25ed4"
                         },
                         "ca-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0fc6cb627d13e6981"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-085d1ce9d5ca2191a"
                         },
                         "ca-west-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-08da3998445de48dd"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0fbccc6e45edba1f2"
                         },
                         "eu-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0b66024079d25259c"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-05043002e120c1714"
                         },
                         "eu-central-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0aaa8f4565aa1f352"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-004965796b8964030"
                         },
                         "eu-north-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-06cef9051c8db7c74"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-07f003ed60de0384a"
                         },
                         "eu-south-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-09757c8055711adca"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0fcadae380b2e619e"
                         },
                         "eu-south-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0a517860e31709a98"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0c6f931577f5c7b60"
                         },
                         "eu-west-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-05bd89df4bd9d42f3"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0d48e59bf1f0f321b"
                         },
                         "eu-west-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0a720ced54b1b0886"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-00fa98d93c9e4f28c"
                         },
                         "eu-west-3": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0eb2630fab36f6b09"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0a9a921008e424fd1"
                         },
                         "il-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-08807858e30015de0"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-09dfb3208e81235df"
                         },
                         "me-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0fdbd29e57e4b574e"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-03a7450dfbce96557"
                         },
                         "me-south-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-071201b03de094ea8"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0fc8aaa2b0490a30e"
                         },
                         "mx-central-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0e6d4980e4c888903"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-027d4fa6832c2e392"
                         },
                         "sa-east-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-023f4043903839045"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-08686ebc21cf28365"
                         },
                         "us-east-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-08b43761885a5da02"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-04c7a3699ad7460c4"
                         },
                         "us-east-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0a245e85d93d558f4"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-06791aff74515fd28"
                         },
                         "us-west-1": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0f18577b690725c41"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0068fdf59447f38f2"
                         },
                         "us-west-2": {
-                            "release": "42.20250526.2.0",
-                            "image": "ami-0f5fbd3aab94f9ae4"
+                            "release": "42.20250609.2.0",
+                            "image": "ami-0f27db563de450313"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250526-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250609-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250526.2.0",
+                    "release": "42.20250609.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:948d0c2adc9d9380287968fe8ab66e8fca42d2face51f6037af9da7979973a80"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ca4d2a41a483ed4f8201d35880c68d4994bfa294eb9b79af7a143f729f89f90a"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-05-28T14:20:16Z"
+    "last-modified": "2025-06-11T04:42:52Z"
   },
   "releases": [
     {
@@ -133,22 +133,22 @@
       }
     },
     {
-      "version": "42.20250512.1.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "42.20250526.1.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "42.20250609.1.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1748448000,
+          "start_epoch": 1749654000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-05-28T14:20:12Z"
+    "last-modified": "2025-06-11T04:42:49Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "42.20250427.3.0",
+      "version": "42.20250512.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "42.20250512.3.0",
+      "version": "42.20250526.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1748448000,
+          "start_epoch": 1749654000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-05-28T14:20:14Z"
+    "last-modified": "2025-06-11T04:42:50Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250512.2.0",
+      "version": "42.20250526.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250526.2.0",
+      "version": "42.20250609.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1748448000,
+          "start_epoch": 1749654000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).