### PR TITLE
Roll out stable 42.20250901.3.0, testing 42.20250914.2.0, next 42.20250914.1.0

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2025-09-04T03:53:31Z",
+        "last-modified": "2025-09-15T21:02:09Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "15affa693b9d057d4b9708ec74898d499331873587cd729992d34a808b7cb440",
-                                "uncompressed-sha256": "6e6d25b6e8d6dfcbc27b692575b0e77b91826dc95500e9b8c904eac2ce96d41f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "c4a52d04cf83d3679cc2476327666d6f8109fe7478733a1646d48aaeee2a6350",
+                                "uncompressed-sha256": "5032c46af2f2e4a8a620587a560ac86bdca389f9d4fa421e5544bbd28cd2f2e5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e8d8225b0765256ac9fd74c689c4e6792e7a51b2b3391da6ebae066bfcdfadd2",
-                                "uncompressed-sha256": "eb7652aba7718e7c6d3df10ade8c5dec39b76b20d704c506d06c0dbf395aad77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "f748c9b9f8f370ef1560a6f342048f27993ec94eda10c454bc870de98923ea90",
+                                "uncompressed-sha256": "fcd1316b2dbd6cbd349924368872fb8d4122a08fecb284b351afa36563763823"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "93053564ba056c533d612aebf6e037ccfb8f6b052238bcf2cf88e381fb23e088",
-                                "uncompressed-sha256": "3610a749d12031fa4f4afa7ce16b12b4eba316ffb0db5bd21b04dcec1f38de7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "b06a2bef250be5b25fd265b117659c6f366c0bdef5654729119accc8d6088220",
+                                "uncompressed-sha256": "59d4159a84cae2bcaad53a16d98c4a646fc1a64ee7fa1a205f8df8bddf2180de"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "5d4e78efeced607afc69dbd36e74e67647e97002e614561130df304e6b74c6d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "c6621ee1edeaca037a0b85b26d1eca87c6ca9259044c8acbe587117cbd8d5771"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "fab9637c9a405d01edb2323ab3c5f49b41be35ce7e20feda3d49872cccd9a28b",
-                                "uncompressed-sha256": "97a7a8c2677fd5717ee715fc1e70463a4b6f69c57ecea94688bf76e39158aaa8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "5f409159f6908a247ba835d5e94670b9dcc47319db63a08ef561847878533333",
+                                "uncompressed-sha256": "c5e4dc9f5e6eb6376e30fb612d04c69ad1f7fb667c8aeb946b45646f2e22b03a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "153c90a1d30bf067b04efdba588e5c1b3d77dc499bbbc289ced234c4b3102fb1",
-                                "uncompressed-sha256": "d04995b2599f12ec2c863b5082f90623e7b6c37837592f4cbe40ac15dc5a3b8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "cf11d29d124ca70100e6e7adaa0fe31f5c6060a140fd403329f112a3d4d7b071",
+                                "uncompressed-sha256": "3dab40c0e8d8e7b4835c4d8ca7f04cd36ae27bc90c1cfbd9a838fa164648305f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2f4c7e4ea132e605d3775fda37361cf8fb71139da42e9719789b95bc0e0b7f80",
-                                "uncompressed-sha256": "fcfb5cc8910f5b1f1a48b24cb790f83a999d8c4e5f7574857fb80080c7ec9e6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "6ad5918c74d31e9fb421e5052d4249f27f1efaaa7ebc1c88316665f8556eee18",
+                                "uncompressed-sha256": "f05fc0b34f37090e01d9c6155bffe02099ea13fc8b13c50c822b0f106efa2392"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-live-iso.aarch64.iso.sig",
-                                "sha256": "d40b459a125a386bc5972d8b187fc56a8f3326247ad3778b2c7df6c8d2482fa0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-live-iso.aarch64.iso.sig",
+                                "sha256": "71b8bb501ae3edb93c1b95b2ae7982c5d7f4176ccdd23c611b9b5c393ce4fc49"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-live-kernel.aarch64.sig",
-                                "sha256": "84c9de1be05405c88e1539df05afdb42d9ef9ba7ddf13d764d1d04652be958ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-live-kernel.aarch64.sig",
+                                "sha256": "9d403d7a67ace122129ef7593b2f5a4b0ae014083583d7722c6827013efb55e2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "85cf43c11e5725157c71b955b2074994309eee95d2e2d4b533687dda3085d04a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "256f39e13299d3d53cf54d2858bde5abdf354243caa5eca892afe173ebea30f4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "b520e987c1458759d13fc94fb8e25994a22d9f2ae9e12410b5e501e00c10a979"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "5bbed5c02a1d31274323dd1a86f4c422e7b68b975f91a859ec6ed8f926312be1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "58f10c3f0d748de9f5ede08e11b4856215bc921aa8f9eeb996f77b46d200ebd6",
-                                "uncompressed-sha256": "1c2390cabe588d56a07ac10d24e8e37601c70e404a3cbafc5272d700a516a25d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "6799020b393f5084e5ad919f5ac9fcddef88aa34b4f6fe296e1f17bde5fab1d1",
+                                "uncompressed-sha256": "a05da52397ace0c6543079a8abaf2c15ba50137861d8001b92fcd15fca6744cd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1bcadc75350d1260774176fdec49eca8363ed8332f76c1ce4b533f7dd5bb9597",
-                                "uncompressed-sha256": "2427d43d3c0103ec603d4e8a8f41c1bcaf8a11d7f68c6c965e31201c46b7d17d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "142122b2657668d77c9983939e63d467f1e8d1b81ea8ed7f34bd174e8e4d2389",
+                                "uncompressed-sha256": "9bce976637c22c7b9e55351cd63c8608ca9fd2dfe6a03e18a07baef82b380727"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "618d3a178a8272e0b6dfb54c638c419e7e73853e1b680b8b4cdeed45f48df7de",
-                                "uncompressed-sha256": "986dbdc59dc51d1f686144d39cc08e0fecbb0c3d189165579c38a27ce96ba84b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "028edf07deb51436da009b3edf01c352156ad65470adae4a2a64df82dc6b59ca",
+                                "uncompressed-sha256": "8d7717695983c942730a5707223c72da2ace114bb2262a277ec5b2836289b5aa"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/aarch64/fedora-coreos-42.20250901.1.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "22b35768042b62da98529c06dbac7d7b4970cb36ddba561b52437a6136dfda86",
-                                "uncompressed-sha256": "1fa03d37636320f77e1ce74f4023562eaa15f9635638d20187848b893f98ba70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/aarch64/fedora-coreos-42.20250914.1.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "1a909b699284b37126fe27544c62c7760784d1e4d2d171c3c6e64e9a99c6db81",
+                                "uncompressed-sha256": "e3b6cf41664c78ca2982e74fbe350db094a34dcff42e74c8b3dbfec541de2ec4"
                             }
                         }
                     }
@@ -173,233 +173,233 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-00a34ee32afffa68e"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0611ad69292ad5ea0"
                         },
                         "ap-east-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0e704523783911963"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0eccdee9f1c4f4fcf"
                         },
                         "ap-east-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0a7c70c034cedf4b4"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-01a3cac89c091d4b6"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-00518db92332fa161"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0988ffdb5a52f7f72"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0fa57e0f6e10abb17"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-058dc96edeebf6402"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0eeb876c4db342e9a"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-09ba5bfb0ced94f0f"
                         },
                         "ap-south-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-008b3aeebdc3a4316"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-08950a5e81c44d7dc"
                         },
                         "ap-south-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-04ca9f5d2e2ea5cbf"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-086c7ff0c94b7df56"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0c7c0febfbd0ade46"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0b00c6411dc8d1392"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-03ee2550d4d27133a"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-08c6b6a04d7d8907b"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-08a71249aaf18ec34"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-08db575ae82d403ad"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-042b3a1004b34c0fb"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0b3c2c5a9dd9be17d"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0e7b24cbe930e968f"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0cd6877fc48d8f403"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-08ab62b4dd5b3a094"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0f0c5cafdfabddfb3"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-00b3325e0fef46642"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0b125e3a10f00db4b"
                         },
                         "ca-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0f6531d0ce73b1449"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-08b50614a9289cadc"
                         },
                         "ca-west-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-083b4aa86b92801d6"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0dba220fb32ad6970"
                         },
                         "eu-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-09301cec962d81d4d"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0ac3bbc99517629aa"
                         },
                         "eu-central-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-03db802a55ad821d9"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-05f29000f2c62f50d"
                         },
                         "eu-north-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-07263f4a245390a28"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-029b366c34e10c219"
                         },
                         "eu-south-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-032a614b959168131"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0eb6ccaee7b1ce2cd"
                         },
                         "eu-south-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0f053bdce082b3845"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0fdfba7215aed8888"
                         },
                         "eu-west-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0b36236eff5069ef4"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0cdb81786f36df3e7"
                         },
                         "eu-west-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-05df29d376a255910"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-04b508bc632e8b532"
                         },
                         "eu-west-3": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0386c0661f28b50a6"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-03610b54e97c97d6d"
                         },
                         "il-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-021a1f2cee20075b9"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-00d6594cd989c2db5"
                         },
                         "me-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-004466b1c16ec2d44"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0a9e92b2069090671"
                         },
                         "me-south-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-01a2f387a7dd1ec95"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0fa07052c9f8fc609"
                         },
                         "mx-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0842c05252dba12b5"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-04251206c64c1b1dc"
                         },
                         "sa-east-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0b8f9de97503d003f"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-07fd8b67c1d9b2c4f"
                         },
                         "us-east-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-075365adc5ede1276"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-08f1ff62664b73e63"
                         },
                         "us-east-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0e2d2e4b8895678bf"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0d00a6fd1a5558284"
                         },
                         "us-west-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0d3a0fbe85f1be58c"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0c46cd790d45da64e"
                         },
                         "us-west-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-068280f05122c8c64"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-053ffdd409c8cbca7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-42-20250901-1-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250914-1-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "597ad8cdc192c7497cb4b65667aa681b34b2d5b762cbf52a3cf2ab7762ef52e8",
-                                "uncompressed-sha256": "af5b2d83edbd1b050200d61cdabd2ff27be023b5db21d6c52cbd6953ad46e23c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f380045ae6d8dca9a4d981428ed60ee10786cfd67ba75a72b41ddb42b1842b5a",
+                                "uncompressed-sha256": "88ec13136b853031a96d9c018c6cb4da3ea9025c597c256d9331f68fc3dc0f40"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "b61e81b5b24457743713dc6b62f11cd7078e5e5a38a7a3bf152105ae94909123"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "627d06d6a0c72ca9f141398fab3ff9a4be694c5850262b07ad37e8dd68781193"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-live-kernel.ppc64le.sig",
-                                "sha256": "a9781422913adbb5746fbf803f2728fe5d62df16cdc3e52a45aaa749c6821b5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-live-kernel.ppc64le.sig",
+                                "sha256": "f6722a51c646e6a15f0a69e01bf2ded92c5affe6481723ee944774744a83379e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "eb5f202da6290dd28630c01d41d13c8925842bbe63fdb4431fceeb5a9e9430fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e29bb1d78a26ee961d88a82da685cf2022dd4db80053010f41bb21600b601f0e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "177149b67e0a737910b033d86a6f83853b9e66be9c1a6111d6a552a2d21d1eda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "76f4bca06878c30ad029df4e82a3c92dfd73ddde353cd0fff56dcb879d2929e1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "71027d0198dd468afd36362a703de013fc3855ddaeeb101c2cf0900c50c645c7",
-                                "uncompressed-sha256": "07f649717f22fd2de019340b25833e1f4e103119f4c496fb518b2f5f3384c045"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "085793f24b3ec3529297b6bd4b6226588f8ce6af203c028249fd7c6678bfa4a2",
+                                "uncompressed-sha256": "096787c6bc89b19f77d1b76e29e8c4fba71f6e19ba92ec66fa4f9d1ffc6421b1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "65b59655c8d0e190d4907836144220bc5bb773d27f850f3c069b73b833eeb553",
-                                "uncompressed-sha256": "4372d8515b006c29d6607b238bdfbcbb05630ee2e65e672d0a6216b57ea2508a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "24236c978994cde00dc6af7a27d63b03fe63f81b6207db9742f080913baae4f1",
+                                "uncompressed-sha256": "54e351fb73ae971a531a762a7868d6294609d2e6c88cb1e8aadeaa895b31b482"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "d2a95166732403b16543ca7a6901b059491e509cc296b27d6c14c99f0652d70b",
-                                "uncompressed-sha256": "b6455db83340001ff392a38fe74d6aa3a471bfac530531aca882e0392c73f2c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f8d4d413fe7e1c6cd4322fcb7afb4d5eb99ce73b01a9c3d97bcd2629e85af25e",
+                                "uncompressed-sha256": "ac0dd9215f267b6578ecccdf0488c83a0901999f95a705b773c937c25610511f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/ppc64le/fedora-coreos-42.20250901.1.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "60e6625f1b1805a7f4a85a6eff0d872eea2a127ee2db10906887aee5341ab187",
-                                "uncompressed-sha256": "4f6e200ea35070df72b99c9664be7a24d10291030947b1b33329f86ecb073655"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/ppc64le/fedora-coreos-42.20250914.1.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4df23f0a7d78ab60dbc6285ac1f733953ebaedf9e5ad60f8776d8113df1ee008",
+                                "uncompressed-sha256": "58dfdfedfad70933da7c6c16fc187b3d1d0aa47058cfbeec3574a70d8e89ebbc"
                             }
                         }
                     }
