### PR TITLE
Roll out stable 42.20250705.3.0, testing 42.20250721.2.0, next 42.20250721.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,156 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-07-07T20:59:48Z",
-        "generator": "fedora-coreos-stream-generator v0.2.17"
+        "last-modified": "2025-07-22T23:33:06Z",
+        "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ce6c2a0850e895da6523d37bb81e99f533af4f82cea33e5e8de7179129c9a221",
-                                "uncompressed-sha256": "3a51965b3c5b34c1258c1be3a8c572519613ca5cd2839250e073d8f5528a50eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "e9629140143420c377b3dd58921896d29171cc2da8380ea28b23b32016fcda8c",
+                                "uncompressed-sha256": "32a8df989436fdbbdbefb72a2fb6fb57bdd8df629b0d11cf5ee4ba6f34948df3"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3b8554eefa64344e1560ddfa7c7472189530d937dc6a47f24f04641100ca8331",
-                                "uncompressed-sha256": "208c311090ae764f73344aa235de413614fee485302b9e5a03d66059f28e375e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fc5545e0d18377d926494c689f02c985f906d75cd8a64e66dfc26807706970e3",
+                                "uncompressed-sha256": "7972c6409c7d070feca845ca6de51df07ef57901ec664b1adec9df0e3859066c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "4560483be8ecbf8a02e679c4a9101bff3638deadcbafc3c490aee5548270d43f",
-                                "uncompressed-sha256": "ead2c18465c575760e6f179bc7ea6fb7cfd0440038c895aa7d8f2637135fb719"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "cfec6e8c32d543361374c5608febef9e2bdac524d98bc5887824e77e63d9201e",
+                                "uncompressed-sha256": "89fde7e2890806f1c7d17154e8688848ab5bddf3dba0c2d8af862a85dc6f9f85"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a579ce7c14aeb18b2c5c20ff24202575ef9242300d800e0740527466d5eb37dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "69739d5693bab0263492a963c376095a1071c27f08193e9a324e9c7f31c9bd79"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "76a858dbfdc7b474b0370c1e87392f0f3ae5c844a60e1258d98f7523f96e50eb",
-                                "uncompressed-sha256": "b73a4ec8738656a75637582d35d81d240ca52c59bb88bdea3fdfec22eb601f55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "4042266d5b86193928d512d57e4a0c3e6823f26f5d7998a0d74f7bb3fc866503",
+                                "uncompressed-sha256": "b4710e9451f2b734131c073f9950256443fd06c6797fd9d925736c58a6e4afa4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "f1494306d76a7d99452398affb2908747acffa3d3d29e9762a955e9ac6e09dac",
-                                "uncompressed-sha256": "190a0afb91dc8ba30184862a6a45a6558c029ce63b8676903b591c39d9ad4d32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "d35e156d7c7d009e4e623580ae51b61532a6197eca44e1411a59fcb24e504aa4",
+                                "uncompressed-sha256": "329a38531f54d4de256bdb0a24157fe710942cc441dc1b40fefdcfe5f4f4246d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f52478d41451612c6a5f207b7b21f663c8d1e1470704c691b177e5ea95b7791d",
-                                "uncompressed-sha256": "8839c2956a4a7789a4d5a81ac57c2a06e7591e312b2977c435b946db11a89830"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "42fac335110cfa80ff3c46dabedf70418553379f273bce5cb8bdcdd2f8a31a69",
+                                "uncompressed-sha256": "ae91b325c0b13bbaa06e77443c4168a472c71366ba203760cf65e9af2041ea19"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "e3f0b2bd96ddd023424eba2d16563a9fd9edd0a128c1ef3924634636fe74aa63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "79b0bd0f142d594c74db4e7dac71e97cef7d763af450f45192f72d14042f96e2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-kernel.aarch64.sig",
-                                "sha256": "912f49b916e957d4c27ac0b4152a41373369fd9f538237ec7486ced3623acc87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-kernel.aarch64.sig",
+                                "sha256": "12b26d4425c80080c89a0efe02c64a41ea5b0b4843abb5297a8e17da894eecbc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "32f7bf029b46b48145a34dc3fe80178cb5696a4752ad41feb52e16ccab3eaeba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "af8502c80176da92c14f4bb95da4129ea50b8e3c73bb1342f0fbe9f1ed214729"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "262fe486031ab419868a4cd92f4ad6df59b7bed8ca7680e6b5d43f9d36e4d640"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "3028f189c2c0df86ce548cc78545a26ffed4ac8a136c61ba670985c74136cb74"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "9e824d28855d84df74928462ee7f8096e2cce7343bd589cf8eb39f2b66e216c6",
-                                "uncompressed-sha256": "1ef27c714d3060d941db62980489812b01ac8ebe9e8eddd254fdf1b93b38d1be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7dd18fb42923fceb57fa943e7eea153602dc7737aec8076171d9895de1ebdfcd",
+                                "uncompressed-sha256": "2f828c1e9f26b408e67cb921b47790d9ba53481e5c18ca6000c33853d0f62cc9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "3c1c876d1acbd91672baacd63068deae584c7582174e6eabdd5e5b10bf872f6b",
-                                "uncompressed-sha256": "d6395bd2b9096813b94f5036a5300868f3dda62473c419450099dc5ef2923121"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "95452e297e8e6dc1b183c62ebe8998975036026648f3ee8fa17e91b14cd524ba",
+                                "uncompressed-sha256": "9cb5e2cdbb9b91e7de2f07247f4567b52e21a7cd5ef42cb4e1aeb084871de295"
+                            }
+                        }
+                    }
+                },
+                "oraclecloud": {
+                    "release": "42.20250721.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "eaa1e536fd207c154310e635a94193775b69f16460643a7ea40735432dac42a2",
+                                "uncompressed-sha256": "2f40009393ab8742da0006493810608281facb8b3fe7280f2802b8d6cf9f4e68"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/aarch64/fedora-coreos-42.20250705.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8438e4f4d207abf1a0996b666289d5491b259c862b73c0add92d6bafc58faedb",
-                                "uncompressed-sha256": "3d32c5c1ef82b7487fbf8e290cab8380eccbde03714f14afc66e646f5fd69e0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8735f28615f16e9df2ee5e17fd49f6aff7c0e265ad0c64ad7df3e2279d338815",
+                                "uncompressed-sha256": "f608c46b6b0774a89e45fa851860f07b1c10ff30991ed87cf9cddf542eff62ba"
                             }
                         }
                     }
@@ -160,229 +173,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-086170f4d67d29ed3"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0329e219d23e9401c"
                         },
                         "ap-east-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-043f1e5d8100b1024"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0b5cd98d7041e47f3"
                         },
                         "ap-east-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0cae14d9e457184ed"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0c049ef12f28b70e3"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-032f38bf1e86b4a38"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-097f2af169fee0094"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0d9fe91e2a6e669c4"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0d19cf96ebe97e09a"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-05a69d3758442dfe8"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-02bb7162e88509ffe"
                         },
                         "ap-south-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-06f6a85a690308393"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-08b58a257eaa608ca"
                         },
                         "ap-south-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-064c96f91f7f27e93"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0ff4c61d4a337f5f8"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-06ed12fbc3e2b2d7b"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0e9757b38601bc0cf"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-09bac75ca6bbbfd6e"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-05681d5594395ab39"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-074b3ba4b01fed8ed"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-099dd34ca92c19cd1"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-07fdf04c5b29af9a1"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0cd4c4442b6ef7ace"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-04898475dce763edf"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0168d1d05f4afc787"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-08242e87aaa6d8119"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0865ed7e3a151cfd1"
                         },
                         "ca-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0eb31b15f7f051c6e"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-05f8f885bbeead004"
                         },
                         "ca-west-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0ba39a01b59ad7c24"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-04351a3790ffdf8b9"
                         },
                         "eu-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0ca683b9b9090ea7d"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-036d94f8dcc9882bc"
                         },
                         "eu-central-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0ef885a5b15557e45"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0e767586fb72850cb"
                         },
                         "eu-north-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-002df0681008b461c"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-04d2c76ae0260827c"
                         },
                         "eu-south-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-09e3a121548c2d6e9"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-04c465252049ab841"
                         },
                         "eu-south-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0947861511de5a10a"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0251bcac75948ddbe"
                         },
                         "eu-west-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-032d350622b8dd193"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-00f406a9807bcaa0f"
                         },
                         "eu-west-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0e5decc39b421ee18"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-044a6eafacd6f8eda"
                         },
                         "eu-west-3": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0f0de42d3b1866f66"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-05b1389bddf30e905"
                         },
                         "il-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0c81ace74afd67df6"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-03fb3c215bffbf003"
                         },
                         "me-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0d4ca495a30007954"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-073bc4c6de19d6695"
                         },
                         "me-south-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-07f6efda90301f9dc"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-05344e0ef958ba871"
                         },
                         "mx-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-014254f6f6cdc486c"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0b2e3c0551b6db1c4"
                         },
                         "sa-east-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-06535abd25ecc968c"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0e956e23580a147b7"
                         },
                         "us-east-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0574816c35e78d6cb"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0ce33f34aad4cc587"
                         },
                         "us-east-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0d169f97e49d47141"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-09a6b7a9cda2ae83d"
                         },
                         "us-west-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0f3263d57abca114e"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0c165d9d596e89f50"
                         },
                         "us-west-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-05cea87827a774111"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-04056d5d015e9a400"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250705-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250721-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6fdd92c05c3f9ff83df69210024925b65ad3c8d49e9da1a0b122356588d744f5",
-                                "uncompressed-sha256": "22d52269c1f40199f849a5f65b0594fe439c81268375d9f0d1f5d5ca80f4aa53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f0cdfdb3f7fb9a26fd25551e10d4674e0fc64c6c60dc9f2b6b0396ef597191fa",
+                                "uncompressed-sha256": "174103993ad34c950a2538e3ac64ecd6f58f06a817a1523aa6f46dcbe8059a38"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "f5b2fb5a91a09fa240cd85e9f0f6c0f7a3e77483d69934c9df5fb5aa6e3acd0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "76e2d7784130b1662de4ecc85b4ce47c598ad404ce20bdb68c1c371e97990af6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "07caeba85e4d5e2aa63bd6b6dcdccb2fa03a9483c5af5003a6964a20c77a4bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "4551f5ac76b46cfa79ae7e9a40f342433d5d8269c8fd4bf3121f33ce45e30250"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e1c9b77837a9853baae9e62b240b0f448e5e685508241e9d3c0e39b36bc61f51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e87e404c2fa1cb7c1448403de86c40256fe8306a62324e50e4b3b263498ce021"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "dba248bbcd3b5c025d6ce4f1fab1e5b6cb58bfd55562a2b44a19f02f24f00076"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "8a49708cfb818e46dea40abd1f71e013b48815c354886196d0c728fdcc572e84"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "41b632cc32572736393233748eb863192a7f1d320654a434ae78cc10910213d0",
-                                "uncompressed-sha256": "09d496207500d9bf8861730284bb1cea251f70e840abce3b732e1d81dcaf6848"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "057a7e047400bee70edb31d40a0ab1679e2489d22acb8e4cf760bc66ab451241",
+                                "uncompressed-sha256": "9a0d5a0a36600b479c7cf13568d0706bb2c031435ff037a909d3ddf19f99b147"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a0efa830256b80a902d40e9fae4468c014047da5915bd3f200f9c4ed1a1bfe3f",
-                                "uncompressed-sha256": "a52ad7f17be83b30f7d2c2c4b3f65d5d66ffb8fa041dad3d7f5939a9e72495a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "024bba2c9ae15045887dd57492a29ed6ad09aefb298fc0a18fa05e03a53eff3d",
+                                "uncompressed-sha256": "9a5b5c914b93de3d17bd43ef31c203e57e08484e0e0a019521c4b73f23953720"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "67419f637c018355c0720d35dde4969ff9702380f48b060b26db249da4208812",
-                                "uncompressed-sha256": "ddce62dd70d554348af7597dc4d99da068cc66737114d33a90f652b2d3c6ce02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "b0c97ccc7fd49b0a55fe9f55a2689f4e999f386c58ad22d5c28fe01731536ff9",
+                                "uncompressed-sha256": "f612cb3f8128f04f81b05a5b26244b9ce5db56a9e23126e1294261b9d6f1e9c8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/ppc64le/fedora-coreos-42.20250705.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "1697d42cd4960658a2196848be4806fafeafee922bd813fe968d41fdd808047f",
-                                "uncompressed-sha256": "77d8eac51a2120f8e2edb6bc01530a07a5d0909a366d8bacad86d624cc71f71e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "11293101fb77eeba34db1422a42f5dcb1637b48cde84f092ed9acdb58c85458c",
+                                "uncompressed-sha256": "d8f7aa2980967b2e9c0d4e2c3bc6719e21d560476980fae3bd3a167c4c2d1176"
                             }
                         }
                     }
