### PR TITLE
Roll out stable 42.20250721.3.0, testing 42.20250803.2.0, next 42.20250803.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-07-22T23:33:06Z",
+        "last-modified": "2025-08-05T16:45:01Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "e9629140143420c377b3dd58921896d29171cc2da8380ea28b23b32016fcda8c",
-                                "uncompressed-sha256": "32a8df989436fdbbdbefb72a2fb6fb57bdd8df629b0d11cf5ee4ba6f34948df3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "7ffd9d8354b569b57d90d0d83eb3339aafd6bc82d8f81a8d74e165d9e7db2adb",
+                                "uncompressed-sha256": "9ccc977c49c4cb73d6aec8ea514a56a16f5c68b913d996952731d3d280a15f44"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fc5545e0d18377d926494c689f02c985f906d75cd8a64e66dfc26807706970e3",
-                                "uncompressed-sha256": "7972c6409c7d070feca845ca6de51df07ef57901ec664b1adec9df0e3859066c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "be051045225f5bab03830f865d27902cf3a8509a01153c283a388e2abdfff225",
+                                "uncompressed-sha256": "c53eb218fef9f58c16bffd4c6f6ea08f3f81a4a2106f8112ceac71bffba4d5d2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "cfec6e8c32d543361374c5608febef9e2bdac524d98bc5887824e77e63d9201e",
-                                "uncompressed-sha256": "89fde7e2890806f1c7d17154e8688848ab5bddf3dba0c2d8af862a85dc6f9f85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "f73c0d598e8090133495f240630910df4a875f2e5b9dbf9210cbdaa6eadd1d78",
+                                "uncompressed-sha256": "cf72ec9baa3fcaac1d1d6e690248cfbb3bd8d7416b9dcd469f21c4856dba877a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "69739d5693bab0263492a963c376095a1071c27f08193e9a324e9c7f31c9bd79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "840aac9801ae0c7dd1c9658e9d0114f870a460970dad8244d2de8cd0ec6a62ca"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "4042266d5b86193928d512d57e4a0c3e6823f26f5d7998a0d74f7bb3fc866503",
-                                "uncompressed-sha256": "b4710e9451f2b734131c073f9950256443fd06c6797fd9d925736c58a6e4afa4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "3f0c84f40c48e6d0192da9bcd4d4606fe1a82ce3c7ba88d71c6d7dfc32cefd06",
+                                "uncompressed-sha256": "b57b5dd3daba12a3a2c04c755eaf597052d823a72924f638030957651f166894"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "d35e156d7c7d009e4e623580ae51b61532a6197eca44e1411a59fcb24e504aa4",
-                                "uncompressed-sha256": "329a38531f54d4de256bdb0a24157fe710942cc441dc1b40fefdcfe5f4f4246d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "7cf573ce48bbbfb9ab086b83c3b7e17820cb9fd708dad5465bb7faa25ec0f91e",
+                                "uncompressed-sha256": "3cd89007a2875dbef88a07511f49c9dd6f3a686851011f280695607335aa6a18"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "42fac335110cfa80ff3c46dabedf70418553379f273bce5cb8bdcdd2f8a31a69",
-                                "uncompressed-sha256": "ae91b325c0b13bbaa06e77443c4168a472c71366ba203760cf65e9af2041ea19"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a4b2e3e44284f25c59dcc4e031a986a8d5e67221781da864bdf1ed5db51f3fbe",
+                                "uncompressed-sha256": "e6dba821f853a2fb8ef417fe9a31ae4d666260dab18be936558ba9893991946e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "79b0bd0f142d594c74db4e7dac71e97cef7d763af450f45192f72d14042f96e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "bb9f50a75707295758a1b7428e5f86c16bfd2519d6ef22753ca06f00c7b87a66"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-kernel.aarch64.sig",
-                                "sha256": "12b26d4425c80080c89a0efe02c64a41ea5b0b4843abb5297a8e17da894eecbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-kernel.aarch64.sig",
+                                "sha256": "acfbfe21fc06d6ca24e1d0005b1dbd6d9743e8b65548af3e0e8ffd8c9321a8f8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "af8502c80176da92c14f4bb95da4129ea50b8e3c73bb1342f0fbe9f1ed214729"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ef174c3a6ab2f222263c87f98cafdea0a3c15528912b3e81eff6470955a53599"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "3028f189c2c0df86ce548cc78545a26ffed4ac8a136c61ba670985c74136cb74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a204c160ccb9014d6299c6531f6c026b5d25e36b5f521b31270e3e0ea24a8a50"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "7dd18fb42923fceb57fa943e7eea153602dc7737aec8076171d9895de1ebdfcd",
-                                "uncompressed-sha256": "2f828c1e9f26b408e67cb921b47790d9ba53481e5c18ca6000c33853d0f62cc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "9d5745235f37c6b9e3d53d86c0b1743cd27d5b02c16adbd8afdb50846d2382be",
+                                "uncompressed-sha256": "3b5d610c7728545ba42147874114e558488bfb1c4e7b1bd1d5a5e8470158a38e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "95452e297e8e6dc1b183c62ebe8998975036026648f3ee8fa17e91b14cd524ba",
-                                "uncompressed-sha256": "9cb5e2cdbb9b91e7de2f07247f4567b52e21a7cd5ef42cb4e1aeb084871de295"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b0b76bdb4dcc673277fadc5620dfbf9e028b582b67f6607742113815c27860c6",
+                                "uncompressed-sha256": "df4686d3d9b95b63722a8644f9bbd58fcae3bc35b14526286bd59af30b2afe38"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "eaa1e536fd207c154310e635a94193775b69f16460643a7ea40735432dac42a2",
-                                "uncompressed-sha256": "2f40009393ab8742da0006493810608281facb8b3fe7280f2802b8d6cf9f4e68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "fa938f35895ee1fa86a36555ddddd53c4128f1eadcdf1f3e90859ad11377f25a",
+                                "uncompressed-sha256": "a0f8a0f8c7987df232ab5eb6731e410513b74bb86117261c0cba14ffa5792f77"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/aarch64/fedora-coreos-42.20250721.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8735f28615f16e9df2ee5e17fd49f6aff7c0e265ad0c64ad7df3e2279d338815",
-                                "uncompressed-sha256": "f608c46b6b0774a89e45fa851860f07b1c10ff30991ed87cf9cddf542eff62ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d3462bde8c9f592338efd4fb71eadf5cb92e97a0d9805195d22578c6a7093b14",
+                                "uncompressed-sha256": "7bab4301d6c7047119e6dbe5a45ad71431d56ed25ab4083d5cd477602c2abd6f"
                             }
                         }
                     }
@@ -173,229 +173,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0329e219d23e9401c"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-073ba117ba21e8788"
                         },
                         "ap-east-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0b5cd98d7041e47f3"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-016162ff37fb9ff5a"
                         },
                         "ap-east-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0c049ef12f28b70e3"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0786114918eadff09"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-097f2af169fee0094"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-02931e8a763fafcbd"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0d19cf96ebe97e09a"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-05c4e34acc2600fe3"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-02bb7162e88509ffe"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0e81ed4b05d15a050"
                         },
                         "ap-south-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-08b58a257eaa608ca"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0f326077c8d389a22"
                         },
                         "ap-south-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0ff4c61d4a337f5f8"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-03e662e8be545d5c4"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0e9757b38601bc0cf"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-017b27d56009c254e"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-05681d5594395ab39"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-05aebcb5aa8c807f5"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-099dd34ca92c19cd1"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-081d53f296feb02c9"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0cd4c4442b6ef7ace"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0c185143a323f8f27"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0168d1d05f4afc787"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0ccbcf3f0c6bcfec3"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0865ed7e3a151cfd1"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-03e62650148b210e4"
                         },
                         "ca-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-05f8f885bbeead004"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-07acaba88e4e39dd2"
                         },
                         "ca-west-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-04351a3790ffdf8b9"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-09d8387f95c46c0ac"
                         },
                         "eu-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-036d94f8dcc9882bc"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0fc17ced68db26c4e"
                         },
                         "eu-central-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0e767586fb72850cb"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-022b5b3fb57cd26dd"
                         },
                         "eu-north-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-04d2c76ae0260827c"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-075c473c0244f624d"
                         },
                         "eu-south-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-04c465252049ab841"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0fcfa409c0f3dbedf"
                         },
                         "eu-south-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0251bcac75948ddbe"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-016b0efefc012de6d"
                         },
                         "eu-west-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-00f406a9807bcaa0f"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-07e8967c4f53a9ce1"
                         },
                         "eu-west-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-044a6eafacd6f8eda"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-02d8ce0a5e55fbe55"
                         },
                         "eu-west-3": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-05b1389bddf30e905"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0afa89d273f8899e3"
                         },
                         "il-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-03fb3c215bffbf003"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-02841e6cd9c7a743e"
                         },
                         "me-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-073bc4c6de19d6695"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-035215295835b099a"
                         },
                         "me-south-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-05344e0ef958ba871"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0603917f92f968ee6"
                         },
                         "mx-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0b2e3c0551b6db1c4"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0b4988792fc549cb9"
                         },
                         "sa-east-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0e956e23580a147b7"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-07efdaf22e9603176"
                         },
                         "us-east-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0ce33f34aad4cc587"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0d5fd0b41f120c8a3"
                         },
                         "us-east-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-09a6b7a9cda2ae83d"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0148b78da60c8bb4b"
                         },
                         "us-west-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0c165d9d596e89f50"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-02def702031f602a2"
                         },
                         "us-west-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-04056d5d015e9a400"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0b14f010bc1652f5f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250721-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250803-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f0cdfdb3f7fb9a26fd25551e10d4674e0fc64c6c60dc9f2b6b0396ef597191fa",
-                                "uncompressed-sha256": "174103993ad34c950a2538e3ac64ecd6f58f06a817a1523aa6f46dcbe8059a38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f90fb940b7c823e428b5eac6c5292e4dd877c556ef2e027234eee7a3c1058a0d",
+                                "uncompressed-sha256": "ee262f0d5f5b48a87a8daf071a473f40ca0e3dab0f4f0b443349de3999a3f93f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "76e2d7784130b1662de4ecc85b4ce47c598ad404ce20bdb68c1c371e97990af6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "20bdc0a4d89d6e9b88cbc35f125e77de5d9eb06cac566e718e0ce4464bd17586"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "4551f5ac76b46cfa79ae7e9a40f342433d5d8269c8fd4bf3121f33ce45e30250"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "e5c615bef1fd6856034a5847fda000910421834ff1f446315959d4ca7c2bde6a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e87e404c2fa1cb7c1448403de86c40256fe8306a62324e50e4b3b263498ce021"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "5dc58b6e21090c3956c4456f942eb3a23a99c7bfb04f0a961a05026a1d204cdf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "8a49708cfb818e46dea40abd1f71e013b48815c354886196d0c728fdcc572e84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "ad4da37fd1a49d1e10e43acf1c5c8e83584e29f64bec02ced0d85625855d8047"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "057a7e047400bee70edb31d40a0ab1679e2489d22acb8e4cf760bc66ab451241",
-                                "uncompressed-sha256": "9a0d5a0a36600b479c7cf13568d0706bb2c031435ff037a909d3ddf19f99b147"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "af5adba1bb5555ed93fe70aa9efff1c4ff72329e5ddea37a6a6286fb56cb6095",
+                                "uncompressed-sha256": "b3dd77ac01170617c6583293268931f3985b68dc6f23f24d23d6fa94f447f712"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "024bba2c9ae15045887dd57492a29ed6ad09aefb298fc0a18fa05e03a53eff3d",
-                                "uncompressed-sha256": "9a5b5c914b93de3d17bd43ef31c203e57e08484e0e0a019521c4b73f23953720"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2b8bdd303118599408439d884ed6f25ae17c59f1facd3af0d0d707900bf6f1ed",
+                                "uncompressed-sha256": "120fde00e914bf063f727aa6eb24d9b5dd5de82ac8eb689ba2cedfca82d05599"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b0c97ccc7fd49b0a55fe9f55a2689f4e999f386c58ad22d5c28fe01731536ff9",
-                                "uncompressed-sha256": "f612cb3f8128f04f81b05a5b26244b9ce5db56a9e23126e1294261b9d6f1e9c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5e9bd25d687e24b174abe204407a76437b4a20357e9cc52e13330030ac57f451",
+                                "uncompressed-sha256": "2a43ff36e5929c2b2c77f9c66b4ef4785cfc731f325c41b0e3390ee58b49ad50"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/ppc64le/fedora-coreos-42.20250721.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "11293101fb77eeba34db1422a42f5dcb1637b48cde84f092ed9acdb58c85458c",
-                                "uncompressed-sha256": "d8f7aa2980967b2e9c0d4e2c3bc6719e21d560476980fae3bd3a167c4c2d1176"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "1c757f3497031cbbdec123387135569bf373487b017259c45ea2ca814f9db0f8",
+                                "uncompressed-sha256": "7bceab6d81da37edfb5c85aae21bbcf4a967ac5f343a6fbfddb2c986714bd6ea"
                             }
                         }
                     }