@@ -410,97 +410,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "459c3fae885632156b86ed9112a0ddd6deeec7a4211d98f7a88109e50fe783b5",
-                                "uncompressed-sha256": "8aa6e906220b81f4210becec461acaa67b13fccc804c08c7cb78f0616a593836"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e79b6dc1da8c6b3c075f7b81d0a77d59b1a8c1090d24564bd57ffb1296d95f7d",
+                                "uncompressed-sha256": "95e7438df71222914927bac57112814cd697b4f465899fab371281830ed81f8f"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "98b9c5fba515b88bf78b36a52cdd3a2c8c5dadaa8782cd72d47d2ca77b212f88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "fe00c3caaac67e093add606ee6a7b9373776755b3900ffdf6f0bd91482e13aae"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "fd203e8306a169b03c3493964d241bcd49db5a71cfbf04b0f2d8afb0c8c9ebee",
-                                "uncompressed-sha256": "d185fcd53922a6472c84a2c4c4a9639dce0100832886b4a8414bb750fa5b231a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "2a4cecfac39ebfca0ae1f55f84b5aecbae4194c78faf446b97b0a7da7c2faeaf",
+                                "uncompressed-sha256": "88ca49bbffcf4b792258d83b6d4cc530b620fc14bf86d361bb822cb2f02eef48"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-live-iso.s390x.iso.sig",
-                                "sha256": "34cc58146456afe359a265a26d7f2afd798851c37cc5ad358f5939a6e81acad5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-live-iso.s390x.iso.sig",
+                                "sha256": "2487609376b03319318f1fe7220f99cffda82e7d70392f77af0746645977bc3b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-live-kernel.s390x.sig",
-                                "sha256": "ecf8903d8068be05b8c64b3ccd5397842625f99f66b14306d5c66680d5a63869"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-live-kernel.s390x.sig",
+                                "sha256": "877752631faf1ace0e0875751cd11ac90c03f5e90fadc879276005f81d1fd97f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-live-initramfs.s390x.img.sig",
-                                "sha256": "403531da41db0e3ebbeaacba208f2c2438b816cd327c03758ac0e599767baec2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ceb5cfdbe508b1e805b54e5ab8cb8b55687c49eb653b79eab296315091410bee"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-live-rootfs.s390x.img.sig",
-                                "sha256": "63e7cba7b0b09bb49223a35d9dc25983f1f4d01ca14f018d34cc3f6773de5768"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-live-rootfs.s390x.img.sig",
+                                "sha256": "ce09f4476af3581c22da4d306fff5051c6366a42b9831b566e05c8947ba531f1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-metal.s390x.raw.xz.sig",
-                                "sha256": "3d095c8e2b9e469e25e75072d5c2c5113d42a79e44559fcf7f947cf6050de008",
-                                "uncompressed-sha256": "676cd6170881686ce5f0738a662e359cd5bd6e3fb6db7b79af90206fbab6aa70"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-metal.s390x.raw.xz.sig",
+                                "sha256": "e2cf9bb653e8a36e928d98df75e18925e4a91d13b7ca61784b391e9785731d83",
+                                "uncompressed-sha256": "0a3a895c16b77d9203bfff5f41e08ecb86bbc6bc8ff38a665ede5b2ef63c2eb3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "de82ce3077ad5a9304e7cfd37b008caefeb52587d795bbe4f17ba4fcbe3ebfaa",
-                                "uncompressed-sha256": "eb97efc8a6a9987d9792214c10c080491190fa24fae2bc8a491b2567c78226f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e5d620dbe2aa997276a533019b4c1bab0b989c4ed259c678eb10016cac339ea6",
+                                "uncompressed-sha256": "a8d05730fab72b0e618c664b9ed39000232177fd16d6012dbd1e11f8e9e8d3fa"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/s390x/fedora-coreos-42.20250901.1.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "7a3ef0ea89dc74c17face3690c9a1ef8474598310d2a40cc3f543681631a89b7",
-                                "uncompressed-sha256": "ce80ea5512aeb7f0613078f938fff9d253de0174b4c608fee11d765a0d199b04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/s390x/fedora-coreos-42.20250914.1.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "5f83e7363724a07e661184383d9a9b01379b81a3250e5dc2c5814375c0dc1a2c",
+                                "uncompressed-sha256": "7ad5a5707e27eaee914060de6110a2359385c094ecbfb86e6e684229820000a5"
                             }
                         }
                     }
@@ -508,310 +508,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6e6cfe17dd4668fd0913bfe13c15877f1e6e20da606e25096636cb58312b9fbf"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d0aad3861783c3030326d6b3195adaba2d3af6c398d3570fa6e80afcd6fb7f85"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ca399d61c584ab8f7c3671a05998aa2ba7ca5cf42163a69596397f0a68038639",
-                                "uncompressed-sha256": "0e4bd3b8159756e54c4dbee80ebc02d96a4c4ffddcb64ca7a22cdb7282d7c49c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "81f69091e0bdd431c869ec4c487963c352ec0d0cc2de12201958594fa52023c3",
+                                "uncompressed-sha256": "8412b6e1c3b2963a496966d080c7f9aff9a8cae19eb5a9a3e7bd03925b7dbbeb"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "5d248033e62d2e075d82606276f10065e1f6293cadd84f9bcf826578d9a1b3d2",
-                                "uncompressed-sha256": "94c75e924377d21a193744061fca0885698518b6f7e7f45232903e656a89a6f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "4aeee41b0d7e761ac60aed87f7b3b368b84a7f1ef9b029c9c60cfb67df764cce",
+                                "uncompressed-sha256": "35b80fd8689f891e4258f52da9683f10e055a24acc482f4165be771e00954188"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "44ab9dc7507a6d5ef4330d209e7ceed9c25f4623eee7118fe5f0e067ac974152",
-                                "uncompressed-sha256": "c1c7c1bcf7c77939b92e0881b834eb643c16fc1c80d08bff4493da878b521ab4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "33e3e5ad3bcd76c5cb03822e4075cb2939830f6bfa346a163922a95758d544ef",
+                                "uncompressed-sha256": "e85349a4d0164ca0c04cd22d36d137da42f0f5984e0e0bf070a1df9438d37641"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "5c019bffda9ba9cba2f17922397e5b5e5cbe0a5c85fc4b75c6bf479515c10ed3",
-                                "uncompressed-sha256": "e2b791833511c892e1f0a3b435df8e3c55686e70a2149df7faf86f2e66d21b24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "1cdb1b5cb424f8755ea4da2c8f9d036d786fdbde22142e375e529089878f2cd0",
+                                "uncompressed-sha256": "98d4a45e6d5863669aa71bc70273766e311b989953beb02f45e1f7b8fa592b4f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "bfa72b390979d2c83562f85b727d4a876a8e8e4429a640083f756f874762b7c6",
-                                "uncompressed-sha256": "797401f3f4f161101342320f278e9a9a609d57b1e4f647acda55f18ce67a6fa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "cc865b36ca7d650e96b3fbac70cd6406ffa9202acceaf3ce55bd96b36abac1d9",
+                                "uncompressed-sha256": "af983e6d87f35fc357c5dc1dde6c572d381775aa311982b9c61d417c58a21076"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b5f0a4c08e86547a9d29abd2f3d42663f7d52645feba732ade17c3800122f070",
-                                "uncompressed-sha256": "fadde6f3a771f63d2f45c85fbc2bf22c76d87d8e088d5748be0cbe343d083e41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ff6ed97df869ee3eb6ad6ea312bef17f196632d62e185663193d2b54ee0900b6",
+                                "uncompressed-sha256": "8b8e3ec99655637e5caf3f549702b8c00e692f3c5c31664c71b3776e5e1d5412"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "855284439784a8bce9a69ba395a4b3027698259603917148cd169db4401d2951",
-                                "uncompressed-sha256": "4c70184b001e62ba9c88107ee0c4a3866b5556769fc75e84cb538446eea5e0db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "23bf688b3a72eaf654e2c1b426096105bfef16bf258a0bbf2f33930acba40fe4",
+                                "uncompressed-sha256": "d6deaab0394a2fb8466e9bec2bef95a738703490c0f8cc722ce5fb5a1d85a3a1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4a6a24d8bed10e372f0a4c01f858aaa7076559c55dd334bfaa6ce13203ed845a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b58dd7441fb348b703a4e1103449a1eaa5c138bbb38413db4e6540ed33911f1b"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "8d0a29c6a30c9df5213a4808bbb970662eaa83a56ca3b64b15357fa62287172a",
-                                "uncompressed-sha256": "85ec165c6a95e742c947b037fa14932d2558541d56de71ab28761186166ba7e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "84b4bb0de1ab9ff63f6a33404bf5f0ed0f1be1ff106a3fec8c8ca69675aa5a7e",
+                                "uncompressed-sha256": "2453ededc6eae8c5ebf65ae91a02de03e6b6cd7d780304668253f5a64af56d5f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e4468d703d5f37c3ad1f606970e6b85f600c82a55f53f1daa3a10bdcf5ba1b49",
-                                "uncompressed-sha256": "b074d6df94bff2d37aabee03a0cf8f3d42da6ea58051790d934e7ec7c67ce578"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "abd72f5336f5ec613aace9190d7b62db0245fb1f33cf312b815030f109254a72",
+                                "uncompressed-sha256": "d3c3963b2394933af888f096db50cb31a43bf0728778e2217cdc78adee1766dd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "33f9e87e83e3d7143ba78c1d82fef8a30fa0fa86d05ddba86fa1941a62fac5e5",
-                                "uncompressed-sha256": "9ae7f0cd91a4dd6c0200c3f3b1f70f2e4306356e4208fa932e919a977b351a06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1a0079f7401390ebb5bbb04bbd3045b7dbf117ddd6f24add3faa394b71b910ea",
+                                "uncompressed-sha256": "c3bae5e3652e9c82d2a17e8be92e3d90ab7be1cc84aa109926c50a6a7c4158c3"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "0c90fa119225087496793ed32d33bde1bc162e7c44d1e02b549b063a40a5f442"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "733e6f24560c70d2c7535f3ff5989941dee8b862a219a187b2810712fb41a730"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e7892688f295fe97de63e7b2da4e9f8d62b2a3d6677c995d4d8c846dee6fa1b6",
-                                "uncompressed-sha256": "68c9964677090eeabbb9450f65c97d7fccb1dae70cc81f4465cb56009d734b37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "49f78482dc5e33b8ce8608519b0e83100a04d86c5fe4481a2eeae3f7773704b9",
+                                "uncompressed-sha256": "9c75d2e3a3cfb691fa0e00584d848bb9d0bb4c0366b8825014fc3c579f408f32"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-live-iso.x86_64.iso.sig",
-                                "sha256": "39da5ce33c8fcc04e83592ec7b0e3f57c70d445a71a27b12e2d3aaca1a1f40a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-live-iso.x86_64.iso.sig",
+                                "sha256": "04c08425eb4fe6bbdd47015fe75cf2a3cec7cdbb710894684f650bf9a270944d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-live-kernel.x86_64.sig",
-                                "sha256": "adb5237403fc4c6ac061d3344e796fc2cdc0c90eda0643b9fdb522d2660f69a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-live-kernel.x86_64.sig",
+                                "sha256": "255cdc70532d6e23827f86b74242833136472022bde9adef8d773c1f32dba09e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e52d556a801be34eb0db156d69aafdc5086944d262d7a5e9eca295d521c98a76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "cd753803cef0a95ef89782656f8770424067db271b61d11e4123b20c138837f2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "586160bd5079e4e594681cecba014f6bcd95f8648d94a0aa127af2e590f8aede"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "b514e6549ec948e4731aebe1d23c449b78e8181e58c09646b6ff2dcfa443089a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "3794f60cc8f6eca8c8af2e69565d8bf1aae63179ae6790ce35cfeac27dc884f1",
-                                "uncompressed-sha256": "a4156caafa7fcf7ef395c2f57542584b79aa28f214ec071c2a5c26797a41c81f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d42658d1f75552f933c2b380959c1cb9935a5af5bb962d678e69860ee681293f",
+                                "uncompressed-sha256": "4ee3c61205a52a47d0c2fcc326dd970951d86865826c97dc35d125c09ef7b726"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "2baae3b5e31632dc7e27e9f14c72743724e1f8a439aa222241045d304645f24b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "223763bd0ef8c7361fc58d62784c6ed835225453712363254f1549a1f7d01ce4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "14fd805702f54a3a7049f28a9f597750297bfe3f78bbea6af9afa4ce1d1a2b5c",
-                                "uncompressed-sha256": "413af8dca97b9b3ae30221f6acf4392033a66059e8a788804429f1970896eb7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ff7c62a7bead16f4e683c1cc7ae00ae18ecaf5d4c955b11199088202458728e7",
+                                "uncompressed-sha256": "5ec0a75955872462fe5ba20f099922d3321b37d50b9bff90de82db9bad80ecfd"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "62a167e349d470a728913021d6fde2264a426b6b07c13a33f3eea04b02cc7304",
-                                "uncompressed-sha256": "847035e63097d34cb16e64d7ab7aa30b5229e625ba9cd21341f0a92293789c10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "70bd88df9896c094c895f9c54d8c7b6760ebe11e5ef4d64122b473209621e842",
+                                "uncompressed-sha256": "3de524262106233e5e5bf01ce2316364828a9595685e222c048e5a377911099a"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "8eb8e1e2209997946573929a2e5d149a8ba22bf0cc54a956d7e27ba0036af83c",
-                                "uncompressed-sha256": "0c7d1158eb6c301bf277f817b588bc86f67b0bb38c3b6b54972bc1cd3e648338"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "e0b6068fe1f93cb37dacaec3661d06008b1299e793c37cc473665e28108ff266",
+                                "uncompressed-sha256": "5356cf1e9e1f16f0362d66e88d6422acefd9420cbbcf4c747acd68c26f1e6903"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "2ce94fd4b53718191b1a31c6055b0c8d80f1a813af060373aa320734313273ad",
-                                "uncompressed-sha256": "04b42dae833a80722b01d5c12c64f9fd28d7144c11ed80a7e8eb7aa4233dd224"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4485b50f4c730d39c7d3236e8de1a6f3fe00a0ea54fc77b3d9383f6d0dee4bca",
+                                "uncompressed-sha256": "50c668232611181749c15b95bfb8bb3506178d9a8420e2ee811fbf8ac6396e1c"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "f2eb6cad5ff5c36b01390bf322ce566a9e73dae8ea7c1e09183eec579fa31fb9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "82deb8186cfccdf70987af6d47102845661d70e5f344b86111a86b7d93d1e635"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-vmware.x86_64.ova.sig",
-                                "sha256": "fb982c7c1b0d06a32a557ab2ea9d31b415c76813fdc2e8eedfe5f714bf916689"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-vmware.x86_64.ova.sig",
+                                "sha256": "31bfa512173286714bf9560b7693e25d8cae0c18a1714d98c12e77391effa7b9"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250901.1.0/x86_64/fedora-coreos-42.20250901.1.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "bcf4aecf86bfebb77ee08bdf2dc5ae854ada5684900cf80120c6e30bc6873cfe",
-                                "uncompressed-sha256": "39a55a1928f681a1f7ab8cf0cd0c1f7e7f8613ddd8d17a8ed5315cd5df3a7c75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/42.20250914.1.0/x86_64/fedora-coreos-42.20250914.1.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "dc44dc94bd7111d07456c329b20a9def3d84d7b6bd255c32e3317c02ebbc28fd",
+                                "uncompressed-sha256": "0f85507008ee06821d795e1244c596c849535e3cf6ee3439f92ba9df62b8e327"
                             }
                         }
                     }