@@ -393,97 +406,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b130d6a70c2bf8f622e4e28db0926a033229ef320cb7a0da81927816bf71c0ae",
-                                "uncompressed-sha256": "ded2a19fe09c48906535d55bd0ec476fe98d3f64eaa0f86f5537846fa1709b89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "fe6be376852de0161a9ed31024a55ca22069fc9e7391b56229ffaa61cebdcbc9",
+                                "uncompressed-sha256": "48a564c151f626ed33d6928c375816bdd2b203d1d1816557f59f10247c813ece"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "2ee9d0f62cd6ac033c4022af9336db7ce953287e08a7c193664625b16b87b36e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "200caf2dde90e427ce7f5c203b7c0017f7a905b14fda099b07509bfa4524dc5f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "56bc7f99e50593472e1ab8d780d047a5b7421a8686aadafcc4e43090dc663e37",
-                                "uncompressed-sha256": "2dbc896b498a8267525facbddab113a52c63a18111107f975e383a2bd4a2b4d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b01be538bf85bfaf123bb66d93db624a275d852c1e38b1ffeeccd2dc58ec9fde",
+                                "uncompressed-sha256": "40a8ed1f7185aa87b76990f418ee6c15d2df6b01add782f96de05aa9962d87c5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "91f2719c9389183a8d539abf4d0d70f6e47b941cc45057522055f84b1bce42ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "1aef470b7cc6f69a1721495a8635ecf350b7b7940dfe293ca54d9636db52c952"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-kernel.s390x.sig",
-                                "sha256": "6b39b4f1186283d9053865431c8ba5ace49fb736e78428f2734247ad7ff86303"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-kernel.s390x.sig",
+                                "sha256": "b357f0c6f4d5c1b25ead6d2779a45919ea0a34539cbbaf5ef547104dd3cde83f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "f9757c092224bd906d857a6754824032b13c18ca6d1155fb981a12cb10a50afe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "f2ea8cf943e3db8fde7e8dda70b61ff19a22b8933ce1d15957f8bc7692c038b1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "cc96f2b2df35c053a3fb9c27cfae53a082375b66f0d490763f01e0818b5212ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "691868c70f4b1d5b7ff0544fff98584a3d443da0d2d3b97b7c683fd4d3f39ac8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "4ae25efe50c25920e634cad4305bc79aae011e5a8f6afa10cb757d59527576c3",
-                                "uncompressed-sha256": "aefe0a858ca7a28dc12ce9dcc70e5d32ff33c3eae88eb8bdd637e92e5e0bc565"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6a653cd2bdded28bb29b59d95bc54ac582e81b4b573295dede7130b65d4b143d",
+                                "uncompressed-sha256": "c35a17c0b7cbdaee0d0cafb8f89bd5194b79f4f4fb79eefa91ef05db87a505c1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "278e5e5f19de33e15faa12fb77afea752b8836161e367f8c2298f1afbb3a3683",
-                                "uncompressed-sha256": "5a18bd23f069676d9d6b6981d7c1166aba8dc4b908da53d5485d239913ff2245"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "07d1b7e342329d9eb1b97673a3e2c595a5cd3112a442f5f56f35c117387bc466",
+                                "uncompressed-sha256": "46ec8b7d44105e4f5d1fcdb0abb4911cb7b0cabe795cbb998923ec4899a71515"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/s390x/fedora-coreos-42.20250705.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "bcf59be9e1df8fdbbb6eb5aa5a8f2accfeffbb4192f26f06b73e24276161ca84",
-                                "uncompressed-sha256": "2220b9b7fc49297eebe4263e86d06c5ecca264c1308b869ec2cdd2042434e63c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "87949a63e93a96f23312a392dc09f7eb82de43bfe0c06391d099dc1c004bc143",
+                                "uncompressed-sha256": "cdd23f9b013705ad6e13e53312dbe300542ed2990314a123f031d581a4cbd0c6"
                             }
                         }
                     }
@@ -491,297 +504,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:680baea7873dc36588d7f0562416f0b268977c24db94f3adcaedd09a3bb8b87c"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a39013ad228aa89d9f9710fdcff3f265a57d6f7602aa420867b2b4b5ecdd9727"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "36b279394e2bb6d73c346874c83b037a2b5ac29b7df515067b103e76d77fa72c",
-                                "uncompressed-sha256": "fc7138de60f8cc1ac0e9d35bf88bc146a11c562fd1d6f1e815336e20b80988c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "86ca06026181d9d393bcd91ed7247eecc2cb42df55f97afddc0e2b42f8f260b5",
+                                "uncompressed-sha256": "1a6ff198ed82885205824a29e3e69de21e96e27214e739d1afdb942704eba490"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "08f57891758161e5a57b1db68d96d5c7044a95bbcb73a573871087c68524bca1",
-                                "uncompressed-sha256": "434a7d34c5592b1d81d07955cdd3b1f487837ff7a2dc16ffdfe8f67cf5600580"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "f69c6a3d791ea39557a423f3beb9e6351c2fccb52db1e00123f6f5655aff2947",
+                                "uncompressed-sha256": "5ee2716a375c12ba639cd92ab5d34b7a2eaadf7edd1094e81959fae66501835a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "47b3f555f60123eef5f3f04db4426bb8073dc6486603f001688fce366e02e0dd",
-                                "uncompressed-sha256": "cfc231886ae762ccc03064d01ea0c9f2683fdc86451b7ca404a00d0624fe84a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "44f4acb4d341bea8d702b2763a642f7e6b40400cfe45c075d0d3333ae25ff2ec",
+                                "uncompressed-sha256": "4318ddc3e5a14a2fe6b8e8f348dcecdad7bc92700ccd71074fd1854320e4896c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "8e483c9f89bda3421a255652b4ad963c123cf0db523df3bf9089821ed183835d",
-                                "uncompressed-sha256": "dc5cadba87e10aa12fbccfff2758ca10b5fecfcb0b8a5961c8d05f74861f3a41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "0993b9d3fe62c803fb64890e419ad90b9d1a86b10a5ba773e5fb89078bb5ad07",
+                                "uncompressed-sha256": "ceb4a20ebc3a7b6aab9db6612b737286a74b09cad0732bf94bac8afbccf5bf03"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c287126e42819a50802b051e41446b725a56d02f9fa2f595a4d4b18cac50b91a",
-                                "uncompressed-sha256": "78f37dd9db6fe2f16aeb36aca236fdfbf8bad696d2de3d36458962c402215ab2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "00a8424314cdb57111f6d60105d13bbc80d5db0786ea6a8b391480872eb1437e",
+                                "uncompressed-sha256": "43a4ca8bbbbbf4dfb413cd3ef91ce1cbfa5512b01f8e0d9bdca48984048465b9"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "374b9d05e57f268290bd8747aa3167b40f1ec555a1f0f12ea835a6cb447c5081",
-                                "uncompressed-sha256": "2bd24368cc58563ec949b7c99c911d5100d268ea152b33c454e525d1f5261f4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "12dbe8a12bbd922c55c1f8c8c10368ea9b88455fc6dfb090f5b72e6a84f1dac4",
+                                "uncompressed-sha256": "6037b7623858da5aceeb41973036b7345451062642f423ad304d6ece755e0f08"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "225bf663aa0aaf998e4dedf44c64eb349f65b954a905ecebdff5ede9734f648d",
-                                "uncompressed-sha256": "1d5b35f175c098f64829036f94e51c06cd4b75a18890d6da40dd5ac233a5d233"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e0d80cf73479bb0a9eac7fab0012677aafb9af6c60a1ca5fdfde1481f01f2ef7",
+                                "uncompressed-sha256": "372bce96988b12e215c9f844b27f142d6bfa26712bd71188d3b46744b830d829"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b561d00078dbacb2f31b1a2de131c44925c3e0d3da036679f046ea5b6ab4f3e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "945367a6e1c5eccc6ec3af1273830dba754fa4c25c04d673f19b0577795ef3c8"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "c1d4eac1238326b3b12bad82c3e58442bc5872f14ffcafbc6fee726c2dc11a36",
-                                "uncompressed-sha256": "635f04fd778098e0c89840562e2e52c631bb1fb587fdce427ad89a69fef3717a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "4b28a0870c63dba3f05f457cfca634eaf49a42b3d4b1f87508a57534d74e30d2",
+                                "uncompressed-sha256": "a837012385e0dc857ead8f616ab56dd3a65f3da2dd0d6f01f1a527fb26f6816d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "bdc7598a97a7df4f5a842c6df5880c5b2da10926efa8fb024ba411278bc6c319",
-                                "uncompressed-sha256": "c8cc3340046313415670903c1431d441fa3b803ccdfc114f2167a67dde7ca1b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0234724043d94c30d9313c3531af4af23fe1b21cb4ed8963771cde4aa575c4ab",
+                                "uncompressed-sha256": "d11fe7c627993fd92176d53dc02e1e754558cb304a4f44960909bb43f2dedf39"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9e7bcee8b95d44f366561901c93f3dfa4c7ebd4927af56d172a3c88f7dc3845e",
-                                "uncompressed-sha256": "586cb817f93513ee8cc9e577c2c9a905de5739ca6c797a1e3448ca249bb89c34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "338fe4697e2d32aaffca58d074d3c9f57c7624e4e879cc2d9591e7e6df1530e7",
+                                "uncompressed-sha256": "b2e4ef316d86cdafdbd819bd214b1430a1a475fd1e788784ba7ceafb0bb7f8e2"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "17ff50463e440b928e16bc2dfcae39c86d65bc1ff72caae52669fafe631b4190"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "aeeaec95c173e316c774a107382b24da132641f42aa243e13377f41932537f41"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "42ce58328ae51ce7eaec07b77fb880f4a33791df7837a105b950bee476a70118",
-                                "uncompressed-sha256": "c4fa0a65eea774442df019f297c78ae1430c484126e69a535b60fc379e632e7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "64af75ecfcd5a4aa018f388488939d5e0c0301d729c4ab3490f7e66cc89451b5",
+                                "uncompressed-sha256": "604ef51ef4a13f31c04584976b659f3347f4eeca97ee4ebde067cd018522a96b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "1a07957ba8fd47e5263951fb0565edd17f33c0a9ec83c5e4a8e91bc26616f28a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "c4da249f794942f062c3494f475f5523fdded69618c38c0b596ee0b3c7207558"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-kernel.x86_64.sig",
-                                "sha256": "ea3eabbbf7a49ea0dc22983601f8a631cfb7b2b92515024ec5a0dacf5a717efd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-kernel.x86_64.sig",
+                                "sha256": "427ace2fc7e2acc423714f8184b74cdd286dc1c0c765cd0c0667aada88b155ea"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "89fb5f4839276af8af50be114b2896e87ecac44e0df91f0d373bb2bf2bc182c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "88f0c7e4504683a6070cd120d86a28c1c5a09d5dab459d26214d06128207a374"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "30625494d682ccafa2e90fd1e06eead10ec2b43b2f8268f064abf8125005e714"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "35062d9d3b95418dafecd1df8eb6ebcc04315a83559e497394f182a662283447"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "eae018593a760d4d67a948a86d3d2f543fa74b96b1153d61b2f3b80c3dd73344",
-                                "uncompressed-sha256": "c971207de5e97dc059bc695f57903752043a5b7e9bf070127a2ef3f9c24ca279"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "68e5623f401f67b51deae1197fdafc58307823c433c8323a24aad521b791e8e4",
+                                "uncompressed-sha256": "9823c4e1b5af69ead90201c65e249b33f0b11b768b5ab6d6e8854b3e47bdc195"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ea91bf28c2d07f684d8df4b175b60c4f053468684279b81b95848997e7d1a3b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0f28e1077965335b2c274ab02352b80d0a791e5e4b60ef61deb85035b0f26dc2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "c79e96266d0cc7eda6a7f62817741d909eeef35fb3a8efdf8b45563a3c40ae18",
-                                "uncompressed-sha256": "a10d4022d4abbb4474bba8a341f0092bfdb3b28b5dfcdac73a41f6809bdeb40f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "251fb00f3b7d04224d3ce1308c8e3cc731c5b20f3f4cf20348ea94fe12090820",
+                                "uncompressed-sha256": "480381419c3cfefa023df3fc21b929ce2a7c494c7811de04b35862ba723cee1f"
+                            }
+                        }
+                    }
+                },
+                "oraclecloud": {
+                    "release": "42.20250721.1.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5f839c4fb5f7773667a9ceafaf8cbb1094e1373a8aaba8be27b63514f5457ffc",
+                                "uncompressed-sha256": "89632d961dc0885b8ddc952930c9baed8e5690dc48fe5068248143b74d237d68"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "b76c9ec942155f196d002e7b44afefcd2f6958aa47b82227d6bbd857f2f0b9b2",
-                                "uncompressed-sha256": "1fd88c89cda2d85897741c6643f7b355f156e6d6dc031e32140901077767e69d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "63b6d1a925f5042ded2b6b149931b9e8e3942c982cf61f6f2f7fac670f06ac8a",
+                                "uncompressed-sha256": "88a85f5fca1774160382b73125b24ee37aa296360367da99f820e1399d71a37b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f4d6262b1059ed037cb8258c1322a04163de904930359cafbc16bc076058abcd",
-                                "uncompressed-sha256": "748e6e4154d8cfdd9e523b65b095a5e876ff80dd7bfc88a3590e586aeec9b587"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4a5eca7270e993ba6744e43db126cc1de3f686a1d7460aaa2477a52400503cdc",
+                                "uncompressed-sha256": "3d30d3dd64b06db10d0f0cfe9837fc9f0e03acc5ef1c43ad793f9e5319e309ba"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "194ecc56fd3d6cc46bbb2a94404766016cc3d06d5768d19a470f3f741291d3a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "50430f1bfa540287d9fec4b35f697832573f9ea9240fdefc844fe173be5f176a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "4187ed53c2f9776dd8af0dda5ecc9100e3e38735e32a285367ed3c7658d664b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "09ef125ec2944e06ebfcd12a0ff17812cef4b7e67c0acf9294007387ae37ef0a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250705.1.0/x86_64/fedora-coreos-42.20250705.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "c4419106ac9c7052e94cc4d932b1313972e591800a6ea098932e1951e7b21e1f",
-                                "uncompressed-sha256": "6a5cab22377216d4950106097a52ea7061216fcc266e4a97a65864c19ffa9e63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "fc005dbe73568020d8db86e8411999d63e533001b192531a0ea25a6911b3b5f7",
+                                "uncompressed-sha256": "27a5f3dd962ee9c750469576ed97db8e829e6d12e5459e88b92d41413f53d878"
                             }
                         }
                     }
