### PR TITLE
Roll out stable 42.20250623.3.1

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,156 +1,156 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-07-07T20:59:46Z",
+        "last-modified": "2025-07-11T03:59:33Z",
         "generator": "fedora-coreos-stream-generator v0.2.17"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "5f6613c01f22426e386758c3b40fe753ccd3d6cc58c93608d908bb70e9a7e6c5",
-                                "uncompressed-sha256": "904b4ab0d10a20fdca2bb6e08a76a156ac146f1d8f9626645f40a6c99366934b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "1e3e7ed916947035043e0c39deec3902c2df8c13ff6bdc456f7d1014279bc98b",
+                                "uncompressed-sha256": "e3d2c33086fd82e4c9685658935271e455ccc5e0ee1bb0c4eb4487485f7aa629"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "02ed3b691df6d19461739aee94b3d805b3c7f11234eeee5d967859c3b5b12263",
-                                "uncompressed-sha256": "0413ab3207a8b1b6885ca3cdb7c316fcd18ce9eab1e5f2b2c6ed70368d97ec1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3b19135ebd43e9b8c75f4db84354c6e7bcabac3407df0236c6f615f808211008",
+                                "uncompressed-sha256": "7c0a0d21a73f1befe34db9ea9dae893d49ee4c31eee7ab1b156c442c6d37cf74"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "6a76605907f84c6e3d278a21d86f7fc6e85efb5186ba311a37f3f6a2699d8ab8",
-                                "uncompressed-sha256": "f0cdc7cd7a4c08e512476955fe11c6945c8eac5804a87698975fbc0a362580a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "e652818c645cce9f2d9d1f9a25150518b956c815b35484c7dbe844acf54399ff",
+                                "uncompressed-sha256": "8d52e03f2b3b5d8032d18ef44b46afacc4bd91e0e6e6c7af6235f6cfe127ee86"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "05e67c877f54af09d0b7e93b823879cd3deb53321f76a20bedde1079322c2c62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "152abb2c1981f667cdcb57b61c6e8db8407eaf4e1afe460700b3ac63496614ab"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "68f1dc1e13728abf6a22d5b5c47dcb8036c3ca56ebba0fce77357fcfd3fbdbbd",
-                                "uncompressed-sha256": "a4c776ddca6db8c74a453198e9416e033c4b3154d8f1bd97a3d2c57d67cbc9a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "5ae7fe6cf92632d5ffe7f6a4876d5f403f1c130c5429389afaa8ede2f9a2c3ef",
+                                "uncompressed-sha256": "95c1ac3b20023f4676d6cc12610190e74c5055e00568471ebae8ab7e42dc7a98"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "faa829de018bac316c26af3dede2a2ea872fe9697a80cd9e22bf0b41b815077f",
-                                "uncompressed-sha256": "93843bfe8a97351e5c2e8415340cb7a8566d7127b8b66b895ba551aafc30ead4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "7ce863e10431b52fe1ee1fa3d34d28feb539a57de562f7f49d8a7a9ac2a5f3a3",
+                                "uncompressed-sha256": "c33a700a55e865179f47ff4e630b475b9b55eae1a09569ced99f99dd9c2f4bec"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a97cf518163c1c9154cffbbe8cd7cf735703ae47c84437872e1a0956d415e86c",
-                                "uncompressed-sha256": "5cf4399e3714f501d0973f46482ce0c544ab04ef23700ff7721b10b8b9de80f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5b38211b57f581780605760f7eeb75deb2a4db7f416e6e5c120654d046f62238",
+                                "uncompressed-sha256": "987689fd37b42a32f1e93f5eea01122058d5b7a33cec7a888870a551558a0e2d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-iso.aarch64.iso.sig",
-                                "sha256": "151460342e963dd426c7c66a088497d40254a612c6b6a0365c3b5b031e6bf5ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "88b36217429c697103a5eff36fcd712e5f0d71b8108e666ccb1eb48b45db250d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-kernel.aarch64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-kernel.aarch64.sig",
                                 "sha256": "30f419a63aeba8bc12ebbe1ec5e2e98259f2f220d6491cc80cd0396d3666bf3f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "d260de2a80fc078d2cc8c235d756dd41ef81cabcad6e710bb4d205309ba2164a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "a0845e37b3fbee206c79447baa5270df79be770777c5ecbef74eb683ae153696"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "afe2c0394f0c828fda8f272f60fcf8f1c28381ae3da3bf48a17d8ffc68f178cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "53608e2afcfdc080439e949512715c76fd24a604cc71bf2d2c84b469e000f5ec"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "564f2f8f36316a89f20d6fcced5efefca539449d87f808c813941caa8d25e54f",
