### PR TITLE
Roll out stable 42.20250803.3.0, testing 42.20250818.2.0, next 42.20250818.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-08-05T16:45:01Z",
+        "last-modified": "2025-08-19T16:17:08Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "7ffd9d8354b569b57d90d0d83eb3339aafd6bc82d8f81a8d74e165d9e7db2adb",
-                                "uncompressed-sha256": "9ccc977c49c4cb73d6aec8ea514a56a16f5c68b913d996952731d3d280a15f44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f74113fe1a10a5e5daa4a4ca3a17cc3edeffa69b6e41a9c5fe553e38d9c83ce0",
+                                "uncompressed-sha256": "584e2bb0a97e22b98c2613e77372c4c8cf7d3a47e8e9de91ace72b1cb841c646"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "be051045225f5bab03830f865d27902cf3a8509a01153c283a388e2abdfff225",
-                                "uncompressed-sha256": "c53eb218fef9f58c16bffd4c6f6ea08f3f81a4a2106f8112ceac71bffba4d5d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "87abe48a1d794bc49df2d8bedfa40a7b5f435649f45f83a8301ae8d5f56e6087",
+                                "uncompressed-sha256": "d6e4b07a7e647c7ebf187a8270c7a13667f753764bd3cfc2afef0a94ff2f6edc"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "f73c0d598e8090133495f240630910df4a875f2e5b9dbf9210cbdaa6eadd1d78",
-                                "uncompressed-sha256": "cf72ec9baa3fcaac1d1d6e690248cfbb3bd8d7416b9dcd469f21c4856dba877a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ee6cad8c98154b764112f2ebd183f8e99b0429361aef23f939c25f8c0c3e49c0",
+                                "uncompressed-sha256": "2c0360320c204eb49eef7c288c7fe728527e78fc6ffa642c5f743a5a7993c3f9"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "840aac9801ae0c7dd1c9658e9d0114f870a460970dad8244d2de8cd0ec6a62ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "fe72a9b2e20dd7ddd1936cecb0de17a78982d9878914fd8073a51461ab1701cb"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "3f0c84f40c48e6d0192da9bcd4d4606fe1a82ce3c7ba88d71c6d7dfc32cefd06",
-                                "uncompressed-sha256": "b57b5dd3daba12a3a2c04c755eaf597052d823a72924f638030957651f166894"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "ddcb594de116bf1bad3c79530ca9f20b138197ab14af69f2abd3fbf4b4b13e8b",
+                                "uncompressed-sha256": "d70a91086e85d4402bba7d06bdb6572cf6ba5747e3a633ae4fb17b7a0af0c65b"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "7cf573ce48bbbfb9ab086b83c3b7e17820cb9fd708dad5465bb7faa25ec0f91e",
-                                "uncompressed-sha256": "3cd89007a2875dbef88a07511f49c9dd6f3a686851011f280695607335aa6a18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "12b2ec3f07d41360f1664b485adc8d01a59590c90b0447b36eefa040ea0dcdda",
+                                "uncompressed-sha256": "7d1ff93edf6f64f7979761eb641954016ffd79dd24d58a36fc74bb4098461151"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a4b2e3e44284f25c59dcc4e031a986a8d5e67221781da864bdf1ed5db51f3fbe",
-                                "uncompressed-sha256": "e6dba821f853a2fb8ef417fe9a31ae4d666260dab18be936558ba9893991946e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "dd6d90fea754d093e90a34b27f13231ff23769662b07188a9e745c74cdbd6a90",
+                                "uncompressed-sha256": "30985dcd70d133ec2f1357f700b5f0dfcc916c67c380859db72f67ec28b60f06"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "bb9f50a75707295758a1b7428e5f86c16bfd2519d6ef22753ca06f00c7b87a66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "4e220fcef5e4bca2424ddddff9974089f66dda5671f31efb2d8f4744fb0b0a41"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-kernel.aarch64.sig",
-                                "sha256": "acfbfe21fc06d6ca24e1d0005b1dbd6d9743e8b65548af3e0e8ffd8c9321a8f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-live-kernel.aarch64.sig",
+                                "sha256": "05c87f5716b3c964d16819a4e2a6c0429d9586df2c269c6f5b2b4ba35c7cab20"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "ef174c3a6ab2f222263c87f98cafdea0a3c15528912b3e81eff6470955a53599"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "616ab73e312dac15b35140b937f94f57d7d9d2bd6401bb7e7e2893f8927d617f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a204c160ccb9014d6299c6531f6c026b5d25e36b5f521b31270e3e0ea24a8a50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "bc0dd71fff7c2ce1be9c79f5fd7499493fc58b6de82c8c2ff1dc4fcb339b3599"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "9d5745235f37c6b9e3d53d86c0b1743cd27d5b02c16adbd8afdb50846d2382be",
-                                "uncompressed-sha256": "3b5d610c7728545ba42147874114e558488bfb1c4e7b1bd1d5a5e8470158a38e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "770711d933a4c5e9320469a36fd0a53f5bbb50e265c5e9b05315d27bd01f062a",
+                                "uncompressed-sha256": "b01b0387a746a4d58a2093e74d1d3f19748edba6717d0715e122a8d788a2ae03"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "b0b76bdb4dcc673277fadc5620dfbf9e028b582b67f6607742113815c27860c6",
-                                "uncompressed-sha256": "df4686d3d9b95b63722a8644f9bbd58fcae3bc35b14526286bd59af30b2afe38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "3c8249e97904f096e2eaffd567b2888de8f5c61a8df937193010e8347a62bba2",
+                                "uncompressed-sha256": "7b0910bf2d66248dd8481748672c26b7ddc0246a9cb85928f63087bb8b0d2774"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "fa938f35895ee1fa86a36555ddddd53c4128f1eadcdf1f3e90859ad11377f25a",
-                                "uncompressed-sha256": "a0f8a0f8c7987df232ab5eb6731e410513b74bb86117261c0cba14ffa5792f77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "f0db4ad2249ea8e525751e6163c770783a2164f9de73ef224affe7eaa24a81ba",
+                                "uncompressed-sha256": "14ea572eddea1cbb3ffe5955b888fed8e8ad244901c1dc50c51b6eef6e766d51"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/aarch64/fedora-coreos-42.20250803.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "d3462bde8c9f592338efd4fb71eadf5cb92e97a0d9805195d22578c6a7093b14",
-                                "uncompressed-sha256": "7bab4301d6c7047119e6dbe5a45ad71431d56ed25ab4083d5cd477602c2abd6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/aarch64/fedora-coreos-42.20250818.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "9a52c576f00810059d4da08a63aa9a0b9cc211c60d8e845ca7b5ead771c15868",
+                                "uncompressed-sha256": "58105b29a781b8de51151704b600781df7f292b5d37f6309d801bad24672d1b7"
                             }
                         }
                     }
@@ -173,229 +173,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-073ba117ba21e8788"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0a4b51d731b8c14de"
                         },
                         "ap-east-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-016162ff37fb9ff5a"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0ca4fba54c4117172"
                         },
                         "ap-east-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0786114918eadff09"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0e3db9d9b1297905c"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-02931e8a763fafcbd"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-011d1d47df670c3b0"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-05c4e34acc2600fe3"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0aa51cf95483ba261"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0e81ed4b05d15a050"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0d93abbca9a356b48"
                         },
                         "ap-south-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0f326077c8d389a22"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0cc65bc35efe13420"
                         },
                         "ap-south-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-03e662e8be545d5c4"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-059f270523551299b"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-017b27d56009c254e"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-06e91bf8421db5798"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-05aebcb5aa8c807f5"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0b40b988db903c4dc"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-081d53f296feb02c9"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-070925985d7500740"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0c185143a323f8f27"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-09abc226c413fddb6"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0ccbcf3f0c6bcfec3"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0996210e015b6c79a"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-03e62650148b210e4"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0f2f4b18c254114d8"
                         },
                         "ca-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-07acaba88e4e39dd2"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0e21e843799df7732"
                         },
                         "ca-west-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-09d8387f95c46c0ac"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0629fd6e56457bdce"
                         },
                         "eu-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0fc17ced68db26c4e"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-02c69fa4c8984b683"
                         },
                         "eu-central-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-022b5b3fb57cd26dd"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0d1c929d597d3dd34"
                         },
                         "eu-north-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-075c473c0244f624d"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0b60855b9632fb27d"
                         },
                         "eu-south-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0fcfa409c0f3dbedf"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-078a73101a1c8cb9e"
                         },
                         "eu-south-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-016b0efefc012de6d"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-01237b67887d2501a"
                         },
                         "eu-west-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-07e8967c4f53a9ce1"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0078b1c5996dae3dd"
                         },
                         "eu-west-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-02d8ce0a5e55fbe55"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0387f201825d6401a"
                         },
                         "eu-west-3": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0afa89d273f8899e3"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0d5fab0d5c836979b"
                         },
                         "il-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-02841e6cd9c7a743e"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-051cb4c0eaa24ade0"
                         },
                         "me-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-035215295835b099a"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0ef0a90f50e3113a9"
                         },
                         "me-south-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0603917f92f968ee6"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0c440197c5e63da33"
                         },
                         "mx-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0b4988792fc549cb9"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0bc5bd8f5ce68679f"
                         },
                         "sa-east-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-07efdaf22e9603176"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-06823c3724734b24b"
                         },
                         "us-east-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0d5fd0b41f120c8a3"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0d714f73bf3808817"
                         },
                         "us-east-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0148b78da60c8bb4b"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-04b956f574eafe3da"
                         },
                         "us-west-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-02def702031f602a2"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-08086b17a7461e9ae"
                         },
                         "us-west-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0b14f010bc1652f5f"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-078dca6cc4230d42e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250803-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250818-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f90fb940b7c823e428b5eac6c5292e4dd877c556ef2e027234eee7a3c1058a0d",
-                                "uncompressed-sha256": "ee262f0d5f5b48a87a8daf071a473f40ca0e3dab0f4f0b443349de3999a3f93f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "74d51a90a325fe29a5a8240cbf35dde85bba529695f85ca3326be16e1bfcb706",
+                                "uncompressed-sha256": "0d83d4b9b9265714c4697e276ab0d47382e4cacedb579fcf848e4da90cf68d38"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "20bdc0a4d89d6e9b88cbc35f125e77de5d9eb06cac566e718e0ce4464bd17586"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "7abab9beb2058a16c6f4f1613232e0df5c250631ee5faa92e70b8de7b7bd2f44"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "e5c615bef1fd6856034a5847fda000910421834ff1f446315959d4ca7c2bde6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "a9a3359d1e2c48cd7ba499c4a9736aecfdf74e3aa1d4b90fa9b058285d60156d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5dc58b6e21090c3956c4456f942eb3a23a99c7bfb04f0a961a05026a1d204cdf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "217c815c0adcd549f2c08f1d3223b667bfdfcba6f472dcde6c10b7e64cfbf8b9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "ad4da37fd1a49d1e10e43acf1c5c8e83584e29f64bec02ced0d85625855d8047"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f97d79f0eeb8fbab28392fc5bd3ce3ca410916975b44c58f773efc8fb61b6766"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "af5adba1bb5555ed93fe70aa9efff1c4ff72329e5ddea37a6a6286fb56cb6095",
-                                "uncompressed-sha256": "b3dd77ac01170617c6583293268931f3985b68dc6f23f24d23d6fa94f447f712"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "0d7a7e028136b2cccef3867f56fa00807cecd93e4f9dfc759198b6b4028a53e7",
+                                "uncompressed-sha256": "f441f808c732b7c03a9c54687a7d3eea8c307d38fd1968111b6a203391825a13"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "2b8bdd303118599408439d884ed6f25ae17c59f1facd3af0d0d707900bf6f1ed",
-                                "uncompressed-sha256": "120fde00e914bf063f727aa6eb24d9b5dd5de82ac8eb689ba2cedfca82d05599"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "ed3d5cbda12a17fbbb4c9070154b1715fb06221c4dd2f7a8bbea1275e37d6a7e",
+                                "uncompressed-sha256": "707e914014fde4d5e1861d8e27eb684bf08f87752c1b661cc34761a1bc0e7179"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "5e9bd25d687e24b174abe204407a76437b4a20357e9cc52e13330030ac57f451",
-                                "uncompressed-sha256": "2a43ff36e5929c2b2c77f9c66b4ef4785cfc731f325c41b0e3390ee58b49ad50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "6999ab387117bc5acd2438bc9cc75b8e9a27bc4045ca2866635bf4eeb4950b3c",
+                                "uncompressed-sha256": "013e15a3d0cf90d81caaa5fc7b3269eaffb164040918b03e59cf382e0707034d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/ppc64le/fedora-coreos-42.20250803.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "1c757f3497031cbbdec123387135569bf373487b017259c45ea2ca814f9db0f8",
-                                "uncompressed-sha256": "7bceab6d81da37edfb5c85aae21bbcf4a967ac5f343a6fbfddb2c986714bd6ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/ppc64le/fedora-coreos-42.20250818.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "b42f121aaff665746b4fa9309c1223fdf1c3468b6f233685c28355e428aeb671",
+                                "uncompressed-sha256": "75d3bec92221503a209aea027f75df4326c247550a7e0bd90ea57ac1e0ffa2ff"
                             }
                         }
                     }