@@ -406,97 +406,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "fe6be376852de0161a9ed31024a55ca22069fc9e7391b56229ffaa61cebdcbc9",
-                                "uncompressed-sha256": "48a564c151f626ed33d6928c375816bdd2b203d1d1816557f59f10247c813ece"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "0bfd28e3b715908781fbd8cf190cd0f82699da376243036e1a748e701914dcfd",
+                                "uncompressed-sha256": "6992161a3eb2833d2b8f37554ae8e5a23734d76fe0eddce35e7490dc4a91b41e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "200caf2dde90e427ce7f5c203b7c0017f7a905b14fda099b07509bfa4524dc5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "037a3b68ed1b722ec7bf4e82674653503d184750a14bc03f24ef637541eebd89"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b01be538bf85bfaf123bb66d93db624a275d852c1e38b1ffeeccd2dc58ec9fde",
-                                "uncompressed-sha256": "40a8ed1f7185aa87b76990f418ee6c15d2df6b01add782f96de05aa9962d87c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "8ecf10020238b1aa09f10e38e171748b17112ca60d9cbdcd89d68967961a96a8",
+                                "uncompressed-sha256": "b6d4038111f77144a38dff2efdca029e93ff34e9a84c5befe470c7cf5883ea9c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "1aef470b7cc6f69a1721495a8635ecf350b7b7940dfe293ca54d9636db52c952"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "368952d9e7c654bca649ed1766950426244a3671d27d8319e2a0fb45b62d9f4c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-kernel.s390x.sig",
-                                "sha256": "b357f0c6f4d5c1b25ead6d2779a45919ea0a34539cbbaf5ef547104dd3cde83f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-kernel.s390x.sig",
+                                "sha256": "21e1685ea1a58c19fc99f5c80b924b8baa4a6e102074f435e9d849720a621c00"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "f2ea8cf943e3db8fde7e8dda70b61ff19a22b8933ce1d15957f8bc7692c038b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "b5c735dff251f626dee90a64dbf11401dd5f890a38317985fa4aba4676ef4d60"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "691868c70f4b1d5b7ff0544fff98584a3d443da0d2d3b97b7c683fd4d3f39ac8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "ea2664d5cd726126f76d523cafea9e344174ddbc82de19d45a7cf1dcdf508bfa"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "6a653cd2bdded28bb29b59d95bc54ac582e81b4b573295dede7130b65d4b143d",
-                                "uncompressed-sha256": "c35a17c0b7cbdaee0d0cafb8f89bd5194b79f4f4fb79eefa91ef05db87a505c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "cae4d54cec5055f49ab2c3582261cf4fcea8f709a25d0c028141659f21981c35",
+                                "uncompressed-sha256": "f8398105afdf54c25dbb3dee8fb1c3fd4878fbda1a6f6d7a1e55c66cf001287a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "07d1b7e342329d9eb1b97673a3e2c595a5cd3112a442f5f56f35c117387bc466",
-                                "uncompressed-sha256": "46ec8b7d44105e4f5d1fcdb0abb4911cb7b0cabe795cbb998923ec4899a71515"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "6de21f84b44daa00b348a9093a63e4555724160b9abe728d34d7d76ba3bb4dde",
+                                "uncompressed-sha256": "f16f70e1626880165b29dce43f3c8ca315fd274e120a83c19cc366d592a68bf6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/s390x/fedora-coreos-42.20250721.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "87949a63e93a96f23312a392dc09f7eb82de43bfe0c06391d099dc1c004bc143",
-                                "uncompressed-sha256": "cdd23f9b013705ad6e13e53312dbe300542ed2990314a123f031d581a4cbd0c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "9d69d64ccf7681d25bc3c69320d2caf2318fa8da030c53dffc1682728867641a",
+                                "uncompressed-sha256": "40998e73471053266463717bfd02f022fddb518340d8f876e17f79a7ea1517d0"
                             }
                         }
                     }
@@ -504,310 +504,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a39013ad228aa89d9f9710fdcff3f265a57d6f7602aa420867b2b4b5ecdd9727"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6862f26e1133c65f002f322c03ac70cfde27d1068239d251875148a1028c473e"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "86ca06026181d9d393bcd91ed7247eecc2cb42df55f97afddc0e2b42f8f260b5",
-                                "uncompressed-sha256": "1a6ff198ed82885205824a29e3e69de21e96e27214e739d1afdb942704eba490"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "bb633e08885d68ccbd975a1eb129fce29457bee8b7b99f4f2d223a2851bd4906",
+                                "uncompressed-sha256": "2e50b1012abbd8cb1c627248b0a5b557ced01a518edbe18630c18a0a9cf98b20"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "f69c6a3d791ea39557a423f3beb9e6351c2fccb52db1e00123f6f5655aff2947",
-                                "uncompressed-sha256": "5ee2716a375c12ba639cd92ab5d34b7a2eaadf7edd1094e81959fae66501835a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "04f4e721fccaaa5f2b276e10888fd0227576301cbaac6faac3030ffff0bf4562",
+                                "uncompressed-sha256": "94c2ce3b4170c5aec329669af8a674e0b69fe76133af040ff19d78b3103d920a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "44f4acb4d341bea8d702b2763a642f7e6b40400cfe45c075d0d3333ae25ff2ec",
-                                "uncompressed-sha256": "4318ddc3e5a14a2fe6b8e8f348dcecdad7bc92700ccd71074fd1854320e4896c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "5b7398843518d91df19f014dda6a39b40a38c85c8d2b5141dd98781f22113d8b",
+                                "uncompressed-sha256": "ffa9b60ec3a39cedaf54350dc24e03584cf95b1a1c3bf1ac1a698d1da51c8e36"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0993b9d3fe62c803fb64890e419ad90b9d1a86b10a5ba773e5fb89078bb5ad07",
-                                "uncompressed-sha256": "ceb4a20ebc3a7b6aab9db6612b737286a74b09cad0732bf94bac8afbccf5bf03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3ad4749dc0c97ad2c25668067c4e6c282403f6044a51ae5240ea34a885436aa9",
+                                "uncompressed-sha256": "13ba912f91de0d4deba20497cc760dfd34539e3f2bd19369c22d0b3927173879"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "00a8424314cdb57111f6d60105d13bbc80d5db0786ea6a8b391480872eb1437e",
-                                "uncompressed-sha256": "43a4ca8bbbbbf4dfb413cd3ef91ce1cbfa5512b01f8e0d9bdca48984048465b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e1a494c0d1ea041195d6f09fe5bd88eab3c0a536fbbc538966cc8e4cff42d557",
+                                "uncompressed-sha256": "f3ec94557429cf2c8a0c9abebe850c5ddbb79f36569f16466e9258ca190f2de9"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "12dbe8a12bbd922c55c1f8c8c10368ea9b88455fc6dfb090f5b72e6a84f1dac4",
-                                "uncompressed-sha256": "6037b7623858da5aceeb41973036b7345451062642f423ad304d6ece755e0f08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9218578cb8dec01ab4b78e444fd0422649eab41b521872bbb53d04f603ede13d",
+                                "uncompressed-sha256": "38560ab8c42e98d948f7e2226b2745dc8876e4089c97bcc4b258f2cd40228672"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e0d80cf73479bb0a9eac7fab0012677aafb9af6c60a1ca5fdfde1481f01f2ef7",
-                                "uncompressed-sha256": "372bce96988b12e215c9f844b27f142d6bfa26712bd71188d3b46744b830d829"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "28dec876e795ffae5800ff61378f54934fc4d418f1fb0161119eb192c3f28734",
+                                "uncompressed-sha256": "94947a9ea1318f80a90e7fa2f3bbd47b2282710377639bab9cc40100b34ad1c0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "945367a6e1c5eccc6ec3af1273830dba754fa4c25c04d673f19b0577795ef3c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "73eda0da4c56a007625e1bd3e3006a7fe48e8b28f3346f826f8b1c4ed0c7c6e5"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "4b28a0870c63dba3f05f457cfca634eaf49a42b3d4b1f87508a57534d74e30d2",
-                                "uncompressed-sha256": "a837012385e0dc857ead8f616ab56dd3a65f3da2dd0d6f01f1a527fb26f6816d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "3d94abd8f16f5a9bfeb9ea96b7ae5302387b91c2e08646e7a476fbfeeaadfc66",
+                                "uncompressed-sha256": "da35c42ce84467895c15652a37030764077485ed91d2eac3b035d5c490ccbb21"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "0234724043d94c30d9313c3531af4af23fe1b21cb4ed8963771cde4aa575c4ab",
-                                "uncompressed-sha256": "d11fe7c627993fd92176d53dc02e1e754558cb304a4f44960909bb43f2dedf39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e8453a71fed5e79510e77bf63160f4d2426b65e09b383348ade31d1987d55384",
+                                "uncompressed-sha256": "ac036fd83c1c42cf0d385bc195ca634bbb31b869028e5d477e370b31f331045c"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "338fe4697e2d32aaffca58d074d3c9f57c7624e4e879cc2d9591e7e6df1530e7",
-                                "uncompressed-sha256": "b2e4ef316d86cdafdbd819bd214b1430a1a475fd1e788784ba7ceafb0bb7f8e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b1048e9ebb580415ee1a9724b7f5f8e4db4b57c142f5162f7232b8272d04f8b1",
+                                "uncompressed-sha256": "bb9a4e8063807d28ed02898690dec16806937624c1c904d5c51962825fc7f74d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "aeeaec95c173e316c774a107382b24da132641f42aa243e13377f41932537f41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "8986207bdd07e59ec0a1193f7a2199a8ad0206ce62a522c744f8d5adfc7a867b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "64af75ecfcd5a4aa018f388488939d5e0c0301d729c4ab3490f7e66cc89451b5",
-                                "uncompressed-sha256": "604ef51ef4a13f31c04584976b659f3347f4eeca97ee4ebde067cd018522a96b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "ada16734ddb8fdbae3d74da1d2c056dffe8e4824ee4b36371fb463cc51981d2f",
+                                "uncompressed-sha256": "f570e10bd6202c27846e058f7535451a2f32a769d9fb0da2a74b35585a7a3d59"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "c4da249f794942f062c3494f475f5523fdded69618c38c0b596ee0b3c7207558"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "1281f76a211b82d808f3ab9f2553cd0b93b61015ba6dd5a8c20a25addb48bff7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-kernel.x86_64.sig",
-                                "sha256": "427ace2fc7e2acc423714f8184b74cdd286dc1c0c765cd0c0667aada88b155ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-kernel.x86_64.sig",
+                                "sha256": "f34d99ba63c4d8b1456660f98930ad298531be173a8ccf6dea394ccaa58b21c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "88f0c7e4504683a6070cd120d86a28c1c5a09d5dab459d26214d06128207a374"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "9d2a78fb31bef9f808c3105e2aa40e9f08aa897e91f78bba4daf050e855fab62"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "35062d9d3b95418dafecd1df8eb6ebcc04315a83559e497394f182a662283447"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "91761d6b78459ca731d82a61e0ee4f3f43082d2475f74eb996474c65e4cb5abe"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "68e5623f401f67b51deae1197fdafc58307823c433c8323a24aad521b791e8e4",
-                                "uncompressed-sha256": "9823c4e1b5af69ead90201c65e249b33f0b11b768b5ab6d6e8854b3e47bdc195"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "6022642a75fe079aa83e05f61c1daff04f978583082fde270bda2a6ce939aa13",
+                                "uncompressed-sha256": "0983beccf9044ee771f4e2989cb5f79191553904b1f81838edb7ba4e9060881e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0f28e1077965335b2c274ab02352b80d0a791e5e4b60ef61deb85035b0f26dc2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0ba17d02dab5670fa23ef101e99e0288e778cb0b60f7a0b9927b9ffc4e7fde04"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "251fb00f3b7d04224d3ce1308c8e3cc731c5b20f3f4cf20348ea94fe12090820",
-                                "uncompressed-sha256": "480381419c3cfefa023df3fc21b929ce2a7c494c7811de04b35862ba723cee1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9a90a89bd684b5039e64758312bc2ea2dab5ee17799069b73847508f1a8dc8e9",
+                                "uncompressed-sha256": "1974bd79f3aed310d1d884f6127cabfb365d22d1ef5acaa26218bb5b2b598e18"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "5f839c4fb5f7773667a9ceafaf8cbb1094e1373a8aaba8be27b63514f5457ffc",
-                                "uncompressed-sha256": "89632d961dc0885b8ddc952930c9baed8e5690dc48fe5068248143b74d237d68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1c140e53b6604be8e099449d281ea67418d6d12d417acc664be59ab0606fb395",
+                                "uncompressed-sha256": "c88696da7c7e12087c8cfb2921bfe1281fe22ece807dc761fe4e66412a536068"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "63b6d1a925f5042ded2b6b149931b9e8e3942c982cf61f6f2f7fac670f06ac8a",
-                                "uncompressed-sha256": "88a85f5fca1774160382b73125b24ee37aa296360367da99f820e1399d71a37b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "66029034b00db15944b40f29d1c8b2abd397d4228420fabf2b151b4ab7d01c85",
+                                "uncompressed-sha256": "b3a81273dc18cc8e8d727cc8bb2e9833d79e9039e4c1c94a7ed4d89d4027d2eb"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "4a5eca7270e993ba6744e43db126cc1de3f686a1d7460aaa2477a52400503cdc",
-                                "uncompressed-sha256": "3d30d3dd64b06db10d0f0cfe9837fc9f0e03acc5ef1c43ad793f9e5319e309ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3eed9d4a0616484a9fab9db19116a7a36af208c272c9c3ae757e7380e415f67c",
+                                "uncompressed-sha256": "112fe03f63392ad1f95e4068897201d481d0fdd87fd8584cf5349f031a006b91"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "50430f1bfa540287d9fec4b35f697832573f9ea9240fdefc844fe173be5f176a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "964023a594a40cb2c9ccba151f62f09de797401267017e4338753366f6f77aaa"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "09ef125ec2944e06ebfcd12a0ff17812cef4b7e67c0acf9294007387ae37ef0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "6d1abe948cc658a228d516ccbcb2ab4560deb98902e30ec493a84c42e99b2dc6"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250721.1.0/x86_64/fedora-coreos-42.20250721.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "fc005dbe73568020d8db86e8411999d63e533001b192531a0ea25a6911b3b5f7",
-                                "uncompressed-sha256": "27a5f3dd962ee9c750469576ed97db8e829e6d12e5459e88b92d41413f53d878"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "dc793c4503bcace9cf713608d19cccacd76479420687e995471b11817245dc7f",
+                                "uncompressed-sha256": "77210b5ac68be2df238a072c9a4a6a8e901b7a61ba27ef3cf6d4e6b97f1285b0"
                             }
                         }
                     }