@@ -821,153 +821,153 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0c90e316da9543bb7"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0b72ebb05db86b162"
                         },
                         "ap-east-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-09b36b20ed2958ac9"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0aa9a4d5356420b2c"
                         },
                         "ap-east-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-05a75ca65fb2cd112"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0bf3afa678ea06283"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0450c94ec940398fd"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0f8523c036c3d99da"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-07e331cd4a82095d6"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-09090974fbb29a56e"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-04f34d6a5d3bfd432"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0c10813f220ee3838"
                         },
                         "ap-south-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-01a5604c52bb06b49"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-05ec99949911cdc66"
                         },
                         "ap-south-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0c6f5de6f96ba975e"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0f6a40bf6a6cf3329"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0efe883e287ca91e5"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-020a70bf3e02e9e00"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-01d5ea5b5a71e3653"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0f5adda8e152c9246"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-058cf1c376b96dc28"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-04cd21d808b96d219"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0b65b530ffb429788"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0243819fe938c9c08"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-00736ea3fa660c62d"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0c5f1cf76fa904eec"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0bb2b12608210283a"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0c3097bcf3446301a"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0613944263e64d8cb"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-01b951b95d0165ca6"
                         },
                         "ca-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0998c8ae938eff889"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-06058c945cc90403e"
                         },
                         "ca-west-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-02362cd569f7d193a"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-070502d0a32e4255d"
                         },
                         "eu-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-030913a5d92703eaf"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0dae14f57a18e7ffe"
                         },
                         "eu-central-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0e0abff27bb724257"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0d938a7a5787c1ecc"
                         },
                         "eu-north-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-02117edbd5eb531d7"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0ae1c7070d7613c2c"
                         },
                         "eu-south-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-085274432c4ac2bbf"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0d89e31399a9b86c3"
                         },
                         "eu-south-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0e006086fbb7a6c45"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0d8b6aec545691dee"
                         },
                         "eu-west-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-04358673e179f1240"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0998e8b426cc8cafc"
                         },
                         "eu-west-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0ac8f19a868ac0033"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-02fa27b4bbcb3a9ef"
                         },
                         "eu-west-3": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-005700d214f0e2c42"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-00339f4f5547773e5"
                         },
                         "il-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0d2ee95a67349ff61"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-01967b0d6a1f3733f"
                         },
                         "me-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-03687fec4b5d93d0a"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-03ec9e5a4fa5a23cc"
                         },
                         "me-south-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0ef5bf03daceb7013"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-038a5a231dec8134f"
                         },
                         "mx-central-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0cb8fa720f44f9588"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0cdac9ccf7572a3c9"
                         },
                         "sa-east-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-023a7b1b7692a48a2"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-07a8563223e71e4e0"
                         },
                         "us-east-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-05401f2ae0f71fc07"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0d7dd4d99989112ab"
                         },
                         "us-east-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0d1976dc47aeaf273"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-087bf991139cf06f1"
                         },
                         "us-west-1": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-0c1ba4c48d4b68363"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-0bd600886edeaf36b"
                         },
                         "us-west-2": {
-                            "release": "42.20250901.1.0",
-                            "image": "ami-060aa6f636afd27a0"
+                            "release": "42.20250914.1.0",
+                            "image": "ami-012f6d4567ba8df41"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-42-20250901-1-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250914-1-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250901.1.0",
+                    "release": "42.20250914.1.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e2cd06264921890a83302a5505b7b2b7e62b8fe087d8d3606240b26adea72e54"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:eb826a0a4d1faaa47ae7482cc9c1fd41b9b356abcfffb315f878f180aab7a5fd"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-09-04T03:53:30Z",
+        "last-modified": "2025-09-15T21:02:08Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "381958b85ee3e341cf88d40727d0d353ed02c9d68ded96c752500a3e00deba08",
-                                "uncompressed-sha256": "579f5ee1b4c115f7060c38935a13279f9cde71178b82051c50dd001f78ee69a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "a59ac8a70e9b721908e958e3d96ac64772021586603fe2878f519476e95a69cb",
+                                "uncompressed-sha256": "f5762e1bdd2acaf868623304bbfa51b350b56959be7da1d68244d7150b7cbe4c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3bd24041484f900e6fc53039eca6ce3cd590ed800928ebd49f81549db9341d03",
-                                "uncompressed-sha256": "83ee962f08b3a08f05504166aee6f858829e2c8affa7142d68982cee2c3f9fb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "76d161e3bc7a5884fe007e2e05748233b5ff603228628fe6817acb588ede07ae",
+                                "uncompressed-sha256": "b0b9e609b4cdbcafc5cb4f38efbfbd7090ffa637116e4367ceee76a82487c970"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a6d15c921d2ce799c9e3f43049717fdf5793817f6c51d22ab0984db65e7206cd",
-                                "uncompressed-sha256": "51d1147c858e1285acd024a00565430845d00259908f8f6548650e8572e253b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9c42fe48f0e36e81eda35de011dcc8d478e60c03aa0346092917b1a65d8339a2",
+                                "uncompressed-sha256": "b8a149d269a9703c55bdf34d2f6c5cc51d48874cd25b4096fe7542374c0984ca"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "9a9bba786e1135c2ffaaf4d2e0eca85e1a3694a8e563db7f2ecd856be107fa51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "c4fe9c81ae49339fc02fd69579776d690d1889b6c5c2b7399cb4b8707320b0b9"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "c578f68e3d2db051f3bfba3e75acaefd243b277b5097a565bf84235bfddb4dc9",
-                                "uncompressed-sha256": "4054c944b7b14e502c4736e80f349c9d59a8818585af6f95ad2508ead3d20266"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "d52e24eb6da9e45af70efa92c39b284a214750645cca1873bf166d02a7366052",
+                                "uncompressed-sha256": "63c95602284caa826d517479ebac2267e57fadb1c7fb40fb558ad2056d7075e4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "23cbf02e9af8e2087138847f76c10266030a1174460b5dc040ea17440ffb9db8",
-                                "uncompressed-sha256": "2efc87dfadd71db1c9baab8fa41ed693ec147b4701b4d7a53f32b5e32069361b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "a0a6648ac5147534471a94abf5509c06dc341c765020582a070da018e4e16618",
+                                "uncompressed-sha256": "27942eb567d50f760f369b61c743bc5efc7cabfdb89bbb29c48ba0b4dfbed310"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3a29ddf17ebd35a5c27e8214a2001f0012fa91cc0190d0d2cc6f008fc7ad5a25",
-                                "uncompressed-sha256": "893cb84e10f4891fb0e97dcfb5e0fb426c025f6a728a27611918ad59b2352dfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "042e9dd28b8a125311ced11a98dfd7a96d852226345dff72d31bafb43bc1f8f4",
+                                "uncompressed-sha256": "a912b7f0f22d85608852653a109dcb9fb496a969b03ce9a954551a8883dec8be"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-live-iso.aarch64.iso.sig",
-                                "sha256": "0e3ea1f3561af5ad72e3402f1fd928332a7fbcc9d664be205e82235f6723e28e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-iso.aarch64.iso.sig",
+                                "sha256": "ed600afa179257c1f7bebefaa8758c0c173654424a03706ee1d31d14b7108fb2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-live-kernel.aarch64.sig",
-                                "sha256": "05c87f5716b3c964d16819a4e2a6c0429d9586df2c269c6f5b2b4ba35c7cab20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-kernel.aarch64.sig",
+                                "sha256": "84c9de1be05405c88e1539df05afdb42d9ef9ba7ddf13d764d1d04652be958ab"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "58314bcc6f8c358e21fd67f104e7f5f2616318cfe987a6e5597369aa4c5249c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "837eb82ec33bef3356cdaf1209cf364f219880d39fc071cde8af2def279563c2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "8b5b09ebdc29e1b0ca998cc75e6f04959124bcc44ac9b467799689b4e0b06688"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "8d46f820ebbec2bf199029cf155a8f1de0c5bd4f18257a86c6e0237f72f497c0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "1b6130aa6461210eabd2a0ace149f63c2c1e638d9dee11b2828bb152ee7bc1d1",
-                                "uncompressed-sha256": "6b1b3fecc389cea7e7cef27d115d657813cf3cc8fdbc75bc26fe5762e571fd92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "65500db67ad4ad8fec535f056990f23095353f7e586ebfcfd02f72c89c011b2e",
+                                "uncompressed-sha256": "d287672b53fb936c959f3dd745b934592ccc66f09b1d52ce87f849470569cf7a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "845b7f487eebeaaac2784bfd650fb7a1ff5f220dc2fbe86a762bfa8c9456d515",
-                                "uncompressed-sha256": "eab6c880a5b2df4baa89bc86c8eeebf44266b26e99c4f6d7d9be64609656fafb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6d047eac1b557d6c63ba99758de063d8fac0518ca9c61dfbdcdd3de556cca7e2",
+                                "uncompressed-sha256": "bef8192c80a138731fc5ca6fa127a601835a2f5d266c0987c6c1b7551b6dfff3"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "6c2ff26b2c6696f225a9a32f19e0dcc942431065339b2a090d8a77f2b294d5fa",
-                                "uncompressed-sha256": "3ce6e35a58ef836f9af38eaa6b4b350fc82e19f454d52fbd6d615bc5f1507ec6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "d1ce3fa62481f6bcc200629303968e9dab96f563874fa2aca787aa33ebf933c5",
+                                "uncompressed-sha256": "9c9c8580f371b8dddabbde06d879a731ef836ac5ddfd1b9c85030c388a2b33a5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/aarch64/fedora-coreos-42.20250818.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "7367d20cddc050c2a1cd03072c6a30a464a6d2f88f30d0c8227b021e1d671ed4",
-                                "uncompressed-sha256": "1e8e776f14a7f49736b32a1d62f3137f78b77d9b8750081775b53d46d528b44f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "13994c19d10aac25eff86c6079b37cccbeda83d16844e0926d13961e097d96ab",
+                                "uncompressed-sha256": "0699ac653f1e99372fc4c7b4f4861ef58cb0d754f39f72615fafa4ecbed1731a"
                             }
                         }
                     }