@@ -406,97 +406,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "0bfd28e3b715908781fbd8cf190cd0f82699da376243036e1a748e701914dcfd",
-                                "uncompressed-sha256": "6992161a3eb2833d2b8f37554ae8e5a23734d76fe0eddce35e7490dc4a91b41e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e2ab5d81bc21522b7d26650159e0d0a1b99820180cda2bdb4d15e20f290400b1",
+                                "uncompressed-sha256": "e884d78b0fcf3e6a9e03338b65610de111ec22e8e5fb1a79a32e29473fe6f86b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "037a3b68ed1b722ec7bf4e82674653503d184750a14bc03f24ef637541eebd89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "dd6e7ce9a69455e8b44152ad713990ad13e27f715eaac91615c4ad93f23e7e54"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "8ecf10020238b1aa09f10e38e171748b17112ca60d9cbdcd89d68967961a96a8",
-                                "uncompressed-sha256": "b6d4038111f77144a38dff2efdca029e93ff34e9a84c5befe470c7cf5883ea9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c72348dbcad5daadcf423b056308a01c1cb787f9c4d58879a749c58bdcc8bf19",
+                                "uncompressed-sha256": "960040a2e75d137f4195659bff711cfb222fdb0773803d863217a7f7d23b49e3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "368952d9e7c654bca649ed1766950426244a3671d27d8319e2a0fb45b62d9f4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "c6d383c873ccf8a4f7c5717ede8c031cf1320fe0252c0ca38227fe821f74adf5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-kernel.s390x.sig",
-                                "sha256": "21e1685ea1a58c19fc99f5c80b924b8baa4a6e102074f435e9d849720a621c00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-live-kernel.s390x.sig",
+                                "sha256": "7a0485352347f2138d5951f627ba1b791be95d9b47d683efeacb148b59f7942d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "b5c735dff251f626dee90a64dbf11401dd5f890a38317985fa4aba4676ef4d60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "836987a896f2ef17d7332845792c97634af5e207f806bbc9f02beff584fbe67d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "ea2664d5cd726126f76d523cafea9e344174ddbc82de19d45a7cf1dcdf508bfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "fe00d48582474717b2ea96003c8fc1b6ec353d95fd5580e82bb7d909f6f3902b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "cae4d54cec5055f49ab2c3582261cf4fcea8f709a25d0c028141659f21981c35",
-                                "uncompressed-sha256": "f8398105afdf54c25dbb3dee8fb1c3fd4878fbda1a6f6d7a1e55c66cf001287a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "12fd9f09edfb5fc956609b714616a161ed1c802b4ec2412b78a813dc8c46c165",
+                                "uncompressed-sha256": "bfba6c0f566634eb924c3cfbe5967b4b4d436f0a80b44ee5d51a8786240fa45c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "6de21f84b44daa00b348a9093a63e4555724160b9abe728d34d7d76ba3bb4dde",
-                                "uncompressed-sha256": "f16f70e1626880165b29dce43f3c8ca315fd274e120a83c19cc366d592a68bf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "1f00230177a2aa2cb3bb13b6f56e8c7a31c6a017fb12e84c0ed5b4c185ffd65b",
+                                "uncompressed-sha256": "f3245fae272363afd21b081656d07f06bc9845fa73d842852f09bbc09b50e9c1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/s390x/fedora-coreos-42.20250803.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "9d69d64ccf7681d25bc3c69320d2caf2318fa8da030c53dffc1682728867641a",
-                                "uncompressed-sha256": "40998e73471053266463717bfd02f022fddb518340d8f876e17f79a7ea1517d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/s390x/fedora-coreos-42.20250818.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "7de4377132d53953dd6e9deaec9bae4e9ed561bcb3ae7f9c25e586ff003852d2",
+                                "uncompressed-sha256": "7dcabe4dbe6eb0245de09c0acd8f6a97ddadc620f643ad83e64f8e41154c46a8"
                             }
                         }
                     }
@@ -504,310 +504,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6862f26e1133c65f002f322c03ac70cfde27d1068239d251875148a1028c473e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2faa75b39a13f34455bbbf479896a3101be1662f4ce39c59c13d9febe2502593"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "bb633e08885d68ccbd975a1eb129fce29457bee8b7b99f4f2d223a2851bd4906",
-                                "uncompressed-sha256": "2e50b1012abbd8cb1c627248b0a5b557ced01a518edbe18630c18a0a9cf98b20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "c49d60fcc9904bad6ee54322f31d468fa111213e154fbce6c29e83bb4b4b78c6",
+                                "uncompressed-sha256": "9539b09ebbcc32e954d7c20bfdf02745df5ce90d602c5a952966a87474fe3bdc"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "04f4e721fccaaa5f2b276e10888fd0227576301cbaac6faac3030ffff0bf4562",
-                                "uncompressed-sha256": "94c2ce3b4170c5aec329669af8a674e0b69fe76133af040ff19d78b3103d920a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "be709eb558e8e07bc5185b1cbb07b2ad93afef81fd99cac7aff48ee5eb9419b3",
+                                "uncompressed-sha256": "f54eb6c00a6bfb5de5b4791bc87f68970fb18b1fed5da703d7ba575875aab68c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "5b7398843518d91df19f014dda6a39b40a38c85c8d2b5141dd98781f22113d8b",
-                                "uncompressed-sha256": "ffa9b60ec3a39cedaf54350dc24e03584cf95b1a1c3bf1ac1a698d1da51c8e36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8936029ec524b8908bed10a9717f61a2e0b0d39e95397ccda8bba2bac801cfb0",
+                                "uncompressed-sha256": "6db5e4f4d4857655241bba1a06a026b3a4395634c3e04e318f19d4734f3a99f1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3ad4749dc0c97ad2c25668067c4e6c282403f6044a51ae5240ea34a885436aa9",
-                                "uncompressed-sha256": "13ba912f91de0d4deba20497cc760dfd34539e3f2bd19369c22d0b3927173879"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c8bded1d326f8b9dd0bc96c79518233d664172e85ff1587927adea782e258373",
+                                "uncompressed-sha256": "5e8fe5dec71c7f8f016ebe63e162219ff190429ef79f401a897c6111efd822e3"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "e1a494c0d1ea041195d6f09fe5bd88eab3c0a536fbbc538966cc8e4cff42d557",
-                                "uncompressed-sha256": "f3ec94557429cf2c8a0c9abebe850c5ddbb79f36569f16466e9258ca190f2de9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "5af0bdb430473ed5b6dabb721fc64ffbd46dfa4de5153efdec2783faa42bac7c",
+                                "uncompressed-sha256": "8bbbc1afb8eb3794ee2bd58e9330a08d3fcb494f03d4873f1b94adb16b1d6c25"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9218578cb8dec01ab4b78e444fd0422649eab41b521872bbb53d04f603ede13d",
-                                "uncompressed-sha256": "38560ab8c42e98d948f7e2226b2745dc8876e4089c97bcc4b258f2cd40228672"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3b01b4704357d52324cfd3a7c0f912e718302a63d74f25e4c400e7f3eba57cf9",
+                                "uncompressed-sha256": "5b7d42b74e28bbce72f35b0b670ed3d4cc8390566a9d0b9156bf116d50c0e65f"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "28dec876e795ffae5800ff61378f54934fc4d418f1fb0161119eb192c3f28734",
-                                "uncompressed-sha256": "94947a9ea1318f80a90e7fa2f3bbd47b2282710377639bab9cc40100b34ad1c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8f65cdfa86cd3efaf8561f5801296b606cca04c7a00777a1deb80c654e277d50",
+                                "uncompressed-sha256": "ee28ef987ad736204aaa29c5b5630de1bfd755581a5014c35a47d49f5d16415e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "73eda0da4c56a007625e1bd3e3006a7fe48e8b28f3346f826f8b1c4ed0c7c6e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b17e665ec8f88894edd571f72c75bd61273bac1941b9756a2affc7dc92d6cc4d"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "3d94abd8f16f5a9bfeb9ea96b7ae5302387b91c2e08646e7a476fbfeeaadfc66",
-                                "uncompressed-sha256": "da35c42ce84467895c15652a37030764077485ed91d2eac3b035d5c490ccbb21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "c0b4e55166e277118c59a1623c030238cf3e0a701337b0aad83a3b8cceaa3ddb",
+                                "uncompressed-sha256": "57cce134a86fd9fa2366ffefeaef3d3b8c9e725f137590c8dc15adc866978bde"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e8453a71fed5e79510e77bf63160f4d2426b65e09b383348ade31d1987d55384",
-                                "uncompressed-sha256": "ac036fd83c1c42cf0d385bc195ca634bbb31b869028e5d477e370b31f331045c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c59c4acd1ee65b5e55c3dc56f089c7fa6ca88ff6ffb0d9332a2459186b86bf29",
+                                "uncompressed-sha256": "895f0d32824d5a2677e37b1e81722679ba7ce1e02b666cf9f9c02c4a69695805"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "b1048e9ebb580415ee1a9724b7f5f8e4db4b57c142f5162f7232b8272d04f8b1",
-                                "uncompressed-sha256": "bb9a4e8063807d28ed02898690dec16806937624c1c904d5c51962825fc7f74d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "8d42a057e89a0f4f556d0f31caa535f2fcb3b52be0734c0b4bd7abac86ad16e7",
+                                "uncompressed-sha256": "d65c131448951dbdcf5bbcebfddb1854773dbfdc9f852440508eecaf50a66d97"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "8986207bdd07e59ec0a1193f7a2199a8ad0206ce62a522c744f8d5adfc7a867b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "b38f3346c76d0a5f9d4584ee29648f79b62321a448e0a01daeeca804059c09ef"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ada16734ddb8fdbae3d74da1d2c056dffe8e4824ee4b36371fb463cc51981d2f",
-                                "uncompressed-sha256": "f570e10bd6202c27846e058f7535451a2f32a769d9fb0da2a74b35585a7a3d59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4498c67a0ed7dd398fc8c1f3bc7bddf940ef257d0eada4c93bf52c107797b2da",
+                                "uncompressed-sha256": "367b85f38f3cad989b2cb098ab150d082b13bea83c69209ead4077b5da9bfd06"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "1281f76a211b82d808f3ab9f2553cd0b93b61015ba6dd5a8c20a25addb48bff7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "ee7c4363fd52759c2d73750f9ad3b131dd2058493318a986ebb6c3272c9082ca"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-kernel.x86_64.sig",
-                                "sha256": "f34d99ba63c4d8b1456660f98930ad298531be173a8ccf6dea394ccaa58b21c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-live-kernel.x86_64.sig",
+                                "sha256": "fd7cdbd1fde31ab06ec4bc1512051be338783df4d7536f1242d5305c82b88302"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "9d2a78fb31bef9f808c3105e2aa40e9f08aa897e91f78bba4daf050e855fab62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "57727aa47e46b7d84bbf99b4c3ce679c11ac3503f089544d5903462154062a04"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "91761d6b78459ca731d82a61e0ee4f3f43082d2475f74eb996474c65e4cb5abe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "39820f4a047f7a1d22c960d7a8d50f5e223bc7f70a407bd410c29c229be3296f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "6022642a75fe079aa83e05f61c1daff04f978583082fde270bda2a6ce939aa13",
-                                "uncompressed-sha256": "0983beccf9044ee771f4e2989cb5f79191553904b1f81838edb7ba4e9060881e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "eb793d0e9ec8b4fd8efd2856a80802c02600cce150dbf3d2e1a783753b3c9018",
+                                "uncompressed-sha256": "b6a6ac9ae985bf0ebff40a5a608df60d79454b1b324718612243ef45f2b4344e"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0ba17d02dab5670fa23ef101e99e0288e778cb0b60f7a0b9927b9ffc4e7fde04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d663a6065e13b16d8a7e582d77d13fe57f17db2e53df9150b4054f5b5bcd6a80"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9a90a89bd684b5039e64758312bc2ea2dab5ee17799069b73847508f1a8dc8e9",
-                                "uncompressed-sha256": "1974bd79f3aed310d1d884f6127cabfb365d22d1ef5acaa26218bb5b2b598e18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9a4e5d4fc0aa567dacbab328084985869d3faeb1603eb2c374e3503e5bb416b2",
+                                "uncompressed-sha256": "d2594175db6698c7e4f1b6df64a7627ee3ae5f1987e783f4f2fc107f491269e0"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1c140e53b6604be8e099449d281ea67418d6d12d417acc664be59ab0606fb395",
-                                "uncompressed-sha256": "c88696da7c7e12087c8cfb2921bfe1281fe22ece807dc761fe4e66412a536068"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4b293b1430d4a4a90327122ac726996c752f85638be24407b3f93e56d6360002",
+                                "uncompressed-sha256": "5851d81d11d1be7c75cf390846fdfb03f31bd3320120ad70d850e93354ef5ad6"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "66029034b00db15944b40f29d1c8b2abd397d4228420fabf2b151b4ab7d01c85",
-                                "uncompressed-sha256": "b3a81273dc18cc8e8d727cc8bb2e9833d79e9039e4c1c94a7ed4d89d4027d2eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "0718ad484b084bf844321b467d211038293c472b73122faccc2010e8f644d628",
+                                "uncompressed-sha256": "c07158aafa4c3c89950356110cbc7c5e35c8267f811906b6d0f85e6e317579ae"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3eed9d4a0616484a9fab9db19116a7a36af208c272c9c3ae757e7380e415f67c",
-                                "uncompressed-sha256": "112fe03f63392ad1f95e4068897201d481d0fdd87fd8584cf5349f031a006b91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7c6cd9ac7b9d95e49001dd4ff481493b930df90c08c979b64a10c0d8d314be5d",
+                                "uncompressed-sha256": "ff53941e08bfe4a04fb5f23136fa2c6028ae7104c056b89e5b18fee61aa4cb35"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "964023a594a40cb2c9ccba151f62f09de797401267017e4338753366f6f77aaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "8e181caaa1e9085e06def8c1a5c74d4fad2eee0665505591cd3b7a46b34da8d3"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "6d1abe948cc658a228d516ccbcb2ab4560deb98902e30ec493a84c42e99b2dc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "8bae8127576a8f70e359cf6d4da2d3a58a1a0e7c59160700b99bbe7d07c4463a"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250803.1.0/x86_64/fedora-coreos-42.20250803.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "dc793c4503bcace9cf713608d19cccacd76479420687e995471b11817245dc7f",
-                                "uncompressed-sha256": "77210b5ac68be2df238a072c9a4a6a8e901b7a61ba27ef3cf6d4e6b97f1285b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250818.1.0/x86_64/fedora-coreos-42.20250818.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4f05c30d5da8bd2f9b28c3e1ae8acc90cbe376f980d0d9f0db9b1cd41ea3c554",
+                                "uncompressed-sha256": "8d2b2621c28e0d02d0157f51c51091b7408ec83faa9265a0da5a4d83ad1ad214"
                             }
                         }
                     }
