### PR TITLE
updates: pause stable rollout for 42.20250623.3.0

### DIFF
--- a/updates/stable.json
+++ b/updates/stable.json
@@ -131,16 +131,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "42.20250623.3.0",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1752073200,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
We let slip moby 28.2.2, which we didn't intend:
https://github.com/coreos/fedora-coreos-tracker/issues/1973#issuecomment-3057867845