### PR TITLE
updates/next: switch reason for 42.20250914.1.0 barrier

### DIFF
--- a/updates/next.json
+++ b/updates/next.json
@@ -147,7 +147,7 @@
           "start_percentage": 1.0
         },
         "barrier": {
-          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
+          "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/2029"
         }
       }
     },


### PR DESCRIPTION
It just so happens that there are two reasons to make 42.20250914.1.0 a barrier. It's the last `next` release of F42 AND it includes the code for migrating a system to container signature verification. Let's include the link to the signature verification migration here since that one is probably a little more significant.