### PR TITLE
Roll out stable 42.20250623.3.0, testing 42.20250705.2.0, next 42.20250705.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,156 +1,156 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-06-24T18:25:42Z",
+        "last-modified": "2025-07-07T20:59:48Z",
         "generator": "fedora-coreos-stream-generator v0.2.17"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ad74e18032fd49d934fed601a6a4dec2623c698edaed2308f26eff07f5691bde",
-                                "uncompressed-sha256": "453d306ac935ea166e1358e73074db24ab8aaacbcf33f80224092ac28aacbf5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "ce6c2a0850e895da6523d37bb81e99f533af4f82cea33e5e8de7179129c9a221",
+                                "uncompressed-sha256": "3a51965b3c5b34c1258c1be3a8c572519613ca5cd2839250e073d8f5528a50eb"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "aefefabaf21f4289cbf792990fdd510dc10f35ea79b52db21559a00acd7e385a",
-                                "uncompressed-sha256": "ae79e2ffd5c1ae950348cf6dd738fe2c718c33da793fe20c8e3ce82af50e7c07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3b8554eefa64344e1560ddfa7c7472189530d937dc6a47f24f04641100ca8331",
+                                "uncompressed-sha256": "208c311090ae764f73344aa235de413614fee485302b9e5a03d66059f28e375e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "f531e53ceb3f4eb55ce163fadd7b8b42df1b47fce0a17363fc58c3a98a994320",
-                                "uncompressed-sha256": "01ee375ab355754dfa5cd10cd3bf715778960ec6e930af9e8de3640ffc1af8e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "4560483be8ecbf8a02e679c4a9101bff3638deadcbafc3c490aee5548270d43f",
+                                "uncompressed-sha256": "ead2c18465c575760e6f179bc7ea6fb7cfd0440038c895aa7d8f2637135fb719"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "e1efc857fb8a8d27c418c7e38158535566e68581c40e6aa00c97b654519122ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a579ce7c14aeb18b2c5c20ff24202575ef9242300d800e0740527466d5eb37dd"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "3544e1527acd762a96f222fa9e88f1b540e38ba2ced34c7653334a0b97e9c37d",
-                                "uncompressed-sha256": "deea626e3aa7f8af05bd0721d46871a811583f2aca56bac0b806e4b7b11358d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "76a858dbfdc7b474b0370c1e87392f0f3ae5c844a60e1258d98f7523f96e50eb",
+                                "uncompressed-sha256": "b73a4ec8738656a75637582d35d81d240ca52c59bb88bdea3fdfec22eb601f55"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "32fbdea619fa65757b7e22d6d91287b62a73c965254edf3553be0bccabfdf7a4",
-                                "uncompressed-sha256": "721fa20dbb4b8c74fa95f14d8600d960a4fc76ec3088ee3ec091e6d182244f5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "f1494306d76a7d99452398affb2908747acffa3d3d29e9762a955e9ac6e09dac",
+                                "uncompressed-sha256": "190a0afb91dc8ba30184862a6a45a6558c029ce63b8676903b591c39d9ad4d32"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "eecc90820eed63b48623c1f74bc6c6fccb9f78ab353d3bd6b4e62acf47f468ea",
-                                "uncompressed-sha256": "af6593e81ed8b525e94ac63f6cddf983dc3d2ff3b68941eeb7713a9a699fdae3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f52478d41451612c6a5f207b7b21f663c8d1e1470704c691b177e5ea95b7791d",
+                                "uncompressed-sha256": "8839c2956a4a7789a4d5a81ac57c2a06e7591e312b2977c435b946db11a89830"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "f5bf050781b6e8a022a85675277b3f918241e8d9990c884cb1332b34a130af67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "e3f0b2bd96ddd023424eba2d16563a9fd9edd0a128c1ef3924634636fe74aa63"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-live-kernel.aarch64.sig",
-                                "sha256": "30f419a63aeba8bc12ebbe1ec5e2e98259f2f220d6491cc80cd0396d3666bf3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-kernel.aarch64.sig",
+                                "sha256": "912f49b916e957d4c27ac0b4152a41373369fd9f538237ec7486ced3623acc87"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "06bfb2e4f40757c43ab54c63b5182b279bdb6e3bdb0c4175e524baab53927c25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "32f7bf029b46b48145a34dc3fe80178cb5696a4752ad41feb52e16ccab3eaeba"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "5ba73a09758cef37182bdbb7ad7766dac77d33a089898b7e43b0f29a489299e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "262fe486031ab419868a4cd92f4ad6df59b7bed8ca7680e6b5d43f9d36e4d640"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "965d5ee78029fb73c5d3fee5b8294fb4435e9e88a7948f9c253686ff67a66b15",
-                                "uncompressed-sha256": "99db337203552ac71183568273779fbe31e3c5b64df79dae10dc998c4ae280d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "9e824d28855d84df74928462ee7f8096e2cce7343bd589cf8eb39f2b66e216c6",
+                                "uncompressed-sha256": "1ef27c714d3060d941db62980489812b01ac8ebe9e8eddd254fdf1b93b38d1be"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f3e3ce37ec0a68edd939ac29e4dbbbb8c1c82a1d8733ac2284ff07c7bd630515",
-                                "uncompressed-sha256": "95a6e0c2548a46d97c7cba075195c13c1775a4e4556b8a738274079bb6774770"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3c1c876d1acbd91672baacd63068deae584c7582174e6eabdd5e5b10bf872f6b",
+                                "uncompressed-sha256": "d6395bd2b9096813b94f5036a5300868f3dda62473c419450099dc5ef2923121"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/aarch64/fedora-coreos-42.20250623.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "bbcda32759c9bfdac713a577c27cd5d5ee6118a0fc0d5bc7d0162878fd7683bc",
-                                "uncompressed-sha256": "1077b9ce7abcc0896dca9aff4ab151e12140ca10db3ef3cfc19abb6294392ff3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8438e4f4d207abf1a0996b666289d5491b259c862b73c0add92d6bafc58faedb",
+                                "uncompressed-sha256": "3d32c5c1ef82b7487fbf8e290cab8380eccbde03714f14afc66e646f5fd69e0e"
                             }
                         }
                     }
@@ -160,229 +160,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0f804e509ba400bdf"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-086170f4d67d29ed3"
                         },
                         "ap-east-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0a88e98a50fb298b6"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-043f1e5d8100b1024"
                         },
                         "ap-east-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-066ee579d20cf9d85"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0cae14d9e457184ed"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-003b5cfe7071e192c"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-032f38bf1e86b4a38"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-01f8489ac0ee29fab"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0d9fe91e2a6e669c4"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0e7cd0b437b8c6455"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-05a69d3758442dfe8"
                         },
                         "ap-south-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0e345e68d6b432092"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-06f6a85a690308393"
                         },
                         "ap-south-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0fb34dd78db83c015"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-064c96f91f7f27e93"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-097313ade8a008a0c"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-06ed12fbc3e2b2d7b"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-08840798ed3316e2e"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-09bac75ca6bbbfd6e"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-050a0686eb83302ba"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-074b3ba4b01fed8ed"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-093c78f9cb11e6939"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-07fdf04c5b29af9a1"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-00493aa00aaad9541"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-04898475dce763edf"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-02c7fa8338f6127d1"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-08242e87aaa6d8119"
                         },
                         "ca-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0afe7d182ac0b8acd"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0eb31b15f7f051c6e"
                         },
                         "ca-west-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0f56ddab172441b2c"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0ba39a01b59ad7c24"
                         },
                         "eu-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-04a4765000075a752"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0ca683b9b9090ea7d"
                         },
                         "eu-central-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-08777ffc56beab15f"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0ef885a5b15557e45"
                         },
                         "eu-north-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0265f001d3a3f4f2d"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-002df0681008b461c"
                         },
                         "eu-south-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0201b88657c91e755"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-09e3a121548c2d6e9"
                         },
                         "eu-south-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-00a7de29e31fcbe45"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0947861511de5a10a"
                         },
                         "eu-west-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-05cedd6012af98c1f"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-032d350622b8dd193"
                         },
                         "eu-west-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-05c4699e00c863fa8"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0e5decc39b421ee18"
                         },
                         "eu-west-3": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-09daf59c061ceca9d"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0f0de42d3b1866f66"
                         },
                         "il-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-02f8c58acba41f13c"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0c81ace74afd67df6"
                         },
                         "me-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-05c7f0a2711f4c1c4"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0d4ca495a30007954"
                         },
                         "me-south-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0cbc86f07ecba3c62"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-07f6efda90301f9dc"
                         },
                         "mx-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-02c1bed3c3f8a230c"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-014254f6f6cdc486c"
                         },
                         "sa-east-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-084db8e3f88acbafd"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-06535abd25ecc968c"
                         },
                         "us-east-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0799a3edcd459a362"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0574816c35e78d6cb"
                         },
                         "us-east-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-018cf96277cbeabf7"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0d169f97e49d47141"
                         },
                         "us-west-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-01a57e45ed0e0d6ad"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0f3263d57abca114e"
                         },
                         "us-west-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0bc0a1d25b7fc35d6"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-05cea87827a774111"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250623-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250705-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "3098a76ba407a730dfc3defdbbd0725c785ec84b2afb7f2940811c3a360cae55",
-                                "uncompressed-sha256": "30017c9c6536e528ccdeeac296e59f9c5a4ee246027e7c97ff33cfdea6a772b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6fdd92c05c3f9ff83df69210024925b65ad3c8d49e9da1a0b122356588d744f5",
+                                "uncompressed-sha256": "22d52269c1f40199f849a5f65b0594fe439c81268375d9f0d1f5d5ca80f4aa53"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "4263dd4cb6660339289edf3d34de0b3ffcb6dcb029fc078341d29616fc0256c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "f5b2fb5a91a09fa240cd85e9f0f6c0f7a3e77483d69934c9df5fb5aa6e3acd0b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "d656a0ea2c2466ad732af7604b28fd3d48cd558a9cc8b09f6250730bc6bc4ee4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "07caeba85e4d5e2aa63bd6b6dcdccb2fa03a9483c5af5003a6964a20c77a4bee"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "7a57d2c0853e920f9c49bf7af07861476f4c0bad936d4a78f4d8e939537aba63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e1c9b77837a9853baae9e62b240b0f448e5e685508241e9d3c0e39b36bc61f51"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "a808fffb1382e4e12f300095e01d551d1af4ddfc5b1cce90b4c6412c2641203c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "dba248bbcd3b5c025d6ce4f1fab1e5b6cb58bfd55562a2b44a19f02f24f00076"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "141b53c20bf8f8757e6742bf1994d82eecafd2fac98a1041ab82ab34eca5c1cc",
-                                "uncompressed-sha256": "14f4ab1dd59f3f80704685654c766a8e58c2dce28a71d4b3dfcb0982a6cb0a9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "41b632cc32572736393233748eb863192a7f1d320654a434ae78cc10910213d0",
+                                "uncompressed-sha256": "09d496207500d9bf8861730284bb1cea251f70e840abce3b732e1d81dcaf6848"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a81c3ef839acb9512cb1be425843d4e9c5b400ea874df9c88af4a7cb47e536eb",
-                                "uncompressed-sha256": "9100d6ecf799a6ac79917431e9c011669f6abe4439ae4013f2784755b08ec79a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a0efa830256b80a902d40e9fae4468c014047da5915bd3f200f9c4ed1a1bfe3f",
+                                "uncompressed-sha256": "a52ad7f17be83b30f7d2c2c4b3f65d5d66ffb8fa041dad3d7f5939a9e72495a1"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "f931db7c671074533070032ecd4f6567680a517c085854b9928439b3283573b6",
-                                "uncompressed-sha256": "421da9b237ff88b4a61114aa9c8bd05db668a0638f2a8b956c2d332bbe9df3e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "67419f637c018355c0720d35dde4969ff9702380f48b060b26db249da4208812",
+                                "uncompressed-sha256": "ddce62dd70d554348af7597dc4d99da068cc66737114d33a90f652b2d3c6ce02"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/ppc64le/fedora-coreos-42.20250623.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "aa06426ecef9e272a9325982a78ba4d8ada1cff9d2de24da25e372456eb78e49",
-                                "uncompressed-sha256": "e1857f8d0bf18b05844fab5cac21581930a99fd4f3e5da0f8b45dea72c5b5eff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "1697d42cd4960658a2196848be4806fafeafee922bd813fe968d41fdd808047f",
+                                "uncompressed-sha256": "77d8eac51a2120f8e2edb6bc01530a07a5d0909a366d8bacad86d624cc71f71e"
                             }
                         }
                     }
