### PR TITLE
release-notes: add in OCI migration to 42.20250705.2.0

### DIFF
--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -3,6 +3,8 @@ releases:
     issues:
       - text: "CVE-2025-32462, CVE-2025-32463: sudo local privilege escalation"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1978"
+      - text: "Migrate existing systems to OCI updates"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
   42.20250623.2.0:
     issues:
       - text: "Implement Proxmox VE (`proxmoxve`) Support"


### PR DESCRIPTION
We've now rolled it out to `testing`.