@@ -173,233 +173,233 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-008347d2082efc6e3"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-057dca73a04dd0a3e"
                         },
                         "ap-east-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0434dad8c399b7b5f"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-03d9aef4b007d5624"
                         },
                         "ap-east-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0bccba38984659275"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-049a6ebcd63b25200"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-09c703b8996bc8cfb"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0526f1e5bfa19324e"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-02a9782314ba011f2"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0cb52800735d492ec"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-060b3eb0177686266"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0e2b1455eec9d4916"
                         },
                         "ap-south-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-045eaa1f012cfe66d"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0924a1599a76e4232"
                         },
                         "ap-south-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-07c60237840da10cf"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0978645c57f581dc7"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0a2f774783f358414"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0a3ef796ed0cbc6e9"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-01f47c9dd753c27d7"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-08fc2f23653e9b0b8"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-02c1000001030cbfe"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-09ea8f434ad218940"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-03627a73103e139c3"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0cad65a5d1b4d1ac7"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0930395d21b02886b"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-078566813973f2488"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0a441f1f536f591b2"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0e0ef37634d7c9163"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-023bad4b9758fc620"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-06e4b0afbdb8a9b99"
                         },
                         "ca-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0e2008abfe9da43d4"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-051b52fb5347cf2dc"
                         },
                         "ca-west-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-06d7c3f3db44e8838"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0b9d46fe8d8e63dea"
                         },
                         "eu-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-001b0c49594bdb58b"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0f15e31dbbbe5187b"
                         },
                         "eu-central-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-02376507fa9e5ff6a"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0e6a3986f93e84dc8"
                         },
                         "eu-north-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-03b78c5926fdaf03d"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-06657e799d6bef29a"
                         },
                         "eu-south-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0584d6970697eefc2"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-005cdbf32b9fdaead"
                         },
                         "eu-south-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-09b05d3cf1ee67e98"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-08d12c79c0b2688e1"
                         },
                         "eu-west-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0b86e7768a2ea91aa"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-03e318dd533d5d7e8"
                         },
                         "eu-west-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-01a54e63a1cb1f9ca"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-080f05b4b3ec885c2"
                         },
                         "eu-west-3": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-02c43e73970d4d40c"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-007185a9451aeb850"
                         },
                         "il-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-05b5063cf7cd9df4e"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-07b0defdb2f4fff63"
                         },
                         "me-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-08d779b8b22751027"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0c3190266fdd39776"
                         },
                         "me-south-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0bc554c6a00537e31"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0899a1afb53e59576"
                         },
                         "mx-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-049f062c311fb1bd7"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0656982455eaae033"
                         },
                         "sa-east-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0e973d973e1a7c862"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0664280b72288aea3"
                         },
                         "us-east-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0833f4271ee70f6e1"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-06eec0c7362507293"
                         },
                         "us-east-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0bb339f0a57bcfd18"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0b36d07fc83d2b38b"
                         },
                         "us-west-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-045b9b23f767ae474"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-049ef2a83300346d9"
                         },
                         "us-west-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-031c8567b77aeb495"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0d2d824f20a3e4cce"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250818-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250901-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "3968cb1153a51b3afbdd9fe282fd646f26425a7bcdae319108f3b3fd3f3c0d5c",
-                                "uncompressed-sha256": "1ee24d6bd28fdf36dac094c544b14045037a707df6903bda73d36d1093b854b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c4f6f4d93ceb1ca195c4a63514d1fcd3fcb06f521f4ccec6342cecb3372f2c88",
+                                "uncompressed-sha256": "647bf99e94a152340b3b03d13e1ca5a84efce95cbc3520ba397069cb0ea7d1d4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "095ce2dbf7f7eedc0cc0f5ee2002bce76c0450db8ee790d5b406e3cf3bf2f03c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "ac1d024f91d8c3cecfde3b5e6ecdda725547157434be89795af8ab4e4815a721"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-live-kernel.ppc64le.sig",
-                                "sha256": "a9a3359d1e2c48cd7ba499c4a9736aecfdf74e3aa1d4b90fa9b058285d60156d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-kernel.ppc64le.sig",
+                                "sha256": "a9781422913adbb5746fbf803f2728fe5d62df16cdc3e52a45aaa749c6821b5e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e9181d2eb9eb83e7259468d71d6e19b112ba3dbfeb546cc2216221ee6b20c754"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "fb956baaee4eeb42b2a3941f2b434bdfd1fc1ae4b415bdea2373645b968cc528"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c65bb8b1c157123c83566b113bd2cbcfb519072e90c219890fa0108e877979a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "529ad6bc55461f6f2998ae1e0481fa6b6f10632457fb7c9f970e1316a48dc4fe"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "7ab72973015d77e17d926f6773e35767bb4cb39f02a26033101d5fab7a22af3a",
-                                "uncompressed-sha256": "e288b799094136ea2bf148017a1f6b85a9eaf716057a823d1b9fecd0c8168577"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "187b6f8d8140612a88f74e9b80c958eb090f8da352dad76d6d207042dbb3e091",
+                                "uncompressed-sha256": "65cfe51eb27b4b8330e6d3662cc6c39613bdb762975e46b813d79b9d1df53cda"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "359be9296e6a74e40c8b73ab8c2d4dfc9cfa13cf696d2e3f5a8e1d7d5f428d57",
-                                "uncompressed-sha256": "76e6119eae03b030e3b15daac150fb1bd52bae39c6c8b0d6e1caea70074ac303"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e4ff44ef9c034f4724a127662b4ac550399774e83b4a98a0978735de2b384e5d",
+                                "uncompressed-sha256": "09eda620086657e6473c790623341212a44d943f201f4f7fdd595410fd4555c0"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ae0b626cbbdd7fd5d9194cc3aa6a3ef26213344b18a2e2e5b8bf9e4f4dcd6be5",
-                                "uncompressed-sha256": "b67e2ab24823e2be31591c94efe9533d58047c1a9dcfc958addb309f3fa4f07c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ae0259160cf66b956fd7236d8d643fe05da243f9acc61ab464eab49d1349ee6b",
+                                "uncompressed-sha256": "04d588e929b06a4d4cb76eb33e073662052838e00bf796ee66dd8d356fefdb2d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/ppc64le/fedora-coreos-42.20250818.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "a33d9408e93e046050b55d38590fc3fa0288c1545f286d5af5fa1e443bd77b84",
-                                "uncompressed-sha256": "433989a9d394bbe546f4f3d36c280a47ca2ba68da8b282e577a3fcd7042336a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "40572ecd7766a9b95de9ecbec877de93008d5920f9d016c0b288916d1834a8a2",
+                                "uncompressed-sha256": "f4bde33ab4f2ec9f8d2d5cc1ffb0c1a13a5f12933475fd048eca319f3822f189"
                             }
                         }
                     }
@@ -410,97 +410,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "facb590f85ba0f0610275dfe9e6097cfbcc769ba161e3ece608f5d6498f3d8d7",
-                                "uncompressed-sha256": "e4286f59f3f9aae1b055ae54dcca0aab6aef36c853e7cea98748aeb358d1b0d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b3519e9f99d1aca5c5a52182c07b782705056d1c51d1c4f560fe3e2f04d8764e",
+                                "uncompressed-sha256": "3e2df93f8fbd85c8808c12bfda48df648c78ce9c5b4536fc6aff122e6cdda0ba"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "ee4221d0e35cbfd64319556197682b7418542369b406c5337d137d4d59f7478e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "bdb5da49fa9751200d3e4b842a2dc8522b9062cdaa1ed9112b55103242426a8a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3db58ba902b4a78109c8e7a1580324260e72192e3e68cf5dc82fedf520435a0e",
-                                "uncompressed-sha256": "ed7589af2cb9afc549ae260b6751336cab88f1ef842c610f4ce250da48457dfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "5db45b1796c8fcefa4215352e556453b46b316d758aa9840e67a5d47b7689c39",
+                                "uncompressed-sha256": "ca6da6362741a4bd7fcd96a20faf6d28c920618a876b4934893423c7be3a63eb"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-live-iso.s390x.iso.sig",
-                                "sha256": "52fb4a9ca8643f0a2457f5536aea99bf4fc288f0e72361418c833b4586bbe14f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-iso.s390x.iso.sig",
+                                "sha256": "a1bd8aa0281aed3adc92a3552e344790b84399ec1145cced5a92827175778106"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-live-kernel.s390x.sig",
-                                "sha256": "7a0485352347f2138d5951f627ba1b791be95d9b47d683efeacb148b59f7942d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-kernel.s390x.sig",
+                                "sha256": "ecf8903d8068be05b8c64b3ccd5397842625f99f66b14306d5c66680d5a63869"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "9ff80994d4d8d4e8f50151d4652ad45a3957159b9b48cc4ad39587c4e75dd1be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "ef55249e98ed4d5e27318e3e71437e0bb26759e76276f4fa2d5521c2aefa2458"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "27234463646f1cbbefed43d73ca245776a75282d959f569923c55d06892b8e5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "ecbdc2d1a3953100f3ce0d80fd68e27a9db4b567e5bbb4d1a9ba10f037646329"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "7966f26f3008ef696329294f3a2e45573364cfbb9d12e0330429a3dfab3dacdc",
-                                "uncompressed-sha256": "f5726d69a2a66c7ef1503cb62d8f2288ea79a5d7dee55aa9f08f6bc9aa89d9da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "8cd61afab46234878f284be8e45e91e893759db4fbb4e74f2310729ab982a23a",
+                                "uncompressed-sha256": "7cfd308ba783346361b0e68a935227d9a821a27c9bd4122a891bb35a4a3733a1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "8b3a37fdad4dd08ef641fcb0a42b84ff65399e752720198f77314c4b1f5864c9",
-                                "uncompressed-sha256": "5d60486c3cee7579e68b46cd4a1f0a0eeca3b48f3e64a014c41973deb576a1f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "36acdb1f7e8fce6e480f6eb190a5b7ea120141120b1660d678635e4af41f1a17",
+                                "uncompressed-sha256": "feed4771769b34d729de580b5426757fdcaac079ef33e5431c12a99fe85cadaf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/s390x/fedora-coreos-42.20250818.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "361323ab2ac0f37ba8e144c9d3f555e7fdc833056f69c5bcb7c3776775cce88e",
-                                "uncompressed-sha256": "1233e34322cfe8e1fd0531c3ad1ecaea34fdb2fab9d6bf0827b65009564aa647"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "cf70b8587703d0bb7e84a17036f7289035a04d45b43979e4f4c59b91c75e7dce",
+                                "uncompressed-sha256": "58120a141229efcbe0792bad375d95b9f25d8caf09234a644879ae7b1b4a1e46"
                             }
                         }
                     }