@@ -393,97 +393,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "146b1f395e5f291a06205e4f934be2568584231759ecfc06ede94a53673326f8",
-                                "uncompressed-sha256": "542fd17ae5a76e88583825a29df4df3e57d62f6ee342a5aa309ac6c790e397dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b130d6a70c2bf8f622e4e28db0926a033229ef320cb7a0da81927816bf71c0ae",
+                                "uncompressed-sha256": "ded2a19fe09c48906535d55bd0ec476fe98d3f64eaa0f86f5537846fa1709b89"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "bc4df8ede7882d386c982198359642e5eb28ef336704d0161de21b237d334f70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "2ee9d0f62cd6ac033c4022af9336db7ce953287e08a7c193664625b16b87b36e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "7877a2445da149c0903a59cf87c4c07f3354f0b17dbb0ad86c08bd4d61b7b80c",
-                                "uncompressed-sha256": "6c5dc7779c7eb87466f082692136238b6aeea307f5573ae0b46674ee681145fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "56bc7f99e50593472e1ab8d780d047a5b7421a8686aadafcc4e43090dc663e37",
+                                "uncompressed-sha256": "2dbc896b498a8267525facbddab113a52c63a18111107f975e383a2bd4a2b4d7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "924c51d471263a5b63ed5dfae0d9d6ccfd9d1367c160d9938fdab85f20fb135d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "91f2719c9389183a8d539abf4d0d70f6e47b941cc45057522055f84b1bce42ce"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-live-kernel.s390x.sig",
-                                "sha256": "1ca8038c339fc604bbe28a5df1c390a8cc9b70e00859ade0d5f1711360436257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-kernel.s390x.sig",
+                                "sha256": "6b39b4f1186283d9053865431c8ba5ace49fb736e78428f2734247ad7ff86303"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "74125747e1d067b491791c5c3bca0490c73c0c508cba45be339b62aa2a878cc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "f9757c092224bd906d857a6754824032b13c18ca6d1155fb981a12cb10a50afe"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "0d7f8e9788996b1e473092195519477908d3c2623dc99914c87cd86191e4535f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "cc96f2b2df35c053a3fb9c27cfae53a082375b66f0d490763f01e0818b5212ea"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "ed4f5d7d99355b02f03c47d89c968d24bff1fd8e2c2e55e4b133a13649f3f441",
-                                "uncompressed-sha256": "0502d758e39050462f71042599a0e9a6cc4b69f377d087c88e452a919fe8799b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "4ae25efe50c25920e634cad4305bc79aae011e5a8f6afa10cb757d59527576c3",
+                                "uncompressed-sha256": "aefe0a858ca7a28dc12ce9dcc70e5d32ff33c3eae88eb8bdd637e92e5e0bc565"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "d42f49af8b4c8801785573e75e34e8670a40a7d07c06a4b25d0ec84d0d4e14b7",
-                                "uncompressed-sha256": "b4fd5b7164b94daa43dff4032f35ef58c3d89dea630fa4d41ae28f7971329144"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "278e5e5f19de33e15faa12fb77afea752b8836161e367f8c2298f1afbb3a3683",
+                                "uncompressed-sha256": "5a18bd23f069676d9d6b6981d7c1166aba8dc4b908da53d5485d239913ff2245"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/s390x/fedora-coreos-42.20250623.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "17e10f3bd618e2a5ddcc862f375621d2aa7d390767f9619883ddc64135f1eeb0",
-                                "uncompressed-sha256": "2fd8461bb8155b00671e7a49bd6b65710fdeb5a51797053b0d23502c140b853f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "bcf59be9e1df8fdbbb6eb5aa5a8f2accfeffbb4192f26f06b73e24276161ca84",
+                                "uncompressed-sha256": "2220b9b7fc49297eebe4263e86d06c5ecca264c1308b869ec2cdd2042434e63c"
                             }
                         }
                     }
@@ -491,297 +491,297 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:51019ab84d61164213575269214752b248bd5e999498212d47095c0fb6c42f1f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:680baea7873dc36588d7f0562416f0b268977c24db94f3adcaedd09a3bb8b87c"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a9d8121b3d243ca3ec07fcc26cfc42cff988ac82056426aa17f3d540186cdefc",
-                                "uncompressed-sha256": "88e0a198e24df64661ef01e4fe25f2eb0355fe58780894a8dbbdd63c68ee2cc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "36b279394e2bb6d73c346874c83b037a2b5ac29b7df515067b103e76d77fa72c",
+                                "uncompressed-sha256": "fc7138de60f8cc1ac0e9d35bf88bc146a11c562fd1d6f1e815336e20b80988c1"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "b17491bc2e99aa7299a35d2b59eab6ea7d543981226541a46fa981336893e181",
-                                "uncompressed-sha256": "00a0fba9197a67c13bdd9910c21f36d8a30b08dbf3a3555477e086155bec2c9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "08f57891758161e5a57b1db68d96d5c7044a95bbcb73a573871087c68524bca1",
+                                "uncompressed-sha256": "434a7d34c5592b1d81d07955cdd3b1f487837ff7a2dc16ffdfe8f67cf5600580"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c6d0e86c432e2df6476f4108e62298961903cafa681f2c0151e9e263885ad39d",
-                                "uncompressed-sha256": "033d080b178a61a38cd7f4e7546acda2e4c4a37799826d7e3c3aa6a1cd5331f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "47b3f555f60123eef5f3f04db4426bb8073dc6486603f001688fce366e02e0dd",
+                                "uncompressed-sha256": "cfc231886ae762ccc03064d01ea0c9f2683fdc86451b7ca404a00d0624fe84a3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a15177e7cf885de52c9d5bea57aa2a11c506e8f068e4c25ea76557f578e1acfb",
-                                "uncompressed-sha256": "6747eb915c8770f2a72acc634a738f36f25fcec5328252319aed99c209a7bd5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "8e483c9f89bda3421a255652b4ad963c123cf0db523df3bf9089821ed183835d",
+                                "uncompressed-sha256": "dc5cadba87e10aa12fbccfff2758ca10b5fecfcb0b8a5961c8d05f74861f3a41"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a2bfa5fe74e85995cd79da65c6a636567e56e0508f803426fd089fdd30990604",
-                                "uncompressed-sha256": "51d52618645baaba4044b04130e19b65b01c37a29102a8f575e6b8cd789637ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c287126e42819a50802b051e41446b725a56d02f9fa2f595a4d4b18cac50b91a",
+                                "uncompressed-sha256": "78f37dd9db6fe2f16aeb36aca236fdfbf8bad696d2de3d36458962c402215ab2"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "199908bed2f32f81b7f0c1b56c0bc2a5858cb30355f9f73a33c1f5b34d964d3d",
-                                "uncompressed-sha256": "4aa6acaf850cca8a3698ec7f1f29ad089237e4791bd2d3d3cf43faf9cdc50285"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "374b9d05e57f268290bd8747aa3167b40f1ec555a1f0f12ea835a6cb447c5081",
+                                "uncompressed-sha256": "2bd24368cc58563ec949b7c99c911d5100d268ea152b33c454e525d1f5261f4b"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "aaf24c99d138b200058edf165378a3c3e6d0aeeea7522c76e416c23bf7cce4f4",
-                                "uncompressed-sha256": "4023756d6ab565da9ac184de41f07158f1c42f151f752e414eba87fa53fb0340"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "225bf663aa0aaf998e4dedf44c64eb349f65b954a905ecebdff5ede9734f648d",
+                                "uncompressed-sha256": "1d5b35f175c098f64829036f94e51c06cd4b75a18890d6da40dd5ac233a5d233"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1e63cea477fed8d7f560792eb659053433ac077adeb8bee3c8f979fee604a729"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b561d00078dbacb2f31b1a2de131c44925c3e0d3da036679f046ea5b6ab4f3e9"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "de0a3d97400df2389628b9bc51cdee15a96d17f4e094ce706eaa3bf98a681263",
-                                "uncompressed-sha256": "25df0c4b76f3c77394200f5a844514394abd7113aa41616b636a08984f441651"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "c1d4eac1238326b3b12bad82c3e58442bc5872f14ffcafbc6fee726c2dc11a36",
+                                "uncompressed-sha256": "635f04fd778098e0c89840562e2e52c631bb1fb587fdce427ad89a69fef3717a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e8410e0ffd127709fba8204a3c3e9d5a9519653b87e09d7868d4c656fe514eaf",
-                                "uncompressed-sha256": "27aa22b32c451108f401d868d6f9f976c6cc45a63ba3ffd0ceb9490ceb58f458"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "bdc7598a97a7df4f5a842c6df5880c5b2da10926efa8fb024ba411278bc6c319",
+                                "uncompressed-sha256": "c8cc3340046313415670903c1431d441fa3b803ccdfc114f2167a67dde7ca1b3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ec380169964059e36c98d676aad2f059fd97fe7eb03ed7b5ba3bb77b35866263",
-                                "uncompressed-sha256": "6edf79263d06e0273b02a38776d681a0166612dc02fe1c3453a4d2a66eb499b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9e7bcee8b95d44f366561901c93f3dfa4c7ebd4927af56d172a3c88f7dc3845e",
+                                "uncompressed-sha256": "586cb817f93513ee8cc9e577c2c9a905de5739ca6c797a1e3448ca249bb89c34"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "2880a20f5d50bde6505149ce7fa5ee699717b38f0b4432f87cbad7ab3d68903b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "17ff50463e440b928e16bc2dfcae39c86d65bc1ff72caae52669fafe631b4190"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9dbe323a22a4f3c3c00c4989d67f8e7ffeb90a5a535df30623db4413537e913e",
-                                "uncompressed-sha256": "2573c2d953089a7db1f4dc78339249742576e6945245e52db0d646be95650531"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "42ce58328ae51ce7eaec07b77fb880f4a33791df7837a105b950bee476a70118",
+                                "uncompressed-sha256": "c4fa0a65eea774442df019f297c78ae1430c484126e69a535b60fc379e632e7d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "0f84e10ce3be39bf941fa8a717abf8b0a518c93671b57aa31e974e6465085dd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "1a07957ba8fd47e5263951fb0565edd17f33c0a9ec83c5e4a8e91bc26616f28a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-live-kernel.x86_64.sig",
-                                "sha256": "609799621be031f9a65d31d12b1cb90f6fc45df76a630e40f81a45a12cd924b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-kernel.x86_64.sig",
+                                "sha256": "ea3eabbbf7a49ea0dc22983601f8a631cfb7b2b92515024ec5a0dacf5a717efd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e490fc5bd9da3724f7ddcc13164ff24fc16a123101202762f297795ef1aaa228"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "89fb5f4839276af8af50be114b2896e87ecac44e0df91f0d373bb2bf2bc182c8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "9ab44d31cd5e79242b9b27ef42a6376dad068132dbb395353b169dfe86436f05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "30625494d682ccafa2e90fd1e06eead10ec2b43b2f8268f064abf8125005e714"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1a8d6d6fb642710808c1efd13f4be52b9b3bd9bb2737f075936c274f4c05692b",
-                                "uncompressed-sha256": "a7e7511e07296ef5df3a6c3f911d16277fee1dd6098d83fb3f03940954f5140a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "eae018593a760d4d67a948a86d3d2f543fa74b96b1153d61b2f3b80c3dd73344",
+                                "uncompressed-sha256": "c971207de5e97dc059bc695f57903752043a5b7e9bf070127a2ef3f9c24ca279"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9ade5075876eed0f54afcb159d365495978cc9400210b97ed6234de39dc596d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ea91bf28c2d07f684d8df4b175b60c4f053468684279b81b95848997e7d1a3b8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "befb726a555cda55503c8de3af8871f8f6642b18454ced4383e257ebfee8b161",
-                                "uncompressed-sha256": "98d5d243742d0176159a78efc287448a37616a26cb80fad8ce70fc007c0249a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c79e96266d0cc7eda6a7f62817741d909eeef35fb3a8efdf8b45563a3c40ae18",
+                                "uncompressed-sha256": "a10d4022d4abbb4474bba8a341f0092bfdb3b28b5dfcdac73a41f6809bdeb40f"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "0f7476b1c60876afcd9dca1d45ca4c592efe7877ef9d0caa0f34af6640181598",
-                                "uncompressed-sha256": "8d02bbdb3a1f3af982ae8ef28ef7aa0c9eaf7caea85948c017ddfa779da0770e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "b76c9ec942155f196d002e7b44afefcd2f6958aa47b82227d6bbd857f2f0b9b2",
+                                "uncompressed-sha256": "1fd88c89cda2d85897741c6643f7b355f156e6d6dc031e32140901077767e69d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "129d38dc0a90dd0e91255730b7562546afb4df6ad1ba7a1ceed7c00953fec477",
-                                "uncompressed-sha256": "5df0317642d3852975b68913ab1e105896233a1090c314a49a25bb44e0343abe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "f4d6262b1059ed037cb8258c1322a04163de904930359cafbc16bc076058abcd",
+                                "uncompressed-sha256": "748e6e4154d8cfdd9e523b65b095a5e876ff80dd7bfc88a3590e586aeec9b587"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "48a38709b8541ec7ef36de1e5d441acc210552afcafc24f54d28b74d2c974fd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "194ecc56fd3d6cc46bbb2a94404766016cc3d06d5768d19a470f3f741291d3a5"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "061618aa28cd4c21a00e1916b6d3945687e6fd92043d8965ab95d0f03a1afde3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "4187ed53c2f9776dd8af0dda5ecc9100e3e38735e32a285367ed3c7658d664b3"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250623.1.0/x86_64/fedora-coreos-42.20250623.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0a80809555a4f332434a09b68a220694814c5e86ca3c678d3153e1f2ebe3035c",
-                                "uncompressed-sha256": "82bfd245e3a6de148e23e58cd0cad1d11f01ce345c3b16d9f1f072ebabb869df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "c4419106ac9c7052e94cc4d932b1313972e591800a6ea098932e1951e7b21e1f",
+                                "uncompressed-sha256": "6a5cab22377216d4950106097a52ea7061216fcc266e4a97a65864c19ffa9e63"
                             }
                         }
                     }