@@ -791,149 +817,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-06afcd147d0e3f7bd"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0ef097a927351f931"
                         },
                         "ap-east-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-094d392d137f9e8c7"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-07b1e9137b4821a33"
                         },
                         "ap-east-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0dd4e16e70730b145"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0f4545250570ad073"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-035eca4a666039609"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-02adf029834aec4d1"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-07ba635a22cd14c1f"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0a764a1c4ec2d4687"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0d75b25547558daf6"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0a094b165de13ba4f"
                         },
                         "ap-south-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-023445331cfb9ba7d"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-056974046443deee9"
                         },
                         "ap-south-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0018050ffa744e21b"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0885801d504f3b8e7"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-039f58b7b027a40c7"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-073703a7f1a9cc52a"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-09c9bd33abcf829bc"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-073a5f550b01e9845"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0f603e612123a55d9"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0c813dc74dbca2606"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0ead605ddf4ad9df4"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-04f0017d0ce15bb8f"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0269b1628d1816f02"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0a0c7750f7f50805e"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-07b5fe5a3e3bea6b4"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-09b7e30339239f0e7"
                         },
                         "ca-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0d66870eb49c4aaa6"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0f26f03c08ecfb0d4"
                         },
                         "ca-west-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0ade5235e2639acaf"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0fc0807ec1fe7e443"
                         },
                         "eu-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0baf258cb6d042253"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-07eb0bbab61a9e6f9"
                         },
                         "eu-central-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0a7f945b21d3467f5"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-041d88efd84ad5dd1"
                         },
                         "eu-north-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-06ade22495b395265"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-04e9711fd53556dc5"
                         },
                         "eu-south-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-08c9a690af0f2d37e"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-02be0b91ff826ee6c"
                         },
                         "eu-south-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0741f48c942d93470"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0def66b660c07b770"
                         },
                         "eu-west-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0f7faa3205088bc74"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-018f9225d65034196"
                         },
                         "eu-west-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0c23e15533dd405c3"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-09ed51ac5abb17346"
                         },
                         "eu-west-3": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-056fee113ad8309f7"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-09d63fc7d06389ab3"
                         },
                         "il-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-041cd22ca3d6a069e"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0bc2e3bd6c39b8bce"
                         },
                         "me-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-094b1de0f25e027f7"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0050475441ac3b963"
                         },
                         "me-south-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0bc7d05f0e0924ece"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-07a6f74bb9d9f2f23"
                         },
                         "mx-central-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-02a524a3b18c1d203"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-005bb97922b0f564b"
                         },
                         "sa-east-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0afc65ec878f7f6fa"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-081b20183cc8e3dbd"
                         },
                         "us-east-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-08075e541fec6f90e"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-006178beab5cd1300"
                         },
                         "us-east-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0022fa934040dbe0e"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-02aeedd7c2badf75c"
                         },
                         "us-west-1": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-0f1ed01b9bf014c93"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-0a724977148b1f0fc"
                         },
                         "us-west-2": {
-                            "release": "42.20250705.1.0",
-                            "image": "ami-051ceb37191310f9d"
+                            "release": "42.20250721.1.0",
+                            "image": "ami-08ecbe0a79029a165"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250705-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250721-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250705.1.0",
+                    "release": "42.20250721.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e97801f4994c0cf270e350d29de3e95f429ebfed926e1bbb952b102a5227a403"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1d2257434e4486448ad88a428aafabda722b5d5097b11acf938c59361f93d94d"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,156 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-07-11T03:59:33Z",
-        "generator": "fedora-coreos-stream-generator v0.2.17"
+        "last-modified": "2025-07-22T23:33:04Z",
+        "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "1e3e7ed916947035043e0c39deec3902c2df8c13ff6bdc456f7d1014279bc98b",
-                                "uncompressed-sha256": "e3d2c33086fd82e4c9685658935271e455ccc5e0ee1bb0c4eb4487485f7aa629"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "ef78b8ab8da9d87741e5b3b50c250b0058c8f17c6626a13deffaca7af4a1b380",
+                                "uncompressed-sha256": "aac64321ec32b7b735a3c19b8e2450596a2a2b130153ab581e11ba4942fcf0cf"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3b19135ebd43e9b8c75f4db84354c6e7bcabac3407df0236c6f615f808211008",
-                                "uncompressed-sha256": "7c0a0d21a73f1befe34db9ea9dae893d49ee4c31eee7ab1b156c442c6d37cf74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a570278ebc26ce23d209a9e1c910f272bbc2ae8a49852e88577a82e3d141ad6c",
+                                "uncompressed-sha256": "6097f0b51b62ecb403035ceb7fb0071a4502f2d501c4e1d28b3eb0342af93b0f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "e652818c645cce9f2d9d1f9a25150518b956c815b35484c7dbe844acf54399ff",
-                                "uncompressed-sha256": "8d52e03f2b3b5d8032d18ef44b46afacc4bd91e0e6e6c7af6235f6cfe127ee86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "4c36d2ac32da2cb1806809417d29c245f4e0b145faf9efc2adce39e089c62d4c",
+                                "uncompressed-sha256": "6232de30b0e8ef361cf00408ab4f06e657b52266b8543a0220fca0ce94a286c3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "152abb2c1981f667cdcb57b61c6e8db8407eaf4e1afe460700b3ac63496614ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "2782696e14dc00e8e2a6ee27d923d2a0103d5e5fd1c0e799e9f8216375460ed2"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "5ae7fe6cf92632d5ffe7f6a4876d5f403f1c130c5429389afaa8ede2f9a2c3ef",
-                                "uncompressed-sha256": "95c1ac3b20023f4676d6cc12610190e74c5055e00568471ebae8ab7e42dc7a98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "53f7e98f1efd74bc5ec67d4a95fb4347cdb8c920d93d90e5d1dc67b9873cc4a6",
+                                "uncompressed-sha256": "3f0e8ad9319f5144502735606efeb80ce9dab6a17798cb7490919016358aa219"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "7ce863e10431b52fe1ee1fa3d34d28feb539a57de562f7f49d8a7a9ac2a5f3a3",
-                                "uncompressed-sha256": "c33a700a55e865179f47ff4e630b475b9b55eae1a09569ced99f99dd9c2f4bec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "aaac19de8dd5d9eb1fd2dd6a698859c84b616f19664e516762952027bfc092c6",
+                                "uncompressed-sha256": "198284482cb0d93dffa7e8bf9a486ee924878a0bb15a8c5dd291a5e8ec2610ef"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5b38211b57f581780605760f7eeb75deb2a4db7f416e6e5c120654d046f62238",
-                                "uncompressed-sha256": "987689fd37b42a32f1e93f5eea01122058d5b7a33cec7a888870a551558a0e2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "c18366561c734d5f76f555d86b521a720e183237a87057a6efed1f41d6528613",
+                                "uncompressed-sha256": "12e01ebb0efb92aae151ee9e655ae4dd3134a09a344251077bc27a19d702ea87"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "88b36217429c697103a5eff36fcd712e5f0d71b8108e666ccb1eb48b45db250d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-iso.aarch64.iso.sig",
+                                "sha256": "bc63a04ea7ea155e7f278120d9e5af008c4f644a3f70bcf3f46089d0a5225f78"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-kernel.aarch64.sig",
-                                "sha256": "30f419a63aeba8bc12ebbe1ec5e2e98259f2f220d6491cc80cd0396d3666bf3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-kernel.aarch64.sig",
+                                "sha256": "912f49b916e957d4c27ac0b4152a41373369fd9f538237ec7486ced3623acc87"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "a0845e37b3fbee206c79447baa5270df79be770777c5ecbef74eb683ae153696"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "99b11c92bdce6b2121c208e891d4bcf9663977fff3633b3c3e3ea7b4b88ee537"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "53608e2afcfdc080439e949512715c76fd24a604cc71bf2d2c84b469e000f5ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "ee26a68ecbbd1d51f5fadc281c5c13ef9e9fd714b440dc172924bcd559a3a87f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "f56166b02904dd798f4e892ddafd30d3116e9982b76615462fba59972f983f9c",
-                                "uncompressed-sha256": "4b49a4106f9d8e667bdb850382101137185af92c1a22c5649fa07bb2f891b576"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "ae14a7f46d9fdc4e3f6debf0beb48ed25f74864351ecf04a07a925d8e0ce9db3",
+                                "uncompressed-sha256": "23e9a7eab6d0be901792b65a6293250e1665cb16a90bde3511fc2183729dbfc6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "af837200dda3f3a89d62c67af940c425c297f6feb9ef31b1143264de172052ed",
-                                "uncompressed-sha256": "90d0b1673ea10b486e408aab6d976a45a40121e544b290ff7df7b292ec381da0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "bc70cd10e8e1391e7e61f2da2a8532cb4439f013f5a792027180f5e1726e6e06",
+                                "uncompressed-sha256": "ccc3e701350f96aefaf55aa804b70729bf07eefaeb27daebef95cf1ec7e11df8"
+                            }
+                        }
+                    }
+                },
+                "oraclecloud": {
+                    "release": "42.20250705.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "3c2b2b3a1cb1bc9870c2b2899f1da6170678f4c3f1f2e640e1fe86574347337f",
+                                "uncompressed-sha256": "40bb9f5b9152c962a58d19bfc8b5dc0fbb9974fb4d27b50df54c722affb8c177"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/aarch64/fedora-coreos-42.20250623.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "bb08db8a942d7c878eb148312a9d7c37e8847a74372b7c0da5495c84ce139d3e",
-                                "uncompressed-sha256": "32f03993a1c7b4875acaa3cf896d8e10daa5221a543638b9fb6f95bf908150d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d3f47998dea27ff0236ee5d216ea2de4e35d0642afb3480ff1193aab8fa662bd",
+                                "uncompressed-sha256": "7b0e30199f1af235f4754ce09eb072738bbf894796d72c7c22a18132153ad94d"
                             }
                         }
                     }