@@ -508,310 +508,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:674c888c9cb33fcbde0a2450b69b8f47e59ff0fc6dc2512c8cc27f5dfa2115ce"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:acc4da5e5d63108c75b50e550d45b7da593768a61025b24eb35ab799dde01cb7"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "426b21a13413a38ca3a197065352b4b9ca1c53e66043550618d0e456772fb812",
-                                "uncompressed-sha256": "cfbf33cd42cf7690954531441c54d189f1e989244c1c6425124365db3ed40d07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ab9c4190bc16e05b67754678925c6e81d1ff387857f1ca601f9f505695352392",
+                                "uncompressed-sha256": "f2db0daa84b93e81ede038ca524a34e0915384f0b35cec3c758a5ce7c2f18fbf"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "f077e0c3e13e8002c47f6b45eb9a7e3f6c5eed16be41a58c715024155487a552",
-                                "uncompressed-sha256": "3fd47addf2e4b04e58c525095d348014b5d788bfa39967932513874dd1825b23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "a184ea524ffc43b904c9637c0fa27660fe34456b177a0093aff29e82990a605a",
+                                "uncompressed-sha256": "cad59eb7b7bd09157bbac15d6d3d83f5b6320d6a69f14e2e7d43e4ec18155600"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "c0003f4a8d112ea9493dbb34e3b7035a875a76e3fb12051f207a1031d48af5d5",
-                                "uncompressed-sha256": "078c36b8c066f870fc1bd7115dc1fa48d4693bdc84072f25f75b3fbfe7a44b16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1154137bcaeb22c47b80a80d2a97070489a499bc3a4116ec6209afa43844f7b6",
+                                "uncompressed-sha256": "4415053349e24f3c6df9e5fc7ea2103b77f4973d18acd5607edde5f2deb993a6"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7568f74416abcfb363a804c76878c7a836e6c4db4abf317c1dce3f2aceef17d9",
-                                "uncompressed-sha256": "0e7bb2ce2b08dbf21d2bd124ffdfb4f2c9a1d216df11fdb8ddc6a4543e72a1b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "94ee5c4639bd4b593f4e957ca5d8d25f72806d955628a0584d1dddda67d31674",
+                                "uncompressed-sha256": "67d69bd1cc60942fa784d25593458009834b4a31dac5ab70f11b0487fbbadfbc"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "c10e19890309e365efb407f8de8a4fff8d94254a6b2bc7aa13542b5a1f9a5e24",
-                                "uncompressed-sha256": "b188ebde0fae56bf2569370b817d5e22460a1fb1d9a2fd8b70e113a0ba3b54ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "430431ccbfcf1ac03c001b78ad2c45d9279af84cbacb930fe3cfb8fdbda8d850",
+                                "uncompressed-sha256": "99d0da67dd831adfe239769b31bcd560363fc381204a418fbb867f9e052edd67"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4423789982e627be14b6806b4244cfa2dbff2ecffa15a48ee8265c38e1cc85af",
-                                "uncompressed-sha256": "479c79ef8a899c2380c3db42ec2c4665dba4831ec956f0fcd8f78ac691d7a3d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7bc15eb2df253b74d1922826e484fea7ebafdbe9b6d029bb805a98377a065989",
+                                "uncompressed-sha256": "292daf0658c8b3154fe146618031c78cfbbaa1e20c2d1049b5f5511ea5ecd7e9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "30da6aa14aa6f91a24f74e55f55a65959719ca6eb31c6b8ed86b0a55cbba04c3",
-                                "uncompressed-sha256": "4bfc363211f1b56ee4ce8335990d32a0ab424dcbc97b2f06de6ff07f06aebbf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "69e2649de69c8032bf65b397df1827a0c9a9e53954d363813e97ccf893453472",
+                                "uncompressed-sha256": "6556c709c11d100f12cb71dbcc365941bda29b5b240830a3c72e1ad2e580b99d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0e0fd6c9f172d8a6e3d66a8699320a50dab3967b5ec823da002296f17385aaf2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "daa14468c3bfd0043e28bd6065358c49ec9155b0df6549e40754bd28576aeb0a"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "92f270c6667b601afb3e9dc64b2f530bdefb283aa24d5edf93dc49e3e3169f0d",
-                                "uncompressed-sha256": "fcd0c0eeb605bbb48a420bf222a2e0df5c47ab220cf30d78bc52dde1ef13fa79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "e4c7f5bd4bb08a543fd56b98bca4e3472ae62c3a72dd397a0fffc84149080a54",
+                                "uncompressed-sha256": "ac4ff9d930d22df10ad651992863f138346592363144ecc109b8744e90142d89"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "087cf42d8682ff91815fd2928d6fc35a0f3d675d32512b81a0580dc92f339c2c",
-                                "uncompressed-sha256": "7d9a19404c9b843093b48679e457e4f42b8eacc8152c1dd77bfbc716838a90e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "122269e5c29a5268b1da13e7b810bf5aba635c2cdae2484231652c0380fed6e9",
+                                "uncompressed-sha256": "c479de1b52bc83b6b26ed512136376f110f181fcfb3250cb2d810b195123ab02"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "8de840d1c5a567533fd160b0545546cbebd97ec00d9fb46cafe9dd16afc7456f",
-                                "uncompressed-sha256": "63e616b23cc7446404b6486ce8d08578ae82a2b451b6e830ab30ff382134f870"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a733aa45914388f3718099f5e3dddeccfd769f722d625afadb172b888113085b",
+                                "uncompressed-sha256": "65212ba97a5e73b0634cee5ae84df0caa5132c619b29a57b2f20097615579ef0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d4cfaf7d23fcac68093a3b20a16651eda9b521e6537291f7741e76057ee9e259"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "88e1c228e8eb1b053342a7f86a91d931aecc6f368b9ebc806bc49cd5353c46b3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "63138d8c8274fe8ed6d569efd21512d3eb491c5212ffef2d64058e3151c8b056",
-                                "uncompressed-sha256": "586b0091bbca8b7af2eca557a493d84e58f908724557d5f760873ce96c32561c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "002bb376cc7002d8e88288e4734dd343b31868cb67381d1a2c1ec1abf89a0194",
+                                "uncompressed-sha256": "50622b739e620716c931f39e9c7bffbd2265653bd065d912279c80c5c9e731d5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-live-iso.x86_64.iso.sig",
-                                "sha256": "7e3797c74d93afc369f7114b24bb68d76443e317a662b81b591d75c03f1a7275"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-iso.x86_64.iso.sig",
+                                "sha256": "e218b34e83fe03de206cf2de6d59df930e8f3241b4d3b0769c39a38fcfd24d39"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-live-kernel.x86_64.sig",
-                                "sha256": "fd7cdbd1fde31ab06ec4bc1512051be338783df4d7536f1242d5305c82b88302"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-kernel.x86_64.sig",
+                                "sha256": "adb5237403fc4c6ac061d3344e796fc2cdc0c90eda0643b9fdb522d2660f69a8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "4977201c8e96226b828fafec8ffd1c88ccca214a115b2581211015cb8f73a70a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "3032bad3f1332fcf6c084ac4ece040ab86e0b9aa75ae25e9d5b329db765f3d8b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "0975ebd0fbfda70672ce534cb22665b762d6fb66f7c5158bbc93ec12496fec43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "ef254781188442a57f81edc967d5eef83d61096e6354a359158f78240adc8a5b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "f6224fe403eb813b382f30883dd7f8d9829164973bd6ed254e17c179f871b768",
-                                "uncompressed-sha256": "0287a1d8ad8bda31934dfa4e3852746adedf2f9a587abcbaf9e557d44622e162"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "9b3d54193e829fb8d8fa140356788f34a928e709d4737d5b77d56038e7d290b6",
+                                "uncompressed-sha256": "097fc0b29c47c6f3246d1dd6874671838c0e8ed5ee105c7773b3b6dd7dc7facb"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "bc8f1a2d0bf1479c8060934ba6b9466b59fb00d2d00e84b0c5da11859885fce3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9fa3705b1d4d6cb0a3f39ec3264e80c080d0ae5cd40ced57cecb2c7795c304d3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7d2a7ef9a14ac060c6b4370b4ac1757258598ab54f906145f3f50face4f13d57",
-                                "uncompressed-sha256": "ff8f477c1485c609b0f4990f8e0189c4aa1a4f235e4e8e7744296e308ded0de1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "2d3c30ddfd605b6350bd2b64968aa28218681e71c1cb33c1c8daa5efab9b1d41",
+                                "uncompressed-sha256": "002a0ef5a04c67d93397ea118f27628c6efaf24dace8fdd0154ed00ab978d43d"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "fa2400d24ad1b55934a62fe02ffd824a98cd9a8d1e8ad1fbe4af8058b5c94b6f",
-                                "uncompressed-sha256": "06043cb2ec35949f699734bb075b178051c2e532ca8120f82c0f012e95e76ed2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0bd7b940345c871468d4b62778a4b7299db80ef0e52e353c77d8766057339723",
+                                "uncompressed-sha256": "0707038e014b79aad8278bd87fc235678519b342231b1bd2d487d5fcaad5d170"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "e3ee68956c1831c8eddae26c02510403f9f2bd23e2ce3a70476e63da5f1586c8",
-                                "uncompressed-sha256": "ec6145c6b4fcc2318ac7eb5efb441664396713f67294f3a93c12e4e7368fe59f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "3d233c071bb66c40e29d11ced6641d9ce08770f42ea37fec23fa0facb0a85e3a",
+                                "uncompressed-sha256": "a00c53b8216f6fd004471b340a8da2d9e3a0fbc97270b2e159ff8b6cf88e9ce1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "27ee763e2eabc4f0c77e83661ee809ef33b098efbbea0ad6ce2dac00c7ef5066",
-                                "uncompressed-sha256": "5164f3cbf96dbe94059a5d93f0a2845570592127d89d75943f71e9f331bee2ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "17250aa977efcd889f615088ff0d43e59168c38d7c636e776794b4e86bf8d336",
+                                "uncompressed-sha256": "5cd9282a2c6e9266915d30d36e7bf67c7e322fe798087c8c7fbad6391d7764af"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "52cc254ac406cd1663545b29c5e1a454ce7778ccac682f803c74f6d56b4d9ac6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "c83e11f4fb7e26f21cab73cf2279e746263d2d1c69970c40b9f107e8db3bf9f8"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "9db8476080c375a4b1b5e321f44074acbd49198612608501a64779c2e2329a5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "a875b5cf741b040c279ce002d71fff82bdca93e19655a600f9bf21d3c1fce403"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250818.3.0/x86_64/fedora-coreos-42.20250818.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "710a3c0f3de0897e5a847d354f3fbf25caf7372a1568a37624d7d3493ca5d95d",
-                                "uncompressed-sha256": "4eef28105541cf875ad81fcdac3e0327c9e8b941400fac26f2d888432f3ab49f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a8d287b321425ace44d652cb7960adb86b211e38930425a76c1b62c71c35a738",
+                                "uncompressed-sha256": "95e145775a04aee7b551b5e48e61a0bcc02d7c4b7a23f88d9e0fd530eab93ee4"
                             }
                         }
                     }