@@ -791,149 +791,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-07a36ef4f48884d00"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-06afcd147d0e3f7bd"
                         },
                         "ap-east-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0098e1018bcd5ff0b"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-094d392d137f9e8c7"
                         },
                         "ap-east-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0f6c6d580a777ae67"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0dd4e16e70730b145"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-03198ef9ccc46d9c7"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-035eca4a666039609"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0196d04186926b12f"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-07ba635a22cd14c1f"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0769733de47eed34c"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0d75b25547558daf6"
                         },
                         "ap-south-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0e56476a2a180a271"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-023445331cfb9ba7d"
                         },
                         "ap-south-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-05929d8d22784cca0"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0018050ffa744e21b"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-06b2ea5059694cd8e"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-039f58b7b027a40c7"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0c2a813240a6e464a"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-09c9bd33abcf829bc"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0c92f52d8d0dee684"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0f603e612123a55d9"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0d4c090c0d22e3e24"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0ead605ddf4ad9df4"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0526f2a792b9b0101"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0269b1628d1816f02"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0bdd3e79bcebd8558"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-07b5fe5a3e3bea6b4"
                         },
                         "ca-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-03d3f8a905fbd110b"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0d66870eb49c4aaa6"
                         },
                         "ca-west-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0a50df39900d879a5"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0ade5235e2639acaf"
                         },
                         "eu-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-03b05eedacbe94ce6"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0baf258cb6d042253"
                         },
                         "eu-central-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0aaf90405943b36bb"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0a7f945b21d3467f5"
                         },
                         "eu-north-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0ce80ad7c17c656c6"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-06ade22495b395265"
                         },
                         "eu-south-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0fe736e6b4b8697f9"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-08c9a690af0f2d37e"
                         },
                         "eu-south-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-005b81b63862093c9"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0741f48c942d93470"
                         },
                         "eu-west-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0fb60e78967f47ad2"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0f7faa3205088bc74"
                         },
                         "eu-west-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0e94e20be9e00d865"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0c23e15533dd405c3"
                         },
                         "eu-west-3": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-02125e864fd8b9c43"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-056fee113ad8309f7"
                         },
                         "il-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0e0740c8f9a4fd1ee"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-041cd22ca3d6a069e"
                         },
                         "me-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0e364724b9c2c07ca"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-094b1de0f25e027f7"
                         },
                         "me-south-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-036b7215cc7c78fbf"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0bc7d05f0e0924ece"
                         },
                         "mx-central-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-09c5af54da1f8ce4c"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-02a524a3b18c1d203"
                         },
                         "sa-east-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-086d63dda3c43cf02"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0afc65ec878f7f6fa"
                         },
                         "us-east-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-09d1b7128494fbbae"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-08075e541fec6f90e"
                         },
                         "us-east-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0f8db79e1eaa42971"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0022fa934040dbe0e"
                         },
                         "us-west-1": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-0c1baefa5e3003eb4"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-0f1ed01b9bf014c93"
                         },
                         "us-west-2": {
-                            "release": "42.20250623.1.0",
-                            "image": "ami-05c0b9a3c9d52ce1c"
+                            "release": "42.20250705.1.0",
+                            "image": "ami-051ceb37191310f9d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250623-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250705-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250623.1.0",
+                    "release": "42.20250705.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:fe4dd255a4cf85f41496ae7c53fe34f81f6beb72126dd253a8f6f83d6d7fc254"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e97801f4994c0cf270e350d29de3e95f429ebfed926e1bbb952b102a5227a403"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,156 +1,156 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-06-24T18:25:40Z",
+        "last-modified": "2025-07-07T20:59:46Z",
         "generator": "fedora-coreos-stream-generator v0.2.17"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "8f3bff61f75c6991fe2088bbb34490f5511b204e8269e15a94f766db9733ad5b",
-                                "uncompressed-sha256": "7a45c65b44625db9bc43ecb0d91e2d357f9cee91f8b31e083392f78e96357247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "5f6613c01f22426e386758c3b40fe753ccd3d6cc58c93608d908bb70e9a7e6c5",
+                                "uncompressed-sha256": "904b4ab0d10a20fdca2bb6e08a76a156ac146f1d8f9626645f40a6c99366934b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "efebff8315bfcdd5f677a18008fedf0b4c768fe683fcd3ef1b2f04536cdbf805",
-                                "uncompressed-sha256": "4c98755e058f5e4de3fbbc2517e4406aa1702e129cfc656e56153f1422bcb7d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "02ed3b691df6d19461739aee94b3d805b3c7f11234eeee5d967859c3b5b12263",
+                                "uncompressed-sha256": "0413ab3207a8b1b6885ca3cdb7c316fcd18ce9eab1e5f2b2c6ed70368d97ec1e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "b6866bf5341c8c45401e7a270f85a2eee90b3e08227553bd51bd6603a5ed3484",
-                                "uncompressed-sha256": "217628b6dc221a9d3928745d30b5a59e8f4c54c320609af926d9a2fb7280f30c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "6a76605907f84c6e3d278a21d86f7fc6e85efb5186ba311a37f3f6a2699d8ab8",
+                                "uncompressed-sha256": "f0cdc7cd7a4c08e512476955fe11c6945c8eac5804a87698975fbc0a362580a0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "da750e6d73e86538abefc6beb34c69b6de0b585b9ff33c45e678d80daadd2aba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "05e67c877f54af09d0b7e93b823879cd3deb53321f76a20bedde1079322c2c62"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "dde330b9d3d78e5812e54b09b3c4a5313661abe8e9b7e11797729a291fed0bf1",
-                                "uncompressed-sha256": "04cd49355c8f97972c27511de57bd4fb660fdb916e548260addffc078729a8e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "68f1dc1e13728abf6a22d5b5c47dcb8036c3ca56ebba0fce77357fcfd3fbdbbd",
+                                "uncompressed-sha256": "a4c776ddca6db8c74a453198e9416e033c4b3154d8f1bd97a3d2c57d67cbc9a7"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "ea5d25dfe1fc53f8774c0dcbc509e7d148805f79e6e01e6de7aad66882a9d5b2",
-                                "uncompressed-sha256": "bf0209d7178d1fb3d690542a034da1f7c8e7a628a7957781a49c68ee75a13178"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "faa829de018bac316c26af3dede2a2ea872fe9697a80cd9e22bf0b41b815077f",
+                                "uncompressed-sha256": "93843bfe8a97351e5c2e8415340cb7a8566d7127b8b66b895ba551aafc30ead4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "9cf886a94cca7ad9666f6ef4f7e2c966d9a1b447130b9563a927d77829412fa3",
-                                "uncompressed-sha256": "79d6147e1e4876ba10d11658e5342e0ad14d945c8f716c110976dd529ae59a4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a97cf518163c1c9154cffbbe8cd7cf735703ae47c84437872e1a0956d415e86c",
+                                "uncompressed-sha256": "5cf4399e3714f501d0973f46482ce0c544ab04ef23700ff7721b10b8b9de80f6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-live-iso.aarch64.iso.sig",
-                                "sha256": "f0b5428a8a2f3fc1620a75ca1237fd620420893822ed7392092902ec3adf9bd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-iso.aarch64.iso.sig",
+                                "sha256": "151460342e963dd426c7c66a088497d40254a612c6b6a0365c3b5b031e6bf5ca"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-live-kernel.aarch64.sig",
-                                "sha256": "3ef35a83566af12288a6531618c542e8da857c2353359673edc4a6a63503b318"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-kernel.aarch64.sig",
+                                "sha256": "30f419a63aeba8bc12ebbe1ec5e2e98259f2f220d6491cc80cd0396d3666bf3f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "002bf9794752c8eeac5e97dbaba3caf954e80835868fa80950aee37251b2379e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "d260de2a80fc078d2cc8c235d756dd41ef81cabcad6e710bb4d205309ba2164a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ea55dd810555345625ef6c3055a35dae4da4eea7dbf98a00f05eebbb9a3de504"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "afe2c0394f0c828fda8f272f60fcf8f1c28381ae3da3bf48a17d8ffc68f178cc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "21163ce0bc18e73d965d288a94bf12df437d21c5fd292e61ce613ea79ad8b631",
-                                "uncompressed-sha256": "e021372035da767956d556abc5980f2afa015cd45995f854d2738080c11d08ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "564f2f8f36316a89f20d6fcced5efefca539449d87f808c813941caa8d25e54f",
+                                "uncompressed-sha256": "83309d9f332d2c9e3b1c627e337c0de7712f5d086e62976b7ebe07976cc8e79d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "616b5e2774bc51476954044c8168f552e78a26f0ce521037a257189e5d2a03e2",
-                                "uncompressed-sha256": "903d16ee9555c4a88f9d9920be81255fda45f6830b5ebaedf3482406f5db9b31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "79072f5a1425b1a6fb4f3d178308b96cf72703dd1bd695ea8844c27d14d9ffd5",
+                                "uncompressed-sha256": "8a0e73a4fcd9bc299ed0bb63f132907ee37902f7d3901e33952004f188b0ef41"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/aarch64/fedora-coreos-42.20250609.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "3a1230c4ae4e3586ca9950f6519b1131f7887a56b60be70a6662481a94998ee0",
-                                "uncompressed-sha256": "7dd174e9c236a4cc53bc11843925737fe12c725212ecc9c7ec2a80f019b2646d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b21132b03677fe65a2feedd0853de8820244a7fec013cc3a3025e27e9b74cd3f",
+                                "uncompressed-sha256": "fbd2717d159611d0b312a6b16b6a9155af9f0e1c4bce2fc9d3b76388aad386b1"
                             }
                         }
                     }