@@ -817,149 +817,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0e67fd9169163c1f8"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0514239f07d620c52"
                         },
                         "ap-east-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0a0a199f9438b5e65"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0932ccecafc63183a"
                         },
                         "ap-east-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0d8690b335dd522f4"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-09d9ee90e59a5be1e"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0ed9ba27a5579b1a1"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-06b5e522d5549ebb0"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0354e9f6f5b4bc643"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0f5842bdb7fc0d3e8"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0127a9e1108285790"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-089ebe1a10f25febe"
                         },
                         "ap-south-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-07a5ca531bf169abf"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0e7b6ccb8f66ac1e0"
                         },
                         "ap-south-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-010098b3db743ebf3"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0b7eb2c1fa177359f"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-067d6bf006dcb804d"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0a62d093f81e9ceaf"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-001472b1b21b8d5b9"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0e251da8b65a2c4c2"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0339e6137955bb268"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-00e4122dc35fe3a9e"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-021815cd7b2a9e7d6"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0cce8dae777950648"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-076dd2c18f42be667"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-086c811f8a5b31fef"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-09f509c5410d4a70c"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-028764c7735330fc4"
                         },
                         "ca-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-06f8d2ac8c87a0e6d"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-015607def0d8c2ddc"
                         },
                         "ca-west-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0d3dc1736d8f2336e"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-00643bbfd308e7f7d"
                         },
                         "eu-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0be0fc0ebcada3eba"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-009b925fef5ee196d"
                         },
                         "eu-central-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-09112a3474ebd93d9"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0b28a7c6f55086edc"
                         },
                         "eu-north-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-017343be482ffb77b"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-087140df6183a5389"
                         },
                         "eu-south-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0074ef24b0db2e6ad"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0f6c5f33adb113b3b"
                         },
                         "eu-south-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0da3c5acf0d14f327"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-057bc0a1a1a13ebac"
                         },
                         "eu-west-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-012706316fc1e1458"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-058ca43e801fd5b70"
                         },
                         "eu-west-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-00a1af2dd83290a87"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-09ac7f1996c876d3b"
                         },
                         "eu-west-3": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-03c6c5aa807b10506"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0e25aa732e1bc91bf"
                         },
                         "il-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0259608cd255fe639"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-04c3a30b48e7ad406"
                         },
                         "me-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-07948d929bba81f5c"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0ca17239840c03961"
                         },
                         "me-south-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0174a638da9c1650d"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-04de4c460ff5a83c7"
                         },
                         "mx-central-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0198120df732f12ed"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0ab35293ef952ee6b"
                         },
                         "sa-east-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-08fcbc3d669b5062d"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0fa6902f4e46b2fb5"
                         },
                         "us-east-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0cf1f34aea4e771ad"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-0e3c7e422306d8264"
                         },
                         "us-east-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0fad0d28487f4f71a"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-093d01e55bfe25a5e"
                         },
                         "us-west-1": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-0ec1bbd47cd510c23"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-074698f80380560e6"
                         },
                         "us-west-2": {
-                            "release": "42.20250803.1.0",
-                            "image": "ami-06fd89d5b8535ef75"
+                            "release": "42.20250818.1.0",
+                            "image": "ami-01c2bd2570964b49a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250803-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250818-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250803.1.0",
+                    "release": "42.20250818.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d2d948e57559f2e7632cf625dc939cef6f5f04e0b9844ea81ad085ca5ac8a3ae"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:09ed91423651d03d0656bcc96796742c752bd488ea10a5253368b34173dbc36a"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-08-05T16:45:00Z",
+        "last-modified": "2025-08-19T16:17:07Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "c439a97740e9ac1110569a98d93484040251157795921592b99660d13098b892",
-                                "uncompressed-sha256": "ebe2f6add298a1cf7e9d2e5013afbbdeb8d6a77fd063ed6fb4ddcf5eae1e504b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "3c597131c7fbcf9e0a83cc16c36b226d18c02fbe98e0f46f897e1156df5a33b6",
+                                "uncompressed-sha256": "150c43b25c1d9ad5da87ec710bf04066d2ba49ad3228cb5049d561a4b0bb9eac"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ab9a5162b92b2ad312ef57c866c1205339b4b12a29c6a2d9e418eae1e3f93e75",
-                                "uncompressed-sha256": "2fb64ce49eb5bfccbe03b237cba5ae4cf123b651c8b08de861107011bf8ad018"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "66fb55c9c1bee851cc9ffdf3063b1e581434e626d68b1dbb778824d6086c3222",
+                                "uncompressed-sha256": "d0e15140ce2afe198d579de0713d53583db82dd634619454a09336ee18ef0d03"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "1a9be869ea1e6d090a93a8c0cfe50458d753e6de1fcd517c766adaa11a5f5b58",
-                                "uncompressed-sha256": "5cb8290c5c533ec83ccb85642538aaced9bae968c0b14fcf9ae59cf50a7e195d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c29ec247d5654b1704fc86c39500440d011c62c01094053985830fdeb4a8ad50",
+                                "uncompressed-sha256": "d9507c37b4301e6c79a2ee79ff571e5e6f5cdf8dca6e1bf3b1ec46f80dfdae68"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "5b487ba3fb472e122b24c7f15a8626863440fa950c3008f0858834af7c10b12f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "43356227bc2a7cca49d0a1695759a777becf8cfcf24b161299f346c48b6dda86"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "92c4d585d23a9234e44786dae54a9d84fd60688ef01aa3a23ac4bdc8c466a9a5",
-                                "uncompressed-sha256": "7fe0475ab8f7dad73233bcf7ff9930f50453b6f36d593424af3fb3caaa644ed3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "bcf7af9fc8d708a706d13eae91a93d02d7feb655fbb2ad434a121ab0bb96f037",
+                                "uncompressed-sha256": "986a1174a8a0c22dff7d54b35fcbe3135a121b25c951f4d7f2be177dcc41418a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "dcbdc5b874db71e8fdcfab1b0bf560d2ceefcaa8dca4c099feaa9f6ab8a3ed69",
-                                "uncompressed-sha256": "c19978d6d2026c2ffa6b3a26576f294815c3636c8bfec95f0cc1c0caf2e654ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "4f232bef2fe6f2fe7b86a34871ee397544737ac7a5e78dac475d7336a14f011d",
+                                "uncompressed-sha256": "56b5c2566cf917ea4d38048d95fe84fa6ced60446668bf73ed79376dbfa74d21"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e98d8f5fd3ca4b617a021eb33a9bd531a7486d8a72f31bd5ae6583814bd27bcb",
-                                "uncompressed-sha256": "1bbce9809da89d57b3d4f25fab590c05cd15b9044c440b6fb7243226bd170de3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "40048c57016eef18890ced1957f8bc8a64428de5172880b241769f191307efae",
+                                "uncompressed-sha256": "fab5a5e23c7c06e660631cea7767b5dd5a1bda4fdf5175fedec00de3a4896563"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-iso.aarch64.iso.sig",
-                                "sha256": "000e7cbc452e90d3ea194719283d77ba2af11c02c195c7d62ec29784a919e27b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-live-iso.aarch64.iso.sig",
+                                "sha256": "28f8b9a92cd7d3152dc18d4187b65bbe5975e305b2dcef1c9451bb2a33a4a0bf"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-kernel.aarch64.sig",
-                                "sha256": "12b26d4425c80080c89a0efe02c64a41ea5b0b4843abb5297a8e17da894eecbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-live-kernel.aarch64.sig",
+                                "sha256": "acfbfe21fc06d6ca24e1d0005b1dbd6d9743e8b65548af3e0e8ffd8c9321a8f8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "248f9a4f236f6c4267c845f5141524f30831857d2ed07ebc65332f0f4bdd2db9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "ca5f3566e515120f44bbb6490dce5f6e4ce9be9a636cb4210737b23a64e13b42"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "a3ae41dc6ec44ee5e7d796d2acc31d0b332bf0f68703ac29c696de53bc198926"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "a683fa32182cc25bfcac32eef8d356418f44478694bc5dce0b6ae10e22eccc51"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "99356d1b9ee33e1286d55739ac203786f7bb28425a3c69184769ca3c7706a0ea",
-                                "uncompressed-sha256": "1fa9cf14eb40dacdc0b83de840659dc618c89c858699f7f0f1f38a7d22a67de8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "eb401befef295f2e7f31c503ede409523b56c0ee8b410d91d100800eb51a0d46",
+                                "uncompressed-sha256": "718597482a94435eaa0eeeaf0e1c4bd94d6fe0b3b2485065c9aaff7a1e818820"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "02894de2a9a5482134598e6d9fabe6dd6f0373780cc38b1e5ef750120585eab5",
-                                "uncompressed-sha256": "d77308c203a626cde9bdd1ca7e1b40013101f39e82756eb2204ebbc32226cc12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8bb2fddd4a07f55843551b859a16dc04aa092dee1e23f143c9d3feeea53e93cd",
+                                "uncompressed-sha256": "eddd6c76fb0e645e47ccf3eaa400153b191ad9a475218e226ffb45740e83d2fc"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "78ab96ea10b112349142e175b4fccebb9bafdd546045bbd14ba607758d154178",
-                                "uncompressed-sha256": "174c8f229a295ecfae9eb110b005ef5291a7702e92b7c2058a07999c8d05e610"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "320a5f34d0c888ed5b6b07e561438ff2c0728d25ca44997bbcc2779eb06742e2",
+                                "uncompressed-sha256": "96ca8c12ff7d67bce6fde0ee563e8984731deca960659854bc8b702c6629ea95"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/aarch64/fedora-coreos-42.20250721.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "b786d453d52008399a42da608fca912b3bb46ba892a19d2e8e7d6b3cb0a5a6e8",
-                                "uncompressed-sha256": "312c73b5932bf1f0c27ba42310979dbf25fa145faceaafb15d3211276e64c826"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/aarch64/fedora-coreos-42.20250803.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e4aff9117010437ac6ec5ca936c4faded3ad038f94fde741d6bfe34a27a113c9",
+                                "uncompressed-sha256": "91f142e3d5dba8346511b0d7e6f3f1489a39d6f097ac4140a09fa8d078af67b3"
                             }
                         }
                     }