@@ -160,229 +173,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-04ccb736010bf9a06"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-07669c9a1ee4eff92"
                         },
                         "ap-east-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-09b5bd0ec1f12e8ef"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-06dfbdde0452dcfa9"
                         },
                         "ap-east-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-089ff95c932707363"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0e25f5d0c6bb55293"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0023d1b62864bee8e"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0a37c9d21b4429b3d"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-014d52cb3b9cb7996"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0955112d1811bec68"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-095ee6c7e0f0de6c1"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0c4bb693c5b156108"
                         },
                         "ap-south-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0515d1ed3e52d8fb2"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0f47e86b8d3458cb0"
                         },
                         "ap-south-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-05081322a1baa73e4"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0afafa9000671c4e5"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0e1752dadf4460e18"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0fe0957595b4abb24"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-01b2e4a70788951e2"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0a8c18a028d7a0125"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-07fc73feec0104d27"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-05248b9dc162994fb"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-077436756565447f3"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-08e220f2b5f801ddd"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0c1a42ec3035e5120"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0d29c7a1c5dd3f23b"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-09484ecbb45ee02c7"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0daf1d14f24a419a5"
                         },
                         "ca-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-04eacd1d7745f7a94"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-01a77f523f0defe7b"
                         },
                         "ca-west-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0f349c889010ade0e"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-038756d9c1aacb83d"
                         },
                         "eu-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0cedeb921b15af019"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0a0ea36ed065b260e"
                         },
                         "eu-central-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0fe21673306aa5303"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-06d8a1a12ff7e05b7"
                         },
                         "eu-north-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-03843fffd976444cc"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-03d0e79d79fc861c5"
                         },
                         "eu-south-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-048325fcfc8573bbc"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0c2c791c29cd18641"
                         },
                         "eu-south-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-03e88be136a7fdddd"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0fe0bbf77ff84a533"
                         },
                         "eu-west-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-085b76c3142d021ab"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0644ca5b66a34f501"
                         },
                         "eu-west-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0bf990feae95cd3f8"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0991d0cad5b54e8ae"
                         },
                         "eu-west-3": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-094de50ba89232ef8"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-060b0be87f418d851"
                         },
                         "il-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-00a0ef6a8e39888c1"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-078f5dcdcea0bfcc0"
                         },
                         "me-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-04a7b0a9a2bb072b5"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-096cd31f6edc9d5d0"
                         },
                         "me-south-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0cfc44019b4ceb63d"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-009f43313a80960db"
                         },
                         "mx-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-076690eb924f8d909"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0053e85a103db4b9b"
                         },
                         "sa-east-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0d67b4e289dc6841a"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-06b38bb73355e31bc"
                         },
                         "us-east-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0d5a53b8f8629fc26"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0f805521f76f9d8a4"
                         },
                         "us-east-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-09d15e5beabf02fb9"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-08fc204fcf9c925ca"
                         },
                         "us-west-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-04570db530ff34dea"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0f74fb4d0de53ed65"
                         },
                         "us-west-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-008c6655efb864559"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0ed968c964e27a9b0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250623-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250705-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "39f74f59c40b34798ea19785621a5b687933eb01c3b3a10ec1af66b06ea4367a",
-                                "uncompressed-sha256": "95e07a371d7f1d073b18928802f3503c593a42559162bc4a2626a404a09f0775"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c3973bcf9ae1357f515c51b24d0c281fcea6edb033f2e8acb4445873adbffb2d",
+                                "uncompressed-sha256": "6a100039b62862ef5b15394a02cb683f7e8e87f579169cc6bef4230db1f141f8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "78e744e41a2c1ac2f5458bbcf311559ae6a647e30ca132d55304ff7f613d7607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "c5a674faccefc41ced953c7f970efb1a80f77681e6703b7e139321dcbc40953c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "d656a0ea2c2466ad732af7604b28fd3d48cd558a9cc8b09f6250730bc6bc4ee4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-kernel.ppc64le.sig",
+                                "sha256": "07caeba85e4d5e2aa63bd6b6dcdccb2fa03a9483c5af5003a6964a20c77a4bee"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "72fd3279a1c4570a2595fb0c0900a8db5f5f66f13921f8ea7f5e05882ad52fc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "5f3c640b67a2c53a52f1ba9ff3a73d9024a892a6559cddf39bbe072ca9d1355f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "40920257edba907b54820445f07eeed3fcca1ed0f54de47c1f2e66fcc72658bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "9864fcc00751f10b6930a3cb88992e0e6a454f84e7a848a647eec144647e1613"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "aa88e58e34dbedabc6cb895c01b68ea9eddfc95584bc6c864a56e3eceda9d4cf",
-                                "uncompressed-sha256": "2198e67e2b99900ddb7e94bd473fc1462bc75a1fa5ecb8d4a6e338dc711e8935"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "81f7617266f22b74c922335821dbf1392174ebcf16c87fa3a6e88f92c7b6e032",
+                                "uncompressed-sha256": "e3cb58c3e1bc8f6e79d60856317226eb5cdec7bc947615b2c176ad386fc43fe9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "ea924d15042c2fa916542ead45e96911ce446125b0fd4717fd4989ba5ddf44f4",
-                                "uncompressed-sha256": "c98c1c0e41b0321c9a1db9098b9d8da7846e2ab31b44a9f0b713eed4dc24a2a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a2846091bd280366f7294b594652298d6b714042f144a063fd40e2c9ff2ec6ea",
+                                "uncompressed-sha256": "666351dac208deae63b54a2410597276a11db22824d5315eccbdb6fcf8f4171a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "44cd53a907e01dabf0a44d0c5de2a6eafdc30ddd83275c8ae12d4cd4d3dc82b4",
-                                "uncompressed-sha256": "bf5d64c236c67750581df4ad7188da31acc3d95a737c6b89a4285c0f4f0278ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5479a7109f6a608e1a736e03893300a4a97dfcea71dc7c74a68f90448bdf895d",
+                                "uncompressed-sha256": "791d9b5610c5c721e8c3b0419a479723a86bfc7063eb03dd11823b265f0fde09"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/ppc64le/fedora-coreos-42.20250623.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5c3fa52056edc1377726de6e0a1cad0e609890e4bf5b8332af7b1ca0fae0b089",
-                                "uncompressed-sha256": "820cb2b346d5b6fc0636cf8bab8a8555d676fde1840b4b535df166639e9026da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "b4adb4728d73d56fc4d350d99ff5f59bc76e65172165d9cff8d1fb8adfafce52",
+                                "uncompressed-sha256": "d0a3e80f8b2378c489ab368e25d86c16d05ce5012c903408780f6cf2ce35a700"
                             }
                         }
                     }
@@ -393,97 +406,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "1da7201c5e45bb7703a47a5d32ee8112a68adaee80715884579ae341d783612b",
-                                "uncompressed-sha256": "7173b582a4e21cc777e393efd4a1d57f9e0370ddda1e2c3bc90f19a8070b2951"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9b895fcba6f3a98d1f2c2be60c1518bd2dfc078a23b891a03313f26d34b39741",
+                                "uncompressed-sha256": "093a161e10ba225f6e0b204fdcc4596b3bf4288bcb737040c6535ed77792e837"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "65342b09b193d558133000c08507a312f30cb7cb64e9fbe672e363f4b94a5b9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "542d9a276a9e28e11c529afd7b6407ebbbc30c16cb423bf078199441ef074f3b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "adae9fc207ddaa3e692d7d98b6b8fc7810f01f83b0d2022b74f0f69f64748371",
-                                "uncompressed-sha256": "93b71b609205bc30e9695b78b8bca0ef2bce5371fd7f536f7cddb07c06100bdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4df4afa08fe54b617b38098cbb7de453c8661d07dc1aad275458cd91b84c8755",
+                                "uncompressed-sha256": "2577a683d634fb48388fbf131aae649e75ae87e3e2c2a50bc45503408125e6ac"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "483cb59c9b646881a886d609229963c711f1f3d1afa98b9b5a6d1c999d62567e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-iso.s390x.iso.sig",
+                                "sha256": "6f808a74cfc495a4e87c623a4ff53fd35b0d09dde3f2903913e8e2acfab4f6fd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-kernel.s390x.sig",
-                                "sha256": "1ca8038c339fc604bbe28a5df1c390a8cc9b70e00859ade0d5f1711360436257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-kernel.s390x.sig",
+                                "sha256": "6b39b4f1186283d9053865431c8ba5ace49fb736e78428f2734247ad7ff86303"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "3014653fa714097818cc0f9ac9272ecfa662c958ae346075e2cba1346ea0862b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b896df266a92f56c7e616266659156871706e4eaadc582bc3f13fc61c0c7c35a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "375e48b6aaf8d5e8c067ba060b9a9432dbc0ce9754cd1cd4785ad2eac079cb6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "e63ca3c7fbe03d490d88a9605cee43c72362ecdcee21e63682c2547f39b26668"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "3e96c583af26001369a3355b0a8cdd0c4bc97cf2554b3bd5c8710c73f91bbecc",
-                                "uncompressed-sha256": "774aa0b6d29f131649dc5e9597d2f8773a384137ea3cdabd705d48bfd554ca9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "7feaaad4df00aac2fa27307d0e2ceef7e3a9968f7f36356cfef15ed6382077f5",
+                                "uncompressed-sha256": "de34de6ae6c46bb453fcc3a1d11e7c4a89d2444bfb5aed121551c936ad1394cd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5cfb801738605bf508d1cebff591d8264e0911f3b808a0a41dd804482dd9d82f",
-                                "uncompressed-sha256": "3e463ec47d540cdad2c0692115c0f8681c825134b83b4e99656ebf5cf4827ac3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "eb68fba22353f5497240a70a27cbed06994d19cefa2263dffb359f4c7b26d358",
+                                "uncompressed-sha256": "9735d2050c0fae67d4c74171eb3045278e16a760cc94605ddef798ff6e7e1b38"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/s390x/fedora-coreos-42.20250623.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "cc82fbbba39467e8b31f5bd0fcf6245482123cd55e3bb0429bbb3e2d00179b23",
-                                "uncompressed-sha256": "b580ed5105f6369fbd8bf987ad8154a99d2120e0386d6f6357eca5b80ca0ee73"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "075eab5ce77e30c650d83763cb024fcfddaa3fe44807065191e723cf148243d1",
+                                "uncompressed-sha256": "be5b222acc7a77c9f57c43d9620109cc6525a3e89f96e777fe3a278a2486cd4c"
                             }
                         }
                     }