@@ -160,229 +160,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0d0469ece6f538478"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0f044c5028659b8aa"
                         },
                         "ap-east-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-08559c27824fda045"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-071ece5efa5a300e7"
                         },
                         "ap-east-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-01f8a5ed952d28564"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0369ca7d8165ae220"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0e59002c189cd0a17"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-07b2bbd7da8aabfc3"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-06ff00e7ad3fa1b10"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-063ff4d54ba1b5b4b"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0b07b604ce739241e"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-05455a889dd898a4e"
                         },
                         "ap-south-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0c1fd07fc48adc43d"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0a9fc1c0e4848081c"
                         },
                         "ap-south-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0658600c58aa4b561"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0814bd1d07a8fd031"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-07b72a5680fc925c1"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-06c796dc8320d48bb"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0a69f9aee52be38a4"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0fc7cc8f2ca6bf7c8"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0bea7d2b99b807a15"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0af6efeff05e48f7a"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0ee5cfe05ff399894"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-05b0197a9a50bcb61"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-089cf5e3f97b06c09"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0aa59395097be183e"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-002e2fa2e0eeca5ba"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-095d4462a9ee884b2"
                         },
                         "ca-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0741662386db2603e"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0021a0b3e8640d81f"
                         },
                         "ca-west-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-074d8017ecf7c9e0a"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-08e7a9f4c7532bd64"
                         },
                         "eu-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-04bf5003a999c768f"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0a73eeae952360c8d"
                         },
                         "eu-central-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-08b169c4b99dd9bee"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-026f8adaaafb72157"
                         },
                         "eu-north-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-092c268dd34b5fc42"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0fef025b91e390091"
                         },
                         "eu-south-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-090f1b95c7caa0907"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-019b5d4130d25934a"
                         },
                         "eu-south-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-086161cfd2f5e811e"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-04b4c6a2db5df74ae"
                         },
                         "eu-west-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-094eac5fbb693e737"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0207f87379e0dcc5a"
                         },
                         "eu-west-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0b8f7135159ac47b5"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0030d0b210a61ac6e"
                         },
                         "eu-west-3": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0dfa02e951ce2f564"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0542c29294aaed8b9"
                         },
                         "il-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-075497803fdba3c2a"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-00e087fd78d98d48e"
                         },
                         "me-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-08a88ec0d5d2ca6eb"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-078595be77e8604b8"
                         },
                         "me-south-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-02d66f577db085e34"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0500d4c2b7c2d4c8d"
                         },
                         "mx-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0565d84d456a0aa5e"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0dfd46fa4d0dcf5e7"
                         },
                         "sa-east-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0123189269663de44"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0d09145af193e58bc"
                         },
                         "us-east-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0e1d604787f930da6"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0014914f739d78351"
                         },
                         "us-east-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-07c501929329923c4"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0857026aca36aabb8"
                         },
                         "us-west-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-044307d49a89d1d48"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-041491b915040eb04"
                         },
                         "us-west-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-04798d7da0f500a42"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-057973af140970586"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250609-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250623-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "eee485934c2c731c51cea30fbc5e5d394c91500af589676c29145c3dbacd79c3",
-                                "uncompressed-sha256": "58112feb0047e7bf4c848a6bc9751404dda2f34cc2e584db63c3d0e52d8d59aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c9d47d5e2728ae94ac8a7c35a09f0b89b013d611b0fc4c4c75183209cd38e125",
+                                "uncompressed-sha256": "ac610f1654887bfeaa58f34cfd4ffe0e123741dbd8163075072131cedd239f7b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "f98baa6126680bb0841f904d8f6b0c957413f72067e1b5c70ea232059fea7d7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "454e38d78c466dc9c62575a9a19408bc81fe3871cd9363990fee5a777a8e314f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-live-kernel.ppc64le.sig",
-                                "sha256": "4e4b98927b4ce1ba730da001e33521304ea0f5d2ea57ee24845c62bbcf1ee36d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-kernel.ppc64le.sig",
+                                "sha256": "d656a0ea2c2466ad732af7604b28fd3d48cd558a9cc8b09f6250730bc6bc4ee4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "6aaa51935059a2824255a9d58669a95b74bdafe8df977b928b95a3add9e3d37d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "b8d7d9fabb3803ed2b096886e35126e968ede1906f60932816adec8dafe57b6e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "630d54356ee1e844fddede7a78f8fda6a818d3bbfbc2985a4a00599a65d4ff0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "5570d7521730f4b26eed6cbaa95fb1fbbe8f8d5c2dd885ef5b0fe98e78f24b28"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "9f8a2073b18191f6d3c9abaa1dccc1e2e587b3862aa620da12a4eef0851679d4",
-                                "uncompressed-sha256": "9aa610138c0285288c4c02f053f367e76e696844973340cea30db765d9b11384"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "e87345045c9e045ed64f4f2adb05903ba984b3f10d16f69f9963b76a005cba54",
+                                "uncompressed-sha256": "ab270a2243cac4778d81b79b86f2e2722908dfb1ca0983ba6757b70a62afb4de"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "7274b84e3e2304e3ec123b50f0484e0db2b26653e72ee987f1e43aa75bf004d2",
-                                "uncompressed-sha256": "f3a49d9608d4722a0fc27f39d890122bb7effdb5edddb19bdf4fd3225e0ffeb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "eb10ef8582571efd7f4b4af887df757fee7edd2ebb09fc2c76e84acddfd8fc3f",
+                                "uncompressed-sha256": "5c5cf8edc4f6712b1030964df011119494d02f4e97d61e3fd14b4fc9dbe6019f"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ab4c99677bd35507af3d3b1d456e8c1a7bddf61e595e77712f9f8f451952c3f1",
-                                "uncompressed-sha256": "67e9b976e2a44d6612ad5770497dcc3c2a6133b36591675bacb2361fa6d3e88f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2c93cb2fc1900beb6605fd4fc2625d3416e0606f4571e004e7e2db5b659109bf",
+                                "uncompressed-sha256": "13466f2c6e9b9aeca31ebd6aa9e95fe55572d21104d9c7b983a493dc737caae2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/ppc64le/fedora-coreos-42.20250609.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "cf5da1e235f0706d9a195755298fe207aed890b6870330086cfededb9da680c6",
-                                "uncompressed-sha256": "a52605d028528ac003e508358f15a55d467123f79aa16dc1a3b6b1682472ca81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "71e62804053cb0a520e7b6e21e8ad481410b63cfa3002c4c8dc4c9ccf5e10769",
+                                "uncompressed-sha256": "cf952993f9e4f97e0604f79bdf9e08d59ad3159c5e74bf3c79e9ae691e798de5"
                             }
                         }
                     }
@@ -393,97 +393,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8704660b2532cd99fc484f8416f4b5b7c80e7ad938b4c8839e378049396cf29e",
-                                "uncompressed-sha256": "b1afb8ac07ea779484d02ba5cf48f5c82863d09c18a162c4dc3b2c4d440ac454"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d52096cc58b34db6716f9580cc0f3400cd8264d037d8d4429863321ab95f5470",
+                                "uncompressed-sha256": "55407f4edcfc47746f2a9298a38735e1d78ed0249e9f47f9464bf47678a2a0ee"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "dc55fbf3fd52d4c7882cd05559386f4cd285e0888a0cd28d8f32acbc313fe9c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "1704c38723983ffd5961eb525edd3d9d464e6a3ec08ef675cfbcbd2147fa32b7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "a93ad43f85077847fb8a199160ad1bf9b264c27be51f6b67e09f77b24f149fc1",
-                                "uncompressed-sha256": "e12d373e55163648acf9d1fc78dfb968f12e7667b0600f1e44bcb78c8127b523"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c99b64d31db0e4c89c3619815c8d910b1dfe8463026564bfaebc26f8dacf324a",
+                                "uncompressed-sha256": "cae05ac546b4b3aeb499a78cf5472287c93be745d840746d47dbbe05c8da8c05"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-live-iso.s390x.iso.sig",
-                                "sha256": "5626185346d885054099221d8cc377e9c3765d4b142d524fdeb035c93dcec0c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-iso.s390x.iso.sig",
+                                "sha256": "c9c1590fc9bcab40a7acefacdd59de34ae51901a1a07d8615ddabf2a7629bfed"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-live-kernel.s390x.sig",
-                                "sha256": "454c813d03e7323a0d8cf603a3f10e6ace02aba7d204f4de55ae15c7b65d409f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-kernel.s390x.sig",
+                                "sha256": "1ca8038c339fc604bbe28a5df1c390a8cc9b70e00859ade0d5f1711360436257"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "2eb72b04e884d25886769c3071adb2290781123b60890e1092529d90368d8c3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "85f1afd9c9e55f09fd094614a8e78b255bb47f4b28f03b89e6fa71e7ab709987"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "871764781a46af7d9b650a7cb10f70afd2837417b13d14647ccc3a7d85833e0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "6d3995ed7f88a50d6a2e91b355681a8b259a22f14f3faf44eb2fde69f2669b32"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "f7d1bcbc45ac2847b9ffce0dddb0b65ecf230cee2edc3e251f8eae408726f4c4",
-                                "uncompressed-sha256": "aa3b03c7417182c7159079c3da310a0a05595ffd0f364d6f4d720f59e5fc4a5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "58d5f6185cd61c397e5633cb005c5047c17fd6f36c077d1d4df121d0a07aa868",
+                                "uncompressed-sha256": "e4b661a450d53136c16667b05aec8c8fedfd4c48c71ae31ccf0e408d0ed43961"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "a6e5a5198ede6efe34a8e3beb9cf30c86eb55c9f00ea5203ea32f279d60a075a",
-                                "uncompressed-sha256": "a709a7f89a034e3a3d08c9314c2b546367fca46d8d16c107aed429b38d17d11a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "57192654d7794e8d29ff1bf0ee55a8b9811799bd301f67d54afa446e74f0a37a",
+                                "uncompressed-sha256": "3c2b8703bf4dac7239fc3037a821fe82fbad9268d8bc0517159d18de45ba1e26"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/s390x/fedora-coreos-42.20250609.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4ad6497b82319c872237007dd1829523482bab342125add6127c05a84c0efe4b",
-                                "uncompressed-sha256": "52f299aa7303dc6d6a334efbdc14680c6468944671afbcf5cbddf43fec3c8356"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "c470377a1f33be9fb2745183942c54235b04715c23eeffd7f2375a77ec207fe6",
+                                "uncompressed-sha256": "d0ebc81039660c20ff4e888b93968cabcd018932387d2227f52ac1418f4b1a31"
                             }
                         }
                     }