-                                "uncompressed-sha256": "83309d9f332d2c9e3b1c627e337c0de7712f5d086e62976b7ebe07976cc8e79d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "f56166b02904dd798f4e892ddafd30d3116e9982b76615462fba59972f983f9c",
+                                "uncompressed-sha256": "4b49a4106f9d8e667bdb850382101137185af92c1a22c5649fa07bb2f891b576"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "79072f5a1425b1a6fb4f3d178308b96cf72703dd1bd695ea8844c27d14d9ffd5",
-                                "uncompressed-sha256": "8a0e73a4fcd9bc299ed0bb63f132907ee37902f7d3901e33952004f188b0ef41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "af837200dda3f3a89d62c67af940c425c297f6feb9ef31b1143264de172052ed",
+                                "uncompressed-sha256": "90d0b1673ea10b486e408aab6d976a45a40121e544b290ff7df7b292ec381da0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/aarch64/fedora-coreos-42.20250623.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "b21132b03677fe65a2feedd0853de8820244a7fec013cc3a3025e27e9b74cd3f",
-                                "uncompressed-sha256": "fbd2717d159611d0b312a6b16b6a9155af9f0e1c4bce2fc9d3b76388aad386b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "bb08db8a942d7c878eb148312a9d7c37e8847a74372b7c0da5495c84ce139d3e",
+                                "uncompressed-sha256": "32f03993a1c7b4875acaa3cf896d8e10daa5221a543638b9fb6f95bf908150d8"
                             }
                         }
                     }
@@ -160,229 +160,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0f044c5028659b8aa"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-04ccb736010bf9a06"
                         },
                         "ap-east-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-071ece5efa5a300e7"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-09b5bd0ec1f12e8ef"
                         },
                         "ap-east-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0369ca7d8165ae220"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-089ff95c932707363"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-07b2bbd7da8aabfc3"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0023d1b62864bee8e"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-063ff4d54ba1b5b4b"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-014d52cb3b9cb7996"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-05455a889dd898a4e"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-095ee6c7e0f0de6c1"
                         },
                         "ap-south-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0a9fc1c0e4848081c"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0515d1ed3e52d8fb2"
                         },
                         "ap-south-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0814bd1d07a8fd031"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-05081322a1baa73e4"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-06c796dc8320d48bb"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0e1752dadf4460e18"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0fc7cc8f2ca6bf7c8"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-01b2e4a70788951e2"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0af6efeff05e48f7a"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-07fc73feec0104d27"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-05b0197a9a50bcb61"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-077436756565447f3"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0aa59395097be183e"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0c1a42ec3035e5120"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-095d4462a9ee884b2"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-09484ecbb45ee02c7"
                         },
                         "ca-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0021a0b3e8640d81f"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-04eacd1d7745f7a94"
                         },
                         "ca-west-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-08e7a9f4c7532bd64"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0f349c889010ade0e"
                         },
                         "eu-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0a73eeae952360c8d"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0cedeb921b15af019"
                         },
                         "eu-central-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-026f8adaaafb72157"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0fe21673306aa5303"
                         },
                         "eu-north-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0fef025b91e390091"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-03843fffd976444cc"
                         },
                         "eu-south-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-019b5d4130d25934a"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-048325fcfc8573bbc"
                         },
                         "eu-south-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-04b4c6a2db5df74ae"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-03e88be136a7fdddd"
                         },
                         "eu-west-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0207f87379e0dcc5a"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-085b76c3142d021ab"
                         },
                         "eu-west-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0030d0b210a61ac6e"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0bf990feae95cd3f8"
                         },
                         "eu-west-3": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0542c29294aaed8b9"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-094de50ba89232ef8"
                         },
                         "il-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-00e087fd78d98d48e"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-00a0ef6a8e39888c1"
                         },
                         "me-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-078595be77e8604b8"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-04a7b0a9a2bb072b5"
                         },
                         "me-south-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0500d4c2b7c2d4c8d"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0cfc44019b4ceb63d"
                         },
                         "mx-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0dfd46fa4d0dcf5e7"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-076690eb924f8d909"
                         },
                         "sa-east-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0d09145af193e58bc"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0d67b4e289dc6841a"
                         },
                         "us-east-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0014914f739d78351"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0d5a53b8f8629fc26"
                         },
                         "us-east-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0857026aca36aabb8"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-09d15e5beabf02fb9"
                         },
                         "us-west-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-041491b915040eb04"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-04570db530ff34dea"
                         },
                         "us-west-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-057973af140970586"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-008c6655efb864559"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250623-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250623-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c9d47d5e2728ae94ac8a7c35a09f0b89b013d611b0fc4c4c75183209cd38e125",