@@ -491,284 +504,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1cae62a263a13c30d7b7d846e7b08576477b122a13f6d88876bba46dda68c239"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e08ba52a949e35fae3df0190909d97596e4102cd61336e790c47e5b04a55c5b8"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "c4d99cec4ea04f8934ad366b8bb51bda377505020846427a93c453c5ee6e2324",
-                                "uncompressed-sha256": "b796151de41eb9e870790ef95da142f2431850e97c61bde7bdd7fa718c280a7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "34a8fedaaff718db6e1572120f883bef9487828d41b7b26530d638489b7acfdd",
+                                "uncompressed-sha256": "e4a4b80d12510e35944b880059c6bbee50dbeb53c1f26cb8c37ff2166efdbec2"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "d55ae047cf5e2f31ef86df64673eaa12bf1ad8bf0627188df3098d9b0585d40f",
-                                "uncompressed-sha256": "cc21f273b5e74f3b4eed021197f9af0f4d0173bdfd05dc251434c8768bfa3979"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "1ccac2e8d91adb5ffce90762ecff34c5146b74757eca0d6e2c995e0064b5e44d",
+                                "uncompressed-sha256": "a2df7cc6a013bcc045c77e51e0d84f437a41837f4bccd4dc9b0690d4149652cd"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3d98718a2ca6068f1d35f52e0045bab1db9d08382145d5227da27d7fdf2d526e",
-                                "uncompressed-sha256": "67ca5fce913c06dac15060dabbca2bfcd0914068b049d8dc831231e4f517bc4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1b376b8065448ac85620058bc2412d5f2edcf53f5f1f5b2c83a89842b16067d8",
+                                "uncompressed-sha256": "aba7bc70559010b1ade32dbe305c08cd670f04f8b72c6aa31b58d7a5aaaefab5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "51e8f9be547cf123fd4a23e3ed6786871f6b28a57f50cb16637466973c6b5659",
-                                "uncompressed-sha256": "5971c368af00f5da95773f5660ae551646b0592381a172c2065d0563e575afca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1bde1b58e3d3346f23cc999ad837da8cd2d256aaeeda31411fb5d09412097e40",
+                                "uncompressed-sha256": "cc9d19338317c5661bc9a204caa7f11c827709800baf685162309d0324de7cff"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f49ba2fd297bc339c6167ee5fd5b6c02ff2040dfd1b51c4bb3692ea14e8e18d9",
-                                "uncompressed-sha256": "29cef395de53744ee23df912eebc78e8a940631888280a1ebc0c804e2028bcf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "b5a51d49b69bfb5a7edada1356f3eab49b128e5c3461bfd94fcc8231b289df69",
+                                "uncompressed-sha256": "c8d82b0270b954e48195f5c5849e6d3305e5997ed7c8a4aa4b9427b5ac852715"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "5f5642599e5e65ad1dfbb13d354eb30ce9e70de76a97d22009598159ae868cd5",
-                                "uncompressed-sha256": "2962e58f3c57a052e84335e2599559cd8f9cd73464f9e6a385840b2ea8882358"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7531374856de55b5317985e4363f12d802308a3fd2a0e6cafe494b0e16e9f45d",
+                                "uncompressed-sha256": "eb0dffbc2bcb7588397a2f620b42b3e388214429b36f962e4940d5c07ab4fe2e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b6a9285a68bda2ab43b487e03be82f49e3546e39d527efd2222ddd24817e4182",
-                                "uncompressed-sha256": "27eccee074c4f63ce6b89d6eeb459a6635389ef0804a30dbbad2c3ac0c8e8304"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "941f47218f7c2cb1db366f684a5de8d5f07b5588261ae39bef90f76a1ecb910c",
+                                "uncompressed-sha256": "cf4effd2d2c215ec0a22e97e002c6f68605e4131b6e5efeaf61f85c92194427c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a6f71991bc427d1d77b218d65a72b0d9f48af84c930c7bf4042c2d620a84044f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3937c0b5c9d1107fb8162ab5dd627a2999732d9423531d2b29379bdf180ef386"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "629cad534e72ae358840e52765b36e498348a0f4f5f88433db511e9dcbe7763e",
-                                "uncompressed-sha256": "99e494960d9d5a8b59f0d2921be7fc0fb5ce1b351dfe1a01b46b9cc21ac945dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "87578cd72cccc764da233d3c03ee459cc8682ada4827e9df32dce59965df8b95",
+                                "uncompressed-sha256": "dc520d61f3722298b4522b3fe9881595058524342036ab0d82ec4f073f14cb58"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "bb63efff19adb1e66a91a2f749892d149f8d892df6c63867175b115d3bf0fbd6",
-                                "uncompressed-sha256": "c400bb85f3947e2a29cb066db9e1a24c36c96c91261357f28059243900aa7967"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "1f3f78b39efeff4404ec99b04c736aafe370bdfc103c88cc59dcd0da3212f6d7",
+                                "uncompressed-sha256": "374c505f44b985f24588671e428ed35406cc7f04636b3e1e25b69a1df2c4bb2f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "61440cb835722800a52d97592994f98d44e67c334c494efb984805ff9ce48b26",
-                                "uncompressed-sha256": "7597cd70c1d298d4be8067e93ad6d8f4fa61de71b954b96848d51acf6a596a9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4d532ec9cee9b44998d28a5ef096d78682f88e212b917b8ab0a023f79946280d",
+                                "uncompressed-sha256": "aa0e55014a949830eaa99948b5bc479504059553a0ba1bf5b888f260443f8c68"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "de1479258388169807b4edcf7c485a1ac785c8a8b11499a1bcfa9e1833c73028"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c2fb419e3bf64cb8d0ce78a5bf79188e6c81578a4057a4701926e4edd3766f7c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9085fd8a08664b96fe42d3206ee5159bf634adb7df2d562509aa3027a4ea3e2e",
-                                "uncompressed-sha256": "d383b9bfd555893f91b4dcee88e9267b41218efde81eebc2f3ff34b87525b728"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "788f2484a4fb3470fd1ebb11c7954788503397e00ca2586b686815fb17a44f29",
+                                "uncompressed-sha256": "a3e55b082a85ed160364c17969c5faff0cf57f3948dd6359ff055af3463df938"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "ec580d38a8f108b3cc15c5b9bb4b571d114531159093bc4b45dab88ce0c3fee6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-iso.x86_64.iso.sig",
+                                "sha256": "a8f1a6f534b5ec28be62f015f6dda3a776dfc9bfd49872b0c399dded7073a1e2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-kernel.x86_64.sig",
-                                "sha256": "609799621be031f9a65d31d12b1cb90f6fc45df76a630e40f81a45a12cd924b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-kernel.x86_64.sig",
+                                "sha256": "ea3eabbbf7a49ea0dc22983601f8a631cfb7b2b92515024ec5a0dacf5a717efd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "9c1befdd6018af5bc32d954d532d3232e05639616f8ba99526361307600a8b1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "8dbdad561a2a8625dea53e4ce6261efe70737f2cfeb29f47aa190215ab3a2df7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "a4155ffbeabf1c1eec46bd84fd407379be1017c6223d20327912e9ec4af795c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "d7c4e5e15486201d3976cca4b281fa6b0a52a57e13edb0de68fa57474b91200a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "97a75c535fb60fb8395f8e3abed4cee9552be3d0d034b0c6d13219c37f4d76ef",
-                                "uncompressed-sha256": "b251a357251debca48e24b6b22927fbb738df24aa0f097d9931ead5bb8969185"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "4773e73365d5c08a92aa5cc37aa9ba33168276efd73a92197518207e7bbaca8b",
+                                "uncompressed-sha256": "48008b28a98aaf96f6a6ddcf3041f2178109d301deab52a7a1a0e09af4adce0d"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f885a48fce6ad29c12cf95ad35d8c9050290ed52e4b6ac1a9eee8b59c799c0e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "da35bdcf5c30d02256cac9ba47cf139c5ec9cbf50c77c9b67891050dcc2b6283"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "746bce3f7e570605335fb768bcdc746a7dbb9ea4b74adff0ab58a443a8587c5c",
-                                "uncompressed-sha256": "364e57c4eb8c7c901a0d224819a1e699881b22420055759324fa4e54a5a3eb96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "724208ad91016c3e0d03b97f71b9ecb67a65fede4a470199c0c91a9989c2ba89",
+                                "uncompressed-sha256": "6ba2ca937ead1d33d8bb860a30ffd66ea4955d9f3367069cb6b43e8607dbc0ab"
+                            }
+                        }
+                    }
+                },
+                "oraclecloud": {
+                    "release": "42.20250705.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4b780fb921913f3429bf04a44a6d2fcbac755915363a1a9e4c9055be477d7a8d",
+                                "uncompressed-sha256": "08ef0a8f0faabd9c45e829a4e33112a0889b099d32e2fa6f0c7e1ae7fb990c3c"
+                            }
+                        }
+                    }
+                },
+                "proxmoxve": {
+                    "release": "42.20250705.3.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "dab2cfafe397aa96e2885d11ab89a1463bc0dd49a04c7f06bfef7246d13f0437",
+                                "uncompressed-sha256": "fa723f10b0081ac5014f2f4a1d827494b7671723184a508cacaef77478585f54"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "a3176646ea2bd53d2905f7af9537938038a32d49a7e318abc3a9e3ed1ea1e0b3",
-                                "uncompressed-sha256": "0bbf2f3686d990059ab98bc51da590cd337131bf00fd8eac788240c18984e39e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "75349a0f97a0aee44265da1d10d4f22a7a925638af33bf4ccbe3cfd141d51e06",
+                                "uncompressed-sha256": "640e620f6a488bf8b1ab36849a47caae5b2c8184a8b7b4d6afb879d1eebd1378"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "9182cc7d7119de5fc5ef3738e0cdfe912cd3f71e0f9f3ba2e93fd34412a69699"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "b851e586e59ac09c9db5fa2f67e252d3d86db9afc0f1cfec5a9fc2d7f3dc5085"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "7ccbaefe19f3eb904d15aca997fdf42dea09403822a89947cc211f2226da2690"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "cdb2208edd3a75e305690a89d97ab2ad9decc9b7cbd01d4e5282b10101979aaa"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250623.3.1/x86_64/fedora-coreos-42.20250623.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7ccb0b9f9e04a960f9915241ee7f077ed7756905f6378009801addd1617070ea",
-                                "uncompressed-sha256": "0129863dea095a02f9eea631560c5e539157cf6b014cb7e10bae46108f6fd53f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0436212a4466c81aabb96b4c90eea678cdf9404270a061dd86b7154aa248bcea",
+                                "uncompressed-sha256": "f8ab73e9101a631e727ba4359c912777ad5acd714e84da2d29a6c528c963cd7c"
                             }
                         }
                     }
