### PR TITLE
release-notes: add issue #1485 to release notes entries

### DIFF
--- a/release-notes/next.yml
+++ b/release-notes/next.yml
@@ -9,6 +9,8 @@ releases:
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1978"
       - text: "Docker Swarm Overlay Networking Issues w/28.2.2"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1973"
+      - text: "Support updating multiple EFIs in mirrored setups (RAID) in bootupd"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1485"
   42.20250623.1.0:
     issues:
       - text: "Implement Proxmox VE (`proxmoxve`) Support"

--- a/release-notes/stable.yml
+++ b/release-notes/stable.yml
@@ -3,6 +3,8 @@ releases:
     issues:
       - text: "Implement Proxmox VE (`proxmoxve`) Support"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1652"
+      - text: "Support updating multiple EFIs in mirrored setups (RAID) in bootupd"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1485"
   42.20250623.3.1:
     issues:
       - text: "Docker Swarm Overlay Networking Issues w/28.2.2"

--- a/release-notes/testing.yml
+++ b/release-notes/testing.yml
@@ -11,6 +11,8 @@ releases:
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
       - text: "Docker Swarm Overlay Networking Issues w/28.2.2"
         url: "https://github.com/coreos/fedora-coreos-tracker/issues/1973"
+      - text: "Support updating multiple EFIs in mirrored setups (RAID) in bootupd"
+        url: "https://github.com/coreos/fedora-coreos-tracker/issues/1485"
   42.20250623.2.0:
     issues:
       - text: "Implement Proxmox VE (`proxmoxve`) Support"


### PR DESCRIPTION
This was fixed with the new bootupd release so let's add corresponding release notes entries for it.

https://github.com/coreos/fedora-coreos-tracker/issues/1485