@@ -817,149 +817,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0ef097a927351f931"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0e67fd9169163c1f8"
                         },
                         "ap-east-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-07b1e9137b4821a33"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0a0a199f9438b5e65"
                         },
                         "ap-east-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0f4545250570ad073"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0d8690b335dd522f4"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-02adf029834aec4d1"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0ed9ba27a5579b1a1"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0a764a1c4ec2d4687"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0354e9f6f5b4bc643"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0a094b165de13ba4f"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0127a9e1108285790"
                         },
                         "ap-south-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-056974046443deee9"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-07a5ca531bf169abf"
                         },
                         "ap-south-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0885801d504f3b8e7"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-010098b3db743ebf3"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-073703a7f1a9cc52a"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-067d6bf006dcb804d"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-073a5f550b01e9845"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-001472b1b21b8d5b9"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0c813dc74dbca2606"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0339e6137955bb268"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-04f0017d0ce15bb8f"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-021815cd7b2a9e7d6"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0a0c7750f7f50805e"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-076dd2c18f42be667"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-09b7e30339239f0e7"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-09f509c5410d4a70c"
                         },
                         "ca-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0f26f03c08ecfb0d4"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-06f8d2ac8c87a0e6d"
                         },
                         "ca-west-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0fc0807ec1fe7e443"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0d3dc1736d8f2336e"
                         },
                         "eu-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-07eb0bbab61a9e6f9"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0be0fc0ebcada3eba"
                         },
                         "eu-central-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-041d88efd84ad5dd1"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-09112a3474ebd93d9"
                         },
                         "eu-north-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-04e9711fd53556dc5"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-017343be482ffb77b"
                         },
                         "eu-south-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-02be0b91ff826ee6c"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0074ef24b0db2e6ad"
                         },
                         "eu-south-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0def66b660c07b770"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0da3c5acf0d14f327"
                         },
                         "eu-west-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-018f9225d65034196"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-012706316fc1e1458"
                         },
                         "eu-west-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-09ed51ac5abb17346"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-00a1af2dd83290a87"
                         },
                         "eu-west-3": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-09d63fc7d06389ab3"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-03c6c5aa807b10506"
                         },
                         "il-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0bc2e3bd6c39b8bce"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0259608cd255fe639"
                         },
                         "me-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0050475441ac3b963"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-07948d929bba81f5c"
                         },
                         "me-south-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-07a6f74bb9d9f2f23"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0174a638da9c1650d"
                         },
                         "mx-central-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-005bb97922b0f564b"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0198120df732f12ed"
                         },
                         "sa-east-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-081b20183cc8e3dbd"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-08fcbc3d669b5062d"
                         },
                         "us-east-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-006178beab5cd1300"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0cf1f34aea4e771ad"
                         },
                         "us-east-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-02aeedd7c2badf75c"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0fad0d28487f4f71a"
                         },
                         "us-west-1": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-0a724977148b1f0fc"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-0ec1bbd47cd510c23"
                         },
                         "us-west-2": {
-                            "release": "42.20250721.1.0",
-                            "image": "ami-08ecbe0a79029a165"
+                            "release": "42.20250803.1.0",
+                            "image": "ami-06fd89d5b8535ef75"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250721-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250803-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250721.1.0",
+                    "release": "42.20250803.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1d2257434e4486448ad88a428aafabda722b5d5097b11acf938c59361f93d94d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d2d948e57559f2e7632cf625dc939cef6f5f04e0b9844ea81ad085ca5ac8a3ae"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-07-22T23:33:04Z",
+        "last-modified": "2025-08-05T16:45:00Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ef78b8ab8da9d87741e5b3b50c250b0058c8f17c6626a13deffaca7af4a1b380",
-                                "uncompressed-sha256": "aac64321ec32b7b735a3c19b8e2450596a2a2b130153ab581e11ba4942fcf0cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "c439a97740e9ac1110569a98d93484040251157795921592b99660d13098b892",
+                                "uncompressed-sha256": "ebe2f6add298a1cf7e9d2e5013afbbdeb8d6a77fd063ed6fb4ddcf5eae1e504b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a570278ebc26ce23d209a9e1c910f272bbc2ae8a49852e88577a82e3d141ad6c",
-                                "uncompressed-sha256": "6097f0b51b62ecb403035ceb7fb0071a4502f2d501c4e1d28b3eb0342af93b0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ab9a5162b92b2ad312ef57c866c1205339b4b12a29c6a2d9e418eae1e3f93e75",
+                                "uncompressed-sha256": "2fb64ce49eb5bfccbe03b237cba5ae4cf123b651c8b08de861107011bf8ad018"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "4c36d2ac32da2cb1806809417d29c245f4e0b145faf9efc2adce39e089c62d4c",
-                                "uncompressed-sha256": "6232de30b0e8ef361cf00408ab4f06e657b52266b8543a0220fca0ce94a286c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1a9be869ea1e6d090a93a8c0cfe50458d753e6de1fcd517c766adaa11a5f5b58",
+                                "uncompressed-sha256": "5cb8290c5c533ec83ccb85642538aaced9bae968c0b14fcf9ae59cf50a7e195d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "2782696e14dc00e8e2a6ee27d923d2a0103d5e5fd1c0e799e9f8216375460ed2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "5b487ba3fb472e122b24c7f15a8626863440fa950c3008f0858834af7c10b12f"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "53f7e98f1efd74bc5ec67d4a95fb4347cdb8c920d93d90e5d1dc67b9873cc4a6",
-                                "uncompressed-sha256": "3f0e8ad9319f5144502735606efeb80ce9dab6a17798cb7490919016358aa219"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "92c4d585d23a9234e44786dae54a9d84fd60688ef01aa3a23ac4bdc8c466a9a5",
+                                "uncompressed-sha256": "7fe0475ab8f7dad73233bcf7ff9930f50453b6f36d593424af3fb3caaa644ed3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "aaac19de8dd5d9eb1fd2dd6a698859c84b616f19664e516762952027bfc092c6",
-                                "uncompressed-sha256": "198284482cb0d93dffa7e8bf9a486ee924878a0bb15a8c5dd291a5e8ec2610ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "dcbdc5b874db71e8fdcfab1b0bf560d2ceefcaa8dca4c099feaa9f6ab8a3ed69",
+                                "uncompressed-sha256": "c19978d6d2026c2ffa6b3a26576f294815c3636c8bfec95f0cc1c0caf2e654ca"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "c18366561c734d5f76f555d86b521a720e183237a87057a6efed1f41d6528613",
-                                "uncompressed-sha256": "12e01ebb0efb92aae151ee9e655ae4dd3134a09a344251077bc27a19d702ea87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e98d8f5fd3ca4b617a021eb33a9bd531a7486d8a72f31bd5ae6583814bd27bcb",
+                                "uncompressed-sha256": "1bbce9809da89d57b3d4f25fab590c05cd15b9044c440b6fb7243226bd170de3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-iso.aarch64.iso.sig",
-                                "sha256": "bc63a04ea7ea155e7f278120d9e5af008c4f644a3f70bcf3f46089d0a5225f78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-iso.aarch64.iso.sig",
+                                "sha256": "000e7cbc452e90d3ea194719283d77ba2af11c02c195c7d62ec29784a919e27b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-kernel.aarch64.sig",
-                                "sha256": "912f49b916e957d4c27ac0b4152a41373369fd9f538237ec7486ced3623acc87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-kernel.aarch64.sig",
+                                "sha256": "12b26d4425c80080c89a0efe02c64a41ea5b0b4843abb5297a8e17da894eecbc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "99b11c92bdce6b2121c208e891d4bcf9663977fff3633b3c3e3ea7b4b88ee537"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "248f9a4f236f6c4267c845f5141524f30831857d2ed07ebc65332f0f4bdd2db9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ee26a68ecbbd1d51f5fadc281c5c13ef9e9fd714b440dc172924bcd559a3a87f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a3ae41dc6ec44ee5e7d796d2acc31d0b332bf0f68703ac29c696de53bc198926"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "ae14a7f46d9fdc4e3f6debf0beb48ed25f74864351ecf04a07a925d8e0ce9db3",
-                                "uncompressed-sha256": "23e9a7eab6d0be901792b65a6293250e1665cb16a90bde3511fc2183729dbfc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "99356d1b9ee33e1286d55739ac203786f7bb28425a3c69184769ca3c7706a0ea",
+                                "uncompressed-sha256": "1fa9cf14eb40dacdc0b83de840659dc618c89c858699f7f0f1f38a7d22a67de8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "bc70cd10e8e1391e7e61f2da2a8532cb4439f013f5a792027180f5e1726e6e06",
-                                "uncompressed-sha256": "ccc3e701350f96aefaf55aa804b70729bf07eefaeb27daebef95cf1ec7e11df8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "02894de2a9a5482134598e6d9fabe6dd6f0373780cc38b1e5ef750120585eab5",
+                                "uncompressed-sha256": "d77308c203a626cde9bdd1ca7e1b40013101f39e82756eb2204ebbc32226cc12"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "3c2b2b3a1cb1bc9870c2b2899f1da6170678f4c3f1f2e640e1fe86574347337f",
-                                "uncompressed-sha256": "40bb9f5b9152c962a58d19bfc8b5dc0fbb9974fb4d27b50df54c722affb8c177"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "78ab96ea10b112349142e175b4fccebb9bafdd546045bbd14ba607758d154178",
+                                "uncompressed-sha256": "174c8f229a295ecfae9eb110b005ef5291a7702e92b7c2058a07999c8d05e610"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/aarch64/fedora-coreos-42.20250705.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d3f47998dea27ff0236ee5d216ea2de4e35d0642afb3480ff1193aab8fa662bd",
-                                "uncompressed-sha256": "7b0e30199f1af235f4754ce09eb072738bbf894796d72c7c22a18132153ad94d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "b786d453d52008399a42da608fca912b3bb46ba892a19d2e8e7d6b3cb0a5a6e8",
+                                "uncompressed-sha256": "312c73b5932bf1f0c27ba42310979dbf25fa145faceaafb15d3211276e64c826"
                             }
                         }
                     }