@@ -173,229 +173,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0c54380ce0f205e68"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0163e5f29cff7c3d0"
                         },
                         "ap-east-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-08d3e7e28bc9f79d6"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-03de4c38f856f5071"
                         },
                         "ap-east-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-046ac8705961ff9b6"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0da3420d1a3303c03"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-015d43123cfd43975"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0a1ca35290c0c8bdb"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0f59ab9702fc2444d"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-08f32000a60e05b0d"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-06e6a5e27f6523b22"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-026c91c73c38047e0"
                         },
                         "ap-south-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-00cca6b3a1695da04"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-05940cd45e5f94134"
                         },
                         "ap-south-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-00ac3f5e5318a5148"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0f78830bf4e544271"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-048d413693ef5dd33"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-03b59572f0ef781a8"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-08cc644a2f40e51fa"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-06a135f63664d763c"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0c3fd9e8068956c19"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0d0d54be392649353"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-01b4d8691e9a43c06"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-023a29103cb38a9e4"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-049c2feba19a936e6"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0bc7759f9d43a4e84"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0c0299ccf319a8ca3"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-08895b2d575eac022"
                         },
                         "ca-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-03e270b265d00b67e"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-087c61884f2324079"
                         },
                         "ca-west-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0e78d1335fe8f3df8"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0d4e8ec369715d85e"
                         },
                         "eu-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-012c7b5bd25c3d1fb"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-08b55f40c0d9eb540"
                         },
                         "eu-central-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0986e19b3213aba4d"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-006ed6d30c71e13a2"
                         },
                         "eu-north-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-084fcd6aa93f85eba"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-02ee6ea546d81cc5b"
                         },
                         "eu-south-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-043bccf6f5094c368"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-00bcc680d287db1fa"
                         },
                         "eu-south-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0f9994ddf0882fb43"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-00bf7a451ce42e045"
                         },
                         "eu-west-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-00ca029c27d20a6fc"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-06711562b7ed505f3"
                         },
                         "eu-west-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0b828ac5fd8bdf3a2"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-02cfb1e8f77dc7bbc"
                         },
                         "eu-west-3": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0024213d0ff58debd"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-01c4e2b009627f126"
                         },
                         "il-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0cd60efbcbf560a35"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-08d6fcec3459c7190"
                         },
                         "me-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-03ebf5cf768990709"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-041b8bda09dd20c98"
                         },
                         "me-south-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-037d09481a5320d88"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-05f2bd7319baf928a"
                         },
                         "mx-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0ec09b58b1a454094"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-056660a7d2baf5712"
                         },
                         "sa-east-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0fd8382a0922c6734"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0e24fb41d5795eac4"
                         },
                         "us-east-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0702725482b7264eb"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-07ed41b854488ed85"
                         },
                         "us-east-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0f9ca7c4faa9955c4"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0945ed9f9a3fbea80"
                         },
                         "us-west-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-05ed99d379d61bd10"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0ffe1e1472c8f72d3"
                         },
                         "us-west-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0b0696c4acb6cb4ec"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0c21af84ec879947e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250721-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250803-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "e33a8ac966a898233f4c07e7bb01aed636197864991146033db8010eb2a8f43a",
-                                "uncompressed-sha256": "f719973061908c11be7c0360a541f0a4174b9a8d52dc70d1db779a19fc916297"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "3d4c31c6cdac831a1f26ad7da928d6c3820fe15f7d988924ed0e7549ab82fc2b",
+                                "uncompressed-sha256": "28cbdcd5b608b4e00b333a3443d6e715c4346da31d804c0ce0451d85282be0c6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "7be4f8d8d21fa806286f4a3cb6c7d21b630e1dc3a83ef44f3bb06542715c4a2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "c63589996474edd103352940756021714a7144c967b6a8e20d5b72db39febdc8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-kernel.ppc64le.sig",
-                                "sha256": "4551f5ac76b46cfa79ae7e9a40f342433d5d8269c8fd4bf3121f33ce45e30250"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-live-kernel.ppc64le.sig",
+                                "sha256": "e5c615bef1fd6856034a5847fda000910421834ff1f446315959d4ca7c2bde6a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "579e8eeda4c057c322f0ec6520be0718e47ecdfe8b5806c3ad1ea69dedc9132a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "0d01d60acf5a14a7a7e5d4337e29a2113c3222c1ebf9380cebf64c8fdc50c9d6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "270fa5e9313561f7214c529600cb674cd23437f6d3abb49d797c626b19d333c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "0b3bec7151f1d1df3653f78fcd2200ee796e83f6817366b40cc9571572ac2a30"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "69c0ee7356331b7c8ba1552bec72e6a04153be7e61ce5a1db7ad642a338f292b",
-                                "uncompressed-sha256": "46ca09ece316f4bba14829d0ac2204613c3a61508c46d469356b4e0564501498"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "d19efdaf66ce29b08309480f8bea63f26eb50a3e65358766f1897e829f5bfca3",
+                                "uncompressed-sha256": "5b4be3e45e87bec54f2aff1ff2e664db1acd91ece47dcab8ff6291a9507322bf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "bd2f111904bb640405a02826994d8d3bee3b2551678f64902517fd7f04659edc",
-                                "uncompressed-sha256": "8458839905671bef41624ca3ea3a3b0eccd4efb6beeaa2a8a730a888e81c8246"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "52db4f72780a3f1e6e45bf70a9c8867d0fb0ab3f15a467c9cfb3a4385c916a6c",
+                                "uncompressed-sha256": "f18b36055b129b9793c9e5ef85a143cfcbf30ec8f5936d3a4181afb579168cb5"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "dd32d91198fff68e27a9a3506df756087368cfe028b5ea384e7a6146577d94ac",
-                                "uncompressed-sha256": "7ee4fc628652495827cae171ef8a25c433fc5b976eaeed80905f60a167dd2aea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c9653366eb4aa6e59ea31f05af565ed8ff54e493dc1a69133dbf5ffa0a852988",
+                                "uncompressed-sha256": "dae0c76d51f9bb7678fe49d7e75718b5a8237a1c55556f1117d0ad226e245a27"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/ppc64le/fedora-coreos-42.20250721.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "32bc28b4d0fadea51f658f8cad8d2de632b09ca6fef4193fb16fe5b5dc6ed536",
-                                "uncompressed-sha256": "203c12321d5ea912c752f11107524f245f024f53f3b6ce45e70be857cfb2e8d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/ppc64le/fedora-coreos-42.20250803.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2469e66cb4a98de786e0b0c498b84d426078c3cdc9b64877faa538310146bbc3",
+                                "uncompressed-sha256": "426bf81697ff1a4a372dd5717edfad8e30dc0373e80fa9b8d7baf10634bfa54f"
                             }
                         }
                     }
@@ -406,97 +406,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "26465ee8fc2fc1c8ce9178c4ae90a42ac538471f8132abac1267cb876962944f",
-                                "uncompressed-sha256": "9a11c483eaf8b1ffaee82e7b5dd1d0150d4c5629e15450117ea6542f0ef95b30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9997f8ef1b8019ba7a3f0942bae4dbe916d6ae70721a5b2eff7c5c194aab5a8a",
+                                "uncompressed-sha256": "0273ed5d2548b2a0f6e906707985efb2c4f12aae82e19a05a0dc5a3bcd819cc7"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "d7d076cf78556fd144a5686fd858db3146ee161177127f46c171fb3ae6672996"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "fec62aa5531cca8564ae177a69384aefa83df86838f8c7fcb862eed116c8e8e2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "8eb7046a1254d0a9144901aaa9f4defbbeafa9bc711c01103496c3516b483e42",
-                                "uncompressed-sha256": "015e8d0613f308958844998e879a1a115e78226800e23a6609b03f1c41c66142"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4e24d53a64287f4b798a4c7094366d6cc106dffb0a512faf1ea8587cd1c6336e",
+                                "uncompressed-sha256": "4a50a39e0bbc7b2c4c5a38e764514a64b6966713a54476b6961d07f940025c06"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-iso.s390x.iso.sig",
-                                "sha256": "0ea1115a1fa0b4c915a17902df5dc901d926eb32413bd8c48039a5d62d88ca81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-live-iso.s390x.iso.sig",
+                                "sha256": "63cdb001abd04e0ef17d0236044efe700d0e35af7f47ad8a3add8dc0ca1e4d9c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-kernel.s390x.sig",
-                                "sha256": "b357f0c6f4d5c1b25ead6d2779a45919ea0a34539cbbaf5ef547104dd3cde83f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-live-kernel.s390x.sig",
+                                "sha256": "21e1685ea1a58c19fc99f5c80b924b8baa4a6e102074f435e9d849720a621c00"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "59345817500c34106808e3e937534287284f969cc8aad576473179f31393059d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "83e7787639a33f85e052b59df78ae76f11c56c2b83be7332049bd8570e3ef46b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "b0b3df68637276f2a9932c4055416393d65482d412d6a4ebaccf1efb72e00338"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "0a145c40d808be07e5c8c8b6226ff107b3422107ca3495f3f4c03b4a1850a874"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "1a1dd5dc8634dad7524a396a5bebd494e8a16d9a487ec568aaf5f4f1d8a420ea",
-                                "uncompressed-sha256": "9bfa665f0579f5fb25c0378d5accd2fc44433eda87983086ee493b9b1a0a3ce0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "7d98e21fcbf940bd1acdba737d23d177b9356e7a778258a024287f4f7176967b",
+                                "uncompressed-sha256": "1415bd14387a9f95f2b2d7d5e3792201e06cc22fc964ffeeaef55b6a001b9224"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "74cf62db62fbe140b7b207265c47fa1eb8201b0093c59fee293334562e4019b4",
-                                "uncompressed-sha256": "8bc360246ed5558798c7e422a1d7daf75f7176aff0f04e5f9e2222cfe2a96ac6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "7c54f9858e302ee9cac1e6b979bd264e612133a98a14034393b52fc4a62b9945",
+                                "uncompressed-sha256": "665a81897aa8264727412ebed867596e9d30af8cb3255d73bfd52d7e596c8a06"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/s390x/fedora-coreos-42.20250721.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "8482484219d6b4ee2f7b40c87cab344f21c3a1fdd2b333f05f53c1bcfe3ff893",
-                                "uncompressed-sha256": "029bda088d6bf25545c72a5c8b0ee70cf60b8755355cb8cc6b4682fbc8832747"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/s390x/fedora-coreos-42.20250803.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "adb8282f860cc1dbad6a8e76e4d39a6ae2fca157e0b90fd217b83bcc800df833",
+                                "uncompressed-sha256": "e1b9120df135b7b5bd6f1866c2ab4cfba4c0fc4fe70280c57ed51b184840521e"
                             }
                         }
                     }