-                                "uncompressed-sha256": "ac610f1654887bfeaa58f34cfd4ffe0e123741dbd8163075072131cedd239f7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "39f74f59c40b34798ea19785621a5b687933eb01c3b3a10ec1af66b06ea4367a",
+                                "uncompressed-sha256": "95e07a371d7f1d073b18928802f3503c593a42559162bc4a2626a404a09f0775"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "454e38d78c466dc9c62575a9a19408bc81fe3871cd9363990fee5a777a8e314f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "78e744e41a2c1ac2f5458bbcf311559ae6a647e30ca132d55304ff7f613d7607"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-kernel.ppc64le.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-kernel.ppc64le.sig",
                                 "sha256": "d656a0ea2c2466ad732af7604b28fd3d48cd558a9cc8b09f6250730bc6bc4ee4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b8d7d9fabb3803ed2b096886e35126e968ede1906f60932816adec8dafe57b6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "72fd3279a1c4570a2595fb0c0900a8db5f5f66f13921f8ea7f5e05882ad52fc3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "5570d7521730f4b26eed6cbaa95fb1fbbe8f8d5c2dd885ef5b0fe98e78f24b28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "40920257edba907b54820445f07eeed3fcca1ed0f54de47c1f2e66fcc72658bb"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "e87345045c9e045ed64f4f2adb05903ba984b3f10d16f69f9963b76a005cba54",
-                                "uncompressed-sha256": "ab270a2243cac4778d81b79b86f2e2722908dfb1ca0983ba6757b70a62afb4de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "aa88e58e34dbedabc6cb895c01b68ea9eddfc95584bc6c864a56e3eceda9d4cf",
+                                "uncompressed-sha256": "2198e67e2b99900ddb7e94bd473fc1462bc75a1fa5ecb8d4a6e338dc711e8935"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "eb10ef8582571efd7f4b4af887df757fee7edd2ebb09fc2c76e84acddfd8fc3f",
-                                "uncompressed-sha256": "5c5cf8edc4f6712b1030964df011119494d02f4e97d61e3fd14b4fc9dbe6019f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "ea924d15042c2fa916542ead45e96911ce446125b0fd4717fd4989ba5ddf44f4",
+                                "uncompressed-sha256": "c98c1c0e41b0321c9a1db9098b9d8da7846e2ab31b44a9f0b713eed4dc24a2a4"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2c93cb2fc1900beb6605fd4fc2625d3416e0606f4571e004e7e2db5b659109bf",
-                                "uncompressed-sha256": "13466f2c6e9b9aeca31ebd6aa9e95fe55572d21104d9c7b983a493dc737caae2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "44cd53a907e01dabf0a44d0c5de2a6eafdc30ddd83275c8ae12d4cd4d3dc82b4",
+                                "uncompressed-sha256": "bf5d64c236c67750581df4ad7188da31acc3d95a737c6b89a4285c0f4f0278ed"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/ppc64le/fedora-coreos-42.20250623.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "71e62804053cb0a520e7b6e21e8ad481410b63cfa3002c4c8dc4c9ccf5e10769",
-                                "uncompressed-sha256": "cf952993f9e4f97e0604f79bdf9e08d59ad3159c5e74bf3c79e9ae691e798de5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5c3fa52056edc1377726de6e0a1cad0e609890e4bf5b8332af7b1ca0fae0b089",
+                                "uncompressed-sha256": "820cb2b346d5b6fc0636cf8bab8a8555d676fde1840b4b535df166639e9026da"
                             }
                         }
                     }