@@ -821,153 +821,153 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-04a424db63cd1b54b"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0d9acf6413ac9b0a3"
                         },
                         "ap-east-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0fc02b27717f0a7b1"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0d73e7e8ef3c58127"
                         },
                         "ap-east-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0ad63229c29b0dad2"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0647a3ca3055fce7a"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0c14397a5fac4e46e"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0508de514a3bda93e"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-091be3701a57c3b98"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-015578e95d918a151"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0a63780d25d32c4c9"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0c58c9793ea5123b6"
                         },
                         "ap-south-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0cd7049a5dca65e65"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0466f2bdfb36b1fe0"
                         },
                         "ap-south-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0150e36b496f96b89"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0d6dcd530c7e3f0c9"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-046384ea9cbc99596"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0765241181d93db6e"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0d89d6c81c8052072"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-03738797df3b3a457"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-06e7709b5ae361b11"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-01a62ee44fea152fd"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-035b4abb55536e6ce"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0a16d28477d51e8c1"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-068c8c7210864133f"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-05170616e87cd8223"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0c18c1bff4053c7f7"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0ed27032a8ccf1add"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0b5032ead7e40cb76"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0e031266afd4d3fa7"
                         },
                         "ca-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0a119c723a60c4e48"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0a65ccd3a4e08e435"
                         },
                         "ca-west-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-08aec367bdf133850"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0b2fa90ef95fb664d"
                         },
                         "eu-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-07a3004d700b70520"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0c3b05e642456b61b"
                         },
                         "eu-central-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0c2fddb851f69feda"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0167bc226e894be36"
                         },
                         "eu-north-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0d4fea8e0a9a5eefb"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-017ccc03f676bec9e"
                         },
                         "eu-south-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0ce476ecdb350fbb3"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-029de877c1e98e1c0"
                         },
                         "eu-south-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-07cc2bce643fdfff3"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-06666aae6bc9f5fa1"
                         },
                         "eu-west-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-09e24b9c0211fe309"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0d012ab5a34aecb62"
                         },
                         "eu-west-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-007531215e0d93cd7"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0664521bc6439b0e2"
                         },
                         "eu-west-3": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0847af1be6e2f2751"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0c2d46e3f0c71ec3f"
                         },
                         "il-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-05590267c814b5c59"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-06d758bfd0804e193"
                         },
                         "me-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0e28576a9837b5540"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0af6120b73c945a2c"
                         },
                         "me-south-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0c94725f9eba782df"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-00734f84d83887923"
                         },
                         "mx-central-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0efb10208d8e4ad08"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-09ad722e778453d61"
                         },
                         "sa-east-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0a03467a888eccb14"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0efab073544451d0c"
                         },
                         "us-east-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0f040794ae0c6531d"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-08031781c5f9097d1"
                         },
                         "us-east-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0d8a17dfe0b9f1453"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-024ef733546395641"
                         },
                         "us-west-1": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-07e932dd0dc0f3f1a"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-047db74fa1df7a876"
                         },
                         "us-west-2": {
-                            "release": "42.20250818.3.0",
-                            "image": "ami-0752869db3b8ae4a3"
+                            "release": "42.20250901.3.0",
+                            "image": "ami-0b83de2aca017b5e4"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250818-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250901-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250818.3.0",
+                    "release": "42.20250901.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1c77b90217f2e658898e73efb38c0f4e7590857f5dbbb0f2e94e85c0b3ddb489"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:7dec257523f441727220a7dc4e3ecce46228b27f2637ab1363f3be59b2f5a0ed"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-09-04T03:53:31Z",
+        "last-modified": "2025-09-15T21:02:09Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "a68d541eb87d9701018ef2835a3af6e1f9b2ca79caa8d2d30f725899c47e17d3",
-                                "uncompressed-sha256": "a4a4fc760255d2bc545619bbf708e0fe62cabbde5be9edbc50e5a2f9ae7995e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "b02d84b4d76ab4135cb41d298a787f46b4a1cca342a083c09eb323f44ef5ab18",
+                                "uncompressed-sha256": "4061db03a4da55dbc4f61c6e5e85f4ab8015f934754262f0a932620697731ebc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "66d7ed3d5b93b193bfed86ed7c45a27e1b1678df14abb8c654483597d4ddc659",
-                                "uncompressed-sha256": "0a99e5de363e108dd8a1dbee2d40310a37830f0b092f5dd67e010be65f4f69ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "955aaa8b1f658298d6aed9013c6c8b447d3f1902cccab9ae02176be7c3e10d9a",
+                                "uncompressed-sha256": "ae6aba748b4045dc51e798724f6a66b2c171c95b505d0d84ce3c93fc8cee3fda"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a83253cd40bcac22923d347541d046e32d74c4bb4f005a509973aa898215ef15",
-                                "uncompressed-sha256": "b918b5ef30cb51bc239c6a1d0a538013834ccd3314c58854421415d4c775eb2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "40740b5a7e925bcc9b04631dd24269f2569a9e80956139e82a29d4474ca072ef",
+                                "uncompressed-sha256": "397ad827d25304b487568163ea130ff1b13f4ae5617269f4dbc2b8f5a3288893"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "1d3d87c99727fce497dbd6deb6f1076a1ebf3dba0b46d91f5f7064d1fca565ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "90d210984ade44d9719aa55d3a290722d690b3b13a95d254cfd2774eeae8080d"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "21541cd58532e5dc6baf16398b22d461277c860c5482ca83d0d7425b715dcea5",
-                                "uncompressed-sha256": "a251d03169e8e214e3be24786a272d9c415e7680edbe011c6a29665b0df94644"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "24e858c4d6e534a2ae629d3ef8c538ac8f234b523ea99e4bd6a638f77a1b827b",
+                                "uncompressed-sha256": "5fd88a70185bb306338b6d4597600d1d712774ca23fb2643c2e9eba83038e8ef"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "f0043fd3bdf96afb2aa6bf37347b99dbe42a297e65632dac1181c9ac713212b9",
-                                "uncompressed-sha256": "9281ca24c4079b8fbd4fbefd30aa5df476d4936b393208f7941ddb8f4b85a7ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "0e70969d97650c2e03b6e2353d1485b5b62dd202a0b852195a3af7cba6c6f484",
+                                "uncompressed-sha256": "bda3e1098753c3b846ccbc2de482c1622b3033680a5db691c1a854368c8ed572"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "d2417e6ce5d5ce9913821c5f574384c7e701824a937730359a9d0a31d7d3cfc0",
-                                "uncompressed-sha256": "bb7e0a52bfb834bb2c18e693f0e0268ffd33a55d972e9eeb1d262ba19ba3e43c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "728335a25166153ef044c507f9956dfde9f6ad57d6f7dcc7b0226aabfc614c10",
+                                "uncompressed-sha256": "10a1025281a49733eac3d15d430825a433407263f07299928ec4f7cf1f61935a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-live-iso.aarch64.iso.sig",
-                                "sha256": "864f822228c37bc17cc1b4394aa15e3256c82ecbad0541b7b71ff6f8ec28b22c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "8f2b4c7f9c4adb07914bc16160bdfb6c631090a323c745f1e0a8244e10a87379"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-live-kernel.aarch64.sig",
-                                "sha256": "84c9de1be05405c88e1539df05afdb42d9ef9ba7ddf13d764d1d04652be958ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-kernel.aarch64.sig",
+                                "sha256": "9d403d7a67ace122129ef7593b2f5a4b0ae014083583d7722c6827013efb55e2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "07d7912e0064f677cdefe94a7059e11d2904357a9c2534d655321172cbfd1020"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "896f77b65c1d41ed0ba23640b7f4de2fda81c5d5b9e50aa0e5ea87c65e112ebb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "ccd02f9d7a1371b230ff779e768cd284972894871e0f180b467026ee5c8ce56d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d65c2cb7a8914d8bb33c2a170b69dfaa7fb2e9710383ca8f01441aa7227eab49"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "f5fbb13e57269345328eaa7ec9d3a637e253c35db24e02cc6865055b6a41d39f",
-                                "uncompressed-sha256": "0796068f344ad842a97b2e3f069ca8507e392fd964ebe2a8f9aee4caff1677e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "426f655fb7a65ae26dda9173ba2ee856de1ef2cdade4bd77fcb32e574a3f9a53",
+                                "uncompressed-sha256": "a50966a48a486d1791d8a78cbfa0959d2cf1f8f77cce7e8624ce1e2d517de0ca"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6156ef9d70110af1004c9411de9b780461100c9fbc675fad48b47b6b3efa5fa0",
-                                "uncompressed-sha256": "ace1a5efb7ca219001c35b42ff7cc6afc9189cf35ddb60e743a71e624952d5e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "26b2a55427821307a9b8b2c213c3222b16d84258cc4247f17f3779f5c49b9606",
+                                "uncompressed-sha256": "33ad3db69b8695af4d1631d6f1157ad9c031948b3e7ea2fb47908f5757daa5f5"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "eabe52a2b47544c23b23e283686e02a6afda43fb317fc86ac493e09fbbac2dc3",
-                                "uncompressed-sha256": "bc3973d4d323002f5298555c5b835e0ffae8937e3fa3e4a5cde2fbab6c893ca4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "ba41bc21add32beace5457f6ac5a37e02736fbe54e007f49eb81357f9edbcb8f",
+                                "uncompressed-sha256": "9d90482a83d155440c33768f350cfa78645e75742f17868ed95829053ab0e4cd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/aarch64/fedora-coreos-42.20250901.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "cd7fe3e83727813798f371ec8751604ba103165672734585cbdb4859dcd8ac18",
-                                "uncompressed-sha256": "5abbcd3adc785c9d2c5f0b2ace99ee5c6fae1b7bc2e1266719d2c9cf675c83d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "24fcb5ca51f2bde218cc44d4465e8d0245b3b95446719898de7866d7623c54c8",
+                                "uncompressed-sha256": "dd2b42397447f9befe10bfdb130ceaf03fa784b45be0d02a0f592130cbb75db3"
                             }
                         }
                     }
@@ -173,233 +173,233 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0e77bf340b60143fb"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0e16b3a0015217253"
                         },
                         "ap-east-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0971932616410fa01"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0cef7060655e3d640"
                         },
                         "ap-east-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-032b980ac85200972"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0afc05cfc558fee0b"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0616cff32eeb6fbe5"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0110ef970e245e714"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-08a81dc3a1d7b6223"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-054e32f39641c9228"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-02787e6e63ea48acd"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-047ae01a77e1be767"
                         },
                         "ap-south-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0d61163ea2d0353e0"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-07b0870eff15ee0a9"
                         },
                         "ap-south-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-078f3fab043cfb3b5"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-027564cb644943d08"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0571d41c979879adc"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-075c109a1792cbe92"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0a1921dfa19e0346f"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-07ea4d28f4613f2c5"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0077c5771929580e2"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0c00323816a77f3aa"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-08f01e9d973e2b985"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0352625d896b38844"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-05a185a06fa5d5941"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-044423ebeb4080155"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0aa370d15d1c42c6b"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-054e9ad241e2ebfc8"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-00c26a58d445afb26"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0a1f09ae24bd7a194"
                         },
                         "ca-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-03fab63574a80259c"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0e5441f22344bbaed"
                         },
                         "ca-west-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-08037c122eb6664b2"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-07569ce0cd0e90d61"
                         },
                         "eu-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0719faef86cf42735"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0a9a842311d2f3ccc"
                         },
                         "eu-central-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-07ed601df02a8f591"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-02950935bc4529402"
                         },
                         "eu-north-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0b0a414fcf52a715f"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0b6451cc16ddcd832"
                         },
                         "eu-south-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-09d81cadc65f0b4d5"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-05a39a704bc56fba7"
                         },
                         "eu-south-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-09a13fc9a3ae82f29"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0b7b1572df933ee6c"
                         },
                         "eu-west-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0eb9126e4a41e1bc9"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0673513c148a153bf"
                         },
                         "eu-west-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-09e924dd05ab5f891"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-07599e697ba5bb96a"
                         },
                         "eu-west-3": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0ff715db1ae03f7fd"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0e6ee99f336a3d58b"
                         },
                         "il-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0c6465074d16b6cc1"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0ede7fdcbd2c651bf"
                         },
                         "me-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0563f2bf23ad73505"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-013722e5b0261b100"
                         },
                         "me-south-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-075583cd6f77b57ad"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0b8fd52388fdf8afb"
                         },
                         "mx-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-07a4cc2948f42ddd5"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-08577f4d49cc07d48"
                         },
                         "sa-east-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0ad358a7f2cb00190"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0c46396a29ceb27fa"
                         },
                         "us-east-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-05930617774727eb3"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-068ca11081aa26fda"
                         },
                         "us-east-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-02baada97a8b41219"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-012547a863a3a9373"
                         },
                         "us-west-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-01823818b3dfafa1b"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0929441f0fbeb948f"
                         },
                         "us-west-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-05a887a86dbcd00cd"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-060e7f225a27d5418"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250901-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250914-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "667570a5d7dcaa8e269604d858ce54cb5946c387dc4b80554e24f0dbe78e847e",