@@ -504,310 +504,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:33548a7c900bfb3babc662c5ec05316abdfe96c931eb9048a75159ded21ed6b0"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9c94f015c0fb5d6945be1996ee294ae6fba35b922a81bd90648733c189413847"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b56b44157d5a8f654845f4f081a500ce3810c33ad9236dacb604b020a220409f",
-                                "uncompressed-sha256": "c55a1186be10d21c10a5c224f7309ad568308734ec6100d1fe79aebaaf6f729c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "b45aac00cf3e02b315978e0967e9e07c7652d464215f64673099c5b7c06cd2b7",
+                                "uncompressed-sha256": "9608f07be0bffd57438ad7c75e9570178913e3c396aeced36a0dad48721b4539"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "3303c01550901181d0f43cfa9d690e94e367208b9dc0b38eef8adb8247108055",
-                                "uncompressed-sha256": "8148381c97ae8ee560d7242ba7a6a8f05a0eab54ad5c49f11dc08ed33a1b385e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "adfdeb7b81142672861f7df4cb9fa9834409a435a4738a18c0f1d5f29f288ee9",
+                                "uncompressed-sha256": "a4e5abe2d63b168598f58564a016676de1429ddeb60b73a6c73aa70946bbac72"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3ec09046807404c6ef1b213be5cd9aeb15b4f04e78c118973b96f23cfcde1a4f",
-                                "uncompressed-sha256": "7fe391ad4244a873904354305febb60dd3c24940989eb64613d98923d7cc9056"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "092e71a0c68c1ad4a4ffcf01919a89594dec4cefb907accb40c1d0f1019ff71e",
+                                "uncompressed-sha256": "ec534af3a8aff1baa90763129346ce77f0b460e9c06d04cd9b8ded505cb33e66"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "68e805b676f4f419f214af3fc957373750fafddfd19610dca53ca0e158f1296d",
-                                "uncompressed-sha256": "33fc936fb9cd413319eb968212241eaae16d27a920b2547abe18c0513a1c9518"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7653b5ab803fea25880204b4e18c41c22087765c806b504a1fd402b8b43741fe",
+                                "uncompressed-sha256": "1686f2396fa5b2d75fad2ce057b53d6eff38265e8b5ef9c7a0646dbce5015a62"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ab99fca2246960d6c185b075a02449f0385f57621e8415fe89debdee88226df7",
-                                "uncompressed-sha256": "975fc01aef8e1f794367e8cd107b687a3fbf93c55cef369022bd63bfe0e7562d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a0694478392f0c61af9aa2b6320ea6d3e0fc5af1989fad885829a9c5965b9dfc",
+                                "uncompressed-sha256": "4577e41137114cc5d2e834d15a63ae9956f00f705a477eb3c3ed8bbbeed44b0f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "9a61bc9e9227cead8853b8d2175f1e4cc6885618c3be7433e00b93848ffff262",
-                                "uncompressed-sha256": "dd2c004bf2e7ab9b4a81932f890911f36d97a80673e8ac6d9bd977247c179ada"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7d0f78e85fb1af1934d541c287d37abf8cb041375ff3e133fd024046f99ba769",
+                                "uncompressed-sha256": "a612a7c40adcf7e38f307e518c11527309634f588350285c77d949c8c2d33efd"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "b48974eb09eb4e7807e1526d25c186cb70d88c89527507d5ce9b201ea898e65d",
-                                "uncompressed-sha256": "99128344c0f64c7639b117d1ca38de3fcff45b055775cdb1c1c3882b26acd2ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8584cf5bf01a308e371ea0e671c27ca3ae7167fc1e985ffeb1fb8ff967e5170f",
+                                "uncompressed-sha256": "db23870b5b0131c3f4a18f4b1fbe81dd9a91189f4748eb3ec112a16a5354bf03"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "97b30015514940f24bcc10b6ae0850b33b7cc7325e301ecc3b940eb25cdfac72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "d707a9eeb606259b35bc9fd48b85726a226cf0bd55e8732588f18ae8eace6249"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "4e022997e0afe97cd93c0be18f50dca23321b4148016920553b19feb1cbf50a6",
-                                "uncompressed-sha256": "d6afda657dfe81bbef1f7690e11956c2dc0c4404e8bc0272075b593780c00d72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "23425df63c87099a4551b0d50000c7d2d9387f644c4e6e7a701d1ba5922db7ee",
+                                "uncompressed-sha256": "c08ca393f4740c63b2fb7b87f241cffcf173e9c260a32cd0c78d321fccf59e76"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "2117f5ade5a6b84880e77cf8efd5eb75d570052e2de583ecd222e8eeffe87458",
-                                "uncompressed-sha256": "eaaa7225ef2a2701c3889962c77a456d18052cc00bc37acd43ab26a2ec9a4614"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "aa750d480b7ffa1a5317feb576c48b3054de31bf9fcd97a32ddc0c9b86eab9db",
+                                "uncompressed-sha256": "70a1b16e224e4bc354fb3386288d8663f1acf624b0109614991f3275f575ab07"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "48d95e80777ac9c273caddd07bb5dafdce38c5b84851919b4c837bc0b63f7e62",
-                                "uncompressed-sha256": "d01d30f3375b241888ad44b781dc694acdb1aa58c79de57fa73bd7f83436fdc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c2c16bcaa8cdb12a58935e9c76aa67f6b31b8f722aae76c89c9ec7bca93b88d6",
+                                "uncompressed-sha256": "e5c112406d5f52864084706b9784fa39d6c6eaf17a31a7b83bda8610076dac6a"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "3455f8e5576a8217748c79fecf182a41381037ae263b208de307a429603b2302"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "1db4c6b112fb6a8d0612ca2aedd58afec1c484e28e63e10dcc3a7ce607e7fedc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "b625b7760b0108e19d618378d759f0b1c0152051d49207afa6da5e99cf124c07",
-                                "uncompressed-sha256": "286805e686a57fbb27ab38470f99ccd450cbf48043e1d4211f103a1910a4452c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "5a66cf1048c5b158bf98b89a89abae16c7773cce5d597674f857472e5054dce4",
+                                "uncompressed-sha256": "0791262c91e591ea0ad1879886f505db3dc278056ce38da82a642605fe5bb8c4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-iso.x86_64.iso.sig",
-                                "sha256": "56c1195aee84aefdb34f2a29abf992841dd506d45172e575128421aebcd37a02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-live-iso.x86_64.iso.sig",
+                                "sha256": "fc58a6667aa36a39ab604c8fb0aa5f00892137c1963ee933b00c9d99b5d2be7e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-kernel.x86_64.sig",
-                                "sha256": "427ace2fc7e2acc423714f8184b74cdd286dc1c0c765cd0c0667aada88b155ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-live-kernel.x86_64.sig",
+                                "sha256": "f34d99ba63c4d8b1456660f98930ad298531be173a8ccf6dea394ccaa58b21c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "341378e32c71c2f4f7bc3d99730f4c2d7902ba8ae6f02fe41b0c143eca0c28e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "c663c8eb0d1d8a807274567d19d27577148bed56c5b02a854daff425f231beed"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "fcf68260f47a6801f560c9e80db083da44ba0e6fda0797bf9e9338aadebe06c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "a4b8415f299fe58433cabf01b0952ef539f6cf191856d7dfdc43c2ea5d6fbc6b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "1cf2f4ce5bca848312af96159f2bcc593eb3f0d77077e2ef82b1c008ad4b6fb4",
-                                "uncompressed-sha256": "74c0ff498f12ac2fdbb8d72f1c82d8b818e7b78eb47153bc943db6724832a6d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "481c6e295fb88262533e76000a93559afc3a40d81ea12b4b5d899a920073fedf",
+                                "uncompressed-sha256": "e435cf201810aa739f02aa3aae91cdbb3049831bf5de3e8b67f72a6e414507c0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "3981b948ed8e16a9d1659eb6ac50500cca05280b8febc2729c39899216a3ed12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "7f842a75ff3f34aed72a53ef0ec9fba2bab7e65904a6ee34040f19ade0e70544"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a3698b7fd83d0daa109796cd5fd78dbb6654a141e1749985ac926116cf5f318f",
-                                "uncompressed-sha256": "998b8008286e1a93bfb8b7869e2eabe132b24d373f0342dbc593bfc73102b78a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "53a3ca10d7a6ada14dbba246259036afa8e985f7be132e4635e21d3d280d0353",
+                                "uncompressed-sha256": "bcc7f7a530e3a1844b999e070e252ad4c5fbe5dae8594062fdce3108f3ed7c5a"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2dd885abef34171500a6661c1dfead7433825b99e003e0a088bb7535966f6d49",
-                                "uncompressed-sha256": "4ae329c79f7139f9742ebcbebdb3ad16196fabd9c5de8204f828154945dcce13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c9d0f7dd1cd0801fb99df8aa41d09fcdab1f8ff95ed7c1a3e23f5ebec9563ad0",
+                                "uncompressed-sha256": "326de97a7d80d3dbf3a656749a96366faae0b6f71c653a409ed325c3e3bee69c"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "80bc3a4b6569ce7c6f9f9f1f5f23fc614813947cc274a3946302541271c88413",
-                                "uncompressed-sha256": "3d207587f12e716807d0d3126ee7c09c92e56bebe2978a333c9e2a83c42fe858"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "f6de0194baae167c9545e0d9174c24c78aa361d1ce538a1d2a7d7dc934aa9fcd",
+                                "uncompressed-sha256": "999b9818996351f121d486994eb07efca48f0ffcb9d2611ebb527005caab1e74"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "02b6767388a1a22d8e4a17cf56211c65d5d84abd8f9124e249248ac6ab0fc818",
-                                "uncompressed-sha256": "7aeca29fa8abb070f370730f8347609dcce7fe94da13ffa22cd4b349daf634f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e246ce002f823198f5092902fce758ba282593a631292653b7e9a83ebfd34fff",
+                                "uncompressed-sha256": "0e424aa979181a20f73b3f1c4ac5baba22ac203930c43377069364dcd701543b"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "0bbc9f159febcce6702f1eb6b3a0069437f731cb013da6d55dcd0a37131ca435"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "45e6495289a4bcbe50485f81d542cad87a5d4dbb5ff9af9c4fd00d0dc62bfe0f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "a83957bb3cb9d4c489d3c982524b24443fac50aa19ad9ea7a98c9cd9c0de4089"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "38acfa66bb5fec23ff641335617aaeea301ec587d2c4f5d03ae959fa0e427d88"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250721.3.0/x86_64/fedora-coreos-42.20250721.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "faf2fd78e2e6d3be70fe9ab4d312d0a49805eca661d5deaf4cfeae07e95da6ed",
-                                "uncompressed-sha256": "48152c48ea17169fc7002fdf22b1b321908a2efba9218f22e776a50f914a67ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250803.3.0/x86_64/fedora-coreos-42.20250803.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ac9aa67ea0f0a1413e48190f1df0fae94c104dbfb24c2965fcd011020b2f02fa",
+                                "uncompressed-sha256": "7d72ad2ec2e7b95db4c8e7d86717c9f86e7ab5ce1e4f17310ea0561908edee27"
                             }
                         }
                     }