@@ -393,97 +393,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d52096cc58b34db6716f9580cc0f3400cd8264d037d8d4429863321ab95f5470",
-                                "uncompressed-sha256": "55407f4edcfc47746f2a9298a38735e1d78ed0249e9f47f9464bf47678a2a0ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "1da7201c5e45bb7703a47a5d32ee8112a68adaee80715884579ae341d783612b",
+                                "uncompressed-sha256": "7173b582a4e21cc777e393efd4a1d57f9e0370ddda1e2c3bc90f19a8070b2951"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "1704c38723983ffd5961eb525edd3d9d464e6a3ec08ef675cfbcbd2147fa32b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "65342b09b193d558133000c08507a312f30cb7cb64e9fbe672e363f4b94a5b9c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "c99b64d31db0e4c89c3619815c8d910b1dfe8463026564bfaebc26f8dacf324a",
-                                "uncompressed-sha256": "cae05ac546b4b3aeb499a78cf5472287c93be745d840746d47dbbe05c8da8c05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "adae9fc207ddaa3e692d7d98b6b8fc7810f01f83b0d2022b74f0f69f64748371",
+                                "uncompressed-sha256": "93b71b609205bc30e9695b78b8bca0ef2bce5371fd7f536f7cddb07c06100bdb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-iso.s390x.iso.sig",
-                                "sha256": "c9c1590fc9bcab40a7acefacdd59de34ae51901a1a07d8615ddabf2a7629bfed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "483cb59c9b646881a886d609229963c711f1f3d1afa98b9b5a6d1c999d62567e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-kernel.s390x.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-kernel.s390x.sig",
                                 "sha256": "1ca8038c339fc604bbe28a5df1c390a8cc9b70e00859ade0d5f1711360436257"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "85f1afd9c9e55f09fd094614a8e78b255bb47f4b28f03b89e6fa71e7ab709987"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "3014653fa714097818cc0f9ac9272ecfa662c958ae346075e2cba1346ea0862b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "6d3995ed7f88a50d6a2e91b355681a8b259a22f14f3faf44eb2fde69f2669b32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "375e48b6aaf8d5e8c067ba060b9a9432dbc0ce9754cd1cd4785ad2eac079cb6c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "58d5f6185cd61c397e5633cb005c5047c17fd6f36c077d1d4df121d0a07aa868",
-                                "uncompressed-sha256": "e4b661a450d53136c16667b05aec8c8fedfd4c48c71ae31ccf0e408d0ed43961"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "3e96c583af26001369a3355b0a8cdd0c4bc97cf2554b3bd5c8710c73f91bbecc",
+                                "uncompressed-sha256": "774aa0b6d29f131649dc5e9597d2f8773a384137ea3cdabd705d48bfd554ca9c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "57192654d7794e8d29ff1bf0ee55a8b9811799bd301f67d54afa446e74f0a37a",
-                                "uncompressed-sha256": "3c2b8703bf4dac7239fc3037a821fe82fbad9268d8bc0517159d18de45ba1e26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5cfb801738605bf508d1cebff591d8264e0911f3b808a0a41dd804482dd9d82f",
+                                "uncompressed-sha256": "3e463ec47d540cdad2c0692115c0f8681c825134b83b4e99656ebf5cf4827ac3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/s390x/fedora-coreos-42.20250623.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "c470377a1f33be9fb2745183942c54235b04715c23eeffd7f2375a77ec207fe6",
-                                "uncompressed-sha256": "d0ebc81039660c20ff4e888b93968cabcd018932387d2227f52ac1418f4b1a31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "cc82fbbba39467e8b31f5bd0fcf6245482123cd55e3bb0429bbb3e2d00179b23",
+                                "uncompressed-sha256": "b580ed5105f6369fbd8bf987ad8154a99d2120e0386d6f6357eca5b80ca0ee73"
                             }
                         }
                     }