@@ -491,284 +491,284 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:028774d6828effd112c4def984f19304606936dd73d35bf3fe5ac241dc0abd2d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ee00e63bafc8dc45393b4e7a7b8b26fc6c53b7e5c4a805523b388498cbc1f385"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "bc875e1b9345e0fc9721cddf6caffdb8fabad7cf1d90c79831cd52dab8b3dd26",
-                                "uncompressed-sha256": "e7af4281c585765e11677968e02f988bf0ba8ef7c8cd511ebe28a53aff0bbd97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5df7bcbd786b035209546cc8fe4e0ed75916469dc06ec5dcebeba50fd0b1328b",
+                                "uncompressed-sha256": "11bdc678a3cd7124e26e564f95af574da3dbc30e1a8cad9bd3de9e45e6e0a815"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "5c564b12cec557b7ff801cdfab993f2f91a75e87be899dd0c62f5c13a0b4c6c0",
-                                "uncompressed-sha256": "92bb238746b1e86f687338fdaa380ed7c60bbefed5c3c59742d7300fb9ebb821"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "0b2a75cecfc0eb60841df162fbac35764d2d4745833cf051689e10546f613369",
+                                "uncompressed-sha256": "02a0a44daa10bfc2475c86db7ab27d782e1cf76b0be33e657de7f26d1551795f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1e6cda61cf706ca06ce1640028728266aeac29f253c7b10275ac7acdb3319ede",
-                                "uncompressed-sha256": "7d4ef2359189aa248ca22d97ab8aef6856396f93eb07bd8e94b6e23cd6b481e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2007826098a0bc17513b451e153bc5c4ad3330ee3a59f6093ebd94d317d4a924",
+                                "uncompressed-sha256": "92659cc4cd21b73e390e80124d007fe69e39b2e30080bd2f5aa65c6af1ae956c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "edf0393db13243372cc355d9aa9259eba5c3f09c6c4a4c7a6311951ea2f01b1e",
-                                "uncompressed-sha256": "b76f3f80bb6eb07f6186f0b6f2e25b218d570ca452f998686312f0efde168c59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0636b88699dd2a5c91a02a58120723a735063acb0b0ecf5aadbfd3dc48f551cf",
+                                "uncompressed-sha256": "7645ab7298b49b4050120fadb0a21562080112fde9a8272623575c8ded83ad30"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "903be67ae95a5cf03b1d0269a099353da1a0aeffc4d312ac8fe0825a1eb4df84",
-                                "uncompressed-sha256": "d874c0db6791cdaa969b2025a8359c884738d25ea085b59bdec631e50887caf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "6214982fc3fb7de9ec9bc6d3b6f18869bae1c5685a1a0b677a4a9e20f6e3f0ea",
+                                "uncompressed-sha256": "2a7bea6130b5c5d66e01626bcfe06c682596d6a0c9a846be59c7c960cdf75c29"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "5f7f05c9ebdd0adc3286d3c4be0a2ae5299f959d36c36f31a76eb53ca9491636",
-                                "uncompressed-sha256": "b30bf8d2006fa0eaa1a98ce4be390ceb441aecbb44d16a794be0ea65fe4aa859"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "14ecd2d3d23dfcc9ff13c39a9503795897751a137214635f1e9109d677e410a3",
+                                "uncompressed-sha256": "c7ec545dc874d918ec5ad2580708b4068b631476d6ca217b55263791a462a08f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a08a7c489039dfce0099729d6bcf6dad4296e1add16bbec194ec5fdbea1881d5",
-                                "uncompressed-sha256": "1d78190479cc7031a8af3df7de0c186fac81434eda8b605d8e05232fa841558f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7b433539d54953fbb1267c545d122f5d351e9cc4a7492366ec7c34eec965cfe5",
+                                "uncompressed-sha256": "3591cacfc46dd20256b1928eb41ad719973286b6af08b71f53b74f8c2cabbe77"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "6026d058fa618082633865e582b51dc36b525e621cfbfdbe366d88508419ea8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f358f2ae02a00b6e888fcd5d5071e073e762ba5b0bb1d025f39ee5a9a3ba45fc"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "27e68c607943b142b87be3dd579649e898d47ecbe3b88c8078d3cc45f577b4a5",
-                                "uncompressed-sha256": "12881bca21c60416b050422af7e5888aff5a42ae491ec5d0ddefa85bb7eea172"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "cc75d9ff20e6e4c712ab2b87a2ddabb5ec06b17834a3cad7b4add249718efe90",
+                                "uncompressed-sha256": "7e7383df97ba2abf8f1fe0ffa3c601403dcef5c08456f6a84f206ed5ecf746f3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e83c75b66c9a57b8644b571e0c09f9463a82db4283d791a89a32bf8a1021d092",
-                                "uncompressed-sha256": "0380cc926d8479e5eb291daa22285d42913cede75b17e7129b806766f2d7c70a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "9c679616e37f6cb0488291808b76c594c7abc32a70cc8b96e51497f137608415",
+                                "uncompressed-sha256": "17219def5142010ddc29497785d03d5bd43383a84a578419e2213dabed708942"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "824baaa5ea137420f423db564b244b0aff27a78542ddb44f2f1c7c9b41ece1da",
-                                "uncompressed-sha256": "e015991ec099cd15bea3833566df7ed3e17bd5d3a4f42f22829c938b41f9916b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "66363738d89204f7d54517bd84684b5e3764d8379e8142bcfd9a0ff6e6f5b5e4",
+                                "uncompressed-sha256": "57e00549c051181c748c24e46966a26ca7cc3300b9becb72ac5df61007699b88"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "5d22c619766720011236047f79fb57150b8a43c70f0216aa52829f17a81a7ec6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "13b7809c45281b2791936ade8cc5789e599e0eac034b526ba1fc0bd2b5c0670f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b62402fb74fc211e0a5bc9848f5a1de563d01a80311234837333d1bf3432d096",
-                                "uncompressed-sha256": "46a3499d2fa5e6e750fec6d03d17680edb27780894c749aaa6b58e2ee9ac7eee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4c2ef36452c49af89dd7910221eb0f3a3d3d41cde9c55e07dcf6215749017522",
+                                "uncompressed-sha256": "70a009fdfad7700b33192a8658b810b2b080b49038c8db7b754944d3a1fa1c8e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-live-iso.x86_64.iso.sig",
-                                "sha256": "fddb4bcfaf646009f980ee786eeeb38370f0ee51f6bb7914b0d5754a34308b93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-iso.x86_64.iso.sig",
+                                "sha256": "974d2e284e21749d1f001d0ab5872d93de3d0d37f454a7848617e1f1574f554c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-live-kernel.x86_64.sig",
-                                "sha256": "2f045da62edfc39f6f85a1da7d81416873c5a5451f25b08000e2d817523a9967"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-kernel.x86_64.sig",
+                                "sha256": "609799621be031f9a65d31d12b1cb90f6fc45df76a630e40f81a45a12cd924b2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "a2c8fb97ba844ad851870859c241182b47393be0ef89094fc4f60fba8d3c9641"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "29c9e2c6aeb947c66e3b503466fba4e548870d4751b52464b8dad5c0ea4987a8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6bff84912de266629b9538a298ffd77529fad506e256db9110d5e556a3a10076"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "006262630fe6c49a8f49e35f21d8d1077cc6abcd3a9cdf14ccd4c615e3171397"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "0ee8d0856c6e481a6ab6d65f5179357d6084ad141c7607c76954eeffd672df2a",
-                                "uncompressed-sha256": "8f7a187832a7bb800d18e1fb6ff5cb976b8f680e76722adac18fefed6c8b38fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "755bd9249d1fba57343eb2ebd358a4443bb020ea9fb9085654c16ab9a359400b",
+                                "uncompressed-sha256": "d0b1ba8c8ad7c1443730dbc44142728a9089eb0d148b6a866270140839580b39"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c00e0ac4b79889bec0d26c67fb6130e5efd6a963357ed584cfe72209a758c470"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "fbfda676f71b2b321fc52e0c0373c418244c8d2a1bf82d879179d79e262fda7f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9155d36293f223bc8a6ece0e6c7dd2932a271de9ec4e58df1991ff67cd8e7b09",
-                                "uncompressed-sha256": "c74a749dd1d740735d27a5a9474cbe706c8082207fad2d152b156f3903421a81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c66a1f7a2c0057ae5179a42b75df508ad285b64f11177290bc201fc45d8414ca",
+                                "uncompressed-sha256": "c59cb2daca57ebb0cc383ca63d17f30cd410aaad1be3c4283d8f6d06e8d2b977"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f35d6b071140c538630d3fc9d3fb9282abb2133f35bcc233b65013357b1114c9",
-                                "uncompressed-sha256": "9af6f64ccb6db14ca4f1141e6dd86360d3df57e3b01a44d8261fafa25eb457d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "fcccbb0a57411dc32e4dcea9f0dc0ea44557098a9b3c5bd74d75f26e2616f113",
+                                "uncompressed-sha256": "fbd5123685f5e90579965fd028fd168df04ed8b3ba8253cef39a39a53518e94c"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "ef8625f55e88b89313b652c60bcde6cad6a7a65e93ca73e1e215ca36f36d72a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "178aeaf5b31af32f06f71aa7b8d821cc56d62ca4463502e9a5eec2656c378f58"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "77f58f9afdda8fbfb9dd3ca4570237cf1ea7a244501a599765ba2270bc53c236"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "775c5ad6c0630a790d3819a273e8766b735ca995167bb52c9c2a4991c85a34bf"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250609.3.0/x86_64/fedora-coreos-42.20250609.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "84a49bf18ea3ea9f26790e645d2a16885214bbbb0d976b777d0ca06860970758",
-                                "uncompressed-sha256": "2c6cfc10ae2152ce246910dd4a055c8c47e942711a6cda03e63f169f689b5535"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "3ccef8ab0a6ebffce31c14cda7d7a9e8082dc87cf855c1b707719e860e6ca9e2",
+                                "uncompressed-sha256": "402e45b2644c30d1c8b4ff35562c3ef19badb942f03b988133a50735b0ab48e0"
                             }
                         }
                     }