@@ -173,229 +173,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-07669c9a1ee4eff92"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0c54380ce0f205e68"
                         },
                         "ap-east-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-06dfbdde0452dcfa9"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-08d3e7e28bc9f79d6"
                         },
                         "ap-east-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0e25f5d0c6bb55293"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-046ac8705961ff9b6"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0a37c9d21b4429b3d"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-015d43123cfd43975"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0955112d1811bec68"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0f59ab9702fc2444d"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0c4bb693c5b156108"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-06e6a5e27f6523b22"
                         },
                         "ap-south-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0f47e86b8d3458cb0"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-00cca6b3a1695da04"
                         },
                         "ap-south-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0afafa9000671c4e5"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-00ac3f5e5318a5148"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0fe0957595b4abb24"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-048d413693ef5dd33"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0a8c18a028d7a0125"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-08cc644a2f40e51fa"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-05248b9dc162994fb"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0c3fd9e8068956c19"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-08e220f2b5f801ddd"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-01b4d8691e9a43c06"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0d29c7a1c5dd3f23b"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-049c2feba19a936e6"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0daf1d14f24a419a5"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0c0299ccf319a8ca3"
                         },
                         "ca-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-01a77f523f0defe7b"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-03e270b265d00b67e"
                         },
                         "ca-west-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-038756d9c1aacb83d"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0e78d1335fe8f3df8"
                         },
                         "eu-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0a0ea36ed065b260e"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-012c7b5bd25c3d1fb"
                         },
                         "eu-central-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-06d8a1a12ff7e05b7"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0986e19b3213aba4d"
                         },
                         "eu-north-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-03d0e79d79fc861c5"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-084fcd6aa93f85eba"
                         },
                         "eu-south-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0c2c791c29cd18641"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-043bccf6f5094c368"
                         },
                         "eu-south-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0fe0bbf77ff84a533"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0f9994ddf0882fb43"
                         },
                         "eu-west-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0644ca5b66a34f501"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-00ca029c27d20a6fc"
                         },
                         "eu-west-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0991d0cad5b54e8ae"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0b828ac5fd8bdf3a2"
                         },
                         "eu-west-3": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-060b0be87f418d851"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0024213d0ff58debd"
                         },
                         "il-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-078f5dcdcea0bfcc0"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0cd60efbcbf560a35"
                         },
                         "me-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-096cd31f6edc9d5d0"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-03ebf5cf768990709"
                         },
                         "me-south-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-009f43313a80960db"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-037d09481a5320d88"
                         },
                         "mx-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0053e85a103db4b9b"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0ec09b58b1a454094"
                         },
                         "sa-east-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-06b38bb73355e31bc"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0fd8382a0922c6734"
                         },
                         "us-east-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0f805521f76f9d8a4"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0702725482b7264eb"
                         },
                         "us-east-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-08fc204fcf9c925ca"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0f9ca7c4faa9955c4"
                         },
                         "us-west-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0f74fb4d0de53ed65"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-05ed99d379d61bd10"
                         },
                         "us-west-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0ed968c964e27a9b0"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0b0696c4acb6cb4ec"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250705-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250721-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c3973bcf9ae1357f515c51b24d0c281fcea6edb033f2e8acb4445873adbffb2d",
-                                "uncompressed-sha256": "6a100039b62862ef5b15394a02cb683f7e8e87f579169cc6bef4230db1f141f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "e33a8ac966a898233f4c07e7bb01aed636197864991146033db8010eb2a8f43a",
+                                "uncompressed-sha256": "f719973061908c11be7c0360a541f0a4174b9a8d52dc70d1db779a19fc916297"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "c5a674faccefc41ced953c7f970efb1a80f77681e6703b7e139321dcbc40953c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "7be4f8d8d21fa806286f4a3cb6c7d21b630e1dc3a83ef44f3bb06542715c4a2f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-kernel.ppc64le.sig",
-                                "sha256": "07caeba85e4d5e2aa63bd6b6dcdccb2fa03a9483c5af5003a6964a20c77a4bee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-kernel.ppc64le.sig",
+                                "sha256": "4551f5ac76b46cfa79ae7e9a40f342433d5d8269c8fd4bf3121f33ce45e30250"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5f3c640b67a2c53a52f1ba9ff3a73d9024a892a6559cddf39bbe072ca9d1355f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "579e8eeda4c057c322f0ec6520be0718e47ecdfe8b5806c3ad1ea69dedc9132a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "9864fcc00751f10b6930a3cb88992e0e6a454f84e7a848a647eec144647e1613"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "270fa5e9313561f7214c529600cb674cd23437f6d3abb49d797c626b19d333c6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "81f7617266f22b74c922335821dbf1392174ebcf16c87fa3a6e88f92c7b6e032",
-                                "uncompressed-sha256": "e3cb58c3e1bc8f6e79d60856317226eb5cdec7bc947615b2c176ad386fc43fe9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "69c0ee7356331b7c8ba1552bec72e6a04153be7e61ce5a1db7ad642a338f292b",
+                                "uncompressed-sha256": "46ca09ece316f4bba14829d0ac2204613c3a61508c46d469356b4e0564501498"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a2846091bd280366f7294b594652298d6b714042f144a063fd40e2c9ff2ec6ea",
-                                "uncompressed-sha256": "666351dac208deae63b54a2410597276a11db22824d5315eccbdb6fcf8f4171a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "bd2f111904bb640405a02826994d8d3bee3b2551678f64902517fd7f04659edc",
+                                "uncompressed-sha256": "8458839905671bef41624ca3ea3a3b0eccd4efb6beeaa2a8a730a888e81c8246"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "5479a7109f6a608e1a736e03893300a4a97dfcea71dc7c74a68f90448bdf895d",
-                                "uncompressed-sha256": "791d9b5610c5c721e8c3b0419a479723a86bfc7063eb03dd11823b265f0fde09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "dd32d91198fff68e27a9a3506df756087368cfe028b5ea384e7a6146577d94ac",
+                                "uncompressed-sha256": "7ee4fc628652495827cae171ef8a25c433fc5b976eaeed80905f60a167dd2aea"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/ppc64le/fedora-coreos-42.20250705.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "b4adb4728d73d56fc4d350d99ff5f59bc76e65172165d9cff8d1fb8adfafce52",
-                                "uncompressed-sha256": "d0a3e80f8b2378c489ab368e25d86c16d05ce5012c903408780f6cf2ce35a700"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "32bc28b4d0fadea51f658f8cad8d2de632b09ca6fef4193fb16fe5b5dc6ed536",
+                                "uncompressed-sha256": "203c12321d5ea912c752f11107524f245f024f53f3b6ce45e70be857cfb2e8d4"
                             }
                         }
                     }
@@ -406,97 +406,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9b895fcba6f3a98d1f2c2be60c1518bd2dfc078a23b891a03313f26d34b39741",
-                                "uncompressed-sha256": "093a161e10ba225f6e0b204fdcc4596b3bf4288bcb737040c6535ed77792e837"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "26465ee8fc2fc1c8ce9178c4ae90a42ac538471f8132abac1267cb876962944f",
+                                "uncompressed-sha256": "9a11c483eaf8b1ffaee82e7b5dd1d0150d4c5629e15450117ea6542f0ef95b30"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "542d9a276a9e28e11c529afd7b6407ebbbc30c16cb423bf078199441ef074f3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "d7d076cf78556fd144a5686fd858db3146ee161177127f46c171fb3ae6672996"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4df4afa08fe54b617b38098cbb7de453c8661d07dc1aad275458cd91b84c8755",
-                                "uncompressed-sha256": "2577a683d634fb48388fbf131aae649e75ae87e3e2c2a50bc45503408125e6ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "8eb7046a1254d0a9144901aaa9f4defbbeafa9bc711c01103496c3516b483e42",
+                                "uncompressed-sha256": "015e8d0613f308958844998e879a1a115e78226800e23a6609b03f1c41c66142"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-iso.s390x.iso.sig",
-                                "sha256": "6f808a74cfc495a4e87c623a4ff53fd35b0d09dde3f2903913e8e2acfab4f6fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-iso.s390x.iso.sig",
+                                "sha256": "0ea1115a1fa0b4c915a17902df5dc901d926eb32413bd8c48039a5d62d88ca81"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-kernel.s390x.sig",
-                                "sha256": "6b39b4f1186283d9053865431c8ba5ace49fb736e78428f2734247ad7ff86303"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-kernel.s390x.sig",
+                                "sha256": "b357f0c6f4d5c1b25ead6d2779a45919ea0a34539cbbaf5ef547104dd3cde83f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b896df266a92f56c7e616266659156871706e4eaadc582bc3f13fc61c0c7c35a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "59345817500c34106808e3e937534287284f969cc8aad576473179f31393059d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e63ca3c7fbe03d490d88a9605cee43c72362ecdcee21e63682c2547f39b26668"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "b0b3df68637276f2a9932c4055416393d65482d412d6a4ebaccf1efb72e00338"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "7feaaad4df00aac2fa27307d0e2ceef7e3a9968f7f36356cfef15ed6382077f5",
-                                "uncompressed-sha256": "de34de6ae6c46bb453fcc3a1d11e7c4a89d2444bfb5aed121551c936ad1394cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "1a1dd5dc8634dad7524a396a5bebd494e8a16d9a487ec568aaf5f4f1d8a420ea",
+                                "uncompressed-sha256": "9bfa665f0579f5fb25c0378d5accd2fc44433eda87983086ee493b9b1a0a3ce0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "eb68fba22353f5497240a70a27cbed06994d19cefa2263dffb359f4c7b26d358",
-                                "uncompressed-sha256": "9735d2050c0fae67d4c74171eb3045278e16a760cc94605ddef798ff6e7e1b38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "74cf62db62fbe140b7b207265c47fa1eb8201b0093c59fee293334562e4019b4",
+                                "uncompressed-sha256": "8bc360246ed5558798c7e422a1d7daf75f7176aff0f04e5f9e2222cfe2a96ac6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/s390x/fedora-coreos-42.20250705.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "075eab5ce77e30c650d83763cb024fcfddaa3fe44807065191e723cf148243d1",
-                                "uncompressed-sha256": "be5b222acc7a77c9f57c43d9620109cc6525a3e89f96e777fe3a278a2486cd4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "8482484219d6b4ee2f7b40c87cab344f21c3a1fdd2b333f05f53c1bcfe3ff893",
+                                "uncompressed-sha256": "029bda088d6bf25545c72a5c8b0ee70cf60b8755355cb8cc6b4682fbc8832747"
                             }
                         }
                     }