@@ -491,284 +491,284 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ee00e63bafc8dc45393b4e7a7b8b26fc6c53b7e5c4a805523b388498cbc1f385"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1cae62a263a13c30d7b7d846e7b08576477b122a13f6d88876bba46dda68c239"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5df7bcbd786b035209546cc8fe4e0ed75916469dc06ec5dcebeba50fd0b1328b",
-                                "uncompressed-sha256": "11bdc678a3cd7124e26e564f95af574da3dbc30e1a8cad9bd3de9e45e6e0a815"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c4d99cec4ea04f8934ad366b8bb51bda377505020846427a93c453c5ee6e2324",
+                                "uncompressed-sha256": "b796151de41eb9e870790ef95da142f2431850e97c61bde7bdd7fa718c280a7d"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "0b2a75cecfc0eb60841df162fbac35764d2d4745833cf051689e10546f613369",
-                                "uncompressed-sha256": "02a0a44daa10bfc2475c86db7ab27d782e1cf76b0be33e657de7f26d1551795f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "d55ae047cf5e2f31ef86df64673eaa12bf1ad8bf0627188df3098d9b0585d40f",
+                                "uncompressed-sha256": "cc21f273b5e74f3b4eed021197f9af0f4d0173bdfd05dc251434c8768bfa3979"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2007826098a0bc17513b451e153bc5c4ad3330ee3a59f6093ebd94d317d4a924",
-                                "uncompressed-sha256": "92659cc4cd21b73e390e80124d007fe69e39b2e30080bd2f5aa65c6af1ae956c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3d98718a2ca6068f1d35f52e0045bab1db9d08382145d5227da27d7fdf2d526e",
+                                "uncompressed-sha256": "67ca5fce913c06dac15060dabbca2bfcd0914068b049d8dc831231e4f517bc4a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0636b88699dd2a5c91a02a58120723a735063acb0b0ecf5aadbfd3dc48f551cf",
-                                "uncompressed-sha256": "7645ab7298b49b4050120fadb0a21562080112fde9a8272623575c8ded83ad30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "51e8f9be547cf123fd4a23e3ed6786871f6b28a57f50cb16637466973c6b5659",
+                                "uncompressed-sha256": "5971c368af00f5da95773f5660ae551646b0592381a172c2065d0563e575afca"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6214982fc3fb7de9ec9bc6d3b6f18869bae1c5685a1a0b677a4a9e20f6e3f0ea",
-                                "uncompressed-sha256": "2a7bea6130b5c5d66e01626bcfe06c682596d6a0c9a846be59c7c960cdf75c29"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f49ba2fd297bc339c6167ee5fd5b6c02ff2040dfd1b51c4bb3692ea14e8e18d9",
+                                "uncompressed-sha256": "29cef395de53744ee23df912eebc78e8a940631888280a1ebc0c804e2028bcf5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "14ecd2d3d23dfcc9ff13c39a9503795897751a137214635f1e9109d677e410a3",
-                                "uncompressed-sha256": "c7ec545dc874d918ec5ad2580708b4068b631476d6ca217b55263791a462a08f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "5f5642599e5e65ad1dfbb13d354eb30ce9e70de76a97d22009598159ae868cd5",
+                                "uncompressed-sha256": "2962e58f3c57a052e84335e2599559cd8f9cd73464f9e6a385840b2ea8882358"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7b433539d54953fbb1267c545d122f5d351e9cc4a7492366ec7c34eec965cfe5",
-                                "uncompressed-sha256": "3591cacfc46dd20256b1928eb41ad719973286b6af08b71f53b74f8c2cabbe77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b6a9285a68bda2ab43b487e03be82f49e3546e39d527efd2222ddd24817e4182",
+                                "uncompressed-sha256": "27eccee074c4f63ce6b89d6eeb459a6635389ef0804a30dbbad2c3ac0c8e8304"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f358f2ae02a00b6e888fcd5d5071e073e762ba5b0bb1d025f39ee5a9a3ba45fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a6f71991bc427d1d77b218d65a72b0d9f48af84c930c7bf4042c2d620a84044f"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "cc75d9ff20e6e4c712ab2b87a2ddabb5ec06b17834a3cad7b4add249718efe90",
-                                "uncompressed-sha256": "7e7383df97ba2abf8f1fe0ffa3c601403dcef5c08456f6a84f206ed5ecf746f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "629cad534e72ae358840e52765b36e498348a0f4f5f88433db511e9dcbe7763e",
+                                "uncompressed-sha256": "99e494960d9d5a8b59f0d2921be7fc0fb5ce1b351dfe1a01b46b9cc21ac945dd"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "9c679616e37f6cb0488291808b76c594c7abc32a70cc8b96e51497f137608415",
-                                "uncompressed-sha256": "17219def5142010ddc29497785d03d5bd43383a84a578419e2213dabed708942"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "bb63efff19adb1e66a91a2f749892d149f8d892df6c63867175b115d3bf0fbd6",
+                                "uncompressed-sha256": "c400bb85f3947e2a29cb066db9e1a24c36c96c91261357f28059243900aa7967"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "66363738d89204f7d54517bd84684b5e3764d8379e8142bcfd9a0ff6e6f5b5e4",
-                                "uncompressed-sha256": "57e00549c051181c748c24e46966a26ca7cc3300b9becb72ac5df61007699b88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "61440cb835722800a52d97592994f98d44e67c334c494efb984805ff9ce48b26",
+                                "uncompressed-sha256": "7597cd70c1d298d4be8067e93ad6d8f4fa61de71b954b96848d51acf6a596a9a"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "13b7809c45281b2791936ade8cc5789e599e0eac034b526ba1fc0bd2b5c0670f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "de1479258388169807b4edcf7c485a1ac785c8a8b11499a1bcfa9e1833c73028"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4c2ef36452c49af89dd7910221eb0f3a3d3d41cde9c55e07dcf6215749017522",
-                                "uncompressed-sha256": "70a009fdfad7700b33192a8658b810b2b080b49038c8db7b754944d3a1fa1c8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9085fd8a08664b96fe42d3206ee5159bf634adb7df2d562509aa3027a4ea3e2e",
+                                "uncompressed-sha256": "d383b9bfd555893f91b4dcee88e9267b41218efde81eebc2f3ff34b87525b728"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-iso.x86_64.iso.sig",
-                                "sha256": "974d2e284e21749d1f001d0ab5872d93de3d0d37f454a7848617e1f1574f554c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "ec580d38a8f108b3cc15c5b9bb4b571d114531159093bc4b45dab88ce0c3fee6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-kernel.x86_64.sig",
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-kernel.x86_64.sig",
                                 "sha256": "609799621be031f9a65d31d12b1cb90f6fc45df76a630e40f81a45a12cd924b2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "29c9e2c6aeb947c66e3b503466fba4e548870d4751b52464b8dad5c0ea4987a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "9c1befdd6018af5bc32d954d532d3232e05639616f8ba99526361307600a8b1f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "006262630fe6c49a8f49e35f21d8d1077cc6abcd3a9cdf14ccd4c615e3171397"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "a4155ffbeabf1c1eec46bd84fd407379be1017c6223d20327912e9ec4af795c6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "755bd9249d1fba57343eb2ebd358a4443bb020ea9fb9085654c16ab9a359400b",