@@ -778,149 +817,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0602f114f7f43d644"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0c9c5502aab820504"
                         },
                         "ap-east-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-09a278a14a1eca69d"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-06c66be63494d55e3"
                         },
                         "ap-east-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0298fd80e4623c7a6"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-067c44cf480a9de32"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-052cdf5e13576a6d1"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-004f0858b864a184b"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-07d6cd4775f8eca76"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-02ff004bfc80576bc"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0fc8d3d70b0536d12"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0603ba2104629dcdb"
                         },
                         "ap-south-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0fd3644cea15c228f"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0f22fc6f5225bffe9"
                         },
                         "ap-south-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0fcfde0fe4cf741c6"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-07d2875408d62090a"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0dfd97cb80dcfd82c"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-01c3d03239a75223d"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0a0f1403effbd0d82"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-09958691b5cec68d5"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-00eb00f8653eb3066"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0dadd52009226a916"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0d270e0902514b8c6"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0e825b195ed25fdeb"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-01c1fd6653d29d126"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-08b1034222a80012e"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0e197902e08c428db"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-08bda07441dd80e36"
                         },
                         "ca-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-05c53cf7012fa2877"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-07470c15f5f14bef8"
                         },
                         "ca-west-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0965efd51ef5b6dc2"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-00020d5ba506786d3"
                         },
                         "eu-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-083c170f1dcc24532"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0a8fd46be303f8c5e"
                         },
                         "eu-central-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-03c5cc8868b9ea45d"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-00e98fd39ca1f6ada"
                         },
                         "eu-north-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0f7978257f8fe73f0"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-005d8f149d370518e"
                         },
                         "eu-south-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0ad1367200ee044d8"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-020ea9f3ce9c40bfa"
                         },
                         "eu-south-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0547b3df54cb7ad29"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-07092c86a342db941"
                         },
                         "eu-west-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-053655342641ec790"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0d02d41bcb521af08"
                         },
                         "eu-west-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0f8fb15f48f18fc67"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-05981c63830c3d2a6"
                         },
                         "eu-west-3": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0218476a8ad010bdc"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-00c6563d2ef6a6ed2"
                         },
                         "il-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0b9b6fa88635be8fe"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0eabf3be1baf57ea2"
                         },
                         "me-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0a2edc61174716529"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0760b6e79c9f51b33"
                         },
                         "me-south-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0d6aa2b81c05572be"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0fd0e15ec5b4a10f2"
                         },
                         "mx-central-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-061bab686750f90dc"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-068c1c033eaf33523"
                         },
                         "sa-east-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0ae4e44d9424c1ee5"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0150390d473334142"
                         },
                         "us-east-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-0b03c9d9e96494899"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-06e59f2cd7a5200fa"
                         },
                         "us-east-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-091412c76ff724da9"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-03fd5fecc83d82096"
                         },
                         "us-west-1": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-039d988728ac8d633"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0bf765cb91b6723f0"
                         },
                         "us-west-2": {
-                            "release": "42.20250623.3.1",
-                            "image": "ami-01f689e43a9212d97"
+                            "release": "42.20250705.3.0",
+                            "image": "ami-0728c6e757903c9af"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250623-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250705-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250623.3.1",
+                    "release": "42.20250705.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:636be09cebeea7bcb4fe2785e40b572d50622422f699506803891ebb89e43bea"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:66f4a73307d25f6e0c4eda2c622e740a3697000b4fcc92abd028bdccc29bcb92"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,156 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-07-07T20:59:47Z",
-        "generator": "fedora-coreos-stream-generator v0.2.17"
+        "last-modified": "2025-07-22T23:33:05Z",
+        "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "1d90a9084f9e9bb72c5e84b0b00ff216fb408bbbb87aa718a8ac853b32d93c02",
-                                "uncompressed-sha256": "c586472b62fd50469388ef883343c6913661fca736929c61994678c1160a7172"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "01fcc2cc1748907464eaa2dba6d7e94abd2161f5a5b395ef8ddfe1b147ca9fbb",
+                                "uncompressed-sha256": "1283b5e96a919b1e802402145b9c3f45d5a25e2347dff9796ee1f05ebd7e0032"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9f6b6efff5e14029ccffa6586d011e187500cf7b0a946e0b999ffe7c19028f2f",
-                                "uncompressed-sha256": "c3aa66249974ee5f7ae44709d7b43dfe3dd2ac74bbf57fc2e64a57330a0134ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "c2add5f7aa5f073d32cacf16d644501bea74c51843b2e0c93400082355c70ea2",
+                                "uncompressed-sha256": "388e869f854fc0ded5d8f4b6115f6aab31069ba683f87ff0110c62f2f2a627eb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "2cf9fd1f0cc940166020830c6b8bf3fe810a7de8d74546a7109dce1ba06dab8b",
-                                "uncompressed-sha256": "aa4b57b897fe45177664b1a06852d0d8e1c349ba4d64fb906c33900d39d2ff22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9f7ba707009a187b79e56093b5ea0286aa1e000987ce3186bfa53b6d2f8fe3e8",
+                                "uncompressed-sha256": "53acbd0f3f467dff2a40327b2fa57f06a132c2d5d503b41a452ba046720ccb84"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "58bfae4100be3362da1929cfd6213afaf9164f3e0595f29e3d4aa7b4eedf7159"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "81662f744b5cec6c1baca7d482bc996d1fcf6c0680ea88940af9fbba9534531f"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "5af8adec319b5dd5805e9c92ef4053f0399f90989f1a42c0dae36b7abc3a6d20",
-                                "uncompressed-sha256": "4975847877f5dc890fc855fb90ec8c9b702150a99fe2975356ee64c2a201e20e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "8b2f409c320ada6fb8ca9bc0b1be202b680b0843c580d4128041eadfc114025a",
+                                "uncompressed-sha256": "ca4ba726618e7ff7b0d9eac61ec79e7624a159ff99eed75478f586e58b0ec2b8"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "a7bd9afea0a6406f099f8f28471ae748601827272e7595f4d205668fe28852ab",
-                                "uncompressed-sha256": "b8791aa1ef47d6b59432849d46c83653fb22e726912fe07860dc7730bfe9c44c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "ffe3929aa3c88400ccef8ad73425250f1bf3e1ad7ff91f3c1c9389f3a3a3c982",
+                                "uncompressed-sha256": "74fca3d8a083259e13130d8679761baf1ff473a5c6122b67538f3d1947e1c927"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "4171cedf391e3c551cf8b34e5326593ec78207176d56854181bebff178e35091",
-                                "uncompressed-sha256": "61865d45849b697c8233693dbac4d0e8ca6428e922c602f4a702404db84d669b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5ee25cfd4df35093abba099ae9928a309afaba2f8ad0b9810bc6fbf2aea76dd8",
+                                "uncompressed-sha256": "be7e87fc5c495d92dbe5a2e411e1ad75bf248e572d11fad09f7b8494d7419acf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-iso.aarch64.iso.sig",
-                                "sha256": "dbd803a1007c9f5316fd8f80492ba7ff1d03d9897d18fd48677c6a1ac821d411"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "da13a4f177478354425eb0f0acbee4377747c51fecd1692bb17d44ea3f4320d5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-kernel.aarch64.sig",
-                                "sha256": "912f49b916e957d4c27ac0b4152a41373369fd9f538237ec7486ced3623acc87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-kernel.aarch64.sig",
+                                "sha256": "12b26d4425c80080c89a0efe02c64a41ea5b0b4843abb5297a8e17da894eecbc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "61a14f2de05494bf5b4211e4afec6b40c92b05437e8b56ca9706bcc1a4f64c71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "f089963a283ad5b5945bd1559ad067e98f98d52bfa53eb858c7f9bf9d4032040"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "97a133bfbd1f3060c9b3f8b49edffcab11bf4a5fbd708e2133b3f0548b30eb21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "9b9cef07105e918c484e69915634e00437cab841f5c641d2550af3786d627750"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "82808cebff460ea4081470e73a6d3d49d912c0a11449fe8695e873384a766411",
-                                "uncompressed-sha256": "8ef6572e3ce454fcf000f496ec0b486526019b62f96b5912ec41749e40dd9ee7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "f21e972ca83ad44e234903f097f7f9440428895ab81dad4a5cee414ad586ce20",
+                                "uncompressed-sha256": "2d0640ac72747dd8f67871ec5b31cd97acf76510b7108b38f056cfd3c9277342"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "85fc3e90bd2cfb1e81592d5594a5be6b449d999788f50ce755b75cb2951e8ee8",
-                                "uncompressed-sha256": "efc7bd0d86b53fc9e500d045b17b7df1fa0ef7370dc2fd2acb2d834ea04a9199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5c2ed0898ffbf96550a3c0de381e52adac27ce9691e9603756a1883776861985",
+                                "uncompressed-sha256": "8892ac4e79e8b662f38c6e945e0adb0dfede870690c3d272dc2833baad81d580"
+                            }
+                        }
+                    }
+                },
+                "oraclecloud": {
+                    "release": "42.20250721.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "cedbd008391cab3c44a5a99d8432aa43a18823a40fc5e53a0be9a877785310e0",
+                                "uncompressed-sha256": "0157355c12d818c78fa7c1589f19f05f4303b9ffa9b9f9990444a61bf09144ea"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/aarch64/fedora-coreos-42.20250705.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8d98c0197d982ae57c40c24a185f1a99fdeeeaf1694fff6691ed8e733d3e8faf",
-                                "uncompressed-sha256": "a8fe8779e784e7d6a8928e13cf8d907d2f3dbeec3c2043159b8cee0def401d03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "47682ea41bdc8097d4357e27a13b840edfad56903eff0fc9e0c3d45c7e2e280a",
+                                "uncompressed-sha256": "b553b449a337b16e926c9bc62fdff26a4aacd7de0673dcc537248b1dacbe0505"
                             }
                         }
                     }
@@ -160,229 +173,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-029157e74eaef9d7b"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0417fe6dbe98dbcfe"
                         },
                         "ap-east-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-09537086b61951a47"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-02f2ad3f669cf334d"
                         },
                         "ap-east-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-04ec900ae5cd88cf7"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0633e02aaeb902c77"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-05b075225bcae023c"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0428b16d67174b878"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-046e891f7471ae3f8"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-06f17dcae5f7343b1"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-05ed95d9c0d645b67"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-07d6287fa2bb491a8"
                         },
                         "ap-south-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0f13f946d4fdc3a3e"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0e76c1d610d279ec8"
                         },
                         "ap-south-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0ba985ec049ddc0f8"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-062d2de9f8f48b62f"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-00a2335ccb6233c04"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0f5c1701cd0d874b0"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-06d72a85c715bd9e3"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0b7f5fef615d33ca9"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-07c9d2d0f9778dbc7"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0f1bdf12e62079b1f"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-07202cc856cb2e4f7"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0c4f3d5e1c3701398"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-001d5d600bdd97997"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-092f558d547637861"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0bdfebd42239be8e2"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0922c59e9c2405405"
                         },
                         "ca-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0a3c5324640025df7"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-03ce05271077df9d9"
                         },
                         "ca-west-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-06e00cfc064f16d8e"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-09ef9116ed52b849c"
                         },
                         "eu-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-09f3f07a7d70ebb39"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-06eee70feed272594"
                         },
                         "eu-central-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0d58633148c659427"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-07863d45d0285934a"
                         },
                         "eu-north-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-054195c5852511398"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-05768babc1549d987"
                         },
                         "eu-south-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0054389d91c84d23b"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0df601693e192038d"
                         },
                         "eu-south-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-03a5461366fcb15c7"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0932fe7a71004dc37"
                         },
                         "eu-west-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0920daa110cb5b0cb"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-079fd14a12ec2b836"
                         },
                         "eu-west-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-049a1ea3019de9f19"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0cd2d2c9ddd238033"
                         },
                         "eu-west-3": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-010cddb2c8be8120c"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0465f8d004512c9ec"
                         },
                         "il-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0521d5a33f04ae8d7"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-06da7c16128da0469"
                         },
                         "me-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-007d972ecaa0a92ef"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0e02a0540531d0dd2"
                         },
                         "me-south-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0e843b3b5f5874ef9"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-09cc6aaf18e756a06"
                         },
                         "mx-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-032e8153007e94e96"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0a26b15abaeb143c4"
                         },
                         "sa-east-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0d4647ea785ea1015"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-02dfe880d92c64334"
                         },
                         "us-east-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0ce1f6c546cc79353"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0ce5c8faeb5e870d1"
                         },
                         "us-east-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0b8d4c676d0ce5569"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0b2c1e074349d052a"
                         },
                         "us-west-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-06fb6622e50d5fdcd"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0b986f65c2b25716c"
                         },
                         "us-west-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-036b609584d3654a7"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0a69d3f831cde3a88"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250705-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250721-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "bb933801e3554905fa2d1ee46100ffac6d280d1509708534666fb0dc6f47d4fc",