@@ -504,310 +504,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e08ba52a949e35fae3df0190909d97596e4102cd61336e790c47e5b04a55c5b8"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:33548a7c900bfb3babc662c5ec05316abdfe96c931eb9048a75159ded21ed6b0"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "34a8fedaaff718db6e1572120f883bef9487828d41b7b26530d638489b7acfdd",
-                                "uncompressed-sha256": "e4a4b80d12510e35944b880059c6bbee50dbeb53c1f26cb8c37ff2166efdbec2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b56b44157d5a8f654845f4f081a500ce3810c33ad9236dacb604b020a220409f",
+                                "uncompressed-sha256": "c55a1186be10d21c10a5c224f7309ad568308734ec6100d1fe79aebaaf6f729c"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "1ccac2e8d91adb5ffce90762ecff34c5146b74757eca0d6e2c995e0064b5e44d",
-                                "uncompressed-sha256": "a2df7cc6a013bcc045c77e51e0d84f437a41837f4bccd4dc9b0690d4149652cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "3303c01550901181d0f43cfa9d690e94e367208b9dc0b38eef8adb8247108055",
+                                "uncompressed-sha256": "8148381c97ae8ee560d7242ba7a6a8f05a0eab54ad5c49f11dc08ed33a1b385e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1b376b8065448ac85620058bc2412d5f2edcf53f5f1f5b2c83a89842b16067d8",
-                                "uncompressed-sha256": "aba7bc70559010b1ade32dbe305c08cd670f04f8b72c6aa31b58d7a5aaaefab5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3ec09046807404c6ef1b213be5cd9aeb15b4f04e78c118973b96f23cfcde1a4f",
+                                "uncompressed-sha256": "7fe391ad4244a873904354305febb60dd3c24940989eb64613d98923d7cc9056"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "1bde1b58e3d3346f23cc999ad837da8cd2d256aaeeda31411fb5d09412097e40",
-                                "uncompressed-sha256": "cc9d19338317c5661bc9a204caa7f11c827709800baf685162309d0324de7cff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "68e805b676f4f419f214af3fc957373750fafddfd19610dca53ca0e158f1296d",
+                                "uncompressed-sha256": "33fc936fb9cd413319eb968212241eaae16d27a920b2547abe18c0513a1c9518"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b5a51d49b69bfb5a7edada1356f3eab49b128e5c3461bfd94fcc8231b289df69",
-                                "uncompressed-sha256": "c8d82b0270b954e48195f5c5849e6d3305e5997ed7c8a4aa4b9427b5ac852715"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "ab99fca2246960d6c185b075a02449f0385f57621e8415fe89debdee88226df7",
+                                "uncompressed-sha256": "975fc01aef8e1f794367e8cd107b687a3fbf93c55cef369022bd63bfe0e7562d"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7531374856de55b5317985e4363f12d802308a3fd2a0e6cafe494b0e16e9f45d",
-                                "uncompressed-sha256": "eb0dffbc2bcb7588397a2f620b42b3e388214429b36f962e4940d5c07ab4fe2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "9a61bc9e9227cead8853b8d2175f1e4cc6885618c3be7433e00b93848ffff262",
+                                "uncompressed-sha256": "dd2c004bf2e7ab9b4a81932f890911f36d97a80673e8ac6d9bd977247c179ada"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "941f47218f7c2cb1db366f684a5de8d5f07b5588261ae39bef90f76a1ecb910c",
-                                "uncompressed-sha256": "cf4effd2d2c215ec0a22e97e002c6f68605e4131b6e5efeaf61f85c92194427c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b48974eb09eb4e7807e1526d25c186cb70d88c89527507d5ce9b201ea898e65d",
+                                "uncompressed-sha256": "99128344c0f64c7639b117d1ca38de3fcff45b055775cdb1c1c3882b26acd2ea"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3937c0b5c9d1107fb8162ab5dd627a2999732d9423531d2b29379bdf180ef386"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "97b30015514940f24bcc10b6ae0850b33b7cc7325e301ecc3b940eb25cdfac72"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "87578cd72cccc764da233d3c03ee459cc8682ada4827e9df32dce59965df8b95",
-                                "uncompressed-sha256": "dc520d61f3722298b4522b3fe9881595058524342036ab0d82ec4f073f14cb58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "4e022997e0afe97cd93c0be18f50dca23321b4148016920553b19feb1cbf50a6",
+                                "uncompressed-sha256": "d6afda657dfe81bbef1f7690e11956c2dc0c4404e8bc0272075b593780c00d72"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "1f3f78b39efeff4404ec99b04c736aafe370bdfc103c88cc59dcd0da3212f6d7",
-                                "uncompressed-sha256": "374c505f44b985f24588671e428ed35406cc7f04636b3e1e25b69a1df2c4bb2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2117f5ade5a6b84880e77cf8efd5eb75d570052e2de583ecd222e8eeffe87458",
+                                "uncompressed-sha256": "eaaa7225ef2a2701c3889962c77a456d18052cc00bc37acd43ab26a2ec9a4614"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4d532ec9cee9b44998d28a5ef096d78682f88e212b917b8ab0a023f79946280d",
-                                "uncompressed-sha256": "aa0e55014a949830eaa99948b5bc479504059553a0ba1bf5b888f260443f8c68"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "48d95e80777ac9c273caddd07bb5dafdce38c5b84851919b4c837bc0b63f7e62",
+                                "uncompressed-sha256": "d01d30f3375b241888ad44b781dc694acdb1aa58c79de57fa73bd7f83436fdc7"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c2fb419e3bf64cb8d0ce78a5bf79188e6c81578a4057a4701926e4edd3766f7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "3455f8e5576a8217748c79fecf182a41381037ae263b208de307a429603b2302"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "788f2484a4fb3470fd1ebb11c7954788503397e00ca2586b686815fb17a44f29",
-                                "uncompressed-sha256": "a3e55b082a85ed160364c17969c5faff0cf57f3948dd6359ff055af3463df938"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b625b7760b0108e19d618378d759f0b1c0152051d49207afa6da5e99cf124c07",
+                                "uncompressed-sha256": "286805e686a57fbb27ab38470f99ccd450cbf48043e1d4211f103a1910a4452c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-iso.x86_64.iso.sig",
-                                "sha256": "a8f1a6f534b5ec28be62f015f6dda3a776dfc9bfd49872b0c399dded7073a1e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-iso.x86_64.iso.sig",
+                                "sha256": "56c1195aee84aefdb34f2a29abf992841dd506d45172e575128421aebcd37a02"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-kernel.x86_64.sig",
-                                "sha256": "ea3eabbbf7a49ea0dc22983601f8a631cfb7b2b92515024ec5a0dacf5a717efd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-kernel.x86_64.sig",
+                                "sha256": "427ace2fc7e2acc423714f8184b74cdd286dc1c0c765cd0c0667aada88b155ea"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "8dbdad561a2a8625dea53e4ce6261efe70737f2cfeb29f47aa190215ab3a2df7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "341378e32c71c2f4f7bc3d99730f4c2d7902ba8ae6f02fe41b0c143eca0c28e5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "d7c4e5e15486201d3976cca4b281fa6b0a52a57e13edb0de68fa57474b91200a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "fcf68260f47a6801f560c9e80db083da44ba0e6fda0797bf9e9338aadebe06c4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "4773e73365d5c08a92aa5cc37aa9ba33168276efd73a92197518207e7bbaca8b",
-                                "uncompressed-sha256": "48008b28a98aaf96f6a6ddcf3041f2178109d301deab52a7a1a0e09af4adce0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "1cf2f4ce5bca848312af96159f2bcc593eb3f0d77077e2ef82b1c008ad4b6fb4",
+                                "uncompressed-sha256": "74c0ff498f12ac2fdbb8d72f1c82d8b818e7b78eb47153bc943db6724832a6d0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "da35bdcf5c30d02256cac9ba47cf139c5ec9cbf50c77c9b67891050dcc2b6283"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "3981b948ed8e16a9d1659eb6ac50500cca05280b8febc2729c39899216a3ed12"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "724208ad91016c3e0d03b97f71b9ecb67a65fede4a470199c0c91a9989c2ba89",
-                                "uncompressed-sha256": "6ba2ca937ead1d33d8bb860a30ffd66ea4955d9f3367069cb6b43e8607dbc0ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a3698b7fd83d0daa109796cd5fd78dbb6654a141e1749985ac926116cf5f318f",
+                                "uncompressed-sha256": "998b8008286e1a93bfb8b7869e2eabe132b24d373f0342dbc593bfc73102b78a"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4b780fb921913f3429bf04a44a6d2fcbac755915363a1a9e4c9055be477d7a8d",
-                                "uncompressed-sha256": "08ef0a8f0faabd9c45e829a4e33112a0889b099d32e2fa6f0c7e1ae7fb990c3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2dd885abef34171500a6661c1dfead7433825b99e003e0a088bb7535966f6d49",
+                                "uncompressed-sha256": "4ae329c79f7139f9742ebcbebdb3ad16196fabd9c5de8204f828154945dcce13"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "dab2cfafe397aa96e2885d11ab89a1463bc0dd49a04c7f06bfef7246d13f0437",
-                                "uncompressed-sha256": "fa723f10b0081ac5014f2f4a1d827494b7671723184a508cacaef77478585f54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "80bc3a4b6569ce7c6f9f9f1f5f23fc614813947cc274a3946302541271c88413",
+                                "uncompressed-sha256": "3d207587f12e716807d0d3126ee7c09c92e56bebe2978a333c9e2a83c42fe858"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "75349a0f97a0aee44265da1d10d4f22a7a925638af33bf4ccbe3cfd141d51e06",
-                                "uncompressed-sha256": "640e620f6a488bf8b1ab36849a47caae5b2c8184a8b7b4d6afb879d1eebd1378"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "02b6767388a1a22d8e4a17cf56211c65d5d84abd8f9124e249248ac6ab0fc818",
+                                "uncompressed-sha256": "7aeca29fa8abb070f370730f8347609dcce7fe94da13ffa22cd4b349daf634f8"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "b851e586e59ac09c9db5fa2f67e252d3d86db9afc0f1cfec5a9fc2d7f3dc5085"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "0bbc9f159febcce6702f1eb6b3a0069437f731cb013da6d55dcd0a37131ca435"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "cdb2208edd3a75e305690a89d97ab2ad9decc9b7cbd01d4e5282b10101979aaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "a83957bb3cb9d4c489d3c982524b24443fac50aa19ad9ea7a98c9cd9c0de4089"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250705.3.0/x86_64/fedora-coreos-42.20250705.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "0436212a4466c81aabb96b4c90eea678cdf9404270a061dd86b7154aa248bcea",
-                                "uncompressed-sha256": "f8ab73e9101a631e727ba4359c912777ad5acd714e84da2d29a6c528c963cd7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "faf2fd78e2e6d3be70fe9ab4d312d0a49805eca661d5deaf4cfeae07e95da6ed",
+                                "uncompressed-sha256": "48152c48ea17169fc7002fdf22b1b321908a2efba9218f22e776a50f914a67ee"
                             }
                         }
                     }