-                                "uncompressed-sha256": "d0b1ba8c8ad7c1443730dbc44142728a9089eb0d148b6a866270140839580b39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "97a75c535fb60fb8395f8e3abed4cee9552be3d0d034b0c6d13219c37f4d76ef",
+                                "uncompressed-sha256": "b251a357251debca48e24b6b22927fbb738df24aa0f097d9931ead5bb8969185"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "fbfda676f71b2b321fc52e0c0373c418244c8d2a1bf82d879179d79e262fda7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f885a48fce6ad29c12cf95ad35d8c9050290ed52e4b6ac1a9eee8b59c799c0e6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "c66a1f7a2c0057ae5179a42b75df508ad285b64f11177290bc201fc45d8414ca",
-                                "uncompressed-sha256": "c59cb2daca57ebb0cc383ca63d17f30cd410aaad1be3c4283d8f6d06e8d2b977"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "746bce3f7e570605335fb768bcdc746a7dbb9ea4b74adff0ab58a443a8587c5c",
+                                "uncompressed-sha256": "364e57c4eb8c7c901a0d224819a1e699881b22420055759324fa4e54a5a3eb96"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "fcccbb0a57411dc32e4dcea9f0dc0ea44557098a9b3c5bd74d75f26e2616f113",
-                                "uncompressed-sha256": "fbd5123685f5e90579965fd028fd168df04ed8b3ba8253cef39a39a53518e94c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "a3176646ea2bd53d2905f7af9537938038a32d49a7e318abc3a9e3ed1ea1e0b3",
+                                "uncompressed-sha256": "0bbf2f3686d990059ab98bc51da590cd337131bf00fd8eac788240c18984e39e"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "178aeaf5b31af32f06f71aa7b8d821cc56d62ca4463502e9a5eec2656c378f58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "9182cc7d7119de5fc5ef3738e0cdfe912cd3f71e0f9f3ba2e93fd34412a69699"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "775c5ad6c0630a790d3819a273e8766b735ca995167bb52c9c2a4991c85a34bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "7ccbaefe19f3eb904d15aca997fdf42dea09403822a89947cc211f2226da2690"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.0/x86_64/fedora-coreos-42.20250623.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "3ccef8ab0a6ebffce31c14cda7d7a9e8082dc87cf855c1b707719e860e6ca9e2",
-                                "uncompressed-sha256": "402e45b2644c30d1c8b4ff35562c3ef19badb942f03b988133a50735b0ab48e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7ccb0b9f9e04a960f9915241ee7f077ed7756905f6378009801addd1617070ea",
+                                "uncompressed-sha256": "0129863dea095a02f9eea631560c5e539157cf6b014cb7e10bae46108f6fd53f"
                             }
                         }
                     }