-                                "uncompressed-sha256": "513ef2c0caa5fe46224d12a37690bd17dc580615846a4a04b954e4cfacf45640"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "012429b13eb5dbc6d26d75b74e2f7da41eff915b6eeaf2c910fd0a4f94f58b24",
+                                "uncompressed-sha256": "a7f4dcae40dedf10efc9d727b3c7442663c077644d1dc838a619c711245820e8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "3aae91035ac4fc5a5a8b56bc146ffc685f80a097cc627801f716296a25ed135d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "1c1972276c3193e89f012b4bc6528a51cbc6430c41985d62cb238cd12d80a89b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-kernel.ppc64le.sig",
-                                "sha256": "07caeba85e4d5e2aa63bd6b6dcdccb2fa03a9483c5af5003a6964a20c77a4bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "4551f5ac76b46cfa79ae7e9a40f342433d5d8269c8fd4bf3121f33ce45e30250"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f1bbccdcdde9a9d71d6685d4facc99a912c57afb2b56e473e88633deabdcdc0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "f87f00df32107a415cfc00fcaba8fee091bf4e0c29eb533fe44b580ec290d289"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "9fd5725ac7b20553e8c492ff7b9a5159c0b60dafebbafde0646b316376a8a2af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "1e00febe4ebcee6e23e6710d4b80c16acd252453e2a6714258ec5481666ed0be"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "9533a71cb05cb1cd7c49426acbb5947aa413d46cd0502cd21e520429179f7877",
-                                "uncompressed-sha256": "e05f1cc8f6737ed7e6d90f8fd44fe6ba46c46649f5b1df7c91b71cafef75bbda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "aa65acb62f71c102f20322870c1d169ff6f45cd96185a211ea32865322a3da41",
+                                "uncompressed-sha256": "2bf70c88594f493c97e800544fa18f9183a8b81ea780f042a484ffaf10dcad35"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "634f5fe7a1ebbb856f727641423f5ff53b2eecc72c856b17601d718a39d4af90",
-                                "uncompressed-sha256": "921ce3b8f26fc6b89638dae16647772c574dd57101a9cc84f943887c9bfe2827"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6cc980c2532f92bc0a1dc2ae2ee3942b494c2766a30aad58a9bb08f203933b82",
+                                "uncompressed-sha256": "efb0f00e74f38e7ed0795042055c4794e9069b632ae009b3e7cc76faed473473"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "fd9eea9aea2d5675234a9e60a9d296e52139a2e5c9fce44403e46108c09ef632",
-                                "uncompressed-sha256": "b56000610653f488fc20ce19107ecf81ff8cc0d8e61719086913923ecb600b1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "cdc80a884c489e5b4983416217b8d48edb58a9f52dec1fd87f6157ca79c4f295",
+                                "uncompressed-sha256": "7f997596056e3eb72796fad8023e56bd7d2c68ea02eb491f2e33816148063f89"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/ppc64le/fedora-coreos-42.20250705.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "c8176f622ca95c2e3da17a3b6098082c3fe33c87e4bd85219dc0a46c74025c2b",
-                                "uncompressed-sha256": "0ff9ebc193d6d73ae4df65e73d91ac5ad957257783e553264cc0b18a12996bc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "9b0d7c7dc0c7b03b292ba87889a2630492af375ede17ae4b1dbba2b971db2a04",
+                                "uncompressed-sha256": "427666171dc94102a32e4944f07389e00caa62240711eab7dfbe36fb1e27a12e"
                             }
                         }
                     }
@@ -393,97 +406,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "19044bc7bdb0a99609376a26ce79de17e3e9bb8905ffbe0f12328530e543e168",
-                                "uncompressed-sha256": "0ba5ada3ec957e04a93fffc41959ec024464588adbaa613be42e2c99ec8e5700"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "c6c3ae20ad059b68424e97b832f2dcd2622aebd82c52ea7c8f9b5fa5f1f5416c",
+                                "uncompressed-sha256": "55351b9dcadeb10cb5d3a2f27b0d3d1e738ff72180e96749b0b86c5e9da7d3a0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "19bc670eb51de374a688fed6d8288fbfa919062996726982ee088acf6911d76e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "31cbf4c1e3a00ac6e5dcd6ef2c1942b954560908f1a8584790aed4ba8f35a4d6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "525c6a38a994f2d0a71489da0124176f9e605ba7fe1f1da23c05041e7e8e7f9f",
-                                "uncompressed-sha256": "e2355bae8bf7f78acbce5a722e319be6d28ffd372e70c16f76f63c0e0f407dc4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "103e2a2f468c7ed8cc5b781dc999339aa774f4229767b011abea63a71ea31c6a",
+                                "uncompressed-sha256": "c6aca005e3d65298aa5912b02bb0df641981b2365bdb9869fb97a705567237f3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-iso.s390x.iso.sig",
-                                "sha256": "46e5275e5981cff7144a65ff55b4427164e012a3ae8f9f7430ba240b6b9d980a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "70ea2bf8ca0ab37ad62cb3fe47ccb80ce1a8e6fd646f6d8a80e369ea121a6669"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-kernel.s390x.sig",
-                                "sha256": "6b39b4f1186283d9053865431c8ba5ace49fb736e78428f2734247ad7ff86303"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-kernel.s390x.sig",
+                                "sha256": "b357f0c6f4d5c1b25ead6d2779a45919ea0a34539cbbaf5ef547104dd3cde83f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b1b697967df918d32fb406af5b9275630e01bc6597300ea985cb520ec643cf9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b68e33df640ff5d487cd24dca8d186525a0b93df7fdec7bf9ff10a7830497813"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "7b31cf3e8723533de1224699049ee0fb759fce4e2a00040586515248276f41fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "0047ff345df3b1037f1c3af8a2efe5157d31b1ff27952ab2681ea26ee59c200a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "1ce6527a0f00cca7aeb73865e388ba06f5e89d0fac3cece130d701d759443fdc",
-                                "uncompressed-sha256": "d03ca116e72f308ec1f06d2c2994dafc710d343f4f1e04c25e2088ea2b83b222"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "a1df93bb76c0239a1997f4ad96c9c2acd24342b3cee534eb0078ba8e392f4e5e",
+                                "uncompressed-sha256": "ec732baec1e080237ae39fca10a858ae4b5bf7e2d4f298c23ba500484e3a6c36"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f76142dce377f99ba7aa06f45a919bd0bb860dfd405f3cd2bc7f8666a88c8bf3",
-                                "uncompressed-sha256": "17388698183e59b714df639992810a3e4c6b59503a73d9861cb4f518048a01e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "8bbfceff08aa0839994abe1941f85f417271b49afebd27ae42c1782927017377",
+                                "uncompressed-sha256": "0693d3e6eaea7b391bc0c421811e6869a76b60803718fb4c7186df0a9ddae7eb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/s390x/fedora-coreos-42.20250705.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "caebb2618f34e90df1a6751105e86fe698b00fd9ad19bd445cd28463d2d32256",
-                                "uncompressed-sha256": "7440f494d51a0394f4e68529a2150f8abbe3fa50647bd69d34613a71fe5defa6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9823985645a3560e94c09de20ef182368b0d1c7d1fabc0ea650b47ffe12fdef7",
+                                "uncompressed-sha256": "023c484be492591e2e9987b199ac9dd40cf481ad841e3d6c7d7abb75f22ae7b3"
                             }
                         }
                     }