@@ -817,149 +817,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0c9c5502aab820504"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-08996f8feee60d938"
                         },
                         "ap-east-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-06c66be63494d55e3"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-01a2ca660c49654c2"
                         },
                         "ap-east-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-067c44cf480a9de32"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0aec79ac3c2dd1e7f"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-004f0858b864a184b"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0fc7aacb08cd30040"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-02ff004bfc80576bc"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-04c16bb8839290d75"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0603ba2104629dcdb"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-08adf1573ca584eb7"
                         },
                         "ap-south-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0f22fc6f5225bffe9"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-08557ac5281a69017"
                         },
                         "ap-south-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-07d2875408d62090a"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-076fe2d92f9673e54"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-01c3d03239a75223d"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0582de046ecbd9c38"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-09958691b5cec68d5"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0df382c74ed46e95f"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0dadd52009226a916"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0221594f11a5606fc"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0e825b195ed25fdeb"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0dc901f8af423035b"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-08b1034222a80012e"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-02dd80675c2974ca1"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-08bda07441dd80e36"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0f59cd65c034cf030"
                         },
                         "ca-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-07470c15f5f14bef8"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-02a60247e6101281b"
                         },
                         "ca-west-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-00020d5ba506786d3"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-093ebe5eb3e57da8b"
                         },
                         "eu-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0a8fd46be303f8c5e"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0863c3a4853df0c1c"
                         },
                         "eu-central-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-00e98fd39ca1f6ada"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0bcdf48d4da3caa15"
                         },
                         "eu-north-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-005d8f149d370518e"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-00f38a010862fc59d"
                         },
                         "eu-south-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-020ea9f3ce9c40bfa"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0362dd0521c44fa04"
                         },
                         "eu-south-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-07092c86a342db941"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0c153542991f2e943"
                         },
                         "eu-west-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0d02d41bcb521af08"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-02d3f818e44dda077"
                         },
                         "eu-west-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-05981c63830c3d2a6"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-05b31ffbeb6ed1ed1"
                         },
                         "eu-west-3": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-00c6563d2ef6a6ed2"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-05925d5a6673ddc30"
                         },
                         "il-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0eabf3be1baf57ea2"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0bfc7873a691cfe76"
                         },
                         "me-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0760b6e79c9f51b33"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-09b273d02dfac2f6e"
                         },
                         "me-south-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0fd0e15ec5b4a10f2"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0533cd42834cae9fe"
                         },
                         "mx-central-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-068c1c033eaf33523"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-09454db6f7e873797"
                         },
                         "sa-east-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0150390d473334142"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0c4a0bb61c0f1564a"
                         },
                         "us-east-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-06e59f2cd7a5200fa"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0e1fe77546274c1c5"
                         },
                         "us-east-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-03fd5fecc83d82096"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-0c75c2af5666c1ddc"
                         },
                         "us-west-1": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0bf765cb91b6723f0"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-03377a70043898947"
                         },
                         "us-west-2": {
-                            "release": "42.20250705.3.0",
-                            "image": "ami-0728c6e757903c9af"
+                            "release": "42.20250721.3.0",
+                            "image": "ami-01970a529e62cc386"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250705-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250721-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250705.3.0",
+                    "release": "42.20250721.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:66f4a73307d25f6e0c4eda2c622e740a3697000b4fcc92abd028bdccc29bcb92"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e8a7c0f751cbc5459e89bc6f10bd9116b76450b7b289ff2dadfe87e086dd80f6"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-07-22T23:33:05Z",
+        "last-modified": "2025-08-05T16:45:01Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "01fcc2cc1748907464eaa2dba6d7e94abd2161f5a5b395ef8ddfe1b147ca9fbb",
-                                "uncompressed-sha256": "1283b5e96a919b1e802402145b9c3f45d5a25e2347dff9796ee1f05ebd7e0032"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "a50b4d6783bb61c85d83d4bb450bd0ccabe2afef5fb6ad48c42bd25a9ef2ee75",
+                                "uncompressed-sha256": "4f77fcb86c2d5eeb2835ae366ffa6485eee30456f0004ebe67dabd44802ee2cc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "c2add5f7aa5f073d32cacf16d644501bea74c51843b2e0c93400082355c70ea2",
-                                "uncompressed-sha256": "388e869f854fc0ded5d8f4b6115f6aab31069ba683f87ff0110c62f2f2a627eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "18b6481d40db18428632b32f13480268c5acb7685fbf8c716b22a71694c72793",
+                                "uncompressed-sha256": "21236ab7488290946d5635b3297db8da8bf4b04f747b305406875be2e58c5988"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "9f7ba707009a187b79e56093b5ea0286aa1e000987ce3186bfa53b6d2f8fe3e8",
-                                "uncompressed-sha256": "53acbd0f3f467dff2a40327b2fa57f06a132c2d5d503b41a452ba046720ccb84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1bdab4b2bc0431bd83de06b7dd1de98f82235d06e37fb0f89eaae8d5b023c3d0",
+                                "uncompressed-sha256": "3818d345493a842246f3846163b2ad1dffd1aabfe6c5322d93a893dc0b98062e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "81662f744b5cec6c1baca7d482bc996d1fcf6c0680ea88940af9fbba9534531f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0daa52811ae1fa178e9789163f330047bd519dcf4030c6b6952cd3068cd90073"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "8b2f409c320ada6fb8ca9bc0b1be202b680b0843c580d4128041eadfc114025a",
-                                "uncompressed-sha256": "ca4ba726618e7ff7b0d9eac61ec79e7624a159ff99eed75478f586e58b0ec2b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "4cb623896ca2480cc3119f4ecf7a2caa4d74a56b1fa67dbd7734d6b810b594db",
+                                "uncompressed-sha256": "863f86b40e07142edcfd199869fdd967b799cef41f56b269be6067b83e2aa4a9"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "ffe3929aa3c88400ccef8ad73425250f1bf3e1ad7ff91f3c1c9389f3a3a3c982",
-                                "uncompressed-sha256": "74fca3d8a083259e13130d8679761baf1ff473a5c6122b67538f3d1947e1c927"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "6c490393ad673529b02e76b1acedff7d210eae017a67276065a7ce5759de5876",
+                                "uncompressed-sha256": "c3b9d1eaf409cd89f6681a6f8e3cafb8f9ce0ae0f1b9a8ba823ba2c91099f875"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "5ee25cfd4df35093abba099ae9928a309afaba2f8ad0b9810bc6fbf2aea76dd8",
-                                "uncompressed-sha256": "be7e87fc5c495d92dbe5a2e411e1ad75bf248e572d11fad09f7b8494d7419acf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6deeceef8377e39f7206a9da08d870bbc702985913e9248b620e83e8cae309ae",
+                                "uncompressed-sha256": "7df02ea33e2080887d378cc47c088221019ff0279a3587dbf22df01cb2b3cf78"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-iso.aarch64.iso.sig",
-                                "sha256": "da13a4f177478354425eb0f0acbee4377747c51fecd1692bb17d44ea3f4320d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "8172631f1392b6002290b7cb1368da17a3e262cc260dbe1e45061cf13c9f704d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-kernel.aarch64.sig",
-                                "sha256": "12b26d4425c80080c89a0efe02c64a41ea5b0b4843abb5297a8e17da894eecbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-kernel.aarch64.sig",
+                                "sha256": "acfbfe21fc06d6ca24e1d0005b1dbd6d9743e8b65548af3e0e8ffd8c9321a8f8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "f089963a283ad5b5945bd1559ad067e98f98d52bfa53eb858c7f9bf9d4032040"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "e6b6aedf43a534ad9bea8c494c4942cad79244ec0862a7a1acbe13a959de257a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "9b9cef07105e918c484e69915634e00437cab841f5c641d2550af3786d627750"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "2ccd1616b80b295d1e74507d1abab727654eb9db35e708cc369f0fc278b73e4b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f21e972ca83ad44e234903f097f7f9440428895ab81dad4a5cee414ad586ce20",
-                                "uncompressed-sha256": "2d0640ac72747dd8f67871ec5b31cd97acf76510b7108b38f056cfd3c9277342"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "5224c412798c327dae7ecd20460354b77ee1be28ac68e0f5b3583043e1255378",
+                                "uncompressed-sha256": "db21b8c0b7f35c7c944fe0d63f06eb5b7cdddf63c61df150fbdba61f8dc82599"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5c2ed0898ffbf96550a3c0de381e52adac27ce9691e9603756a1883776861985",
-                                "uncompressed-sha256": "8892ac4e79e8b662f38c6e945e0adb0dfede870690c3d272dc2833baad81d580"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "62c050a9d7afe195cc821d4522acec3be24afa99b9a244212e3f57f6fd9b6c02",
+                                "uncompressed-sha256": "97b15e114a9c4e134fe4daf4709ef4cc6603904d29b0312d2f1facb65376757c"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "cedbd008391cab3c44a5a99d8432aa43a18823a40fc5e53a0be9a877785310e0",
-                                "uncompressed-sha256": "0157355c12d818c78fa7c1589f19f05f4303b9ffa9b9f9990444a61bf09144ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "9f5a2e0b77b26f86d4e99dc52dd881c71926752eea5064a649164eddb47f3d76",
+                                "uncompressed-sha256": "d15b74ab57b538b160dfd5c4df681a025815875076cc88f9c654aedc2b02b4e8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/aarch64/fedora-coreos-42.20250721.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "47682ea41bdc8097d4357e27a13b840edfad56903eff0fc9e0c3d45c7e2e280a",
-                                "uncompressed-sha256": "b553b449a337b16e926c9bc62fdff26a4aacd7de0673dcc537248b1dacbe0505"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "5ce8a25fde503836d86beff6d1e6102c3ef6f2e052b9777cdfefa899fb181ca2",
+                                "uncompressed-sha256": "380e8c19e575ddb1c44a516ffe2bcbf5e34557b486580bd90f2fc0bf5e26249f"
                             }
                         }
                     }
@@ -173,229 +173,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0417fe6dbe98dbcfe"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-06cc90997d9476095"
                         },
                         "ap-east-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-02f2ad3f669cf334d"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0fa97ba7ae9000fd3"
                         },
                         "ap-east-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0633e02aaeb902c77"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-08abf070dc1b6b2e3"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0428b16d67174b878"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-035fc48e0399fdcf3"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-06f17dcae5f7343b1"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-01088273683b20b46"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-07d6287fa2bb491a8"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0c43c12c8d036f6b6"
                         },
                         "ap-south-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0e76c1d610d279ec8"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-018499f85dbc28dc1"
                         },
                         "ap-south-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-062d2de9f8f48b62f"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0512aff0356ae6a0a"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0f5c1701cd0d874b0"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-076d0e466a7096353"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0b7f5fef615d33ca9"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0a3b0095af80082dc"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0f1bdf12e62079b1f"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-081e3577229641d7a"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0c4f3d5e1c3701398"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-08f2f1be6c4b9ecd6"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-092f558d547637861"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-00bff172f54435fc6"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0922c59e9c2405405"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0a8f57466b6601553"
                         },
                         "ca-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-03ce05271077df9d9"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0f169cb12a4b586ea"
                         },
                         "ca-west-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-09ef9116ed52b849c"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-04a045662c7238064"
                         },
                         "eu-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-06eee70feed272594"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-01528525a0813b2d2"
                         },
                         "eu-central-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-07863d45d0285934a"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0bf2995434d381ec9"
                         },
                         "eu-north-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-05768babc1549d987"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-09cd826c639809bde"
                         },
                         "eu-south-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0df601693e192038d"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0537ec9fb18035365"
                         },
                         "eu-south-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0932fe7a71004dc37"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0ae5279c24fec8419"
                         },
                         "eu-west-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-079fd14a12ec2b836"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0ba62cd874a1452c4"
                         },
                         "eu-west-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0cd2d2c9ddd238033"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0d2a16d8e0bb3b71e"
                         },
                         "eu-west-3": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0465f8d004512c9ec"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0db23620701d5b9e9"
                         },
                         "il-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-06da7c16128da0469"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0478654f178a32e4d"
                         },
                         "me-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0e02a0540531d0dd2"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-004599c04ce5795db"
                         },
                         "me-south-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-09cc6aaf18e756a06"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-064e5356e55048b03"
                         },
                         "mx-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0a26b15abaeb143c4"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-071af5bbc9c140100"
                         },
                         "sa-east-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-02dfe880d92c64334"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0e55975a18ccf5c22"
                         },
                         "us-east-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0ce5c8faeb5e870d1"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0ae4a090a4afc49af"
                         },
                         "us-east-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0b2c1e074349d052a"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0fdc4edb7b2aae7cc"
                         },
                         "us-west-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0b986f65c2b25716c"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-06ef07c7007d0523e"
                         },
                         "us-west-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0a69d3f831cde3a88"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-07e2a772ebcdee936"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250721-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250803-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "012429b13eb5dbc6d26d75b74e2f7da41eff915b6eeaf2c910fd0a4f94f58b24",