@@ -778,149 +778,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0a7cf5bd030956515"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-08bfd7fe5c56edbf5"
                         },
                         "ap-east-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0c52e61feb657d72e"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-09e79b270408ed64e"
                         },
                         "ap-east-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-00c49e1d2a69649bf"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0cc3a61e89b40935a"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-023fa655b8d0a5721"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0e6efa1dd6aed3140"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-00821704b30d0b571"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-062184d91d1f14bf8"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-00558c597a0f6770f"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-09bf9a40eab8d4b24"
                         },
                         "ap-south-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-047220842b1e397ba"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-048f641817a8466a1"
                         },
                         "ap-south-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-08584fb3d8418039e"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0105becac41dc9c75"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-03a881f3547f118ca"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0d61f0a88f7bd6252"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0a9d2d3133840b5b8"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-002669e9f165ff12f"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0b8d06d118d9f01af"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0551adf1fd419f8da"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0a430fb3cb732193b"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0237ea1dcce9a8308"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-017b57e9eac3d4e67"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-09df6a3da49b6abc4"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0770af7559f69f5c5"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-08d37ec19d51f82f4"
                         },
                         "ca-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-024079f67aa7c5fec"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-055f762788142a770"
                         },
                         "ca-west-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-08767cdd99f7a6736"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-031888e155d272b1b"
                         },
                         "eu-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-017ce1c0488566c4a"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0bec4acc7a271fa60"
                         },
                         "eu-central-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0522ab08aff21ae4b"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0e624662636a60bf7"
                         },
                         "eu-north-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0699ef32d95276d5e"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0d1634da5a5c8d70e"
                         },
                         "eu-south-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-01c690d0e541a3dd1"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0d906aab0c7286299"
                         },
                         "eu-south-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0cce7d3bb7e27241d"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0d96a0ba21ba68fdc"
                         },
                         "eu-west-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-07397e0be68b801aa"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-06c663f8e2a9055d2"
                         },
                         "eu-west-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-093f715b77abce600"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0c2a0fbcfa902cee0"
                         },
                         "eu-west-3": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-031f70bb9322a1157"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0206748a1ea7ceedb"
                         },
                         "il-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-01acf9d0db3069594"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0720bdd9203554a9b"
                         },
                         "me-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0c6ce7a1eaabdcb52"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-045f33f091f2af3ac"
                         },
                         "me-south-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-054cc26fea5faf73b"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-05699bde06643926f"
                         },
                         "mx-central-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0647bc53cfacc912e"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-08189de7839d61824"
                         },
                         "sa-east-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-01f49ef3b43c48ea2"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0816c13424e706657"
                         },
                         "us-east-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-04ae6f9bac277175f"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-04c7b9f24acf1f8c0"
                         },
                         "us-east-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-01de1c5b93cf4fc80"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0f4b01f1245f11be3"
                         },
                         "us-west-1": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-07b3285896f4aa117"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-0f501c6a2f5edd801"
                         },
                         "us-west-2": {
-                            "release": "42.20250609.3.0",
-                            "image": "ami-0b93afc2e34752ab8"
+                            "release": "42.20250623.3.0",
+                            "image": "ami-079e19c3e7ffb3278"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250609-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250623-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250609.3.0",
+                    "release": "42.20250623.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:124167731fc730050c9953d92325cd3ce768eb394d6fc9aea09d4b3ffd2cdfa9"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0ddd3e90becfa2411052307620ce40df860514ca24c9d70957083462988a139f"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,156 +1,156 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-06-24T18:25:41Z",
+        "last-modified": "2025-07-07T20:59:47Z",
         "generator": "fedora-coreos-stream-generator v0.2.17"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "f86ba5e807ff3f5efb170286e206a353cacb9d09cd71a024d79ee7b237a2263e",
-                                "uncompressed-sha256": "9dcd933e865fd84e7a22d985d98d6922842b808264501b84d76f22fbc8f0a426"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "1d90a9084f9e9bb72c5e84b0b00ff216fb408bbbb87aa718a8ac853b32d93c02",
+                                "uncompressed-sha256": "c586472b62fd50469388ef883343c6913661fca736929c61994678c1160a7172"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e8b5d5d14e284a9393b2537c86ad25b7df8fe915e6489684c0acedb6a91b9af5",
-                                "uncompressed-sha256": "65010f51bb05069305953f666950fccd6f6893a4677f40e9eafe1641fc77207a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "9f6b6efff5e14029ccffa6586d011e187500cf7b0a946e0b999ffe7c19028f2f",
+                                "uncompressed-sha256": "c3aa66249974ee5f7ae44709d7b43dfe3dd2ac74bbf57fc2e64a57330a0134ca"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "5f2df98b8d49b670b13dc31a753917bbebcf933d6c8cb1318ae47bb4b7e43eb7",
-                                "uncompressed-sha256": "235a7ce0a58d7f3f0a30cd4cc8dd143002e13cefe582fc9b60daef469fd69d25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "2cf9fd1f0cc940166020830c6b8bf3fe810a7de8d74546a7109dce1ba06dab8b",
+                                "uncompressed-sha256": "aa4b57b897fe45177664b1a06852d0d8e1c349ba4d64fb906c33900d39d2ff22"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "f5fc62f2b5f378d57c24bd8eb1590e81197560e17f19364c7127233bf25b039b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "58bfae4100be3362da1929cfd6213afaf9164f3e0595f29e3d4aa7b4eedf7159"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "ecda3c9e85dfa7972f201fdb89bb06c1e77d0f184bb2b695beec8c2cb8672ccb",
-                                "uncompressed-sha256": "c9ad30b7077ceb72aab79d02f935163122e1c46bfe04dca1fec6cb8b0644721d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "5af8adec319b5dd5805e9c92ef4053f0399f90989f1a42c0dae36b7abc3a6d20",
+                                "uncompressed-sha256": "4975847877f5dc890fc855fb90ec8c9b702150a99fe2975356ee64c2a201e20e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "201795dd39c5ffaa787e5319a0efd2b7f7a3c4c7ab5c4749d6e957910611d78a",
-                                "uncompressed-sha256": "a42c86820d4a3c71c5bbc626d4ec91cc171f2413b88e03ced9bebf14d00be3bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "a7bd9afea0a6406f099f8f28471ae748601827272e7595f4d205668fe28852ab",
+                                "uncompressed-sha256": "b8791aa1ef47d6b59432849d46c83653fb22e726912fe07860dc7730bfe9c44c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "8c60d35c09e8e87c49d8f9dbccd8b20e52d383e7d7d5b37fa4ad40bbeeebce6b",
-                                "uncompressed-sha256": "d135ca290847f26ffc5a34dc9d4020bd5d418f636ba03d348fba25293fb290fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "4171cedf391e3c551cf8b34e5326593ec78207176d56854181bebff178e35091",
+                                "uncompressed-sha256": "61865d45849b697c8233693dbac4d0e8ca6428e922c602f4a702404db84d669b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-live-iso.aarch64.iso.sig",
-                                "sha256": "d7371e98ade6933ad8ac8d3bf9693064593339e13fdbb81e1a3c6d861b73219e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "dbd803a1007c9f5316fd8f80492ba7ff1d03d9897d18fd48677c6a1ac821d411"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-live-kernel.aarch64.sig",
-                                "sha256": "30f419a63aeba8bc12ebbe1ec5e2e98259f2f220d6491cc80cd0396d3666bf3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-kernel.aarch64.sig",
+                                "sha256": "912f49b916e957d4c27ac0b4152a41373369fd9f538237ec7486ced3623acc87"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "1b546b3d918ee51312a90e7c713ea99d9e4039668137180bd937aa1c5ac7aa07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "61a14f2de05494bf5b4211e4afec6b40c92b05437e8b56ca9706bcc1a4f64c71"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "66447e9c9caf63f5ade1d94772352e5f5f99530fc54abe77baf12e5aa4d7f92e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "97a133bfbd1f3060c9b3f8b49edffcab11bf4a5fbd708e2133b3f0548b30eb21"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "804f0cba51d3f4f4dadfeabab7683729141b661ca87028040ea05b8b292965d2",
-                                "uncompressed-sha256": "cc09e5fa7f16ec911baae27b0d009ad398cce63c11df4926627a9fe994d52892"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "82808cebff460ea4081470e73a6d3d49d912c0a11449fe8695e873384a766411",
+                                "uncompressed-sha256": "8ef6572e3ce454fcf000f496ec0b486526019b62f96b5912ec41749e40dd9ee7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "542ba3f003c3bdb4343bc7d886af304b8dbc73759dc0a5f96845ab3a343191c2",
-                                "uncompressed-sha256": "517ed55e902afd40c5d25dbcad7520decbc2715f75b47e2c6cd9417ac8ee5c4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "85fc3e90bd2cfb1e81592d5594a5be6b449d999788f50ce755b75cb2951e8ee8",
+                                "uncompressed-sha256": "efc7bd0d86b53fc9e500d045b17b7df1fa0ef7370dc2fd2acb2d834ea04a9199"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/aarch64/fedora-coreos-42.20250623.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d87bba1d8c3fa97c1fa9d86c01a98183008041b8099d1a90c264f116cb5930fe",
-                                "uncompressed-sha256": "26d663ff2da499338aee8cce83fac2766892d6c6cd59e92dec2973ccb8cf7fd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8d98c0197d982ae57c40c24a185f1a99fdeeeaf1694fff6691ed8e733d3e8faf",
+                                "uncompressed-sha256": "a8fe8779e784e7d6a8928e13cf8d907d2f3dbeec3c2043159b8cee0def401d03"
                             }
                         }
                     }
@@ -160,229 +160,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-01290e8b56140e81d"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-029157e74eaef9d7b"
                         },
                         "ap-east-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-01d3be6047ba0c53d"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-09537086b61951a47"
                         },
                         "ap-east-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-06c1660b530ac5906"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-04ec900ae5cd88cf7"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0fdb6a3ec8d082019"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-05b075225bcae023c"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0e3543bbd5f361465"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-046e891f7471ae3f8"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-05747228adc420971"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-05ed95d9c0d645b67"
                         },
                         "ap-south-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0bbc014334a904fff"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0f13f946d4fdc3a3e"
                         },
                         "ap-south-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0d9c76818dd794016"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0ba985ec049ddc0f8"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0e7d2bb3390fa602a"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-00a2335ccb6233c04"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-08879c0564b4ce68f"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-06d72a85c715bd9e3"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0c26b4f694c9e8f91"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-07c9d2d0f9778dbc7"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-02512942895f9b9e4"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-07202cc856cb2e4f7"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0e85f3f942683398e"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-001d5d600bdd97997"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-016dac92ae4b9c48c"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0bdfebd42239be8e2"
                         },
                         "ca-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0f318715576bae4b5"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0a3c5324640025df7"
                         },
                         "ca-west-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-03785601563501678"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-06e00cfc064f16d8e"
                         },
                         "eu-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0595304b2ebdac042"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-09f3f07a7d70ebb39"
                         },
                         "eu-central-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-050b1fe09e624850b"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0d58633148c659427"
                         },
                         "eu-north-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-01e729ad1b3c6c551"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-054195c5852511398"
                         },
                         "eu-south-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-090a0cd2f88c7ca03"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0054389d91c84d23b"
                         },
                         "eu-south-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0eebc8eb17233eb36"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-03a5461366fcb15c7"
                         },
                         "eu-west-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0c04c21641d888838"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0920daa110cb5b0cb"
                         },
                         "eu-west-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-00010736db7938a01"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-049a1ea3019de9f19"
                         },
                         "eu-west-3": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0e5ebb69fc6bb9dea"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-010cddb2c8be8120c"
                         },
                         "il-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-06e6be83e264c5a49"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0521d5a33f04ae8d7"
                         },
                         "me-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0b9c92c5fef1e8697"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-007d972ecaa0a92ef"
                         },
                         "me-south-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-08eb5d63fb9e282a2"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0e843b3b5f5874ef9"
                         },
                         "mx-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-015a34e22dddd8534"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-032e8153007e94e96"
                         },
                         "sa-east-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-06d0ec268043a1ef0"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0d4647ea785ea1015"
                         },
                         "us-east-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-07e9b92e2bc8beaec"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0ce1f6c546cc79353"
                         },
                         "us-east-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0383306202391cdcf"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0b8d4c676d0ce5569"
                         },
                         "us-west-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-012d0d2e2a1220d2d"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-06fb6622e50d5fdcd"
                         },
                         "us-west-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-038f440f35a6acef7"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-036b609584d3654a7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250623-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250705-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "1bbf6cad79dc28dfe4e4fac3e2b76f59f29a8112bc0188adabfbb2936e50ce44",