@@ -491,297 +504,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2b0a16b1a871c16bc9b1f6e81a9384da5616e0dccf8a051841f10c11b7c3b0c3"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e663b4973d70ae459db912e14711aedad4b7ef95bc654455a416671fe12ff354"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "793507ecd9d55173bad180693e7097358c1264feb559a3c3f2557a936d58177a",
-                                "uncompressed-sha256": "a671df5d33007ac31a027afa91b8a6577baa654d502d65edbefd37e06097daa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9728c7bf60e3228c07dd27dec12671c28acbd1796e1cc0442f459be8a12f47c3",
+                                "uncompressed-sha256": "11c6ba5699993ace8e7585bdc796db691e3f180fee3fc14162025c402247014e"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "6af7d773b1446823742d2027e6469b609e58a04738404478380588ef3e214e25",
-                                "uncompressed-sha256": "5993098aa4339d0ea5e63c14989418b5a2bd16b94a3473700fca31addc5491ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "f848e2612d51978277f36e7ca56318cb14a5bbd57a0e3fe200e2fefc75d3b50f",
+                                "uncompressed-sha256": "478f322090f710850d44272c11787b3f5f84c13b0ce88a39d5d27bf3ad2255f8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "86fddf7ec8a8502e829c56de0280fa7fb5bafee1d9bb8bc72a4fc855ba9612bc",
-                                "uncompressed-sha256": "69ce35467a41cb7dbdc306d9c18fc2588505f585fa5b4c83f55ac56a8eed3bf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "30d816c3810407f8ae8ad9ca43f50083504bd837c4593a5d73d5fae4eaa308ea",
+                                "uncompressed-sha256": "a7519649fd086b9822b724f3999f4f026aec0d42e39942ddcf9e0459cfa52649"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "ffe8860f145c55c0ac4775deeea904c2454634f4793d80fd957446a5420278fd",
-                                "uncompressed-sha256": "067fd08707703baabc69084b2b1af7906b2b2ed9233392a6c18ed539813e1f17"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "2fb34c75897fabc2c2e668cad31fbf5b4cec0db258f140c62a3b875dabd45083",
+                                "uncompressed-sha256": "fceb623bc30d727919deaec3c4779523f3625a69339339dd22df4c038daf8449"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a0854943e5fefb38c7183a27443d6e45736847d48351c7c0f42f4f3c3cfade5a",
-                                "uncompressed-sha256": "0165349493291c2dad2b2e156b5dc8e02559d4f72ccfe2a31fe19337d274dc03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ebd1aa645cc5e345a53a92af6e55a6776da9e1a3f42be89a69599504ec5e7d94",
+                                "uncompressed-sha256": "9504f4a746d3c266e938951b9bcdbf679a8ae75ef7f4bd4f548f2ff576740590"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "673f68d43b6c9e044a618dad0c479f9c64b55bf2cfd5a276b543fb39100aefb7",
-                                "uncompressed-sha256": "22ee81dbbf7e9c23216db69828e6c6e462810606fc59a212c4ffc5e2ca18f5e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e40c26c4d88dee7b2a3fa4c519891aa44d68be1411a5b3daca3a7a3909b889c4",
+                                "uncompressed-sha256": "7a9008634107bb9a58a34fbbbf12edfdd81c5e919925b735a3e5acc8792e459a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "03b1059c8b775375ce6201f0327d8300c143a5c21f1b5743c0fa8ea6b0ff4f8b",
-                                "uncompressed-sha256": "eb5d4bd183cceb7c8b83e11b5c3e5c877d0f4a90638243c24145161b521d5d71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "2136d288dc0e99ef81a647a712473809ee0bbfbeab44e2fba259465a0fc029ae",
+                                "uncompressed-sha256": "d8559931f52dbf038b1e38e4268dc48d077eed4f25c440ee78961a5463cb9c99"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "a4556a1ef0a36f0a26ae036f0714c14015603f806d438f2d037160351cdf853f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "2c1f82deff25e929ee687121064098e4232556fc208859db4a44ba2c7be05cc5"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "ecc383d18b84d27b0541fb2a346946ed204d545cef3bc3e1667ac03ceb6af38a",
-                                "uncompressed-sha256": "99f50e0ec786e71c5232960501d716720c944c48b9503f29523ae80b04209be4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "63ecb4348f8e90136989cc28d04e1f5a6069cef9fe283a75173957a76273eac4",
+                                "uncompressed-sha256": "36d26eead54f297fe689b2a5cadd47e377ffe68f9f03d41928ae6595208ca14f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "46985e5494809a42581b1766746883deb489383fadf4be1b61f4a2f2006ad28e",
-                                "uncompressed-sha256": "0929297f2374572aed1f70e8b8ddf1259a5d89996017ec499e76af4a2a15ec26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "120a0453efe4e5446dd5f89c2542961a04906689277c9d50c4a70afdbabc17b1",
+                                "uncompressed-sha256": "de9ff55707df46de09f5bd6d3ca70a4bc3c14d633dbe654e13fea878b913a427"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4d5e5badd1ce61d8f02eb9277203c1db479f3f5df4f9b2ef509ce6641b324e89",
-                                "uncompressed-sha256": "e750db9fbb49fcc29ab5c9c569923df4be81469c146b6b07ef642f29cdf01483"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4ef03da80cdc238e1750e9ce0ebe4dca1e1eed03ab1cfbc75854367f74c0d36e",
+                                "uncompressed-sha256": "4b48b0beadea9bb1b9ff0888c6708d2d4efad4c3a13626de3ddb81cdb4e60fc5"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "bc4eafe5db68514c4b8964ea3b48917b38d419b3e586e253c1a6ebb8973cc46d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a0f120eaa84018761f1eb2085d3c924930708a1317af055ace4a6a39b17b546a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "276e48c46721631a3e7f8344f5b9c639768b6d752a247c620f419e1b96e8b1ea",
-                                "uncompressed-sha256": "cbdc182f5e5b9849874ab6865c5b18d61770e33376b0a0bdaa8acc5d9ed1325e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1d51db2500613a5a6bcd43f3560c9ab66fab8d927985335f89dedb51009a27fe",
+                                "uncompressed-sha256": "acdcc564742e46984b2bb37fd11296bbef8af6cbe50c0e0688c263d8c7cda44d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-iso.x86_64.iso.sig",
-                                "sha256": "b91e9e99c4ee663c7ef28a4c88be312e35bc60f7950d8a464bad9b4ba763774c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "847d2ff6963a8b2f02dea36ff318bd7ebcceff4d3c3d42377ef5447dbb5d6725"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-kernel.x86_64.sig",
-                                "sha256": "ea3eabbbf7a49ea0dc22983601f8a631cfb7b2b92515024ec5a0dacf5a717efd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-kernel.x86_64.sig",
+                                "sha256": "427ace2fc7e2acc423714f8184b74cdd286dc1c0c765cd0c0667aada88b155ea"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "55fd81f5a5421c65e42ac46014c144903ab312b7d99b70bf19af2299b72889f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9e07867a90b86d40aec056b91b9d78e53c8457e6d0ea19e983b15160901fde26"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "6844db4a5fd6e505227684fb94a8d6403d1cd6e37253846528690d6804ca65e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e3e798893635a0a01e33471276bc9ea44de4b5bf3236bd33540782de17d7b191"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b1992bf86d7792a9e6a696d462a4045091c3ca13a31ef5ada439175cd368811d",
-                                "uncompressed-sha256": "2cd64bb8a3037f5bf887a69f822bd438fa7c841d59bc5bf72e7245a4cf88979e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "22f0526f7e46dd9f751a6ca1d82c80dad798e5806cc9b67295d5d10e0995be3c",
+                                "uncompressed-sha256": "5ed0a654c72171c7f1c51a4734b9c95f3467770b681023dd226be2c76e72c9ca"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "7dab0e0a5416deeb78d73af19c35dd9773790536ab9805c8624f5413b5da90c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e73dad6661166ca2cb12c7c1869072bf867e7d29fe0e4ef211ea14696ae74b6e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "236cd247ef2bad57cf83274819214ab6ea35670aa2bd7404e20cbd2ce01ae168",
-                                "uncompressed-sha256": "f5aca6ef4beab4debcf6c9999ac088e50ac9a3b929ac6e0d5c252bb5db75a767"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f8195ae23e157d60f62768bd4a213fa3d8761ba4d4a9b45f57d10c33fe367f7b",
+                                "uncompressed-sha256": "760e4be09debc0f84e4cab2fd8d8053e48249fbe83675589ca7b82e58f0dd9f3"
+                            }
+                        }
+                    }
+                },
+                "oraclecloud": {
+                    "release": "42.20250721.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ff552e23b02c099fd26d543193dd635f00cee68e3e1ca41f29871dcd38999c0a",
+                                "uncompressed-sha256": "92a58cc4b992de4e47811bd6d52aef3ae798388583e031afd33156bba4fcbf9e"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "7fb66f45fd80e2bb33c5d1c1899fdce47b00c2abc9159f6c03f60a7ebd9c18a1",
-                                "uncompressed-sha256": "6e023efe8e769cc13223097be60694983096cba6f3d5d95fd9fdee43bdfb5580"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "2077469b9b9c8bf3c821b8c376e6df7fa2c9984fea4f2802f5c9bf079aae2cf5",
+                                "uncompressed-sha256": "c7424fb99564c7a9b4ec9ee0e65b311ce6279b4d109a48b1790127fa3c46c2fd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8ba06c2bd62a3ae92ba27052387e614f37469fdb799dd6c4c641b0596e6984b5",
-                                "uncompressed-sha256": "2673a57731eac3a22c330cbebbe88fff6342189a2358c8496d6b2b101d58a765"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b2931a3d1f7b04750b603c5c9f189321bf7ba820eaefae2d05a51fe22716124e",
+                                "uncompressed-sha256": "44a1c3fdfee2092fc126c050758444487c1f9104c356305d4dcb8627daf9a3c5"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "7dad69930770339a78095187483a9ef3ebf1dced40f85798eb10c8c2464a4263"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "3b6a848c07b55c7bfe55d4e3f1737d1de51d880dc2a45d78ebb5a4bbb25d8ad2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "d2a1d86540eb788f0054d7450d87e75fb88f2b625ef9edb5bb66bdcf376d5c2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "75ca35a7cf4e260355508e57b11ed406fbccc886933ef53d1b59ae2cf87d3466"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250705.2.0/x86_64/fedora-coreos-42.20250705.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9900447add59b6678ea3e4ce103e5229c5b7f34e78bb748492a8aa252868ad5d",
-                                "uncompressed-sha256": "c040af950ac4952c8dd2246a4d389daecb80039c53eaaf5c968bc3acfdb00f06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5e427adf6e0afce1e863e156b38cf112e32d33046560c79bec4936bc0af3db55",
+                                "uncompressed-sha256": "ceffd612b3380c465779325e5ef8e5a79fedc9b6fc58a569a597abec72ca1b75"
                             }
                         }
                     }
@@ -791,149 +817,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0fd357a18d4ba758b"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-00d091543ab6e1058"
                         },
                         "ap-east-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0494f234801d801aa"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-03011418ab6c994fd"
                         },
                         "ap-east-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-06ea16430d3898b7d"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-039bbf3081ac8c0f2"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-00cdd7464bc5f8a34"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0171fb08ead631955"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0cdf1a2be7853e595"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-04cb4fc549e2c4db1"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-003986761adec4c44"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-034b7622e14fa981f"
                         },
                         "ap-south-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0918c8c21dbfb1b56"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-01102ddf20340224d"
                         },
                         "ap-south-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-004a7f1a67adfc72a"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0609e68d76ccab327"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-01e28f4bd652353e4"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0935ee238759cc95b"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0b092d0e43f6192eb"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-07829af1c5375ebdf"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-065818c9f8c51b999"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0e3042279cd20ca0e"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0ab0474a2fca52e1b"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0588c2ea8ad8e3cce"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-03e7f8e6395a70cad"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-083401a567a2dd913"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-003c1808115a66829"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0e4358fe7b28becf7"
                         },
                         "ca-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-02ed1420d020864bb"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-03a6ff2a03489d868"
                         },
                         "ca-west-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0bafb415bb564df47"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-08be5808e0bc524c9"
                         },
                         "eu-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-08e9aaf1f6f3801a7"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0ecc140fa1c81449d"
                         },
                         "eu-central-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-01f084208bc53a80e"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0beb2daa78c002e28"
                         },
                         "eu-north-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-01ee38121fd60da4d"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0fc37c5baf14315dd"
                         },
                         "eu-south-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0a2dd922531a5061c"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0ab0a96e5f55e932d"
                         },
                         "eu-south-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0ecb88b9989d0a269"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0e4ef5a92c54dacfc"
                         },
                         "eu-west-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-099fbe29b76551a6a"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-00617c61bcda5f655"
                         },
                         "eu-west-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0d79ad6e5af1387e1"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0e15a5497a0ca26db"
                         },
                         "eu-west-3": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0a79bdfd35d588972"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0cb38e87210f370d6"
                         },
                         "il-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-07022bce2c84ba8e2"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-08f60d532af4cda02"
                         },
                         "me-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-004e864817a82f461"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0ec7279e0e8dc0a8e"
                         },
                         "me-south-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0102a3ccf2e993927"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-02e3ea70826d50eb9"
                         },
                         "mx-central-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-07643dd44cc9743b7"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-025e28571d149ef5d"
                         },
                         "sa-east-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0e42b7145ba82814f"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-065d716b0bd139cd7"
                         },
                         "us-east-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-03d27976669c84a34"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-097e41cdd2e74e255"
                         },
                         "us-east-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-041b2ef44d9b4c9c3"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-07c53d2192593ec29"
                         },
                         "us-west-1": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0f8f308efb609437e"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-0561d89a5ac3d2d4d"
                         },
                         "us-west-2": {
-                            "release": "42.20250705.2.0",
-                            "image": "ami-0e9c70032728f4d40"
+                            "release": "42.20250721.2.0",
+                            "image": "ami-010634c4237e2066d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250705-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250721-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250705.2.0",
+                    "release": "42.20250721.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5f278c94564dea9e266582d66826d7121a4b912b3c73098182e6776691113b79"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9623e2610782956fbca973e5371e1a13911c5ba05a20d01e0c50289076808352"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-07-07T20:59:49Z"
+    "last-modified": "2025-07-22T23:33:06Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250623.1.0",
+      "version": "42.20250705.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250705.1.0",
+      "version": "42.20250721.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1751923800,
+          "start_epoch": 1753279200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-07-11T03:59:33Z"
+    "last-modified": "2025-07-22T23:33:05Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "42.20250609.3.0",
+      "version": "42.20250623.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "42.20250623.3.1",
+      "version": "42.20250705.3.0",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1080,
-          "start_epoch": 1752224400,
+          "duration_minutes": 2880,
+          "start_epoch": 1753279200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-07-07T20:59:47Z"
+    "last-modified": "2025-07-22T23:33:05Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250623.2.0",
+      "version": "42.20250705.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250705.2.0",
+      "version": "42.20250721.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1751923800,
+          "start_epoch": 1753279200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).