-                                "uncompressed-sha256": "94317187a06d9e7268fa7b61952d01d1c74be8cf6cbb8ed6c6f123df55618eb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "bf55d94cff79e7d3b8403cfafc0fc1946c2f74c4bc81471daab4a5cd3c937985",
+                                "uncompressed-sha256": "611df8092e6cb93e3a1b16262e7e67e8ecf52340c0ae106fb694f91cf83b8995"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "e94b884becbe558801a44ee393960058cafa91084faaf7c4dd50b3e0053ff3eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "b428c86d02ff4e6d40553f0e6ccc2af7c962420d197f81c054167738cdab123a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-live-kernel.ppc64le.sig",
-                                "sha256": "a9781422913adbb5746fbf803f2728fe5d62df16cdc3e52a45aaa749c6821b5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "f6722a51c646e6a15f0a69e01bf2ded92c5affe6481723ee944774744a83379e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "ade27fd779effaa12cde32d02bb449cacbc90209263315a37ab2898a733b3403"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "6f137238cb68e5ffc30d840634c6937373b405c4661ace8ec42502232eaec088"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3a98a037d9eeb3892ddd83ae0e179c4a2ea1906728b9cde26aa10427afe83dfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "ee9cb692665513ddd282c43d348a5c35a0da39493704c7ee9af1b7d1c6597a7c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "76761004862e203f9986db8102e7c23d1a3f857472279c8eebbb68c74ccfbfef",
-                                "uncompressed-sha256": "6790655379be01c34ff420abcd97dd3de1736de1a27adddf51f25b8c97ab7651"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "c3ea5cc45e5cd750198cfcf1f86e9352be2c9062b978e7348e9aecde54eb6862",
+                                "uncompressed-sha256": "053c74ff8831b78150be4d83470747bfb92b424d84208c4a03e8e20e06b12f3b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "71ff52b11046402470636bee4756ef0e8fcd985e93642883d19737b032565050",
-                                "uncompressed-sha256": "c51c32547228147f36819052c660f8329e58b14e43dc05befff58acbff874139"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "cc851231cd20d676697b55fdc7c9a281444a6a33c93feadf6c46a76d8f9b157a",
+                                "uncompressed-sha256": "daba47e25e9f69d70edb3af4d7747a42cbfedbcc80307981f1203a3c46b5aea5"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "c1f4a3486beed6432aea7b11d3b5bc0670b397a0e70c4d46bafdf677877ffba4",
-                                "uncompressed-sha256": "7feb970feef6fcdd50224f69dd07c9ed7e4da4cd7ad70c720b3a57f5d7eedc42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "b183b9b64983225f7150ca8adf3b77b8ffcefc41d5f4c28ada695a20984361fc",
+                                "uncompressed-sha256": "8953df5efcd3ef6457e6527b83e8af3659377020999ac4207bd2bc21ee62dadf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/ppc64le/fedora-coreos-42.20250901.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "9fb44631b75bb4539f0135c305a1ddee2f32536b7d172b5593fb69cea58ed107",
-                                "uncompressed-sha256": "bab20fb44917005af94c01c347110e10973fba935682f107a28b121e7611a788"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "565066930cff882b610befd9aa297e6fbe057f7127cb6c3a2e4c3f0b5cfa0bdd",
+                                "uncompressed-sha256": "8348f9b6aefb9c704d19f861cb376741b1fc325610e3e693d1190e9539b1e72f"
                             }
                         }
                     }
@@ -410,97 +410,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "80d4132c58410bb7c446c6f1887d264c8d398391f4fbaef121ffdb3dd9e77b0c",
-                                "uncompressed-sha256": "8e64ab0dd897c1c457f8a1f242bd6b7d3e89ecfee1dd139186dde7346dc559f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "cbf8b8bf40a2d7a0b20dc33b2232f30f3052b67183e8c3d619c2adb4838647b4",
+                                "uncompressed-sha256": "bbe9fa32a46f7e9bd306abeb45eeaa736da4f7d031db2936c57b6ac1ef2080f6"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "e028707b967b7a29df67fb6b380cd8262543924df373edff23df95ef463bd6f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "4f0556363ef485b12b308d86bd824a872a1427c135384e003af8575a2536060a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b77b8a68e3bb9924f13944d635ac5c9569d7ce00c9913ae45be9e6ff1aead000",
-                                "uncompressed-sha256": "9cc12381e0e803f0277ac202422dd39e5f9cbfc55fc741dcb2d295bf7dba8cda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "87908433a2d3354fc334c46cbee0d07d4e304bb98b9c30cb70a73a82288b08f9",
+                                "uncompressed-sha256": "3c11f391ffcfc8c9bcf5483deaec94a1e06c523089e294ecb757731bb38275d0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-live-iso.s390x.iso.sig",
-                                "sha256": "63d76a3e573b6ce0742f21bb1b3bca29c7ce5f2b3fe41af25e124e4df2434a61"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "b0604ecd24973e58955bad1aae29785bf4b9dd2412567f8addf95215b82ee746"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-live-kernel.s390x.sig",
-                                "sha256": "ecf8903d8068be05b8c64b3ccd5397842625f99f66b14306d5c66680d5a63869"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-kernel.s390x.sig",
+                                "sha256": "877752631faf1ace0e0875751cd11ac90c03f5e90fadc879276005f81d1fd97f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "dbe311276c0e1d8c7ad1f4db16df87e7b77e6cdf3b69c323037e96ef14f4889d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "cd3ffd06d234417119c6cecec4773a9517ca1f0b6eb91653e74c30aca4ecd8b6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "c9afa828ac370ecc18da6c073d67a204aec6adb75411982569aaeca345901908"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "e64cb694fb7cf3b2904d4c3e02a342db7bb79eedceff6df903a360a4b324706c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "1765685a13d20ced0b221eb9ff0adfa9fd29dbc64be5d75414743d118d279ed2",
-                                "uncompressed-sha256": "72553984a3e9094546bc09834ea6ef04172702f10755b3e92cddb28ed091204b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "7e57d6ea5b6b77ea201e3960a2a8fdd6d08b79f0ae6cba9e08af4d3883a55288",
+                                "uncompressed-sha256": "47bd15c68dc47348161323bf36073f6b74c301060dcff58668aec72f82464fdc"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "810ed474b729f2e9beb9d05947fd8dde5c6d30713f866d0b31c7a284655971f5",
-                                "uncompressed-sha256": "01758059c4facbb7347e556b60466b616afd7a4f1b5aac28727b6c5fc53763e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "89af52cf794c8666cbd2dd74d956248e879f5e9125cf8447bd03e7267cfada45",
+                                "uncompressed-sha256": "1e8c886dbebcacebbfb1506cb1990daa5a0963218f8cad010a5590c2cf6cdfcf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/s390x/fedora-coreos-42.20250901.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4c09f1ae45a6e0911e0188420fd349c32a9ce63ffbcff925ce139ce6a1e18070",
-                                "uncompressed-sha256": "05c2f668bd30edcccdaf6c2e5ad20e67cad6d91aa9700d81e976e2f7effe5df6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "baae4e1a7b161bd60e04f1d6f75eee0487b56b59f1ba9b0420216863004c1128",
+                                "uncompressed-sha256": "0c792dfd19d5b864494e657bd03a51b3ebbbfc0fd842eb47969ecd723139becc"
                             }
                         }
                     }