@@ -817,149 +817,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-08996f8feee60d938"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-058008d9492adb299"
                         },
                         "ap-east-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-01a2ca660c49654c2"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-00b3724994204627c"
                         },
                         "ap-east-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0aec79ac3c2dd1e7f"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0b594788238a7e6a3"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0fc7aacb08cd30040"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-061e88a733be880c8"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-04c16bb8839290d75"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-02a3c613a377088c4"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-08adf1573ca584eb7"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-01629512a7c5af2dd"
                         },
                         "ap-south-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-08557ac5281a69017"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0cf22151b9967fc8c"
                         },
                         "ap-south-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-076fe2d92f9673e54"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-074a5e3f0ae713309"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0582de046ecbd9c38"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-01a48d353fea9f190"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0df382c74ed46e95f"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-02faa3e31d5255e12"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0221594f11a5606fc"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-090e9e3406a8609be"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0dc901f8af423035b"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0ca97a02229ab13d4"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-02dd80675c2974ca1"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0d4127cfee5d1553c"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0f59cd65c034cf030"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0c3762d3db683a704"
                         },
                         "ca-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-02a60247e6101281b"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0c0eb208b83ad2830"
                         },
                         "ca-west-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-093ebe5eb3e57da8b"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0d5dcd5075ba836e9"
                         },
                         "eu-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0863c3a4853df0c1c"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0bd12f233501db8fa"
                         },
                         "eu-central-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0bcdf48d4da3caa15"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-031c79e2f3d15ad8a"
                         },
                         "eu-north-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-00f38a010862fc59d"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0d097b1ced36c42ab"
                         },
                         "eu-south-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0362dd0521c44fa04"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-020d6034140d80848"
                         },
                         "eu-south-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0c153542991f2e943"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-02e9c19a823d73f71"
                         },
                         "eu-west-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-02d3f818e44dda077"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-080ea77dcec26b508"
                         },
                         "eu-west-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-05b31ffbeb6ed1ed1"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0cd01232a5108f553"
                         },
                         "eu-west-3": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-05925d5a6673ddc30"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0813e7992b8d43824"
                         },
                         "il-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0bfc7873a691cfe76"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0fa56045d0a3d8dc0"
                         },
                         "me-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-09b273d02dfac2f6e"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0d8ed7b9893ce7820"
                         },
                         "me-south-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0533cd42834cae9fe"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0baaa3300be786595"
                         },
                         "mx-central-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-09454db6f7e873797"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-00638ccf3727637a7"
                         },
                         "sa-east-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0c4a0bb61c0f1564a"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-053903f2de561af08"
                         },
                         "us-east-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0e1fe77546274c1c5"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-00e1290d3fff8b582"
                         },
                         "us-east-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-0c75c2af5666c1ddc"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-0ece557fc260fe28f"
                         },
                         "us-west-1": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-03377a70043898947"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-01021c5a1753bc31f"
                         },
                         "us-west-2": {
-                            "release": "42.20250721.3.0",
-                            "image": "ami-01970a529e62cc386"
+                            "release": "42.20250803.3.0",
+                            "image": "ami-05ff19e4cfa04a494"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250721-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250803-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250721.3.0",
+                    "release": "42.20250803.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e8a7c0f751cbc5459e89bc6f10bd9116b76450b7b289ff2dadfe87e086dd80f6"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:50b1e0798f596ce491c4cb93694c95d1aaf11285c5f3c57b11f8e1c390d70fe4"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-08-05T16:45:01Z",
+        "last-modified": "2025-08-19T16:17:07Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "a50b4d6783bb61c85d83d4bb450bd0ccabe2afef5fb6ad48c42bd25a9ef2ee75",
-                                "uncompressed-sha256": "4f77fcb86c2d5eeb2835ae366ffa6485eee30456f0004ebe67dabd44802ee2cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "37b08e9164435d29fb789f5ccf684a20a3280465438ff29de569af58a5f5889e",
+                                "uncompressed-sha256": "a76f68252a4f37ee1e0a8e28f243afcde2d0c59a46de07f7cc1e215e159aa465"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "18b6481d40db18428632b32f13480268c5acb7685fbf8c716b22a71694c72793",
-                                "uncompressed-sha256": "21236ab7488290946d5635b3297db8da8bf4b04f747b305406875be2e58c5988"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f8eaaabed77bf79f1b6b2e30bfec48d87e53cd262fa57d97499e31cf3482a9aa",
+                                "uncompressed-sha256": "8a17b7ae011c01da70db0044a704abe3f1c8f280d2d89da438923ea152093509"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "1bdab4b2bc0431bd83de06b7dd1de98f82235d06e37fb0f89eaae8d5b023c3d0",
-                                "uncompressed-sha256": "3818d345493a842246f3846163b2ad1dffd1aabfe6c5322d93a893dc0b98062e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "d09695e68b42b9d3b36f308b387cbde9ee433fb5abf96754b72dbdb51c983dc0",
+                                "uncompressed-sha256": "14632f48fdce923d70f9bf4f03e427b1ada087bc3781dd49768b606e0dc817bd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0daa52811ae1fa178e9789163f330047bd519dcf4030c6b6952cd3068cd90073"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "52fcaa393a53291eeaf395155ea0a6e0ad05912c1df8252ecde21bb7667c18d8"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "4cb623896ca2480cc3119f4ecf7a2caa4d74a56b1fa67dbd7734d6b810b594db",
-                                "uncompressed-sha256": "863f86b40e07142edcfd199869fdd967b799cef41f56b269be6067b83e2aa4a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "ea32576578090cd72c31246d22f4862e98402824fcfdf04cf57cf403f14e9aed",
+                                "uncompressed-sha256": "3f4aa4f8796ca32662f330aa5c86e018180a7705bb26f13bb40a2224ece2cc54"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "6c490393ad673529b02e76b1acedff7d210eae017a67276065a7ce5759de5876",
-                                "uncompressed-sha256": "c3b9d1eaf409cd89f6681a6f8e3cafb8f9ce0ae0f1b9a8ba823ba2c91099f875"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "278292fe962cbc18a0dce8db90910b6c07c5d44d1a3202e4f445faa9d4c5eb8a",
+                                "uncompressed-sha256": "efa7a0f2ead501fb52bc98293d7fd378b110503af1a28c71a84c218cee0cfcf9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "6deeceef8377e39f7206a9da08d870bbc702985913e9248b620e83e8cae309ae",
-                                "uncompressed-sha256": "7df02ea33e2080887d378cc47c088221019ff0279a3587dbf22df01cb2b3cf78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "d39758bd819ad576637cbd8aad26001492094c8d0d2914c72022363b5fd8fae9",
+                                "uncompressed-sha256": "b6aa6904daa8e847dab98be1a46455ec6820e2a8cf03ac575af3b74fa14d663b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-iso.aarch64.iso.sig",
-                                "sha256": "8172631f1392b6002290b7cb1368da17a3e262cc260dbe1e45061cf13c9f704d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "9fc32eda41b31cee30a7907effa733d9f7593f5ac4c6df7814f46f44df5bb4a1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-kernel.aarch64.sig",
-                                "sha256": "acfbfe21fc06d6ca24e1d0005b1dbd6d9743e8b65548af3e0e8ffd8c9321a8f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-live-kernel.aarch64.sig",
+                                "sha256": "05c87f5716b3c964d16819a4e2a6c0429d9586df2c269c6f5b2b4ba35c7cab20"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "e6b6aedf43a534ad9bea8c494c4942cad79244ec0862a7a1acbe13a959de257a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "866fb903a23dbc6a34f12f76792966076e6879872f0c98611936bb387c0bd029"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "2ccd1616b80b295d1e74507d1abab727654eb9db35e708cc369f0fc278b73e4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "bbaf204fbfe1cd6c2b29a024a00bb492e77b6efbb9b7b88ed82308a5d2c46b03"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "5224c412798c327dae7ecd20460354b77ee1be28ac68e0f5b3583043e1255378",
-                                "uncompressed-sha256": "db21b8c0b7f35c7c944fe0d63f06eb5b7cdddf63c61df150fbdba61f8dc82599"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "60125d4e789fe11e60a03b2bc43dd0068b22e47081a158361b6fa563bc58e6f0",
+                                "uncompressed-sha256": "0447d489651a1cddadb640136cd72929bae8a807046d27c6d985e2a7f6cea271"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "62c050a9d7afe195cc821d4522acec3be24afa99b9a244212e3f57f6fd9b6c02",
-                                "uncompressed-sha256": "97b15e114a9c4e134fe4daf4709ef4cc6603904d29b0312d2f1facb65376757c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "17e1ff42f062b4f548e0e97b44ceff9230cfa68ec703330fbd3c26e480de4ea4",
+                                "uncompressed-sha256": "e7cde40d804de8c22a774da1435e27dd77ef1cbc374cf63abea5a24c08e4da7c"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "9f5a2e0b77b26f86d4e99dc52dd881c71926752eea5064a649164eddb47f3d76",
-                                "uncompressed-sha256": "d15b74ab57b538b160dfd5c4df681a025815875076cc88f9c654aedc2b02b4e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "f5c8235411ef52b486120e7797338310b429d9fb25c9f40580666b19ece22856",
+                                "uncompressed-sha256": "3dbe0bbd70b37d0e62f39ae36634c272aac5fdbfb73a72c4381797ea54d18cf8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/aarch64/fedora-coreos-42.20250803.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "5ce8a25fde503836d86beff6d1e6102c3ef6f2e052b9777cdfefa899fb181ca2",
-                                "uncompressed-sha256": "380e8c19e575ddb1c44a516ffe2bcbf5e34557b486580bd90f2fc0bf5e26249f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/aarch64/fedora-coreos-42.20250818.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "acb62336b71cccf494c48f8abadf82d827d19c1d50b0a168858722ea4ee248f6",
+                                "uncompressed-sha256": "0b09eafc47ad3e6d23d77d11b38815138236c8c062280cbd22468ff09e744db4"
                             }
                         }
                     }
@@ -173,229 +173,229 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-06cc90997d9476095"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0b69a7f79507a7300"
                         },
                         "ap-east-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0fa97ba7ae9000fd3"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-09ab284f4f4b98b5f"
                         },
                         "ap-east-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-08abf070dc1b6b2e3"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0b5fce59130aacaa5"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-035fc48e0399fdcf3"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-01b72a8c229d5911b"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-01088273683b20b46"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-00ba02eeae67a50ba"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0c43c12c8d036f6b6"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-06c3b49bab157bbf6"
                         },
                         "ap-south-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-018499f85dbc28dc1"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0ee43cda92eec48bf"
                         },
                         "ap-south-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0512aff0356ae6a0a"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-09e97a1c17abaaee6"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-076d0e466a7096353"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0433787e62b1d54d8"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0a3b0095af80082dc"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0bb2d25374b94aa5f"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-081e3577229641d7a"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-006b1004cb24cd5b1"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-08f2f1be6c4b9ecd6"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-05a029ef84ebb31bb"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-00bff172f54435fc6"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-07b264cc6c6522e65"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0a8f57466b6601553"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-01be7f09791ec529c"
                         },
                         "ca-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0f169cb12a4b586ea"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-04bf3d09aaf1caadd"
                         },
                         "ca-west-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-04a045662c7238064"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-02b48da5303ad25db"
                         },
                         "eu-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-01528525a0813b2d2"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0de705688adab8781"
                         },
                         "eu-central-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0bf2995434d381ec9"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0a80edaaf22f42b01"
                         },
                         "eu-north-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-09cd826c639809bde"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-04d1a009310866e2e"
                         },
                         "eu-south-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0537ec9fb18035365"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-005bd1247d3d75fae"
                         },
                         "eu-south-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0ae5279c24fec8419"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0415ef41b6c7de86c"
                         },
                         "eu-west-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0ba62cd874a1452c4"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-08b608960cd524311"
                         },
                         "eu-west-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0d2a16d8e0bb3b71e"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0bb7a4506610d982a"
                         },
                         "eu-west-3": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0db23620701d5b9e9"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0c3d005dbb025384f"
                         },
                         "il-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0478654f178a32e4d"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-028fd78817617a540"
                         },
                         "me-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-004599c04ce5795db"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-06200d827c64dba65"
                         },
                         "me-south-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-064e5356e55048b03"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-09fe7927c720f04f4"
                         },
                         "mx-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-071af5bbc9c140100"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-047413814e3dfb45f"
                         },
                         "sa-east-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0e55975a18ccf5c22"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0171f913ebd0b7e99"
                         },
                         "us-east-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0ae4a090a4afc49af"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-05627256c6689d47e"
                         },
                         "us-east-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0fdc4edb7b2aae7cc"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0b68ef44e437ab83d"
                         },
                         "us-west-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-06ef07c7007d0523e"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0838434b4c4a430bf"
                         },
                         "us-west-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-07e2a772ebcdee936"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0c12315432acf0a99"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250803-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250818-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "0ee72292d48d27f6f372ee699df76ec0dabb29309f4b8af560ff2cbc7fa3d3d9",