-                                "uncompressed-sha256": "25eeb01afa593b35ec70531d3f1c4874e56eb5d65e016eab132ff9161496a3f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "bb933801e3554905fa2d1ee46100ffac6d280d1509708534666fb0dc6f47d4fc",
+                                "uncompressed-sha256": "513ef2c0caa5fe46224d12a37690bd17dc580615846a4a04b954e4cfacf45640"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "989612a6a26aeffceb25317cf58d9abe8d9e125cc42b39d028f495a1019dfa5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "3aae91035ac4fc5a5a8b56bc146ffc685f80a097cc627801f716296a25ed135d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-live-kernel.ppc64le.sig",
-                                "sha256": "d656a0ea2c2466ad732af7604b28fd3d48cd558a9cc8b09f6250730bc6bc4ee4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "07caeba85e4d5e2aa63bd6b6dcdccb2fa03a9483c5af5003a6964a20c77a4bee"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f6c1e6f05357f00bca58d1fe3da2476f8836fa3bb94172e6f2112e0e9a9b8f27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "f1bbccdcdde9a9d71d6685d4facc99a912c57afb2b56e473e88633deabdcdc0c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c00ab132f22e00ac03511b119d13f0013edf5ca9f1f828f52a565210fedb09f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "9fd5725ac7b20553e8c492ff7b9a5159c0b60dafebbafde0646b316376a8a2af"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "934b3d0ff4dc73229139c3bdcfaec1fb31522084fe55eb6ed8b221949a7b8d1a",
-                                "uncompressed-sha256": "2abed0eae64a87a84df74fb360384138337919f23b30998d6904a17f45d58311"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "9533a71cb05cb1cd7c49426acbb5947aa413d46cd0502cd21e520429179f7877",
+                                "uncompressed-sha256": "e05f1cc8f6737ed7e6d90f8fd44fe6ba46c46649f5b1df7c91b71cafef75bbda"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "90cfe9b7909f458bed99adcd5b1cbc5e54c78e2649f8ea157654c24eb7334f13",
-                                "uncompressed-sha256": "89f9f8b52f8db951ce97346c24900ff031a962a6d6abe9d5b917fa5121d3ad46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "634f5fe7a1ebbb856f727641423f5ff53b2eecc72c856b17601d718a39d4af90",
+                                "uncompressed-sha256": "921ce3b8f26fc6b89638dae16647772c574dd57101a9cc84f943887c9bfe2827"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "57806fda14f011049c662e6ddcd2fca70fbe3360c0d56fb1fec22f551bbf9ab0",
-                                "uncompressed-sha256": "b39f82c7f45a20607f3d9549bc33bf1fba9d9895bac1258d3170b82665fc78d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "fd9eea9aea2d5675234a9e60a9d296e52139a2e5c9fce44403e46108c09ef632",
+                                "uncompressed-sha256": "b56000610653f488fc20ce19107ecf81ff8cc0d8e61719086913923ecb600b1b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/ppc64le/fedora-coreos-42.20250623.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "613ab716961e58b6dabf4252cc16153e95de9f16df284645075ac9f5435ace99",
-                                "uncompressed-sha256": "63475dcaae86fef50690fae2ad91d1cd66062a16052556606042895123a0ab8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "c8176f622ca95c2e3da17a3b6098082c3fe33c87e4bd85219dc0a46c74025c2b",
+                                "uncompressed-sha256": "0ff9ebc193d6d73ae4df65e73d91ac5ad957257783e553264cc0b18a12996bc1"
                             }
                         }
                     }
@@ -393,97 +393,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "61cbc40175680b4b16e6aba4882ff64340f47ea6733807f288a75aa54df9c041",
-                                "uncompressed-sha256": "3766040133db4142fbcc5993962fb37df12319c1117493419c1351dfd2a80267"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "19044bc7bdb0a99609376a26ce79de17e3e9bb8905ffbe0f12328530e543e168",
+                                "uncompressed-sha256": "0ba5ada3ec957e04a93fffc41959ec024464588adbaa613be42e2c99ec8e5700"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "bc3eeb46f10bdc4b2d0b3b44ebe32219f54daa046fb59cbcbaa7bc8fcb69bb4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "19bc670eb51de374a688fed6d8288fbfa919062996726982ee088acf6911d76e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "864ee9b05fbfda1421d72f99e94168857a79d99e47b852270edef86171a456e2",
-                                "uncompressed-sha256": "8ae33c5d64804d79841677ac5d5728731d2d1ca8d5345e54ae3217f65127daef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "525c6a38a994f2d0a71489da0124176f9e605ba7fe1f1da23c05041e7e8e7f9f",
+                                "uncompressed-sha256": "e2355bae8bf7f78acbce5a722e319be6d28ffd372e70c16f76f63c0e0f407dc4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-live-iso.s390x.iso.sig",
-                                "sha256": "d90a12b458704447763eaea804971b88198815e27d2b5ed3584fbddd330bd080"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "46e5275e5981cff7144a65ff55b4427164e012a3ae8f9f7430ba240b6b9d980a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-live-kernel.s390x.sig",
-                                "sha256": "1ca8038c339fc604bbe28a5df1c390a8cc9b70e00859ade0d5f1711360436257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-kernel.s390x.sig",
+                                "sha256": "6b39b4f1186283d9053865431c8ba5ace49fb736e78428f2734247ad7ff86303"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "a077faa14ee874b7bc8702804d909293a0ed05b076e17173a4c7c8976699b8bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b1b697967df918d32fb406af5b9275630e01bc6597300ea985cb520ec643cf9e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "3cfaa3aa62f0a7889a5eac59c306183f4988b97b0500f40d03dad01e50a406a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "7b31cf3e8723533de1224699049ee0fb759fce4e2a00040586515248276f41fc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "9e21ab00c8fb83066a041b6d20788e37357182aa9dc797b326205109ce3838ab",
-                                "uncompressed-sha256": "c07d687df481608dc23a1116537ae05ce964426c3176e5cca4bf9c1e72255695"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "1ce6527a0f00cca7aeb73865e388ba06f5e89d0fac3cece130d701d759443fdc",
+                                "uncompressed-sha256": "d03ca116e72f308ec1f06d2c2994dafc710d343f4f1e04c25e2088ea2b83b222"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "187b5c8fe87ed06588d673e7b04c71751783e0eb709a624cb87882f9128c8cce",
-                                "uncompressed-sha256": "9f7aadc92112f6492c803cb064363d511a49b6d89917fe47becece8812dc4aaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "f76142dce377f99ba7aa06f45a919bd0bb860dfd405f3cd2bc7f8666a88c8bf3",
+                                "uncompressed-sha256": "17388698183e59b714df639992810a3e4c6b59503a73d9861cb4f518048a01e2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/s390x/fedora-coreos-42.20250623.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "21292cfd20fe3f271cd50be3e31ec0b26805677028634bda7480d1713f854fb6",
-                                "uncompressed-sha256": "7d455cf78451a27b453856aed269dd195dcff80b2d8e4971ed7fa1d72834da60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "caebb2618f34e90df1a6751105e86fe698b00fd9ad19bd445cd28463d2d32256",
+                                "uncompressed-sha256": "7440f494d51a0394f4e68529a2150f8abbe3fa50647bd69d34613a71fe5defa6"
                             }
                         }
                     }