@@ -508,310 +508,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6488aafb75a11d4e9284bc602b8625f983ce6ed8121c2bf05fca3fad018a1f22"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d4cb3b87fa04b061303dbeb91562dbd1e80f6e819f33e9bf86b351f394917859"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "d57035595b58c35c8154a37fac81bd22818e571b4845bc5b704f0539888deccd",
-                                "uncompressed-sha256": "8a891de6eff364e59498f4188c55f0f39ef72644d6fc6d10811261b70976c607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2dd1dd5fb8364e1564db3b71063706f6c573bb6bd3cb1adf40943716a5cde5c9",
+                                "uncompressed-sha256": "757f4409fca161714511ac08b6c71771db75364961bc96e606aeb9866d2ed623"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "5471e6e4fc8539a8ff968b6f05c791e83ae9c55f74b87b017936ea668f6ce161",
-                                "uncompressed-sha256": "84d9bc1e29a9148862b3d7acc78572c7b63970a2e747ac9683e30309064e91d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "36848f0a233cfeb7c10223e6a5652c002d435e2d8c65f1fc2150b57ea32fe350",
+                                "uncompressed-sha256": "906b9c74396e7923befbbdea84aeb0a610facce2d2b707e7605e2c3dcac0bb4b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9b37d9703e9dfbaf88030eb5b84a0cbd1bc6acb48c1848b6d80268c932e4fe62",
-                                "uncompressed-sha256": "def837663e62846f149352a2d0921ca6e2a6d061e060001d5dba47071ff472e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "8e7f8d632e18c2b52233633d4186a0a2a1b93c71140160a897d374f0b7837a94",
+                                "uncompressed-sha256": "99ea1560089fc0a72a25e4f4e26e3015ceef7f79efd8e91e60f087eee612a962"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "cdd2790332fc8c9c609f883b34452540d6c583ed8f391aacd7ac43e9cdfdbf20",
-                                "uncompressed-sha256": "c04e83ba388f1b351ecd1edb06640ce87013d5380aa087ede8979d60b9ef550c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e355897a27a9946186982d9a7324c36b4506b7dd717801c30e38d5949577df11",
+                                "uncompressed-sha256": "3cc4615ef4abd043cbf9d3ea70776bb16e61760810d4ef964631c550217eca14"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0b835b1cb24e78cfab52b3a023b34f4fd09e5fa6fed4aa3c3b1b2bb8a87eb1a0",
-                                "uncompressed-sha256": "ec94a5c330ac2c7727f2f3c3cbd474c111c22511f9952ec13a7bc818f7e5cf51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "0622b99cfc24c0e1a759df57e459cbdebe2e3f45c34bcebc942c5e69f7ed55d7",
+                                "uncompressed-sha256": "a07e8182d6d0d2c86f1e4018cec6962fbc205451d8c703bb7c2d16f974fefd16"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "49c6f00d0ad2b74d9115b394b0cdf423625997fae3a1c563569521a705e1d91e",
-                                "uncompressed-sha256": "4026985dcb5b170d1e91088c2578fb830c24a5527c5df1dec3bba1e69e4c9c96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "b944894ecd7e4c8118acaf8295c0350a56f4c5e6140e5170b25ac8d921f0c241",
+                                "uncompressed-sha256": "213c164602d378696badbfc66fea7f4fd8df7d83c4cb8487dbbb1d61a2e9aeef"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "14bb92e710c027219200b4a28156cd89cc9ab2970b4fe1e48e263bd005e7c85a",
-                                "uncompressed-sha256": "ccfbd03c20abe0a80e9fcb95b3a6a77a47ea0ced12a5b492852ed4d7af3a1b94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "76c37eae45f88ad0e8fd325aa1a2f511b0e74b6f30fdee8847704ef4a815cb31",
+                                "uncompressed-sha256": "fcccd85621b5d90ba2f1c73523dd5ae2d1df06f6204e4c01c596fb0bdf3aa113"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "84a3da217464a533de32d893248aba0e3975a0eea3d22de69bde41d679b1ed7d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c2b10a3f7dd4db65f77af5345bd01206ae816bf335e1d223e5a3570234e6a30c"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "c967ddd33f4fd5381377e59559541ecb84bb08c431086c2d9f3cc0b4b924ce9b",
-                                "uncompressed-sha256": "68110d96da1c8f61fa63fcb64a4a535e4fc5fa733f9a0dd1e909cbd9413ee51c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "e38bea1a2775fff92e54d73f90596c82476376cce408031928c38e1c89b90f83",
+                                "uncompressed-sha256": "cc33b39f2246161d2678dd5f00e82d1219220ac50f879edd46941d5c1c79a3cd"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "400eba726d9e3bcc3bb81cd3b63902e1da096ca69b6b02a97fac51390635f623",
-                                "uncompressed-sha256": "7a2e08059367403559aa5e3167c43d4f1c478e90193848ed9dde3038c487f371"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "6c3b23fc442cb7b661fcadc1b7eb23ffd81cc55ae5f71157f3001831c0d35784",
+                                "uncompressed-sha256": "fc1dd9e1be53b1ae503f191e07b5f4256469ff7bbb873e2bcbb124da0c524f98"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1d7d153cb8a13c1d4c9df05fbc8af66cc4de053df9ba92597b36d9a7bb808e3c",
-                                "uncompressed-sha256": "0a0ed34196742ec4528f442ab536dd2fcda15b7be9558db5b0fe400874f3ccb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "08e3900e5d21e17f0ee94a9916ebcf58889ec5ad6ece4b955fa0e1c15a8f5402",
+                                "uncompressed-sha256": "c283bbc3a7a7b418677a0a36ee87f2287f7f85874cd8e44c2088b2934dd39225"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c5e81746899e4efe458d62dc24cd3eba37f382ca8a200b84ccb9a57580aa8b24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "ecab4530286a5c61a538f22d5fd7341dc4267828904289b45634378e99be2c22"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "58eeb88cc45b6c5e218e20d545d8c1787cba7569c8f1ffecb47cf2209d4f4641",
-                                "uncompressed-sha256": "97373f8d27defe0eb9a7ad5b3b28b37648b8a15ddfb3e816dce51b9de21f6ae8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "23b1f48228a60dbf62acf9a3b8a230b266e3cc6979a81a2f57cb03e9271d930d",
+                                "uncompressed-sha256": "f9f8f96454145cb1d461e2c8d800eeb60b8bc1cc11e77a1c2b4bdff92e41b607"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-live-iso.x86_64.iso.sig",
-                                "sha256": "bd889a56a906c1dd62c31d6684eee120c94ea2aa3cf7fc27e9c1d142ba635f53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "2f9f3b2077443a562aea6279ce989190cf1d97215662706ca461566d67d36c72"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-live-kernel.x86_64.sig",
-                                "sha256": "adb5237403fc4c6ac061d3344e796fc2cdc0c90eda0643b9fdb522d2660f69a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-kernel.x86_64.sig",
+                                "sha256": "255cdc70532d6e23827f86b74242833136472022bde9adef8d773c1f32dba09e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ea0cd73b5aa71f9a0087585910e1a5449508c35047d7be9a484ce1cafffe5c36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "ef960a5e2e82ebde21849c0cbd4dbf73e68471d2d0bf2fd2bca9f790094c1f86"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "65cfa9e7cc1f480d6b96a6b581b53a522cf0de042cd5642eb02b2c076ceb2358"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "91bab36b96df2a8616208a4f4b5f5c61959e1ceae85ddaa323c24c1621849a37"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "c306adcf118b4926c308952758a0a9647f3c8c3c2be31e62158d0b6f2126ef8d",
-                                "uncompressed-sha256": "b1dd75465c48e5d69372823e40587bf29a03e4487c877dd9548e1fdf039e8dad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "5b57580bc239b6e3947eed7587abb9d623a78bc9eab8b30f92ebdd3074a3aff9",
+                                "uncompressed-sha256": "53134596856a000a4325a17ac806ab372c8f2c40b68e083ace69b965656e90aa"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "6f006a79f058cf9fd6607c50668c803100dd43dbe81e115605a2ddda64587772"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "a7a585e757339d3e38c98798b3e167f93e11c3acc6c47e5f12096d6d5271417d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "e1d41659da6d2fbee6f1c8d869b59c992cc0cef02adbff8bcdc3f5c115857071",
-                                "uncompressed-sha256": "49026da3a48a6c5898b8931ca6883a04ed9f8865be513163323624c5209c9f30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1dba39e67a4ace9aea2052dd2a56575b430891211e05bd0c8af7aa2dfb3d0227",
+                                "uncompressed-sha256": "9efc6038a1e82c0a7bbb0b70d8860dcf7c2dc9134406e83a91624bc27361e453"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f012e76c250111e698e885b5c38340c7442eae1400462770fb21d110ab41971e",
-                                "uncompressed-sha256": "e874226e57c97e98c0848897310e495a935fd6879b1cdabe466523f7616cc917"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "88ba2496baf6f3bebf181a3868346146022e951f781fa8af387fd13ead48df4b",
+                                "uncompressed-sha256": "9f374ee66e8b25839116bd5bd36a0c1be4127bb5cb3040aca0338ac55b427ba9"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "e33211a9c293edddcbfd33136d602e5a8628943c6b62debb22afc80e4926a572",
-                                "uncompressed-sha256": "c4450649f93883a0371c62628fb3b56c5867ed6649016ae79b6ae610d137ff96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "a0750e09ea165fb118bfac453b3e4f036157b7c70e65ff610a6c856de1579931",
+                                "uncompressed-sha256": "a373405f5b2be5c660e5a517ad9651ee4e2645bc091bc79a21fe6e7afae25155"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "0c9d35f2b4539cda1220b9ff10ec981f237718611223806a4ac93e016fd4eff9",
-                                "uncompressed-sha256": "ca68d30a49ba7088286b076e9768b0a724e3c151fd283ff7912b2b38d35b55b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7f032482b77428be09fed4eda9d411338730aaa95d43fb14001b8283f23e5aee",
+                                "uncompressed-sha256": "f8303d0b09c6ca4d98c5a2d93849a15ef469c78b00cf664718a284f1ee3e0cb5"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "99ae84aee5639a8b0c6f0e9896780e3638cf7d2a8b9021e605e41cf1d312bb2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "76c169fd28c2280913f55cceb6b279c9a7fe17607796635beb77a3907a46ca00"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "0900aa0d303add455d18aee9cc566879471c641cbbbe5541b83b3eae0f82fa6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "714cf0cfb36dcad2a41a81a0d1f7493d9847ccbc3861e5227d8da74977b84407"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250901.2.0/x86_64/fedora-coreos-42.20250901.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6aed331149a7f05cdef6481ce55dcae0493603365e2bb88897d0d0a8a5b24bea",
-                                "uncompressed-sha256": "26fe50b8d6f2c9bf25126f00648d7907e17d1a397d100130991dc0337c5ce493"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "dd3d37d3cebced20522251664f0bd86a3e548c0e1c7a1903b976ab12824129f0",
+                                "uncompressed-sha256": "88f08de5818b375d9e90085e12c609d76ee4df94696a47a016042de8c71cf4c7"
                             }
                         }
                     }
@@ -821,153 +821,153 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-05ed368ce5a5882e7"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-093972ca75ecaec69"
                         },
                         "ap-east-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-001e35c31fefb364e"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0e94bffcbd6833c02"
                         },
                         "ap-east-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-045c9f5e9c5fe12e7"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0f16b6e03b1cca0d8"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0396ac66d6e4a02f1"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-04b5ebec928dc7650"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0f050e44295cd26e6"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0e4361f37792d3164"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-06308b7b6d09925ef"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-06b3fe7a02fe566b2"
                         },
                         "ap-south-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0b3de8a1f509b0058"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0f5cb05e1b351d0e8"
                         },
                         "ap-south-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0a21e921abed1f433"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0fadaad747f21eeb9"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0092e8683944751ed"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0e6efaefa66e7214a"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-00b48d89879429d52"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0e1831acc483a256a"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0c0042c203c301717"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-09d95c5c19527bce0"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0ba3a57fe906fb92b"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0739bb62fad7ac654"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-04c08ac9848e1cf6e"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0d1a064a92d185203"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-03443b1589554ef48"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-000d0fd47a149c71d"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-028cbbf3ad39d685f"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0ce7c4337b5bade78"
                         },
                         "ca-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0cd39345dcf8216b7"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-063f89fa722d11b93"
                         },
                         "ca-west-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0ecab38cb7d1e116f"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-08cfa56585256521b"
                         },
                         "eu-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0ab4e3fd5dd6ea9af"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0274fee471c1b6130"
                         },
                         "eu-central-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0b89f74a8e1573530"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-08d0d966f25c9db6c"
                         },
                         "eu-north-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0c9e85144bd654e45"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0c83852458ad156aa"
                         },
                         "eu-south-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0208cfd96f321d078"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-00a8302deba00d442"
                         },
                         "eu-south-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-002e3dc15a055d15f"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0f5455de04dd51161"
                         },
                         "eu-west-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0c8540e6edf3476e8"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0684caaed6227e449"
                         },
                         "eu-west-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0bf214c9c2f2903d6"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-050c606ca43e52d99"
                         },
                         "eu-west-3": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-02a154aae414df89a"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-05fd192b3c8a9ce94"
                         },
                         "il-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-02718638c10f91aef"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0065a47c70578315e"
                         },
                         "me-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0f0ae27fdcfd6d637"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0aebc83c2f654d547"
                         },
                         "me-south-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0984e14e3aae569a3"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0d2288f0fe471de3d"
                         },
                         "mx-central-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-042739912b237a7ed"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-09a57927dd33ad45d"
                         },
                         "sa-east-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-01e85a0f734d0459a"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-01c62e57751993662"
                         },
                         "us-east-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-09a7792d6a9e5f04b"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0eb53aef6297adc89"
                         },
                         "us-east-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-0f3e16712a6a1344e"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-0fee38da8cbe8b06f"
                         },
                         "us-west-1": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-06efdf766dca7a2ff"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-02c873e1154116dc3"
                         },
                         "us-west-2": {
-                            "release": "42.20250901.2.0",
-                            "image": "ami-022b1817bcff65ea9"
+                            "release": "42.20250914.2.0",
+                            "image": "ami-031aaa57711d58452"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250901-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250914-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250901.2.0",
+                    "release": "42.20250914.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bd9572156b2edc18a785991cc607aedcf7cd7fd1c2e135a4c980a0cca95eb72a"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1bb487f3787cf155faaa50acc5f34dc2b65ead91973ccd46af32b5536ca62738"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2025-09-04T03:53:32Z"
+    "last-modified": "2025-09-15T21:02:10Z"
   },
   "releases": [
     {
@@ -141,7 +141,7 @@
       }
     },
     {
-      "version": "42.20250818.1.0",
+      "version": "42.20250901.1.0",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -149,11 +149,11 @@
       }
     },
     {
-      "version": "42.20250901.1.0",
+      "version": "42.20250914.1.0",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1756994400,
+          "start_epoch": 1758031200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-09-04T03:53:30Z"
+    "last-modified": "2025-09-15T21:02:08Z"
   },
   "releases": [
     {
@@ -125,22 +125,22 @@
       }
     },
     {
-      "version": "42.20250803.3.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "42.20250818.3.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "42.20250901.3.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1756994400,
+          "start_epoch": 1758031200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-09-04T03:53:31Z"
+    "last-modified": "2025-09-15T21:02:09Z"
   },
   "releases": [
     {
@@ -141,22 +141,22 @@
       }
     },
     {
-      "version": "42.20250818.2.0",
-      "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        }
-      }
-    },
-    {
       "version": "42.20250901.2.0",
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
         },
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "42.20250914.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1756994400,
+          "start_epoch": 1758031200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).