-                                "uncompressed-sha256": "b037ef541ab797cc951cfda5c185d52b7d381566ba93ccf3066fe877443ab48d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "111b70307781ed40978d7e30d17249404e5edcaadb24034dd606355c61f030b2",
+                                "uncompressed-sha256": "ccb85b8bd4a01e59bcb541a8ce0b1121824497090bd2ea0b1ff009966feb4fc9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "30122d12de3aa88fea30cdb752ca3c9b924e4f6db2f9abb3245ac58693dad7ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "f8d95e8f9aaeaae21def7a1d67a9a743bfaa14db11cce16908fd0d62ff37a8e5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-kernel.ppc64le.sig",
-                                "sha256": "e5c615bef1fd6856034a5847fda000910421834ff1f446315959d4ca7c2bde6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "a9a3359d1e2c48cd7ba499c4a9736aecfdf74e3aa1d4b90fa9b058285d60156d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "2bf55ebbbed12bfc48a3044f7b5e66ad7da7aa29d63da98a6460cbbd973f0baf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "f0a9d56595394eb9ba357878d93806c06100e8d99bcb1c71bf85b2b88f3cec6c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "f9fbbd52484764ed4f87afcde2598425e52a584bf913f7bbab89634b47cd6089"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "70dd344381091dc41bd5af2b01c1e851e2442711ca9ad653a41a710d491ee5ae"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "1618e9a69a43de7eb3cbeceed51d26b982dfe5672783d2e915f5374237bb0346",
-                                "uncompressed-sha256": "42bd89e8efe3d26040e7a68d40435fb2f759679ae5ac899b175f9d2ce36a5f75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "2ad4acce59a88e34893c8904a586f2c623bf7561e66dd77047170c13b86577c3",
+                                "uncompressed-sha256": "2cf8ad5032812e34ef17b698ee504a3fd7e5f7579731b4bba7d43005998b694f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "912e4388a4bccbf984991e556c5f5eac70dd4a2ca3941c2832c45913b6be4aa6",
-                                "uncompressed-sha256": "b06a9d99716fc1de7cfad41cd0b1e9326b1251277d70c08d65a10d5b8349d871"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "62523f792da146b24f2d24ff23f3c60d8fd45ff9d7eeec0fa4bada1fed8b45ea",
+                                "uncompressed-sha256": "b213b691f9a8de2c916da4bcc40d590946316d5d36b362f2d98a6aa2bff28d6f"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "47c5fd00e13af738c2c83bb4c87d719ef58775192499e9a30c54c80d85ec1c66",
-                                "uncompressed-sha256": "f1c8d2f68ae4496eff53c5735dcb47da49df1d24e4e8efaa20ced02916e876f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "6b607b67ab29b754bcb9e1ddff4b10d0717a0b0ceacca100490ae1bade46edca",
+                                "uncompressed-sha256": "4065bb31b5d785a8b2e58bdb6035d46d604b816bac0564b0a472e376f449ae17"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/ppc64le/fedora-coreos-42.20250803.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "2b67941edae693e2205ba2e9d878ad931c3c223772ee4a16911b8a3c3908e08a",
-                                "uncompressed-sha256": "b638511fd92f6f78aa8841d6183a75954101537985d495ae633892507029c5a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/ppc64le/fedora-coreos-42.20250818.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "df266f0209085b32ea8d267f7a75cf84df06fea29e4280bcd249d2b3aa074750",
+                                "uncompressed-sha256": "49f921bdc28c7a804161b0e297a4702982209dead68cea4c513f346eb9ce0444"
                             }
                         }
                     }
@@ -406,97 +406,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "cd1946b34c4b40622e10e5143775c4a0aca283d4cd53586ce26865d70d031363",
-                                "uncompressed-sha256": "812d3cac18de5d9e8f4f00e8c0f07577e3df6256a25d52839d91028334dec1eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "65f049d3e533af11a85c31721674c8f5844eaef9d451e3536c511b8ea56de18b",
+                                "uncompressed-sha256": "1a182e20582cc9bca8c2534082c0d72ef324a4ef58cd6761e71640be0ad38a7f"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "3f65135ca58595fd083cd7a77d004342479a33ad4458e99b77964cae0af725a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "657b1feb99c5a9cb3056fb7fb4b3ef293c2ad757c7e0f1ae0d78c6318cf0bafb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "abf8b4a6599ef530f1e15dc6fdeb5982f072a8384e4208dc21921ec281e3004e",
-                                "uncompressed-sha256": "42e4be8773a5aacf321ef8f5d6edca62ec0d137805d61d9da19ae4152d433303"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "93a1cb0bd64a2aa3e1ad12c099673f3c40a34c7975a8a8ad2c0c3be2d9e26b89",
+                                "uncompressed-sha256": "9eca3be83e74d32c7719d3899e853a66b662b7490710ae98ae1c6e12127c3471"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-iso.s390x.iso.sig",
-                                "sha256": "dd9baa73e9f428fdaaf83fbdeebae185cb0dab1e6391280c03d69de8ba59dbb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "52bb93ef6cfe552e4c9242addb9b427e7446733ab1d6290da3c75dbcb6c069cd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-kernel.s390x.sig",
-                                "sha256": "21e1685ea1a58c19fc99f5c80b924b8baa4a6e102074f435e9d849720a621c00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-live-kernel.s390x.sig",
+                                "sha256": "7a0485352347f2138d5951f627ba1b791be95d9b47d683efeacb148b59f7942d"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "73ccb91fdfa96205b9c5ea870d7b7b3151145ac6a24d3c8afacb2a6c6331fc79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "c737ce2e6d4fb949bf682b9ccd72d44f006adb6fab5032a22d901772a56e2a0b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "f7cf4e9eefa3fa53d8893ebe234e008625e318fd3d1a682d369dc7aaec30f752"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "142fd2029be8e727faf1d87e5136c3c3e9220e328a04edc2aa2508b31703f9b6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "688c5d63e91b4cdb78b09743ca5c5b84afac6c64ed44d549c0fa418d7ab301d7",
-                                "uncompressed-sha256": "017529ed3d1426c422265c7abc313f014ce33a92d073373350edaa1a0ad56b3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "441e9611a8754a61ee6d943df082f1fc2f30c5d2ac65e3c56dfae99b1db84e77",
+                                "uncompressed-sha256": "251bf3cd6ecfbf5b8c9ae684a2ddc6e4937f1e41f57b8bb3ee8c5bc7582e38be"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "9d20c5929c0a56b2190b9f42ee9d0a212146d93ba3c0a329b63e0568ecb36720",
-                                "uncompressed-sha256": "1809880e369c6e25bbab1e442e7f5ec041165316d1900b8f25a466a6321d12e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "86eba44b62498ac5ac3e0ee8c50f8961c8ee4c9482adc2f9f649af96d1b03250",
+                                "uncompressed-sha256": "cc738183d4a0320e7c2d4e7d2078d25651b1538aa1aa771c156a3d55707bfd94"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/s390x/fedora-coreos-42.20250803.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6af8bc7941d3bb1d447fe336dea8c0844f3c142a9d9c8634d4bf01a4f5be5436",
-                                "uncompressed-sha256": "eb8b8f11c6f7ce23318cc5b3eb7e6497418209f5e0ee848088275e9b22682fb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/s390x/fedora-coreos-42.20250818.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "72aafe680f8f8365ffc69588a398e9de4a94fac5e7db9d67e424926eb467e66a",
+                                "uncompressed-sha256": "ceaf75bfea577f0b1430481e120048becd96fec2cd79d531fc7253fc35d67e2d"
                             }
                         }
                     }