@@ -491,297 +491,297 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5f2d050adddf3b888248897a0c162b8daf640270cab565554a7cb6ce01af88ac"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2b0a16b1a871c16bc9b1f6e81a9384da5616e0dccf8a051841f10c11b7c3b0c3"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "630fe764d726c172ccb984afbaefe32981c0a3eda7b55ce8aee9eec68042fea8",
-                                "uncompressed-sha256": "4b19b18c7310122d06da103b1f5b32f559dbdec2660d5d8f338d25b41cb4affd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "793507ecd9d55173bad180693e7097358c1264feb559a3c3f2557a936d58177a",
+                                "uncompressed-sha256": "a671df5d33007ac31a027afa91b8a6577baa654d502d65edbefd37e06097daa1"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "57aa3c54480b016fec7fa5ea0c64f8c8366317552d30b2b72fcae22d1f2cfb03",
-                                "uncompressed-sha256": "25897548dc73ff838160876069899eef4bb79200baa03b453dd91fd57bbc2128"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "6af7d773b1446823742d2027e6469b609e58a04738404478380588ef3e214e25",
+                                "uncompressed-sha256": "5993098aa4339d0ea5e63c14989418b5a2bd16b94a3473700fca31addc5491ec"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "0281f8c7470395b14a21a85844a56462010593c67f146a472820279bbbddef0a",
-                                "uncompressed-sha256": "ecbb39826bf13c107b265eae455b2e349b0389066d13d7d4911a5fede8ed1928"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "86fddf7ec8a8502e829c56de0280fa7fb5bafee1d9bb8bc72a4fc855ba9612bc",
+                                "uncompressed-sha256": "69ce35467a41cb7dbdc306d9c18fc2588505f585fa5b4c83f55ac56a8eed3bf7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "19e6c21b6928df68a97063b4dc786e764163a3913329e315e845fb63b58c7947",
-                                "uncompressed-sha256": "355d7975f0383a4bcf2dd889ecf526be4b0ab1974c55b507e7949624ffc3a87a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "ffe8860f145c55c0ac4775deeea904c2454634f4793d80fd957446a5420278fd",
+                                "uncompressed-sha256": "067fd08707703baabc69084b2b1af7906b2b2ed9233392a6c18ed539813e1f17"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c767df91cc1536517b3583c141c91b30c585585bbd9021c079e45f6ceb89b4c9",
-                                "uncompressed-sha256": "98c3373b012207c7b5be25afd7ef1adf4de053f4c07c63f3f00f0b5c3d682ab3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a0854943e5fefb38c7183a27443d6e45736847d48351c7c0f42f4f3c3cfade5a",
+                                "uncompressed-sha256": "0165349493291c2dad2b2e156b5dc8e02559d4f72ccfe2a31fe19337d274dc03"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "bba5cbe15cff023b8900a7dcad122ba36f3d8bd010cfc6b7fc3f207cdbe61e4d",
-                                "uncompressed-sha256": "d55192594da0b18d44f7e8309e9de027f9c64683031b6e60f38d1c786b6f9505"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "673f68d43b6c9e044a618dad0c479f9c64b55bf2cfd5a276b543fb39100aefb7",
+                                "uncompressed-sha256": "22ee81dbbf7e9c23216db69828e6c6e462810606fc59a212c4ffc5e2ca18f5e9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "043c0f5b36df230203d570a6f94efdbd8e37e23b656a3b50d89363db8076dc96",
-                                "uncompressed-sha256": "d8682452e02a48e4ea7b573c0b9c684f9f02b62d748efe295d9b884cca14d819"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "03b1059c8b775375ce6201f0327d8300c143a5c21f1b5743c0fa8ea6b0ff4f8b",
+                                "uncompressed-sha256": "eb5d4bd183cceb7c8b83e11b5c3e5c877d0f4a90638243c24145161b521d5d71"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "81c5065adab19e67bd98088ebc9eabfe356cf46b3a9cbf9e95621cb76b62a1a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a4556a1ef0a36f0a26ae036f0714c14015603f806d438f2d037160351cdf853f"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "6f77531c4ecc1f897b2b2cc965fbb486acc267770db203737926cab10a08e249",
-                                "uncompressed-sha256": "878b5bd6c30b81501205b42942b7288ce06635e1059814937d1c32a26444d5de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "ecc383d18b84d27b0541fb2a346946ed204d545cef3bc3e1667ac03ceb6af38a",
+                                "uncompressed-sha256": "99f50e0ec786e71c5232960501d716720c944c48b9503f29523ae80b04209be4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "9317c2f904cf582c3c5370abb993db3d4c70ff246348f61ef6860f9fd1b25a63",
-                                "uncompressed-sha256": "f2b302ab0bbf0ae2c04d60d57cadb237c0a647b69e358a834bf94cf7d56fdb80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "46985e5494809a42581b1766746883deb489383fadf4be1b61f4a2f2006ad28e",
+                                "uncompressed-sha256": "0929297f2374572aed1f70e8b8ddf1259a5d89996017ec499e76af4a2a15ec26"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "844756ad53caf2ec49cf7d3cdfeeb5157c4ed071a31da663839dbf9e88c413f1",
-                                "uncompressed-sha256": "0a3a36ee595fce227b251bb08c13221e4e9ec6550fc6a2980c3ffe55a94ff566"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4d5e5badd1ce61d8f02eb9277203c1db479f3f5df4f9b2ef509ce6641b324e89",
+                                "uncompressed-sha256": "e750db9fbb49fcc29ab5c9c569923df4be81469c146b6b07ef642f29cdf01483"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "1532f22756ba41e19c15401cca4c372a261e79176f1b34523573917c6d7b224e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "bc4eafe5db68514c4b8964ea3b48917b38d419b3e586e253c1a6ebb8973cc46d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4a0fba247ee002aca54f5c6e2aab1d6cada36221d9709bbdf0d733a264c490e3",
-                                "uncompressed-sha256": "dbd04c0069e94eb6dccfca19b6a099bd92880309f04ac3997e11b42ff1a9d343"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "276e48c46721631a3e7f8344f5b9c639768b6d752a247c620f419e1b96e8b1ea",
+                                "uncompressed-sha256": "cbdc182f5e5b9849874ab6865c5b18d61770e33376b0a0bdaa8acc5d9ed1325e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-live-iso.x86_64.iso.sig",
-                                "sha256": "ad1d6a905198f60cf40f9a6110c388c0ae422be23e9c8b15bbba6ddecbda35a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "b91e9e99c4ee663c7ef28a4c88be312e35bc60f7950d8a464bad9b4ba763774c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-live-kernel.x86_64.sig",
-                                "sha256": "609799621be031f9a65d31d12b1cb90f6fc45df76a630e40f81a45a12cd924b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-kernel.x86_64.sig",
+                                "sha256": "ea3eabbbf7a49ea0dc22983601f8a631cfb7b2b92515024ec5a0dacf5a717efd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "7fee030153c5d446afb26f670d5a5fd3c3dae0ef0b4ba09329e51eae39c6ca96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "55fd81f5a5421c65e42ac46014c144903ab312b7d99b70bf19af2299b72889f1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "b01b522fefefc9a3dedbf7e08489cf4c7eb568792917eed430f429fc7ea77b4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "6844db4a5fd6e505227684fb94a8d6403d1cd6e37253846528690d6804ca65e2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "311e2015b927030f8ad302d77f0caa1ff695e285fa9b5f00d3041a63c813eefd",
-                                "uncompressed-sha256": "923f683bc01790e3437d4de6ef4e5d70f7d903c0d09ff835d98bf1d6cfa33ffe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b1992bf86d7792a9e6a696d462a4045091c3ca13a31ef5ada439175cd368811d",
+                                "uncompressed-sha256": "2cd64bb8a3037f5bf887a69f822bd438fa7c841d59bc5bf72e7245a4cf88979e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e5ef42f3dc047c3efd7fa9fd10a0ac29933731d2c840cf9104006fb317bcd887"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "7dab0e0a5416deeb78d73af19c35dd9773790536ab9805c8624f5413b5da90c5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bc62f184d47818058adcce252fadb59605a5ea321e1b0e74c168d05f2ce2cdeb",
-                                "uncompressed-sha256": "ba775a012d2ac636557ee843147786ec04bfa9f2a828bd0a93c64b5cf7f9118c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "236cd247ef2bad57cf83274819214ab6ea35670aa2bd7404e20cbd2ce01ae168",
+                                "uncompressed-sha256": "f5aca6ef4beab4debcf6c9999ac088e50ac9a3b929ac6e0d5c252bb5db75a767"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "a2a7735343ccd2442fee425e8beaa7cc8da41fa50f681b77cb3064b45cbb0ecd",
-                                "uncompressed-sha256": "aed4679cef573a86738c86e23771b9a879f176df77b590e96ecd5d4ae31cf189"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "7fb66f45fd80e2bb33c5d1c1899fdce47b00c2abc9159f6c03f60a7ebd9c18a1",
+                                "uncompressed-sha256": "6e023efe8e769cc13223097be60694983096cba6f3d5d95fd9fdee43bdfb5580"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e02b4a764af9d1ef63c6088f6dc15a9f8ff683aa52828a9dc7fb0105b26c598a",
-                                "uncompressed-sha256": "63c6c9b6112e3d5ce69a8026a657e9c75b0943551c6bbadf28b77dca927b4178"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8ba06c2bd62a3ae92ba27052387e614f37469fdb799dd6c4c641b0596e6984b5",
+                                "uncompressed-sha256": "2673a57731eac3a22c330cbebbe88fff6342189a2358c8496d6b2b101d58a765"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "10348f0efaa5e0d8553cdfbe0f76f39bb5d866d43f0243e92623903f72dbe01f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "7dad69930770339a78095187483a9ef3ebf1dced40f85798eb10c8c2464a4263"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "6a210fdab170d6b5e01bb8141ba151d97d6d44894fbe89e6ddc52ae7981dd83f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "d2a1d86540eb788f0054d7450d87e75fb88f2b625ef9edb5bb66bdcf376d5c2e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250623.2.0/x86_64/fedora-coreos-42.20250623.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "d8c2ef2e9bf0b8d16391018b1ed190e43a86381c6341641f4b5adcbf2efe211d",
-                                "uncompressed-sha256": "1d25135bfed65ca294532078cc124053802ea645859e91ed726db1e5fb8863b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9900447add59b6678ea3e4ce103e5229c5b7f34e78bb748492a8aa252868ad5d",
+                                "uncompressed-sha256": "c040af950ac4952c8dd2246a4d389daecb80039c53eaaf5c968bc3acfdb00f06"
                             }
                         }
                     }
@@ -791,149 +791,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0365765103e2a6aa7"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0fd357a18d4ba758b"
                         },
                         "ap-east-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0f28c0e353ed09d32"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0494f234801d801aa"
                         },
                         "ap-east-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0f40ebf9ae0b7dab6"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-06ea16430d3898b7d"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-09760b8e7616819b3"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-00cdd7464bc5f8a34"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0c7eeb5f30ce81ec3"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0cdf1a2be7853e595"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-09d8225f64818c3a6"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-003986761adec4c44"
                         },
                         "ap-south-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0829b10261c704ab4"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0918c8c21dbfb1b56"
                         },
                         "ap-south-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0adde716943006061"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-004a7f1a67adfc72a"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0864e3deefd881d57"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-01e28f4bd652353e4"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-08240f518680d8402"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0b092d0e43f6192eb"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-015ac5780e0500fc2"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-065818c9f8c51b999"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-09986686b0e54af8d"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0ab0474a2fca52e1b"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0245dbc1c65e2f72b"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-03e7f8e6395a70cad"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-03d897688eeb560b2"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-003c1808115a66829"
                         },
                         "ca-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-08dc6c8e9e1d23317"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-02ed1420d020864bb"
                         },
                         "ca-west-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0287c3e58071c82a9"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0bafb415bb564df47"
                         },
                         "eu-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0112c7788d162feee"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-08e9aaf1f6f3801a7"
                         },
                         "eu-central-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-05fb2ad7918585c53"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-01f084208bc53a80e"
                         },
                         "eu-north-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-095db95623b92d290"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-01ee38121fd60da4d"
                         },
                         "eu-south-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-048d7e977eb76612c"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0a2dd922531a5061c"
                         },
                         "eu-south-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0a40d46bc086d2bf6"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0ecb88b9989d0a269"
                         },
                         "eu-west-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-047796ba89066d0b6"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-099fbe29b76551a6a"
                         },
                         "eu-west-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0e0770a7e72a7c416"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0d79ad6e5af1387e1"
                         },
                         "eu-west-3": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-02f220c95d43eed3b"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0a79bdfd35d588972"
                         },
                         "il-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-006a6eeed23a0df1f"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-07022bce2c84ba8e2"
                         },
                         "me-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-019a250e3d6453d70"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-004e864817a82f461"
                         },
                         "me-south-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0d27c5c075ac1f5dd"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0102a3ccf2e993927"
                         },
                         "mx-central-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-031655fa144e162ae"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-07643dd44cc9743b7"
                         },
                         "sa-east-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0c6b80873db845d63"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0e42b7145ba82814f"
                         },
                         "us-east-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0da5eab8a2d263fe3"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-03d27976669c84a34"
                         },
                         "us-east-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0f3ceeb7ca9bde287"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-041b2ef44d9b4c9c3"
                         },
                         "us-west-1": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-0ce7cd5f492089461"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0f8f308efb609437e"
                         },
                         "us-west-2": {
-                            "release": "42.20250623.2.0",
-                            "image": "ami-06df00d3349634bd9"
+                            "release": "42.20250705.2.0",
+                            "image": "ami-0e9c70032728f4d40"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250623-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250705-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250623.2.0",
+                    "release": "42.20250705.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9d9c8204775e78a6589eae86c7999e90ae169d364a972b7d1a5ebf0ad091884f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5f278c94564dea9e266582d66826d7121a4b912b3c73098182e6776691113b79"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-06-24T18:25:42Z"
+    "last-modified": "2025-07-07T20:59:49Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250609.1.0",
+      "version": "42.20250623.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250623.1.0",
+      "version": "42.20250705.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1750791600,
+          "start_epoch": 1751923800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-07-07T20:59:46Z"
+    "last-modified": "2025-07-07T21:01:38Z"
   },
   "releases": [
     {
@@ -137,7 +137,7 @@
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1751923800,
+          "start_epoch": 1752073200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-06-24T18:25:41Z"
+    "last-modified": "2025-07-07T20:59:46Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "42.20250526.3.0",
+      "version": "42.20250609.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "42.20250609.3.0",
+      "version": "42.20250623.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1750791600,
+          "start_epoch": 1751923800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-06-24T18:25:41Z"
+    "last-modified": "2025-07-07T20:59:47Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250609.2.0",
+      "version": "42.20250623.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250623.2.0",
+      "version": "42.20250705.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1750791600,
+          "start_epoch": 1751923800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).