-                                "uncompressed-sha256": "a7f4dcae40dedf10efc9d727b3c7442663c077644d1dc838a619c711245820e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "0ee72292d48d27f6f372ee699df76ec0dabb29309f4b8af560ff2cbc7fa3d3d9",
+                                "uncompressed-sha256": "b037ef541ab797cc951cfda5c185d52b7d381566ba93ccf3066fe877443ab48d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "1c1972276c3193e89f012b4bc6528a51cbc6430c41985d62cb238cd12d80a89b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "30122d12de3aa88fea30cdb752ca3c9b924e4f6db2f9abb3245ac58693dad7ed"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-kernel.ppc64le.sig",
-                                "sha256": "4551f5ac76b46cfa79ae7e9a40f342433d5d8269c8fd4bf3121f33ce45e30250"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "e5c615bef1fd6856034a5847fda000910421834ff1f446315959d4ca7c2bde6a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f87f00df32107a415cfc00fcaba8fee091bf4e0c29eb533fe44b580ec290d289"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "2bf55ebbbed12bfc48a3044f7b5e66ad7da7aa29d63da98a6460cbbd973f0baf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "1e00febe4ebcee6e23e6710d4b80c16acd252453e2a6714258ec5481666ed0be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f9fbbd52484764ed4f87afcde2598425e52a584bf913f7bbab89634b47cd6089"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "aa65acb62f71c102f20322870c1d169ff6f45cd96185a211ea32865322a3da41",
-                                "uncompressed-sha256": "2bf70c88594f493c97e800544fa18f9183a8b81ea780f042a484ffaf10dcad35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "1618e9a69a43de7eb3cbeceed51d26b982dfe5672783d2e915f5374237bb0346",
+                                "uncompressed-sha256": "42bd89e8efe3d26040e7a68d40435fb2f759679ae5ac899b175f9d2ce36a5f75"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "6cc980c2532f92bc0a1dc2ae2ee3942b494c2766a30aad58a9bb08f203933b82",
-                                "uncompressed-sha256": "efb0f00e74f38e7ed0795042055c4794e9069b632ae009b3e7cc76faed473473"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "912e4388a4bccbf984991e556c5f5eac70dd4a2ca3941c2832c45913b6be4aa6",
+                                "uncompressed-sha256": "b06a9d99716fc1de7cfad41cd0b1e9326b1251277d70c08d65a10d5b8349d871"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "cdc80a884c489e5b4983416217b8d48edb58a9f52dec1fd87f6157ca79c4f295",
-                                "uncompressed-sha256": "7f997596056e3eb72796fad8023e56bd7d2c68ea02eb491f2e33816148063f89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "47c5fd00e13af738c2c83bb4c87d719ef58775192499e9a30c54c80d85ec1c66",
+                                "uncompressed-sha256": "f1c8d2f68ae4496eff53c5735dcb47da49df1d24e4e8efaa20ced02916e876f2"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/ppc64le/fedora-coreos-42.20250721.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "9b0d7c7dc0c7b03b292ba87889a2630492af375ede17ae4b1dbba2b971db2a04",
-                                "uncompressed-sha256": "427666171dc94102a32e4944f07389e00caa62240711eab7dfbe36fb1e27a12e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2b67941edae693e2205ba2e9d878ad931c3c223772ee4a16911b8a3c3908e08a",
+                                "uncompressed-sha256": "b638511fd92f6f78aa8841d6183a75954101537985d495ae633892507029c5a8"
                             }
                         }
                     }
@@ -406,97 +406,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "c6c3ae20ad059b68424e97b832f2dcd2622aebd82c52ea7c8f9b5fa5f1f5416c",
-                                "uncompressed-sha256": "55351b9dcadeb10cb5d3a2f27b0d3d1e738ff72180e96749b0b86c5e9da7d3a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cd1946b34c4b40622e10e5143775c4a0aca283d4cd53586ce26865d70d031363",
+                                "uncompressed-sha256": "812d3cac18de5d9e8f4f00e8c0f07577e3df6256a25d52839d91028334dec1eb"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "31cbf4c1e3a00ac6e5dcd6ef2c1942b954560908f1a8584790aed4ba8f35a4d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "3f65135ca58595fd083cd7a77d004342479a33ad4458e99b77964cae0af725a9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "103e2a2f468c7ed8cc5b781dc999339aa774f4229767b011abea63a71ea31c6a",
-                                "uncompressed-sha256": "c6aca005e3d65298aa5912b02bb0df641981b2365bdb9869fb97a705567237f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "abf8b4a6599ef530f1e15dc6fdeb5982f072a8384e4208dc21921ec281e3004e",
+                                "uncompressed-sha256": "42e4be8773a5aacf321ef8f5d6edca62ec0d137805d61d9da19ae4152d433303"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-iso.s390x.iso.sig",
-                                "sha256": "70ea2bf8ca0ab37ad62cb3fe47ccb80ce1a8e6fd646f6d8a80e369ea121a6669"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "dd9baa73e9f428fdaaf83fbdeebae185cb0dab1e6391280c03d69de8ba59dbb0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-kernel.s390x.sig",
-                                "sha256": "b357f0c6f4d5c1b25ead6d2779a45919ea0a34539cbbaf5ef547104dd3cde83f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-kernel.s390x.sig",
+                                "sha256": "21e1685ea1a58c19fc99f5c80b924b8baa4a6e102074f435e9d849720a621c00"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b68e33df640ff5d487cd24dca8d186525a0b93df7fdec7bf9ff10a7830497813"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "73ccb91fdfa96205b9c5ea870d7b7b3151145ac6a24d3c8afacb2a6c6331fc79"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "0047ff345df3b1037f1c3af8a2efe5157d31b1ff27952ab2681ea26ee59c200a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "f7cf4e9eefa3fa53d8893ebe234e008625e318fd3d1a682d369dc7aaec30f752"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "a1df93bb76c0239a1997f4ad96c9c2acd24342b3cee534eb0078ba8e392f4e5e",
-                                "uncompressed-sha256": "ec732baec1e080237ae39fca10a858ae4b5bf7e2d4f298c23ba500484e3a6c36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "688c5d63e91b4cdb78b09743ca5c5b84afac6c64ed44d549c0fa418d7ab301d7",
+                                "uncompressed-sha256": "017529ed3d1426c422265c7abc313f014ce33a92d073373350edaa1a0ad56b3f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "8bbfceff08aa0839994abe1941f85f417271b49afebd27ae42c1782927017377",
-                                "uncompressed-sha256": "0693d3e6eaea7b391bc0c421811e6869a76b60803718fb4c7186df0a9ddae7eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9d20c5929c0a56b2190b9f42ee9d0a212146d93ba3c0a329b63e0568ecb36720",
+                                "uncompressed-sha256": "1809880e369c6e25bbab1e442e7f5ec041165316d1900b8f25a466a6321d12e4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/s390x/fedora-coreos-42.20250721.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9823985645a3560e94c09de20ef182368b0d1c7d1fabc0ea650b47ffe12fdef7",
-                                "uncompressed-sha256": "023c484be492591e2e9987b199ac9dd40cf481ad841e3d6c7d7abb75f22ae7b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6af8bc7941d3bb1d447fe336dea8c0844f3c142a9d9c8634d4bf01a4f5be5436",
+                                "uncompressed-sha256": "eb8b8f11c6f7ce23318cc5b3eb7e6497418209f5e0ee848088275e9b22682fb5"
                             }
                         }
                     }