@@ -778,149 +778,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-08bfd7fe5c56edbf5"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0602f114f7f43d644"
                         },
                         "ap-east-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-09e79b270408ed64e"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-09a278a14a1eca69d"
                         },
                         "ap-east-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0cc3a61e89b40935a"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0298fd80e4623c7a6"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0e6efa1dd6aed3140"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-052cdf5e13576a6d1"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-062184d91d1f14bf8"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-07d6cd4775f8eca76"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-09bf9a40eab8d4b24"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0fc8d3d70b0536d12"
                         },
                         "ap-south-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-048f641817a8466a1"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0fd3644cea15c228f"
                         },
                         "ap-south-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0105becac41dc9c75"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0fcfde0fe4cf741c6"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0d61f0a88f7bd6252"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0dfd97cb80dcfd82c"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-002669e9f165ff12f"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0a0f1403effbd0d82"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0551adf1fd419f8da"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-00eb00f8653eb3066"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0237ea1dcce9a8308"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0d270e0902514b8c6"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-09df6a3da49b6abc4"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-01c1fd6653d29d126"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-08d37ec19d51f82f4"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0e197902e08c428db"
                         },
                         "ca-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-055f762788142a770"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-05c53cf7012fa2877"
                         },
                         "ca-west-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-031888e155d272b1b"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0965efd51ef5b6dc2"
                         },
                         "eu-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0bec4acc7a271fa60"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-083c170f1dcc24532"
                         },
                         "eu-central-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0e624662636a60bf7"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-03c5cc8868b9ea45d"
                         },
                         "eu-north-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0d1634da5a5c8d70e"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0f7978257f8fe73f0"
                         },
                         "eu-south-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0d906aab0c7286299"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0ad1367200ee044d8"
                         },
                         "eu-south-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0d96a0ba21ba68fdc"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0547b3df54cb7ad29"
                         },
                         "eu-west-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-06c663f8e2a9055d2"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-053655342641ec790"
                         },
                         "eu-west-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0c2a0fbcfa902cee0"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0f8fb15f48f18fc67"
                         },
                         "eu-west-3": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0206748a1ea7ceedb"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0218476a8ad010bdc"
                         },
                         "il-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0720bdd9203554a9b"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0b9b6fa88635be8fe"
                         },
                         "me-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-045f33f091f2af3ac"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0a2edc61174716529"
                         },
                         "me-south-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-05699bde06643926f"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0d6aa2b81c05572be"
                         },
                         "mx-central-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-08189de7839d61824"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-061bab686750f90dc"
                         },
                         "sa-east-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0816c13424e706657"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0ae4e44d9424c1ee5"
                         },
                         "us-east-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-04c7b9f24acf1f8c0"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-0b03c9d9e96494899"
                         },
                         "us-east-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0f4b01f1245f11be3"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-091412c76ff724da9"
                         },
                         "us-west-1": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-0f501c6a2f5edd801"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-039d988728ac8d633"
                         },
                         "us-west-2": {
-                            "release": "42.20250623.3.0",
-                            "image": "ami-079e19c3e7ffb3278"
+                            "release": "42.20250623.3.1",
+                            "image": "ami-01f689e43a9212d97"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250623-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250623-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250623.3.0",
+                    "release": "42.20250623.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0ddd3e90becfa2411052307620ce40df860514ca24c9d70957083462988a139f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:636be09cebeea7bcb4fe2785e40b572d50622422f699506803891ebb89e43bea"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-07-07T21:01:38Z"
+    "last-modified": "2025-07-11T03:59:33Z"
   },
   "releases": [
     {
@@ -129,6 +129,16 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "42.20250623.3.1",
+      "metadata": {
+        "rollout": {
+          "duration_minutes": 1080,
+          "start_epoch": 1752224400,
+          "start_percentage": 0.0
         }
       }
     }


### PR DESCRIPTION
Requested by @dustymabe via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).