@@ -504,310 +504,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9157398f1303e32cd51eb86e01d0903a21fd43eb54c6aa3637d81c5aefab6d61"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:609f291fcee5010b17fd4f8b688e21f990fcbc7ce63a3c2117ec493c9318a107"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1c87ebe09f35ca8325b2cf67a040cb72827375a48e075bb1ea4bc0f622693908",
-                                "uncompressed-sha256": "47300edc9e1bf8836d5bebcfe37f3cd30065c1536cc81a338e3ec20b70f14aa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "0b775f4dc78a8a47d059b1fd377cc3bbe248d8007c3f7e37059f088211f25ce5",
+                                "uncompressed-sha256": "53bd7978aef0d820818c2afeadb030add174c53f53aaf4e04da67e030f690e90"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "1230269e1f90d540d15e8772e41a90c2995f9295bce32280171f94ba42b60f81",
-                                "uncompressed-sha256": "50e42475c09f3d32da027e0ce4802c11187fb889dc7dc48a372d59c6deeeb5d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "2fe14ec18e48957e96e33e893dc952cb133875c5b773330a5fe63f9dba47f8e6",
+                                "uncompressed-sha256": "082320cbc65bd0dd970c4320ead54f41277e81758e3a197f0f4e325342a6ca36"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a33838567e6705a199c88bdf6e39cafe9e520aadbf2bc0cf908d1a33de480b50",
-                                "uncompressed-sha256": "b66af2d0b3006ee7ab1094f6ba2cbc5eb89b95223db4b251e5b82f38f8c0a71c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "74d173d80bcd928ad5cde74b6334cb1cfefe81884fcb188ef099d97b4fb094a3",
+                                "uncompressed-sha256": "bd5da69a73f1ec445176da813dcbf91d1785990933fdb093701173aab4fadcf9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e3f4f559eda59ec9b17bb5603016b091931c38370b7e0578c7acbc8b67df6902",
-                                "uncompressed-sha256": "e68ff4fadf0c90797fdcb92bd099da99e2adc7a8f6cd46d6524064dfcf4b19dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b71d4818bad93c08d0630cee56e4104dcc3356bfdb5b23e11a136aebc3def8a8",
+                                "uncompressed-sha256": "88132bb6af9f200cf1e1e918359b3e8b17b17acf52a6119e5ce51840519824b9"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c60573d0a643bbbb18337ce9f26c31102bb9e74bbf918529233da1277004deb5",
-                                "uncompressed-sha256": "d85fd18db7e37396e6eebd8f1e3e6fab31a9ed513a77f9e8386508d45efc96b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "339990608dc63fdab9f6d91911b0c6ba7ad455cf0e3fe255d517bf391ae8e1e9",
+                                "uncompressed-sha256": "26491cb6bbd70ce9256fad9467e16831188320e16200afa47766cab4fb34600b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "338967954c6f41341c23572dee6a3cdf1f5423e8cfa969c5a35ef362bf3d3ae3",
-                                "uncompressed-sha256": "bd1e54ea8b11c3c2d6bd6b6846a8572d5310ae86aeb79a0661f683bb58ec1284"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "08be340e2e75fb71bc7efa903e4efe22a45ee040d43cad68c8512a58ec09dcb6",
+                                "uncompressed-sha256": "1ab8c562ddd4d42f48e852ae028ff20891b28387933241c5f6bc600cf0bf09a0"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f83b08d7613bd5d80fbbca9f7d748058da860f49b4e3900103b43c95eec6487f",
-                                "uncompressed-sha256": "a40018b49e6b586b9696df9abc67fadb44e04e474537b2cdae13bc8c4a55c5ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c40a8102679d07e103218263a84314f7ed86b6ee9451705d5f02b467f1540663",
+                                "uncompressed-sha256": "6724f9c2b80d4e4d40c5d0f18679d7cb9a10c222f8e4df5ebc299baa3bef1edc"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "08cac7d3d3e7fb4e095d5ee8d6f40dcc418d804bd5af5675866cd9180831a3e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9aa792620d23062cda4cf476f6f07046df8c86578bfc2e8e839d569703bf90e4"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "8bd8acfaf4146fec1b98e7aec6413a9abcd705a50db77475e6d896749c8075bc",
-                                "uncompressed-sha256": "91778e2b8c9308f1889291dfa54c24b577d19ce38da92060359f678a05b05bf4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "25d172861ceece228318b8b4d47800c08087c8189f64f871256e1d38bb954f1b",
+                                "uncompressed-sha256": "6d7815a4e91713f141a367efffe2136e79c03bcfc73b1a785cc8eb20f7bf346c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "51fd7ed02ce0f80c9e4cc16c21fd901d3d2bba18f81476ccbd3cca2212d4d8df",
-                                "uncompressed-sha256": "6f7a3d48f4def5f783f3a59c26ee1252dc581792ca80879329ccd4aa39826237"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "c5839a8d9e2986814cbe56f5c9d2dc2cc170cb28a17e9e4af57e3f9b2206e438",
+                                "uncompressed-sha256": "401874a1c7de3c2d2249be0f4d56c341dd15412674e6d74b6f40701cad1eef66"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4d0be265e5986dc657bfa8f550909bb131f3bf43e7d148ad2d76fadc5efccdb3",
-                                "uncompressed-sha256": "67b113d3856eb75a5cec0fe07b9e085be8a3e320d252720e8dcd49e0f3e1851e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "853f97436fd88dc3a860de97512cd7731488780c3c95816670e3a4d832a40535",
+                                "uncompressed-sha256": "73b4bdec9509b659210cdb0b3c610a012bff7a91916f872900235303ebcd045b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "cf96322021663522f8085251d487284dbd13ee1e096d9e79e11a51a32d35821f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "535bfa9783f022e82b90a51e03a6da5ac348838ce1becebeda79861624421127"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9b9b20c534a91944e42f63f742407c6cde4c095d49077613089a7aac2b2d11bb",
-                                "uncompressed-sha256": "24a6f7080c1c896efdfae4ef13c99daa4f71884ef870288591d1ce3047a1f939"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "f1d3ce4ded9fa77ed19d8e008a9616e1b5059cbf8900a966816a9ef3aa2f8839",
+                                "uncompressed-sha256": "8a1ce46f1074f0f8ef400e777b8d555b10ec86292a512e4f9b363378ae26c15d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-iso.x86_64.iso.sig",
-                                "sha256": "f8769b3028da05b386a630d179ae0e5bee36ab798cf0a5d3a5848a49d40a1d34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "1484f5d1d9ad87355743071d1e2e7daae66c6804b7ab658916ad9b878b6629b3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-kernel.x86_64.sig",
-                                "sha256": "f34d99ba63c4d8b1456660f98930ad298531be173a8ccf6dea394ccaa58b21c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-live-kernel.x86_64.sig",
+                                "sha256": "fd7cdbd1fde31ab06ec4bc1512051be338783df4d7536f1242d5305c82b88302"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "6410df79883eed855e6bbdb445a80da2194a02c36a5c4e9aec5eb3b37b33601a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "878c34a9400688bbdef7b4845a870e1ec9dcfcd0422d4d572d85ada0d1098e69"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "b12b3038416f22c11c3be879419031e01a5c0b5ba01373f24d68aa4640796b39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "b425f2ffc527b01fdf49439b7c0af75fcb3fece3028c4fe8a57e9acf8122d03c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "b8ad7a994eecdff62534c74f4b573be47c23e2e30c11e5b7d350d4ebab477773",
-                                "uncompressed-sha256": "f8edf3d2a2eec9da9e44cb6073df2c51bf68fe74a6f07133c61ddc51bc2a5414"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d07e61905a2b37f4191f9edcaa95630fef65e310dd824e39330355697be80b2d",
+                                "uncompressed-sha256": "bf41db5aab272d95ec93c00cedf62a259c7711deeaedb7a3c3aaa74de056c43c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "d510d07b3ea12c9a378380f40f2787511469a0780225f92b8aa09092b09c48dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "11d96739d487b68477435022fd2714188a717f0262cafa8ce624364e2746b021"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "d651bb525b59e601d0d519879de364454e6ea81fad57c2ca6e4efba88efcb51e",
-                                "uncompressed-sha256": "bce653d12ef10e872e128cdfa2400fd80a8511503a906fe490407a51824f6a7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "f31e4771d54e2366c2546c0e26affe9d7d69f2896c55ad936e8f380e00ca5c56",
+                                "uncompressed-sha256": "04e0c888ed8912e9708459319d2ac3d07ab1d2b39ce5184d2fa746c25db1beab"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "205069cfd6a7330ee08c7d3c363c651981c5e464cc349a2223649ccc3764bb62",
-                                "uncompressed-sha256": "5670495aa1aba2c9b7ee411d6a39d22b3ddd160232ce18b31269afb5372e9869"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "33e62fde5771a11bf87c19429fcb11757752f3085812f8d679a7d29fcd258c54",
+                                "uncompressed-sha256": "e8402e36fe71a502cdc240b1635d639bcbac41825d88c9d32aa0c72bee2fc0a3"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "435fade994d94c47802bb4e02693c848818758745489c1715e4e5801f5aaa3a8",
-                                "uncompressed-sha256": "9cdfe7d43fb8a4460da3a6c1cf31955b29e3a00b92323cc1f17d71773a9e5459"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "2d17b938a799b8283d9d659b33b0f8a9deedbd5f56fd11bb80894976d44b7b11",
+                                "uncompressed-sha256": "1653ec070fb34511a21a3aa74d1d61a71292fbc8af59ebfb150146859039c7b3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0f18cd2fb0d76b26367eb51e7af07b63ab925a8587045f9ce8fec3dff98bbcb0",
-                                "uncompressed-sha256": "f1150b7f198a0ab03d3d797f14db3a62017ea316cf921605f0f0d55884bd7376"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "13ff4d5751be1fa549da6be29e72deb97fcba879931a9a15fbac9ddb89702d00",
+                                "uncompressed-sha256": "e9d8e5489c7c33ded11720d3479b0fa970a02176f80cd2fb6b0e8f78e3f87bfa"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "82478d41be6b63ff7086f6f1680582e4d8d61b69610ebc55324714472e6200c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "86d33ab835a230579b8b4c0d809b990e9058bdbe0752aa1dfcedc45857d9c1f0"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "ddaffdc4a8cd2d03c816a103e6d1cd6ecf6f2c92bfd38900c60108f274c8e7a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "5deed843af931c4d3818ab7914820debb740d386c8c787b3693bdc042a5549b5"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250803.2.0/x86_64/fedora-coreos-42.20250803.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "964a220a3daebebf58e0d02fc59c49ae3148d8a01c791756f6147ae96391c876",
-                                "uncompressed-sha256": "3039cdb1baa09b0c1e1a3a9d8150ded08a1851cd184bbd78d0f76635cdf64e53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250818.2.0/x86_64/fedora-coreos-42.20250818.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a9d0430d4060d5cc8d78262bbb40f4d5ba47c0fdd5160a5df0788c14740f83a3",
+                                "uncompressed-sha256": "55d36b48c7c22ec7375533fbe2ef482daec4655501cdd7f838d2a0c98ae923f0"
                             }
                         }
                     }
@@ -817,149 +817,149 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-00104f0c06ccf2927"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0db931aa11a12934d"
                         },
                         "ap-east-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-01b85013c761b147f"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0bf4c2bd37f0b2bd7"
                         },
                         "ap-east-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-03a80e17529eb9c03"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-030a7b69d8d76728f"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0476f587228902882"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0dd10b6e1f6b9d995"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-060b47ae600b7b069"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0d74a611229d93a7a"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-025ee41c174271111"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-03c4aac704d4b5d8f"
                         },
                         "ap-south-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-01030abbe350d55f6"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-022e837ef9d76ebec"
                         },
                         "ap-south-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-067936385544ed226"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-00ca3e514a180bd42"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-01247e969ab31d3ec"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0c75aa45863b84696"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0e1c5c9e85bc59022"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-01c21668569ffcd59"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0859cb1df3e967935"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0e21127e315fa5165"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-03b5bfff69040c91e"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0152ef3420496b164"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0bb083a4c8cf49315"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0388c98dd8828d736"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0291323b8979a0c6c"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0178c3c793539d32b"
                         },
                         "ca-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-094e58e73aad512f6"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0c2fa746f9cd6de49"
                         },
                         "ca-west-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0b18ccc3602855689"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-067c771e7736e34e1"
                         },
                         "eu-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0533280948a4e188b"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-044ccc211f2cc2505"
                         },
                         "eu-central-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-09cfceea1dd75141c"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-004e2a9e907febb75"
                         },
                         "eu-north-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-05a4bfbcc6e744e19"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-07ed94dfa261645c6"
                         },
                         "eu-south-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-060cbb2a8ff01009c"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-016e61ee2da21dbe5"
                         },
                         "eu-south-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-05e120b1859f50a02"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-02b95c4f4e6d9dbaa"
                         },
                         "eu-west-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-09fe35da96a42dcc9"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0faec69cdfc207193"
                         },
                         "eu-west-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-045af28cf37bf67cc"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-064103bbd3a66a252"
                         },
                         "eu-west-3": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-015378d40184a19cf"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-02007fa8df3227832"
                         },
                         "il-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0e69ca8690b16315c"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0f2fda2836994d833"
                         },
                         "me-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-09aa171d0968198b3"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0505cb04295502973"
                         },
                         "me-south-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-022bbe3f8489b08db"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-038dc0e38ba361663"
                         },
                         "mx-central-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-07990a8ecb2921bb7"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-05cb1b5049bd28e9a"
                         },
                         "sa-east-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-035ddb1574b909de4"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0695909f5a999ed64"
                         },
                         "us-east-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0056f5c5bc27d60c5"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-089ad56a696c0f562"
                         },
                         "us-east-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0ed40d7a4b54d6008"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-0cae1533cb5d58c47"
                         },
                         "us-west-1": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-0881fa3f2db84b727"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-090ba200b72a9c220"
                         },
                         "us-west-2": {
-                            "release": "42.20250803.2.0",
-                            "image": "ami-09183ab88fb34b177"
+                            "release": "42.20250818.2.0",
+                            "image": "ami-013eddde04d5609d6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250803-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250818-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250803.2.0",
+                    "release": "42.20250818.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:7c9926dec3207fd106a041360d8173ce794a461635b03fd914edc681788c582c"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b336546d443d1297a36f08fda2776ae33a7fa6bbea535f179053a45ffcd8348c"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-08-05T16:45:02Z"
+    "last-modified": "2025-08-19T16:17:08Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250721.1.0",
+      "version": "42.20250803.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250803.1.0",
+      "version": "42.20250818.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1754488800,
+          "start_epoch": 1755624600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-08-05T16:45:01Z"
+    "last-modified": "2025-08-19T16:17:07Z"
   },
   "releases": [
     {
@@ -125,7 +125,7 @@
       }
     },
     {
-      "version": "42.20250705.3.0",
+      "version": "42.20250721.3.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -133,11 +133,11 @@
       }
     },
     {
-      "version": "42.20250721.3.0",
+      "version": "42.20250803.3.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1754488800,
+          "start_epoch": 1755624600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-08-05T16:45:01Z"
+    "last-modified": "2025-08-19T16:17:07Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250721.2.0",
+      "version": "42.20250803.2.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250803.2.0",
+      "version": "42.20250818.2.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1754488800,
+          "start_epoch": 1755624600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).