@@ -504,310 +504,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e663b4973d70ae459db912e14711aedad4b7ef95bc654455a416671fe12ff354"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9157398f1303e32cd51eb86e01d0903a21fd43eb54c6aa3637d81c5aefab6d61"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9728c7bf60e3228c07dd27dec12671c28acbd1796e1cc0442f459be8a12f47c3",
-                                "uncompressed-sha256": "11c6ba5699993ace8e7585bdc796db691e3f180fee3fc14162025c402247014e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1c87ebe09f35ca8325b2cf67a040cb72827375a48e075bb1ea4bc0f622693908",
+                                "uncompressed-sha256": "47300edc9e1bf8836d5bebcfe37f3cd30065c1536cc81a338e3ec20b70f14aa9"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "f848e2612d51978277f36e7ca56318cb14a5bbd57a0e3fe200e2fefc75d3b50f",
-                                "uncompressed-sha256": "478f322090f710850d44272c11787b3f5f84c13b0ce88a39d5d27bf3ad2255f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "1230269e1f90d540d15e8772e41a90c2995f9295bce32280171f94ba42b60f81",
+                                "uncompressed-sha256": "50e42475c09f3d32da027e0ce4802c11187fb889dc7dc48a372d59c6deeeb5d3"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "30d816c3810407f8ae8ad9ca43f50083504bd837c4593a5d73d5fae4eaa308ea",
-                                "uncompressed-sha256": "a7519649fd086b9822b724f3999f4f026aec0d42e39942ddcf9e0459cfa52649"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a33838567e6705a199c88bdf6e39cafe9e520aadbf2bc0cf908d1a33de480b50",
+                                "uncompressed-sha256": "b66af2d0b3006ee7ab1094f6ba2cbc5eb89b95223db4b251e5b82f38f8c0a71c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "2fb34c75897fabc2c2e668cad31fbf5b4cec0db258f140c62a3b875dabd45083",
-                                "uncompressed-sha256": "fceb623bc30d727919deaec3c4779523f3625a69339339dd22df4c038daf8449"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e3f4f559eda59ec9b17bb5603016b091931c38370b7e0578c7acbc8b67df6902",
+                                "uncompressed-sha256": "e68ff4fadf0c90797fdcb92bd099da99e2adc7a8f6cd46d6524064dfcf4b19dc"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ebd1aa645cc5e345a53a92af6e55a6776da9e1a3f42be89a69599504ec5e7d94",
-                                "uncompressed-sha256": "9504f4a746d3c266e938951b9bcdbf679a8ae75ef7f4bd4f548f2ff576740590"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c60573d0a643bbbb18337ce9f26c31102bb9e74bbf918529233da1277004deb5",
+                                "uncompressed-sha256": "d85fd18db7e37396e6eebd8f1e3e6fab31a9ed513a77f9e8386508d45efc96b4"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e40c26c4d88dee7b2a3fa4c519891aa44d68be1411a5b3daca3a7a3909b889c4",
-                                "uncompressed-sha256": "7a9008634107bb9a58a34fbbbf12edfdd81c5e919925b735a3e5acc8792e459a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "338967954c6f41341c23572dee6a3cdf1f5423e8cfa969c5a35ef362bf3d3ae3",
+                                "uncompressed-sha256": "bd1e54ea8b11c3c2d6bd6b6846a8572d5310ae86aeb79a0661f683bb58ec1284"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2136d288dc0e99ef81a647a712473809ee0bbfbeab44e2fba259465a0fc029ae",
-                                "uncompressed-sha256": "d8559931f52dbf038b1e38e4268dc48d077eed4f25c440ee78961a5463cb9c99"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f83b08d7613bd5d80fbbca9f7d748058da860f49b4e3900103b43c95eec6487f",
+                                "uncompressed-sha256": "a40018b49e6b586b9696df9abc67fadb44e04e474537b2cdae13bc8c4a55c5ee"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "2c1f82deff25e929ee687121064098e4232556fc208859db4a44ba2c7be05cc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "08cac7d3d3e7fb4e095d5ee8d6f40dcc418d804bd5af5675866cd9180831a3e1"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "63ecb4348f8e90136989cc28d04e1f5a6069cef9fe283a75173957a76273eac4",
-                                "uncompressed-sha256": "36d26eead54f297fe689b2a5cadd47e377ffe68f9f03d41928ae6595208ca14f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "8bd8acfaf4146fec1b98e7aec6413a9abcd705a50db77475e6d896749c8075bc",
+                                "uncompressed-sha256": "91778e2b8c9308f1889291dfa54c24b577d19ce38da92060359f678a05b05bf4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "120a0453efe4e5446dd5f89c2542961a04906689277c9d50c4a70afdbabc17b1",
-                                "uncompressed-sha256": "de9ff55707df46de09f5bd6d3ca70a4bc3c14d633dbe654e13fea878b913a427"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "51fd7ed02ce0f80c9e4cc16c21fd901d3d2bba18f81476ccbd3cca2212d4d8df",
+                                "uncompressed-sha256": "6f7a3d48f4def5f783f3a59c26ee1252dc581792ca80879329ccd4aa39826237"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4ef03da80cdc238e1750e9ce0ebe4dca1e1eed03ab1cfbc75854367f74c0d36e",
-                                "uncompressed-sha256": "4b48b0beadea9bb1b9ff0888c6708d2d4efad4c3a13626de3ddb81cdb4e60fc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4d0be265e5986dc657bfa8f550909bb131f3bf43e7d148ad2d76fadc5efccdb3",
+                                "uncompressed-sha256": "67b113d3856eb75a5cec0fe07b9e085be8a3e320d252720e8dcd49e0f3e1851e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a0f120eaa84018761f1eb2085d3c924930708a1317af055ace4a6a39b17b546a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "cf96322021663522f8085251d487284dbd13ee1e096d9e79e11a51a32d35821f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1d51db2500613a5a6bcd43f3560c9ab66fab8d927985335f89dedb51009a27fe",
-                                "uncompressed-sha256": "acdcc564742e46984b2bb37fd11296bbef8af6cbe50c0e0688c263d8c7cda44d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9b9b20c534a91944e42f63f742407c6cde4c095d49077613089a7aac2b2d11bb",
+                                "uncompressed-sha256": "24a6f7080c1c896efdfae4ef13c99daa4f71884ef870288591d1ce3047a1f939"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-iso.x86_64.iso.sig",
-                                "sha256": "847d2ff6963a8b2f02dea36ff318bd7ebcceff4d3c3d42377ef5447dbb5d6725"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "f8769b3028da05b386a630d179ae0e5bee36ab798cf0a5d3a5848a49d40a1d34"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-kernel.x86_64.sig",
-                                "sha256": "427ace2fc7e2acc423714f8184b74cdd286dc1c0c765cd0c0667aada88b155ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-kernel.x86_64.sig",
+                                "sha256": "f34d99ba63c4d8b1456660f98930ad298531be173a8ccf6dea394ccaa58b21c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9e07867a90b86d40aec056b91b9d78e53c8457e6d0ea19e983b15160901fde26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "6410df79883eed855e6bbdb445a80da2194a02c36a5c4e9aec5eb3b37b33601a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "e3e798893635a0a01e33471276bc9ea44de4b5bf3236bd33540782de17d7b191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "b12b3038416f22c11c3be879419031e01a5c0b5ba01373f24d68aa4640796b39"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "22f0526f7e46dd9f751a6ca1d82c80dad798e5806cc9b67295d5d10e0995be3c",
-                                "uncompressed-sha256": "5ed0a654c72171c7f1c51a4734b9c95f3467770b681023dd226be2c76e72c9ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "b8ad7a994eecdff62534c74f4b573be47c23e2e30c11e5b7d350d4ebab477773",
+                                "uncompressed-sha256": "f8edf3d2a2eec9da9e44cb6073df2c51bf68fe74a6f07133c61ddc51bc2a5414"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e73dad6661166ca2cb12c7c1869072bf867e7d29fe0e4ef211ea14696ae74b6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d510d07b3ea12c9a378380f40f2787511469a0780225f92b8aa09092b09c48dc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "f8195ae23e157d60f62768bd4a213fa3d8761ba4d4a9b45f57d10c33fe367f7b",
-                                "uncompressed-sha256": "760e4be09debc0f84e4cab2fd8d8053e48249fbe83675589ca7b82e58f0dd9f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "d651bb525b59e601d0d519879de364454e6ea81fad57c2ca6e4efba88efcb51e",
+                                "uncompressed-sha256": "bce653d12ef10e872e128cdfa2400fd80a8511503a906fe490407a51824f6a7b"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ff552e23b02c099fd26d543193dd635f00cee68e3e1ca41f29871dcd38999c0a",
-                                "uncompressed-sha256": "92a58cc4b992de4e47811bd6d52aef3ae798388583e031afd33156bba4fcbf9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "205069cfd6a7330ee08c7d3c363c651981c5e464cc349a2223649ccc3764bb62",
+                                "uncompressed-sha256": "5670495aa1aba2c9b7ee411d6a39d22b3ddd160232ce18b31269afb5372e9869"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "2077469b9b9c8bf3c821b8c376e6df7fa2c9984fea4f2802f5c9bf079aae2cf5",
-                                "uncompressed-sha256": "c7424fb99564c7a9b4ec9ee0e65b311ce6279b4d109a48b1790127fa3c46c2fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "435fade994d94c47802bb4e02693c848818758745489c1715e4e5801f5aaa3a8",
+                                "uncompressed-sha256": "9cdfe7d43fb8a4460da3a6c1cf31955b29e3a00b92323cc1f17d71773a9e5459"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b2931a3d1f7b04750b603c5c9f189321bf7ba820eaefae2d05a51fe22716124e",
-                                "uncompressed-sha256": "44a1c3fdfee2092fc126c050758444487c1f9104c356305d4dcb8627daf9a3c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0f18cd2fb0d76b26367eb51e7af07b63ab925a8587045f9ce8fec3dff98bbcb0",
+                                "uncompressed-sha256": "f1150b7f198a0ab03d3d797f14db3a62017ea316cf921605f0f0d55884bd7376"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "3b6a848c07b55c7bfe55d4e3f1737d1de51d880dc2a45d78ebb5a4bbb25d8ad2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "82478d41be6b63ff7086f6f1680582e4d8d61b69610ebc55324714472e6200c7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "75ca35a7cf4e260355508e57b11ed406fbccc886933ef53d1b59ae2cf87d3466"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "ddaffdc4a8cd2d03c816a103e6d1cd6ecf6f2c92bfd38900c60108f274c8e7a6"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250721.2.0/x86_64/fedora-coreos-42.20250721.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5e427adf6e0afce1e863e156b38cf112e32d33046560c79bec4936bc0af3db55",
-                                "uncompressed-sha256": "ceffd612b3380c465779325e5ef8e5a79fedc9b6fc58a569a597abec72ca1b75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "964a220a3daebebf58e0d02fc59c49ae3148d8a01c791756f6147ae96391c876",
+                                "uncompressed-sha256": "3039cdb1baa09b0c1e1a3a9d8150ded08a1851cd184bbd78d0f76635cdf64e53"
                             }
                         }
                     }
@@ -817,149 +817,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-00d091543ab6e1058"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-00104f0c06ccf2927"
                         },
                         "ap-east-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-03011418ab6c994fd"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-01b85013c761b147f"
                         },
                         "ap-east-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-039bbf3081ac8c0f2"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-03a80e17529eb9c03"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0171fb08ead631955"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0476f587228902882"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-04cb4fc549e2c4db1"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-060b47ae600b7b069"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-034b7622e14fa981f"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-025ee41c174271111"
                         },
                         "ap-south-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-01102ddf20340224d"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-01030abbe350d55f6"
                         },
                         "ap-south-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0609e68d76ccab327"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-067936385544ed226"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0935ee238759cc95b"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-01247e969ab31d3ec"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-07829af1c5375ebdf"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0e1c5c9e85bc59022"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0e3042279cd20ca0e"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0859cb1df3e967935"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0588c2ea8ad8e3cce"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-03b5bfff69040c91e"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-083401a567a2dd913"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0bb083a4c8cf49315"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0e4358fe7b28becf7"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0291323b8979a0c6c"
                         },
                         "ca-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-03a6ff2a03489d868"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-094e58e73aad512f6"
                         },
                         "ca-west-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-08be5808e0bc524c9"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0b18ccc3602855689"
                         },
                         "eu-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0ecc140fa1c81449d"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0533280948a4e188b"
                         },
                         "eu-central-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0beb2daa78c002e28"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-09cfceea1dd75141c"
                         },
                         "eu-north-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0fc37c5baf14315dd"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-05a4bfbcc6e744e19"
                         },
                         "eu-south-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0ab0a96e5f55e932d"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-060cbb2a8ff01009c"
                         },
                         "eu-south-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0e4ef5a92c54dacfc"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-05e120b1859f50a02"
                         },
                         "eu-west-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-00617c61bcda5f655"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-09fe35da96a42dcc9"
                         },
                         "eu-west-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0e15a5497a0ca26db"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-045af28cf37bf67cc"
                         },
                         "eu-west-3": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0cb38e87210f370d6"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-015378d40184a19cf"
                         },
                         "il-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-08f60d532af4cda02"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0e69ca8690b16315c"
                         },
                         "me-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0ec7279e0e8dc0a8e"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-09aa171d0968198b3"
                         },
                         "me-south-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-02e3ea70826d50eb9"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-022bbe3f8489b08db"
                         },
                         "mx-central-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-025e28571d149ef5d"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-07990a8ecb2921bb7"
                         },
                         "sa-east-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-065d716b0bd139cd7"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-035ddb1574b909de4"
                         },
                         "us-east-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-097e41cdd2e74e255"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0056f5c5bc27d60c5"
                         },
                         "us-east-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-07c53d2192593ec29"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0ed40d7a4b54d6008"
                         },
                         "us-west-1": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-0561d89a5ac3d2d4d"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-0881fa3f2db84b727"
                         },
                         "us-west-2": {
-                            "release": "42.20250721.2.0",
-                            "image": "ami-010634c4237e2066d"
+                            "release": "42.20250803.2.0",
+                            "image": "ami-09183ab88fb34b177"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250721-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250803-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250721.2.0",
+                    "release": "42.20250803.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9623e2610782956fbca973e5371e1a13911c5ba05a20d01e0c50289076808352"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:7c9926dec3207fd106a041360d8173ce794a461635b03fd914edc681788c582c"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-07-22T23:33:06Z"
+    "last-modified": "2025-08-05T16:45:02Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250705.1.0",
+      "version": "42.20250721.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250721.1.0",
+      "version": "42.20250803.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1753279200,
+          "start_epoch": 1754488800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-07-22T23:33:05Z"
+    "last-modified": "2025-08-05T16:45:01Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "42.20250623.3.1",
+      "version": "42.20250705.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "42.20250705.3.0",
+      "version": "42.20250721.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1753279200,
+          "start_epoch": 1754488800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-07-22T23:33:05Z"
+    "last-modified": "2025-08-05T16:45:01Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250705.2.0",
+      "version": "42.20250721.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250721.2.0",
+      "version": "42.20250803.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1753279200,
+          "start_epoch": 1754488800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).