### PR TITLE
updates: set 42.20250901.x.0 barriers for stable/testing

### DIFF
--- a/updates/stable.json
+++ b/updates/stable.json
@@ -135,6 +135,9 @@
     {
       "version": "42.20250818.3.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
+        },
         "rollout": {
           "duration_minutes": 2880,
           "start_epoch": 1756994400,

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -151,6 +151,9 @@
     {
       "version": "42.20250901.2.0",
       "metadata": {
+        "barrier": {
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
+        },
         "rollout": {
           "duration_minutes": 2880,
           "start_epoch": 1756994400,


### PR DESCRIPTION
The script for OCI migration has been in stable/testing for a while and we're ready to remove that script in favor of a new migration (that will require it's own barrier). Let's add barriers for stable/testing now for https://github.com/coreos/fedora-coreos-tracker/issues/1890