### PR TITLE
Roll out stable 42.20250914.3.0, testing 42.20250929.2.0

### DIFF
--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2025-09-15T21:02:08Z",
+        "last-modified": "2025-10-01T14:40:10Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "a59ac8a70e9b721908e958e3d96ac64772021586603fe2878f519476e95a69cb",
-                                "uncompressed-sha256": "f5762e1bdd2acaf868623304bbfa51b350b56959be7da1d68244d7150b7cbe4c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "c8d502ef5db305c5fb2f5b32ac82dc923453562617e15b15f68d204f66cae4fe",
+                                "uncompressed-sha256": "cd02f408e816e84fa2dc297dbde21ab42b6b62a984b17c53ca03cb963afca786"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "76d161e3bc7a5884fe007e2e05748233b5ff603228628fe6817acb588ede07ae",
-                                "uncompressed-sha256": "b0b9e609b4cdbcafc5cb4f38efbfbd7090ffa637116e4367ceee76a82487c970"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "2331bf34a7f704e40b6faf4c4409655dab58655538fbe6f5054bb643303ed326",
+                                "uncompressed-sha256": "6ee53eeb01f28af55c1bb9b1c3f393971a5e741809c97c389befd68267f6cf19"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "9c42fe48f0e36e81eda35de011dcc8d478e60c03aa0346092917b1a65d8339a2",
-                                "uncompressed-sha256": "b8a149d269a9703c55bdf34d2f6c5cc51d48874cd25b4096fe7542374c0984ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5001d1de1cf66dc243514616801c81e826e6542bd07a16131b64aa96fbd68425",
+                                "uncompressed-sha256": "e145d826a8f6f70a2cec655a4f8b2eef5a1cb41c4fb02210812e9aa8d53880b6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "c4fe9c81ae49339fc02fd69579776d690d1889b6c5c2b7399cb4b8707320b0b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "d46fca5d41118f654a82f22842183861e84edcf0e46bcdfa4a61f72e5c1236b0"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "d52e24eb6da9e45af70efa92c39b284a214750645cca1873bf166d02a7366052",
-                                "uncompressed-sha256": "63c95602284caa826d517479ebac2267e57fadb1c7fb40fb558ad2056d7075e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "2efd1ca97ebd6a673f1c824ba2ba69f6111e55eee151e70f87ed1666f37adcff",
+                                "uncompressed-sha256": "afb94215971a06608303774e1b019a8629df15e1d1266d2f5b449bc0ec436489"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "a0a6648ac5147534471a94abf5509c06dc341c765020582a070da018e4e16618",
-                                "uncompressed-sha256": "27942eb567d50f760f369b61c743bc5efc7cabfdb89bbb29c48ba0b4dfbed310"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "6057ccd8971b08300776f40fdb876bbb7cff877b6a6f587a12b35497e4e1f59b",
+                                "uncompressed-sha256": "f72bd23e807c4c7f7798b43eaa1b7d8a2259b2fad98b443cebaaafaa281279f0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "042e9dd28b8a125311ced11a98dfd7a96d852226345dff72d31bafb43bc1f8f4",
-                                "uncompressed-sha256": "a912b7f0f22d85608852653a109dcb9fb496a969b03ce9a954551a8883dec8be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "4b42e826c57822685a760fbf55a435a27390c95e86682b569f85e5af5ab3ebcd",
+                                "uncompressed-sha256": "a11bce603c09a373a18283b622f198b55e308347fda3311d05e1ee94404818f3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-iso.aarch64.iso.sig",
-                                "sha256": "ed600afa179257c1f7bebefaa8758c0c173654424a03706ee1d31d14b7108fb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-live-iso.aarch64.iso.sig",
+                                "sha256": "8b279c9c096ac007fdc48e05090dbf1223b66bc1d6bc3c8986c95874331bfd7e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-kernel.aarch64.sig",
-                                "sha256": "84c9de1be05405c88e1539df05afdb42d9ef9ba7ddf13d764d1d04652be958ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-live-kernel.aarch64.sig",
+                                "sha256": "9d403d7a67ace122129ef7593b2f5a4b0ae014083583d7722c6827013efb55e2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "837eb82ec33bef3356cdaf1209cf364f219880d39fc071cde8af2def279563c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "25b77acd95fba93a1506e9879e4c4babfe0e6998b4649efacde366bcf70efca7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "8d46f820ebbec2bf199029cf155a8f1de0c5bd4f18257a86c6e0237f72f497c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "66d9a8fbf6056b3cd91f38f56a996dacfe55cd0c036094f7be6182ba8beffc5b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "65500db67ad4ad8fec535f056990f23095353f7e586ebfcfd02f72c89c011b2e",
-                                "uncompressed-sha256": "d287672b53fb936c959f3dd745b934592ccc66f09b1d52ce87f849470569cf7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "43c311270c04a8ef3c8a7702a963001d7c327c43ac3aefdb8e35cf26002f781d",
+                                "uncompressed-sha256": "f3c58dd5f8f11903a21722304e70cdef54be584c5f84cbef5fd71a25a2db7fa4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "6d047eac1b557d6c63ba99758de063d8fac0518ca9c61dfbdcdd3de556cca7e2",
-                                "uncompressed-sha256": "bef8192c80a138731fc5ca6fa127a601835a2f5d266c0987c6c1b7551b6dfff3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "5387544c20c3811fcbf5af74c988f2639bca5c04c57f089071a2dc579870ae9d",
+                                "uncompressed-sha256": "50abfe920746ba218dc9f66b806637318eb945dc91d3ba7da6b3d84c3d3ad0fd"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "d1ce3fa62481f6bcc200629303968e9dab96f563874fa2aca787aa33ebf933c5",
-                                "uncompressed-sha256": "9c9c8580f371b8dddabbde06d879a731ef836ac5ddfd1b9c85030c388a2b33a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "621912c8cb5769c7655b78ec3c75020be2c4adb8b2553a7bda6c630589b42a0b",
+                                "uncompressed-sha256": "5a4179478db59094706af0f065c74e5c45e6178585fc97d4632646bfdbc1685c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/aarch64/fedora-coreos-42.20250901.3.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "13994c19d10aac25eff86c6079b37cccbeda83d16844e0926d13961e097d96ab",
-                                "uncompressed-sha256": "0699ac653f1e99372fc4c7b4f4861ef58cb0d754f39f72615fafa4ecbed1731a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/aarch64/fedora-coreos-42.20250914.3.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6eed903fb1f7d7ca9765f0ae8a27a9409678125630cbcb7bd243d65337a024f4",
+                                "uncompressed-sha256": "ba1b386f04c921ec87084bebe9b43d4413515018b9f2f4535d0c1ede64cc94ff"
                             }
                         }
                     }
@@ -173,233 +173,233 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-057dca73a04dd0a3e"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-071f59f4d4dc0d32d"
                         },
                         "ap-east-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-03d9aef4b007d5624"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-06841d68742a2d93b"
                         },
                         "ap-east-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-049a6ebcd63b25200"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-09fb95fa4d8d4dfe8"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0526f1e5bfa19324e"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0016222b892b2579d"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0cb52800735d492ec"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-00b62cc2f3943a56b"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0e2b1455eec9d4916"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-02778bea3e6d73135"
                         },
                         "ap-south-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0924a1599a76e4232"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0721e8112b323ce56"
                         },
                         "ap-south-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0978645c57f581dc7"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0d2c665336828d01a"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0a3ef796ed0cbc6e9"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-079e1092dd706d098"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-08fc2f23653e9b0b8"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0ee580866d02e2f87"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-09ea8f434ad218940"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0ecfb274ead46ca5e"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0cad65a5d1b4d1ac7"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0784b9a6bb8947527"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-078566813973f2488"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-08c0e828137d2caaa"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0e0ef37634d7c9163"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0e06da2ed8e31a083"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-06e4b0afbdb8a9b99"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0809f80f4ab905585"
                         },
                         "ca-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-051b52fb5347cf2dc"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0fc8ac636ee2454ba"
                         },
                         "ca-west-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0b9d46fe8d8e63dea"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-037b5255bfd119f5a"
                         },
                         "eu-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0f15e31dbbbe5187b"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0edf96020684ca73e"
                         },
                         "eu-central-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0e6a3986f93e84dc8"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0f3ff7f2091dfeab0"
                         },
                         "eu-north-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-06657e799d6bef29a"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0130c026bfd7fd018"
                         },
                         "eu-south-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-005cdbf32b9fdaead"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0d751c1c91308a6a8"
                         },
                         "eu-south-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-08d12c79c0b2688e1"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-07b7b69c7c5379132"
                         },
                         "eu-west-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-03e318dd533d5d7e8"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0df9c6147ede111f1"
                         },
                         "eu-west-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-080f05b4b3ec885c2"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-04a5dcfc81d8074eb"
                         },
                         "eu-west-3": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-007185a9451aeb850"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0080024ab9800164f"
                         },
                         "il-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-07b0defdb2f4fff63"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-02f6ea85090b088e2"
                         },
                         "me-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0c3190266fdd39776"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-091ba9738956c6b3e"
                         },
                         "me-south-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0899a1afb53e59576"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0ff0d33641e4171d8"
                         },
                         "mx-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0656982455eaae033"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-01021fcf80216f494"
                         },
                         "sa-east-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0664280b72288aea3"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0e12b2418bea025ac"
                         },
                         "us-east-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-06eec0c7362507293"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-02512d8e518f2ff89"
                         },
                         "us-east-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0b36d07fc83d2b38b"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-01ab1b56fe89af677"
                         },
                         "us-west-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-049ef2a83300346d9"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-02147084b1ab8c732"
                         },
                         "us-west-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0d2d824f20a3e4cce"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0aeb29c380a509d83"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-42-20250901-3-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250914-3-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c4f6f4d93ceb1ca195c4a63514d1fcd3fcb06f521f4ccec6342cecb3372f2c88",
-                                "uncompressed-sha256": "647bf99e94a152340b3b03d13e1ca5a84efce95cbc3520ba397069cb0ea7d1d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "88dd77fa0f3927d5af6ec1f6951e56b0ef8fde122c12267eb747ef35b127e91c",
+                                "uncompressed-sha256": "aaa89b178cf1e666e817920bc4c56ec9a174a6b62f94d4f3391125df55aa4bfd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "ac1d024f91d8c3cecfde3b5e6ecdda725547157434be89795af8ab4e4815a721"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "c064a0f18fad5a5474b026cfa3228c77f5c26dc4430dd503490d9a1fdd115841"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-kernel.ppc64le.sig",
-                                "sha256": "a9781422913adbb5746fbf803f2728fe5d62df16cdc3e52a45aaa749c6821b5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-live-kernel.ppc64le.sig",
+                                "sha256": "f6722a51c646e6a15f0a69e01bf2ded92c5affe6481723ee944774744a83379e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "fb956baaee4eeb42b2a3941f2b434bdfd1fc1ae4b415bdea2373645b968cc528"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "7be21b0a8c568bec8915f2f4783bdaeb4d4ba3cda44114a85fb82aad7d548601"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "529ad6bc55461f6f2998ae1e0481fa6b6f10632457fb7c9f970e1316a48dc4fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "08621b8982b330dc352df895062908b0fc988239f3591312249134ea83e9de3a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "187b6f8d8140612a88f74e9b80c958eb090f8da352dad76d6d207042dbb3e091",
-                                "uncompressed-sha256": "65cfe51eb27b4b8330e6d3662cc6c39613bdb762975e46b813d79b9d1df53cda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "a30472f010ee08831a75543c26021b7514b3e86b828077de9e615056c2f72d85",
+                                "uncompressed-sha256": "28c4fc75987a730698bfc3ae29561890d8c0afa3e94c9e9ff64500e7a2cf52e2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e4ff44ef9c034f4724a127662b4ac550399774e83b4a98a0978735de2b384e5d",
-                                "uncompressed-sha256": "09eda620086657e6473c790623341212a44d943f201f4f7fdd595410fd4555c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "209269c83a9d7a4395b3330686fd36fe6b015994e90f3c2df5db9c5081597f99",
+                                "uncompressed-sha256": "1052eda2ea0088acb5d9c8feee672549e4cdd7ed36683421afeb7f97369b57a2"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ae0259160cf66b956fd7236d8d643fe05da243f9acc61ab464eab49d1349ee6b",
-                                "uncompressed-sha256": "04d588e929b06a4d4cb76eb33e073662052838e00bf796ee66dd8d356fefdb2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "d7ee56ef82eaad532a1035f9bb698c7b16083758bfcd99c18014f0c1f266f416",
+                                "uncompressed-sha256": "175974c2e69b5e90df67adc5b5b5c4bed393b2f5b75eb4c95c937a162171841a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/ppc64le/fedora-coreos-42.20250901.3.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "40572ecd7766a9b95de9ecbec877de93008d5920f9d016c0b288916d1834a8a2",
-                                "uncompressed-sha256": "f4bde33ab4f2ec9f8d2d5cc1ffb0c1a13a5f12933475fd048eca319f3822f189"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/ppc64le/fedora-coreos-42.20250914.3.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "a3c3731fa8c7757510f65b7a48849e3222fcfa69eaf77ac77c8ca9b185479f49",
+                                "uncompressed-sha256": "08aef9fe4366de65bd0848cf06e4e7602427904ae5ffe8b1bca21d800795d5af"
                             }
                         }
                     }
@@ -410,97 +410,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b3519e9f99d1aca5c5a52182c07b782705056d1c51d1c4f560fe3e2f04d8764e",
-                                "uncompressed-sha256": "3e2df93f8fbd85c8808c12bfda48df648c78ce9c5b4536fc6aff122e6cdda0ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6b433b301bdd99f02569d66aa1de4cc8ef5414e6c36884f0bdd361bec7fdebf9",
+                                "uncompressed-sha256": "97d4fc494644292993b41d0c486ed89592d7c4e4d6387d0d0c2894d4a0c72835"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "bdb5da49fa9751200d3e4b842a2dc8522b9062cdaa1ed9112b55103242426a8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "f68e756785f1165a358fdd331a8c31a72fdc0e1bbfe0510cdf975bd10219531e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "5db45b1796c8fcefa4215352e556453b46b316d758aa9840e67a5d47b7689c39",
-                                "uncompressed-sha256": "ca6da6362741a4bd7fcd96a20faf6d28c920618a876b4934893423c7be3a63eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3b55b412161fbec49e2838d72588360ed869bb354d4573ccbe82751e34f27233",
+                                "uncompressed-sha256": "005e76a2373477cdd47c30f4ec6e852713a05b3ecbbacbe079349110c852426c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-iso.s390x.iso.sig",
-                                "sha256": "a1bd8aa0281aed3adc92a3552e344790b84399ec1145cced5a92827175778106"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-live-iso.s390x.iso.sig",
+                                "sha256": "65d90343d4615ff32e5224cc90fbbdb7f5cbcfd83cd402ff0d059a4c5d1345bb"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-kernel.s390x.sig",
-                                "sha256": "ecf8903d8068be05b8c64b3ccd5397842625f99f66b14306d5c66680d5a63869"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-live-kernel.s390x.sig",
+                                "sha256": "877752631faf1ace0e0875751cd11ac90c03f5e90fadc879276005f81d1fd97f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-initramfs.s390x.img.sig",
-                                "sha256": "ef55249e98ed4d5e27318e3e71437e0bb26759e76276f4fa2d5521c2aefa2458"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-live-initramfs.s390x.img.sig",
+                                "sha256": "3b1dabbfc0902951ba58ad8c89861dfc0239dcc23d6bf467a0f4dcc10e2d328d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-live-rootfs.s390x.img.sig",
-                                "sha256": "ecbdc2d1a3953100f3ce0d80fd68e27a9db4b567e5bbb4d1a9ba10f037646329"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-live-rootfs.s390x.img.sig",
+                                "sha256": "49599c2c45da0e5bc1870c733c3c29384375784b0f5d6fe32a05b3ad45fe3387"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-metal.s390x.raw.xz.sig",
-                                "sha256": "8cd61afab46234878f284be8e45e91e893759db4fbb4e74f2310729ab982a23a",
-                                "uncompressed-sha256": "7cfd308ba783346361b0e68a935227d9a821a27c9bd4122a891bb35a4a3733a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-metal.s390x.raw.xz.sig",
+                                "sha256": "6b903e2694104d404b8d96713739018c5cd754d67c56154b2af97cd573392a60",
+                                "uncompressed-sha256": "a88554cad0a04fe41472bbdd655b86bc39afaffed5fe306285180a2f58ed42d2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "36acdb1f7e8fce6e480f6eb190a5b7ea120141120b1660d678635e4af41f1a17",
-                                "uncompressed-sha256": "feed4771769b34d729de580b5426757fdcaac079ef33e5431c12a99fe85cadaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "38344e1ee3abc9f4a9623314b0205132ad25bf06d191df51ced25988fac39dde",
+                                "uncompressed-sha256": "880f6dd77b3b8166fd91c73c8d4a942769f07a8f0f18c50fd15cb459b65ee06e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/s390x/fedora-coreos-42.20250901.3.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "cf70b8587703d0bb7e84a17036f7289035a04d45b43979e4f4c59b91c75e7dce",
-                                "uncompressed-sha256": "58120a141229efcbe0792bad375d95b9f25d8caf09234a644879ae7b1b4a1e46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/s390x/fedora-coreos-42.20250914.3.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "1f51e7858b7ee1df7dbaf54162838185b9e97176161400cc953eec4eb8fa0f81",
+                                "uncompressed-sha256": "3fe4063392317688ef7f2b703df71261a93798e77cefb69711deb618b1430f7b"
                             }
                         }
                     }
@@ -508,310 +508,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:acc4da5e5d63108c75b50e550d45b7da593768a61025b24eb35ab799dde01cb7"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:71ed2475ed6c6eddd275afc7d9afb4dd403a30bec604e5248ba254fdc94b5e11"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ab9c4190bc16e05b67754678925c6e81d1ff387857f1ca601f9f505695352392",
-                                "uncompressed-sha256": "f2db0daa84b93e81ede038ca524a34e0915384f0b35cec3c758a5ce7c2f18fbf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "7152dbf80ea04b745dfa72004fa1c708b530ae9e7cb750389e086ea1f25b99d7",
+                                "uncompressed-sha256": "ae580c36ae47406258c2d3f5979696ae47a403212325aebf91427923a4d6cc2a"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "a184ea524ffc43b904c9637c0fa27660fe34456b177a0093aff29e82990a605a",
-                                "uncompressed-sha256": "cad59eb7b7bd09157bbac15d6d3d83f5b6320d6a69f14e2e7d43e4ec18155600"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "61d425a7f0d894cba69669b6bef03931c6dfc86a71beffb0d8c7f7f368f1a25f",
+                                "uncompressed-sha256": "8e004a1c550186376dea9c39723c283deb4910723e26d8db2778997c43844a79"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1154137bcaeb22c47b80a80d2a97070489a499bc3a4116ec6209afa43844f7b6",
-                                "uncompressed-sha256": "4415053349e24f3c6df9e5fc7ea2103b77f4973d18acd5607edde5f2deb993a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c2b0ca7d68fd5e45308474263de5ca84e2e2ddfda5959b9c36f99784dbb2f90d",
+                                "uncompressed-sha256": "a31bae3276697aa12067ddd067ac77bb1d4590bf61749c167d30ede690d04b67"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "94ee5c4639bd4b593f4e957ca5d8d25f72806d955628a0584d1dddda67d31674",
-                                "uncompressed-sha256": "67d69bd1cc60942fa784d25593458009834b4a31dac5ab70f11b0487fbbadfbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "03c7c7ef971994facdc15dd9f55b923ba0ff480f6d3383b70f2ac013370c2078",
+                                "uncompressed-sha256": "a5fc309bc4597215fd75e55a901f5278d19568b29419abc6fb4e22f51d1a9971"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "430431ccbfcf1ac03c001b78ad2c45d9279af84cbacb930fe3cfb8fdbda8d850",
-                                "uncompressed-sha256": "99d0da67dd831adfe239769b31bcd560363fc381204a418fbb867f9e052edd67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "623e7b1932692f167874b0390387550ba6a23ed461a05825984a8d7546f49fd7",
+                                "uncompressed-sha256": "0fb2624915fa06ff39fc880b174ebbbcfc289af3636ebdba0dbb899db40b495e"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7bc15eb2df253b74d1922826e484fea7ebafdbe9b6d029bb805a98377a065989",
-                                "uncompressed-sha256": "292daf0658c8b3154fe146618031c78cfbbaa1e20c2d1049b5f5511ea5ecd7e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e6968a4b0ab3c1cc0b0a3636e6ad2d7ed0272bc32f1f0a8623cca61bd70f2a9b",
+                                "uncompressed-sha256": "bd1fd0be8276cc5a84b0a28756afd30f151002f98e7ea117aa7147ea9eaecac6"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "69e2649de69c8032bf65b397df1827a0c9a9e53954d363813e97ccf893453472",
-                                "uncompressed-sha256": "6556c709c11d100f12cb71dbcc365941bda29b5b240830a3c72e1ad2e580b99d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "884944896a950bf2e83e0cd339c2da8d33390ed9c66fd6a7ab23335ccc7c9f39",
+                                "uncompressed-sha256": "a437ae7da91c4aecdda677b6c452484625c544ac74642065651e0a66c3b87a3e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "daa14468c3bfd0043e28bd6065358c49ec9155b0df6549e40754bd28576aeb0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "736666067d378af2e127ef5908e1a7cf906b4aaf868d2b81f7c984d48aa97ae8"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "e4c7f5bd4bb08a543fd56b98bca4e3472ae62c3a72dd397a0fffc84149080a54",
-                                "uncompressed-sha256": "ac4ff9d930d22df10ad651992863f138346592363144ecc109b8744e90142d89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "6c21a1654608a9b273fed7e2372d73420056775f4b2cd6038a0e5fd12ce86244",
+                                "uncompressed-sha256": "b631bfd0df0a903f421aa4328db9af64f81781130f16baff3ba9886268d3a750"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "122269e5c29a5268b1da13e7b810bf5aba635c2cdae2484231652c0380fed6e9",
-                                "uncompressed-sha256": "c479de1b52bc83b6b26ed512136376f110f181fcfb3250cb2d810b195123ab02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "6bf64c7e20a79362d17d701e5458f7538ca60a42bc8a5c9316e918c0a07bf487",
+                                "uncompressed-sha256": "534b502539896ae8b06b493dbfc8c284ab2b52b79a9032796cfe52515416aafa"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a733aa45914388f3718099f5e3dddeccfd769f722d625afadb172b888113085b",
-                                "uncompressed-sha256": "65212ba97a5e73b0634cee5ae84df0caa5132c619b29a57b2f20097615579ef0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e0cf4260524f22ec0b06c40ea85214753d99faeaebe7cb3f69fd28f7ea7660ed",
+                                "uncompressed-sha256": "694b0590fe23b961756bfe36cd011d68630dcabc2f38291a9ab93abf03d6ea9e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "88e1c228e8eb1b053342a7f86a91d931aecc6f368b9ebc806bc49cd5353c46b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d390b6fce5ba3171341305e7b10545e021c47bbbb643bb451e5b903b0fac1d97"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "002bb376cc7002d8e88288e4734dd343b31868cb67381d1a2c1ec1abf89a0194",
-                                "uncompressed-sha256": "50622b739e620716c931f39e9c7bffbd2265653bd065d912279c80c5c9e731d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "b8990cf8252c15c662e91d35dc52706d5e6bf0dbd3e4a1de3360f88bb2148f02",
+                                "uncompressed-sha256": "d9023ff431b71fe5b0b2a8d5f1673d0bef60ef0a57144c56de9ae08415e08814"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-iso.x86_64.iso.sig",
-                                "sha256": "e218b34e83fe03de206cf2de6d59df930e8f3241b4d3b0769c39a38fcfd24d39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-live-iso.x86_64.iso.sig",
+                                "sha256": "7517391cb04bbce8959574f048f32fefc1deb47d27aa2b94b69884c2fc68cde4"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-kernel.x86_64.sig",
-                                "sha256": "adb5237403fc4c6ac061d3344e796fc2cdc0c90eda0643b9fdb522d2660f69a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-live-kernel.x86_64.sig",
+                                "sha256": "255cdc70532d6e23827f86b74242833136472022bde9adef8d773c1f32dba09e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "3032bad3f1332fcf6c084ac4ece040ab86e0b9aa75ae25e9d5b329db765f3d8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "805187be69b2b41d357d01bf9a278dec26826745a2fa6d942ca19d84af272d0c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "ef254781188442a57f81edc967d5eef83d61096e6354a359158f78240adc8a5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "13b8d624ddd3b307e07463d9c9e012315023fffe4c1ac194b4f3714b15c47823"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "9b3d54193e829fb8d8fa140356788f34a928e709d4737d5b77d56038e7d290b6",
-                                "uncompressed-sha256": "097fc0b29c47c6f3246d1dd6874671838c0e8ed5ee105c7773b3b6dd7dc7facb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "d7a49e64200604788cbe5d0d93c9a8c322d428dd1084499056cb022e7968bfb7",
+                                "uncompressed-sha256": "1bc195f039b777a255ef23fe37f1c0830d287d8a5339a225f651cecbe5af9e2f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9fa3705b1d4d6cb0a3f39ec3264e80c080d0ae5cd40ced57cecb2c7795c304d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "309bb4ca4ec96b3a092b64c1e6ae35afc07fd766e16b3c039671604ccc4609fd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2d3c30ddfd605b6350bd2b64968aa28218681e71c1cb33c1c8daa5efab9b1d41",
-                                "uncompressed-sha256": "002a0ef5a04c67d93397ea118f27628c6efaf24dace8fdd0154ed00ab978d43d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "a96a41cf7058b5d150abadf8b5402f7b8c3ea338051c925375813d46ca1a18cf",
+                                "uncompressed-sha256": "831c0f45ea072a81834a974aeda4b74b8b594b8519fbeb9bd332cd33b3dca71a"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0bd7b940345c871468d4b62778a4b7299db80ef0e52e353c77d8766057339723",
-                                "uncompressed-sha256": "0707038e014b79aad8278bd87fc235678519b342231b1bd2d487d5fcaad5d170"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "cab6ea297b1aa16efe672794973f469335adab59e2429f200d27f6b11d6863d6",
+                                "uncompressed-sha256": "66a01609b21bb61e1e8114850ef08d1e7d4b599ca0ccb4b0948a0efb98d839de"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "3d233c071bb66c40e29d11ced6641d9ce08770f42ea37fec23fa0facb0a85e3a",
-                                "uncompressed-sha256": "a00c53b8216f6fd004471b340a8da2d9e3a0fbc97270b2e159ff8b6cf88e9ce1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "dcef8517301711c8f51f6d264b1f0a956cd6f02b9150a540b21d0b022f17563c",
+                                "uncompressed-sha256": "b21cc6c8fa4acb7813232093415d8ef3c9efafe1acbcc023568f8e24e5ec999d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "17250aa977efcd889f615088ff0d43e59168c38d7c636e776794b4e86bf8d336",
-                                "uncompressed-sha256": "5cd9282a2c6e9266915d30d36e7bf67c7e322fe798087c8c7fbad6391d7764af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "de60a6a1f10723ef54621952665d3d72758a476fa32f58e47ce8756941f7bd75",
+                                "uncompressed-sha256": "30866e13921e79075ad73c1081206a5645b3c7b5fe6dc2ad55218ebf2607c507"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "c83e11f4fb7e26f21cab73cf2279e746263d2d1c69970c40b9f107e8db3bf9f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "bb22bfadd6e8f43495b505917aecc5cbbd3ddc135e4f4ddb299e09582e1850b9"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-vmware.x86_64.ova.sig",
-                                "sha256": "a875b5cf741b040c279ce002d71fff82bdca93e19655a600f9bf21d3c1fce403"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-vmware.x86_64.ova.sig",
+                                "sha256": "77133d99073ff2c6134931eb6a765e64eff969f2d65daafc4f0030fb458f8353"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250901.3.0/x86_64/fedora-coreos-42.20250901.3.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a8d287b321425ace44d652cb7960adb86b211e38930425a76c1b62c71c35a738",
-                                "uncompressed-sha256": "95e145775a04aee7b551b5e48e61a0bcc02d7c4b7a23f88d9e0fd530eab93ee4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/42.20250914.3.0/x86_64/fedora-coreos-42.20250914.3.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "13b19ef3f378c9a34f26c50c7da50bbd82c02681a946b91d196dad8957eed8c0",
+                                "uncompressed-sha256": "28cca071f3737f99399dddfdff14800f741af43ea215eb86f03048968d28e02d"
                             }
                         }
                     }
@@ -821,153 +821,153 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0d9acf6413ac9b0a3"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-095315aa5898fa99e"
                         },
                         "ap-east-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0d73e7e8ef3c58127"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0cf52f882fea784dd"
                         },
                         "ap-east-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0647a3ca3055fce7a"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-075d82eedeaca4e9e"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0508de514a3bda93e"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0e7f02faf6528fccf"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-015578e95d918a151"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-099471d1cc5e223a3"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0c58c9793ea5123b6"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0cbe51caff9a72531"
                         },
                         "ap-south-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0466f2bdfb36b1fe0"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-05e96e826770b78fd"
                         },
                         "ap-south-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0d6dcd530c7e3f0c9"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0d87aa8d1e4695b1f"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0765241181d93db6e"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-044385236694a2ded"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-03738797df3b3a457"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-069d6fa6fc2a054a5"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-01a62ee44fea152fd"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-08d3aa043e443f69f"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0a16d28477d51e8c1"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-03f8b522f979f4f6a"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-05170616e87cd8223"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-05aaaef1a72ac5ec7"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0ed27032a8ccf1add"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0d59b1fafaf267aad"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0e031266afd4d3fa7"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0b5997f054a4c6439"
                         },
                         "ca-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0a65ccd3a4e08e435"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-05418bbc83b87a40c"
                         },
                         "ca-west-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0b2fa90ef95fb664d"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-01733447e782a81cd"
                         },
                         "eu-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0c3b05e642456b61b"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0b0e5f2feb4aa1e1c"
                         },
                         "eu-central-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0167bc226e894be36"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0c945ac078ef9ee73"
                         },
                         "eu-north-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-017ccc03f676bec9e"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0edb08a7066e74317"
                         },
                         "eu-south-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-029de877c1e98e1c0"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-094c4770c74544a27"
                         },
                         "eu-south-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-06666aae6bc9f5fa1"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0aac06b38822c808f"
                         },
                         "eu-west-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0d012ab5a34aecb62"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0681793d4c8da1b65"
                         },
                         "eu-west-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0664521bc6439b0e2"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0c79c91d14f9796a2"
                         },
                         "eu-west-3": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0c2d46e3f0c71ec3f"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-00037e928c4a9d02c"
                         },
                         "il-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-06d758bfd0804e193"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-009ec19b40ac7af6f"
                         },
                         "me-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0af6120b73c945a2c"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0136bdbb178b80d01"
                         },
                         "me-south-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-00734f84d83887923"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-06ca33b239351674f"
                         },
                         "mx-central-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-09ad722e778453d61"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0c617c31e6e87223f"
                         },
                         "sa-east-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0efab073544451d0c"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0462a461c7eecab28"
                         },
                         "us-east-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-08031781c5f9097d1"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-064b5c44e077b77f6"
                         },
                         "us-east-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-024ef733546395641"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-03292a45e669c3405"
                         },
                         "us-west-1": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-047db74fa1df7a876"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0e190a6ac6f1fcda8"
                         },
                         "us-west-2": {
-                            "release": "42.20250901.3.0",
-                            "image": "ami-0b83de2aca017b5e4"
+                            "release": "42.20250914.3.0",
+                            "image": "ami-0574999428cfc6f19"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-42-20250901-3-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250914-3-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250901.3.0",
+                    "release": "42.20250914.3.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:7dec257523f441727220a7dc4e3ecce46228b27f2637ab1363f3be59b2f5a0ed"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9aae8d3bd6efc4d2fb0f49fb45d187bbfa2f98f33c1bf8f23093269e319f572f"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2025-09-15T21:02:09Z",
+        "last-modified": "2025-10-01T14:40:11Z",
         "generator": "fedora-coreos-stream-generator v0.2.18"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-applehv.aarch64.raw.gz.sig",
-                                "sha256": "b02d84b4d76ab4135cb41d298a787f46b4a1cca342a083c09eb323f44ef5ab18",
-                                "uncompressed-sha256": "4061db03a4da55dbc4f61c6e5e85f4ab8015f934754262f0a932620697731ebc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-applehv.aarch64.raw.gz.sig",
+                                "sha256": "4b996f0339d7149bbecedee624535f96ba95e127982a9788ed2267671fea78cb",
+                                "uncompressed-sha256": "f42ebf572a0cf7d6fa2ba711c5cb91426aa6168d6816863d532c4e94863469d9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "955aaa8b1f658298d6aed9013c6c8b447d3f1902cccab9ae02176be7c3e10d9a",
-                                "uncompressed-sha256": "ae6aba748b4045dc51e798724f6a66b2c171c95b505d0d84ce3c93fc8cee3fda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "eb6d19dc333477b0bcf2abc302be770e689e467fe9ff0f0ebbe46231a8abb13d",
+                                "uncompressed-sha256": "4e426119316442cba73cdcbe255b7e5e4cd961cddf3a53f791eafb3850546578"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-azure.aarch64.vhd.xz.sig",
-                                "sha256": "40740b5a7e925bcc9b04631dd24269f2569a9e80956139e82a29d4474ca072ef",
-                                "uncompressed-sha256": "397ad827d25304b487568163ea130ff1b13f4ae5617269f4dbc2b8f5a3288893"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5ac0cbc1bc0076597142f418accd8f08b96f95d9d72cb28ae530eb4fde135b38",
+                                "uncompressed-sha256": "8c8146c6c9174e7296d9c5576f53031079a2cd028c8ab5acd160fc5c3de76fdd"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-gcp.aarch64.tar.gz.sig",
-                                "sha256": "90d210984ade44d9719aa55d3a290722d690b3b13a95d254cfd2774eeae8080d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-gcp.aarch64.tar.gz.sig",
+                                "sha256": "d60896a40dd81bcb7119dbb6783f545352c9473422b823b0e88d50df76aa8893"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "24e858c4d6e534a2ae629d3ef8c538ac8f234b523ea99e4bd6a638f77a1b827b",
-                                "uncompressed-sha256": "5fd88a70185bb306338b6d4597600d1d712774ca23fb2643c2e9eba83038e8ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "4839bae746508e5cd9cf99ffe9646cdd83b621fcecec0bd521ea3456f3cb7ac7",
+                                "uncompressed-sha256": "2639ba4b20fc8183f4713605f427e1d6d23fc14986ccb4e8e0ae1aad251587f3"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "0e70969d97650c2e03b6e2353d1485b5b62dd202a0b852195a3af7cba6c6f484",
-                                "uncompressed-sha256": "bda3e1098753c3b846ccbc2de482c1622b3033680a5db691c1a854368c8ed572"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "b2c457d4525a9821c16ef882c29b6443e9127f9383a210d80d776c387ed49afe",
+                                "uncompressed-sha256": "1b23bd4d11469bf14f2c920e439b3386dbb2da84c082dbbefba5f6ee2d74c616"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "728335a25166153ef044c507f9956dfde9f6ad57d6f7dcc7b0226aabfc614c10",
-                                "uncompressed-sha256": "10a1025281a49733eac3d15d430825a433407263f07299928ec4f7cf1f61935a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "7eef7bdf3ec49d798b085cee8fe947afc4e6b4b07caad03deac66bb1224cb058",
+                                "uncompressed-sha256": "6393d9cb339900e6f7617867a71c2175e1eaf5dda9ea9755dda8045210966d57"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-iso.aarch64.iso.sig",
-                                "sha256": "8f2b4c7f9c4adb07914bc16160bdfb6c631090a323c745f1e0a8244e10a87379"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-live-iso.aarch64.iso.sig",
+                                "sha256": "0f6cffc303bbb6b9a5ee2484710f4971979f8f16ad76c08bfe718f01c2bda0b3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-kernel.aarch64.sig",
-                                "sha256": "9d403d7a67ace122129ef7593b2f5a4b0ae014083583d7722c6827013efb55e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-live-kernel.aarch64.sig",
+                                "sha256": "79c2e1c8b9df48724e422613e33cd67d49a83e81fc54f400132a7d9308b1a63a"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-initramfs.aarch64.img.sig",
-                                "sha256": "896f77b65c1d41ed0ba23640b7f4de2fda81c5d5b9e50aa0e5ea87c65e112ebb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "70631d4fe7b4cf0e48864130586da6da98976c9d2085b68030d4ba70517b61f3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-live-rootfs.aarch64.img.sig",
-                                "sha256": "d65c2cb7a8914d8bb33c2a170b69dfaa7fb2e9710383ca8f01441aa7227eab49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "d2fdc7fdfab970261a98082836db30d40cacc5a3c07f3be9176677f099685928"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-metal.aarch64.raw.xz.sig",
-                                "sha256": "426f655fb7a65ae26dda9173ba2ee856de1ef2cdade4bd77fcb32e574a3f9a53",
-                                "uncompressed-sha256": "a50966a48a486d1791d8a78cbfa0959d2cf1f8f77cce7e8624ce1e2d517de0ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "c7ede79c03af547c72069991fd2b1195db23189019805127823f3b038e1f829e",
+                                "uncompressed-sha256": "cc92a8ef5945ea32cbeb42020dc61635fde2380b43db56b7ba918f5345202b5c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "26b2a55427821307a9b8b2c213c3222b16d84258cc4247f17f3779f5c49b9606",
-                                "uncompressed-sha256": "33ad3db69b8695af4d1631d6f1157ad9c031948b3e7ea2fb47908f5757daa5f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e5f312f6e4b9a0807b3f78005a82b6c30044cccdffdaeb52668325639adb0c01",
+                                "uncompressed-sha256": "f2090f852b353f1ddd15f145ee1e0d477f47db342961456c73959ad88de98aee"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "ba41bc21add32beace5457f6ac5a37e02736fbe54e007f49eb81357f9edbcb8f",
-                                "uncompressed-sha256": "9d90482a83d155440c33768f350cfa78645e75742f17868ed95829053ab0e4cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "4a601a9870344fd5d5e8ccb1ce65e2006b44ff70b6f777403e46116eef8140a1",
+                                "uncompressed-sha256": "1f45d67a5b2f9061bc4e634ecab7fb811a5cb42d7eb895f9413dff5c2e187cee"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/aarch64/fedora-coreos-42.20250914.2.0-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "24fcb5ca51f2bde218cc44d4465e8d0245b3b95446719898de7866d7623c54c8",
-                                "uncompressed-sha256": "dd2b42397447f9befe10bfdb130ceaf03fa784b45be0d02a0f592130cbb75db3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/aarch64/fedora-coreos-42.20250929.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6c59449a14c680ad4c7e48df47cd244732cf8c666ca1e902e9d68432cef98924",
+                                "uncompressed-sha256": "d8ddd98ce6ef73a788e6af884e07a3f71ea11176e1f660f02eca8b36bb379be3"
                             }
                         }
                     }
@@ -173,233 +173,233 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0e16b3a0015217253"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-043b4e5649c554458"
                         },
                         "ap-east-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0cef7060655e3d640"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-08be6536c378917f7"
                         },
                         "ap-east-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0afc05cfc558fee0b"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-065b6ca86454432ee"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0110ef970e245e714"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-09b103628a12d7298"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-054e32f39641c9228"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-013e5b9c145319eed"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-047ae01a77e1be767"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-04670475ee3063905"
                         },
                         "ap-south-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-07b0870eff15ee0a9"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0dd543c6662f16f4c"
                         },
                         "ap-south-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-027564cb644943d08"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-09bb58ae6a5f3cba0"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-075c109a1792cbe92"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-051e6fd85ef443a76"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-07ea4d28f4613f2c5"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-08c82693299c8d936"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0c00323816a77f3aa"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-04db4d19547de811c"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0352625d896b38844"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-04ddf4219fd4e8e39"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-044423ebeb4080155"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-05b2ce72facaa95a5"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-054e9ad241e2ebfc8"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-071fa06d145f2af36"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0a1f09ae24bd7a194"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0dd501fcec1b02a54"
                         },
                         "ca-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0e5441f22344bbaed"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-02f3b224e08f5fda3"
                         },
                         "ca-west-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-07569ce0cd0e90d61"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-05949b5023060551a"
                         },
                         "eu-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0a9a842311d2f3ccc"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-09b907b58b43d3b1f"
                         },
                         "eu-central-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-02950935bc4529402"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-04ace0074d59b6550"
                         },
                         "eu-north-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0b6451cc16ddcd832"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0088b1ac2b88c1ac5"
                         },
                         "eu-south-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-05a39a704bc56fba7"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0d6237e19b711d581"
                         },
                         "eu-south-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0b7b1572df933ee6c"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-059d5dbbc95719766"
                         },
                         "eu-west-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0673513c148a153bf"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0ced2f3a632fd114a"
                         },
                         "eu-west-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-07599e697ba5bb96a"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-085850bd6e5332f6c"
                         },
                         "eu-west-3": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0e6ee99f336a3d58b"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0d7452e757c10b7f7"
                         },
                         "il-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0ede7fdcbd2c651bf"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-02f49366c1dfc8808"
                         },
                         "me-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-013722e5b0261b100"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-01a164cc1fcda2506"
                         },
                         "me-south-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0b8fd52388fdf8afb"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-09a80b292931a33de"
                         },
                         "mx-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-08577f4d49cc07d48"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-008bf2e169a3f04b4"
                         },
                         "sa-east-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0c46396a29ceb27fa"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0db50084db22d4497"
                         },
                         "us-east-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-068ca11081aa26fda"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0b38eefa9b7c85a83"
                         },
                         "us-east-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-012547a863a3a9373"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-03d52f4d2035c5755"
                         },
                         "us-west-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0929441f0fbeb948f"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-09362a7838c4f9267"
                         },
                         "us-west-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-060e7f225a27d5418"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-011cd9f85e9f408fb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-42-20250914-2-0-gcp-aarch64"
+                    "name": "fedora-coreos-42-20250929-2-0-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "bf55d94cff79e7d3b8403cfafc0fc1946c2f74c4bc81471daab4a5cd3c937985",
-                                "uncompressed-sha256": "611df8092e6cb93e3a1b16262e7e67e8ecf52340c0ae106fb694f91cf83b8995"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "369e30d487109e2c40205f27d42cafde6ebb72c703d57f13dd5d60240e45b7ab",
+                                "uncompressed-sha256": "ba048a903fbc06bedaa8adf6b572488c332e24aaabf79ac4487042b6897ce7e3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-iso.ppc64le.iso.sig",
-                                "sha256": "b428c86d02ff4e6d40553f0e6ccc2af7c962420d197f81c054167738cdab123a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-live-iso.ppc64le.iso.sig",
+                                "sha256": "87ff843e04e37be768ac13c10da88e88a4e82938f380eb5b135b690de982792b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-kernel.ppc64le.sig",
-                                "sha256": "f6722a51c646e6a15f0a69e01bf2ded92c5affe6481723ee944774744a83379e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-live-kernel.ppc64le.sig",
+                                "sha256": "db4744a90479d2e79dacc9325bf7cb50dd1ab71fb519a2982968e6aa35d444e5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-initramfs.ppc64le.img.sig",
-                                "sha256": "6f137238cb68e5ffc30d840634c6937373b405c4661ace8ec42502232eaec088"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e5327356210b99172d4f8255d43b80d7d31a35e09d15d50bda3303409beaad4c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-live-rootfs.ppc64le.img.sig",
-                                "sha256": "ee9cb692665513ddd282c43d348a5c35a0da39493704c7ee9af1b7d1c6597a7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f89a49734aadfdd9b945b916917b241625598215515f207b0ea0c1cfc2ba51b4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-metal.ppc64le.raw.xz.sig",
-                                "sha256": "c3ea5cc45e5cd750198cfcf1f86e9352be2c9062b978e7348e9aecde54eb6862",
-                                "uncompressed-sha256": "053c74ff8831b78150be4d83470747bfb92b424d84208c4a03e8e20e06b12f3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-metal.ppc64le.raw.xz.sig",
+                                "sha256": "d5ab1a1d21646c8501e941001092cc84f219ac54d68792368eef0c8dd9f69dc1",
+                                "uncompressed-sha256": "dee788c40baa29142091a3b0814da973bba50d59b6f05bcb29176979a24c44a5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "cc851231cd20d676697b55fdc7c9a281444a6a33c93feadf6c46a76d8f9b157a",
-                                "uncompressed-sha256": "daba47e25e9f69d70edb3af4d7747a42cbfedbcc80307981f1203a3c46b5aea5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "007e45e273576b120247c97545972f1f7c53934312ce0baa2cf5cfe8f90ea748",
+                                "uncompressed-sha256": "be8a3060aca91e2e990464c1f1d7853aedfe76f79173b84ba819c03718dd4a01"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b183b9b64983225f7150ca8adf3b77b8ffcefc41d5f4c28ada695a20984361fc",
-                                "uncompressed-sha256": "8953df5efcd3ef6457e6527b83e8af3659377020999ac4207bd2bc21ee62dadf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "acde230501152fe91e25420593ab7136f7f87e98b45a9bf94b352ee97bf8da18",
+                                "uncompressed-sha256": "32006522269e3284840ec395dacffd7f051ee74a3a213ad2c77a42a446bd3b14"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/ppc64le/fedora-coreos-42.20250914.2.0-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "565066930cff882b610befd9aa297e6fbe057f7127cb6c3a2e4c3f0b5cfa0bdd",
-                                "uncompressed-sha256": "8348f9b6aefb9c704d19f861cb376741b1fc325610e3e693d1190e9539b1e72f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/ppc64le/fedora-coreos-42.20250929.2.0-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "2cb4a794b1d7b86c7b79b80e9c1070a3f6e8dcd692538ba843cb129448051d6f",
+                                "uncompressed-sha256": "4b885b4ba829d79dde8544f0a722465624fb8d8aacd18cd25d408370cb2192f3"
                             }
                         }
                     }
@@ -410,97 +410,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "cbf8b8bf40a2d7a0b20dc33b2232f30f3052b67183e8c3d619c2adb4838647b4",
-                                "uncompressed-sha256": "bbe9fa32a46f7e9bd306abeb45eeaa736da4f7d031db2936c57b6ac1ef2080f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "c04d5343ac8193225f8c9b6ee7f4cc128c69c406e261f5b34059d7bf82140ab2",
+                                "uncompressed-sha256": "43ef023e4eaf371c4c2eafeb362a500c5b9244c0b5be8926e01af32c439dce80"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "4f0556363ef485b12b308d86bd824a872a1427c135384e003af8575a2536060a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "9d8e9fa7b88e41f7d64f725161ba7e6a8beaba609b6309dccb71073cf740441d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-metal4k.s390x.raw.xz.sig",
-                                "sha256": "87908433a2d3354fc334c46cbee0d07d4e304bb98b9c30cb70a73a82288b08f9",
-                                "uncompressed-sha256": "3c11f391ffcfc8c9bcf5483deaec94a1e06c523089e294ecb757731bb38275d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-metal4k.s390x.raw.xz.sig",
+                                "sha256": "27ee970226bc79b9c0ae5d6d2d17d549648d31e234ab4d4180dc33c4973ee396",
+                                "uncompressed-sha256": "9c32505e135f704d7c0684fcb6cbad48351ae910e9c23758cb514e2cab2a6621"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-iso.s390x.iso.sig",
-                                "sha256": "b0604ecd24973e58955bad1aae29785bf4b9dd2412567f8addf95215b82ee746"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-live-iso.s390x.iso.sig",
+                                "sha256": "79d60cd1ba9817627a0077e6a51af09da45ca6d441df2686fb60fd7bb6914b6c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-kernel.s390x.sig",
-                                "sha256": "877752631faf1ace0e0875751cd11ac90c03f5e90fadc879276005f81d1fd97f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-live-kernel.s390x.sig",
+                                "sha256": "f954ed4829add6c91659b8287ac77ee18f06af5bd65090c1270b76fb4348f46b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-initramfs.s390x.img.sig",
-                                "sha256": "cd3ffd06d234417119c6cecec4773a9517ca1f0b6eb91653e74c30aca4ecd8b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-live-initramfs.s390x.img.sig",
+                                "sha256": "777628e5a8b736a80bdd6deed4849099e42393a73016f61d0a3f95976073046a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-live-rootfs.s390x.img.sig",
-                                "sha256": "e64cb694fb7cf3b2904d4c3e02a342db7bb79eedceff6df903a360a4b324706c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-live-rootfs.s390x.img.sig",
+                                "sha256": "bb706077a0894dcc21bad96e7c1beec8bbdc5be1d26bbfb56388dfc3f70cc0fd"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-metal.s390x.raw.xz.sig",
-                                "sha256": "7e57d6ea5b6b77ea201e3960a2a8fdd6d08b79f0ae6cba9e08af4d3883a55288",
-                                "uncompressed-sha256": "47bd15c68dc47348161323bf36073f6b74c301060dcff58668aec72f82464fdc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-metal.s390x.raw.xz.sig",
+                                "sha256": "c3e27247b90c4d2feafc1b1e8babe62872b4c5ca8faf3c870749945bf99669f7",
+                                "uncompressed-sha256": "e3f7ab7a6d7369377c30847a0aec9927236352871ca488b6becad9f87101a17d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "89af52cf794c8666cbd2dd74d956248e879f5e9125cf8447bd03e7267cfada45",
-                                "uncompressed-sha256": "1e8c886dbebcacebbfb1506cb1990daa5a0963218f8cad010a5590c2cf6cdfcf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5fddd0b3528106055b3a336eb0ef85c9e2ccbb466ad6622abe7d79c6852f120e",
+                                "uncompressed-sha256": "3b6ec0ac1538634f5ae3064e6abbb0dbab55760bdc6bf3ab4a69fcd5eb5f5c40"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/s390x/fedora-coreos-42.20250914.2.0-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "baae4e1a7b161bd60e04f1d6f75eee0487b56b59f1ba9b0420216863004c1128",
-                                "uncompressed-sha256": "0c792dfd19d5b864494e657bd03a51b3ebbbfc0fd842eb47969ecd723139becc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/s390x/fedora-coreos-42.20250929.2.0-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "67c5a3de21ff6fd3be41fa7194b21574942b15198f53e52c1147eb5b44916476",
+                                "uncompressed-sha256": "acfdb3a489bfa67cf150c05fdb05970e690eef27a9f1133676ad9387000debe4"
                             }
                         }
                     }
@@ -508,310 +508,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d4cb3b87fa04b061303dbeb91562dbd1e80f6e819f33e9bf86b351f394917859"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0b7c0e0c51007af3f37ed88f16882c8cda8109a839623e58039ef542c5fdc83e"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "2dd1dd5fb8364e1564db3b71063706f6c573bb6bd3cb1adf40943716a5cde5c9",
-                                "uncompressed-sha256": "757f4409fca161714511ac08b6c71771db75364961bc96e606aeb9866d2ed623"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "43846c7f4d142c47ad80d680e60f6e7fd174949088a823341a23ba36f22c78cd",
+                                "uncompressed-sha256": "4c1df73be9d459b57c3914ea67dd1ac122cbec523b0b1cfa9c29a6c4d68afe5b"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-applehv.x86_64.raw.gz.sig",
-                                "sha256": "36848f0a233cfeb7c10223e6a5652c002d435e2d8c65f1fc2150b57ea32fe350",
-                                "uncompressed-sha256": "906b9c74396e7923befbbdea84aeb0a610facce2d2b707e7605e2c3dcac0bb4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-applehv.x86_64.raw.gz.sig",
+                                "sha256": "cce9c82928723a89ffbf4d98bb5f61427335aba041a209b9253fc4df67611954",
+                                "uncompressed-sha256": "55efdefe9f48f6818ce101b112ad4dcc395b93768c3f58fa197e0fffd4baece0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "8e7f8d632e18c2b52233633d4186a0a2a1b93c71140160a897d374f0b7837a94",
-                                "uncompressed-sha256": "99ea1560089fc0a72a25e4f4e26e3015ceef7f79efd8e91e60f087eee612a962"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "cd9fe66feebab297dfea5857d5fc24bf5d089be936c66ef917b538f6bdc8e7e3",
+                                "uncompressed-sha256": "348c8661ea1eab2b21c061c132bee034402f301c32cd4811fb88726b63c3cae2"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e355897a27a9946186982d9a7324c36b4506b7dd717801c30e38d5949577df11",
-                                "uncompressed-sha256": "3cc4615ef4abd043cbf9d3ea70776bb16e61760810d4ef964631c550217eca14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9da788265957dab504f93a6316f4a77e0f87e4b144ecf9272b1ec5eb61df3a5b",
+                                "uncompressed-sha256": "496c70ec3f08001faf480c2f1c66779302b9f63c367f32e65ee0c5686dd6c70f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0622b99cfc24c0e1a759df57e459cbdebe2e3f45c34bcebc942c5e69f7ed55d7",
-                                "uncompressed-sha256": "a07e8182d6d0d2c86f1e4018cec6962fbc205451d8c703bb7c2d16f974fefd16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "46cced5095e0841ce2864d2dc775e9fdcaf8982e210683696d1681338da23c65",
+                                "uncompressed-sha256": "161ac77745a9a2ea2afe20e794c633ba2d2527228d124b087e104300c4dc0c30"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "b944894ecd7e4c8118acaf8295c0350a56f4c5e6140e5170b25ac8d921f0c241",
-                                "uncompressed-sha256": "213c164602d378696badbfc66fea7f4fd8df7d83c4cb8487dbbb1d61a2e9aeef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7ef4dd407cbf01fd867d444f0566a19c6ff8628e54caf44c31ba0ead2d586d48",
+                                "uncompressed-sha256": "a810ee0d5d3ce2dba9254df3c7adc63f05c8ef683dc71c2f1a1f059ced22e7eb"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "76c37eae45f88ad0e8fd325aa1a2f511b0e74b6f30fdee8847704ef4a815cb31",
-                                "uncompressed-sha256": "fcccd85621b5d90ba2f1c73523dd5ae2d1df06f6204e4c01c596fb0bdf3aa113"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e4b19edeacc9d00eaf902c40844d77fe77561980504ced2d2e53770241f9e256",
+                                "uncompressed-sha256": "9769f8896cdc629b64f56cd2d51c65c374ef3c9ccdcb7aadccf9c982cc68e92e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "c2b10a3f7dd4db65f77af5345bd01206ae816bf335e1d223e5a3570234e6a30c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "67df24afaa9bcde7e172e18358aa79394310e7a9f833ddab6ca7ab55930c4e77"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "e38bea1a2775fff92e54d73f90596c82476376cce408031928c38e1c89b90f83",
-                                "uncompressed-sha256": "cc33b39f2246161d2678dd5f00e82d1219220ac50f879edd46941d5c1c79a3cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "7dbf917c100b47938218994898d30bdc318fa3f8bd800072912cfcc2fbda29f3",
+                                "uncompressed-sha256": "ea420faeeea7948092f68ac7b4a8e82798836c0d631b844a3af83f567f9db93e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "6c3b23fc442cb7b661fcadc1b7eb23ffd81cc55ae5f71157f3001831c0d35784",
-                                "uncompressed-sha256": "fc1dd9e1be53b1ae503f191e07b5f4256469ff7bbb873e2bcbb124da0c524f98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "d291db4174be139858aa6a0e01d50f9e17cf14ed8e5763e137e47172659af08d",
+                                "uncompressed-sha256": "bfa370a617a2b4b3bf34ba79a30bcb3d1f9e3e9c07814b15d29c66e3e59451fc"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "08e3900e5d21e17f0ee94a9916ebcf58889ec5ad6ece4b955fa0e1c15a8f5402",
-                                "uncompressed-sha256": "c283bbc3a7a7b418677a0a36ee87f2287f7f85874cd8e44c2088b2934dd39225"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "07c845e86a3e6fa35c69188db3d102e1babee30fdd3b1383ac0be462d2e3d07a",
+                                "uncompressed-sha256": "ae8449a0b665662f8345b31e23c8c24ebe9916a5c0e8b8f912b5f25c07efaa31"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ecab4530286a5c61a538f22d5fd7341dc4267828904289b45634378e99be2c22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "4972c90c3b1a6facc963072880b0ae30dba01e59a2ef24f016beebb1a4315598"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "23b1f48228a60dbf62acf9a3b8a230b266e3cc6979a81a2f57cb03e9271d930d",
-                                "uncompressed-sha256": "f9f8f96454145cb1d461e2c8d800eeb60b8bc1cc11e77a1c2b4bdff92e41b607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3561bceb269f64591821502aef8efa9a8a17cfee314ad768605e63ca69e6d958",
+                                "uncompressed-sha256": "4950042f3e5bb3b90e2d745894eb691e6c5a174128db14445fe1ac4bfc82138a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-iso.x86_64.iso.sig",
-                                "sha256": "2f9f3b2077443a562aea6279ce989190cf1d97215662706ca461566d67d36c72"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-live-iso.x86_64.iso.sig",
+                                "sha256": "eefe61b0e994c6d3fd9eafaf2707a7b6a7739060228ddb2538be2f4c6c56cda2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-kernel.x86_64.sig",
-                                "sha256": "255cdc70532d6e23827f86b74242833136472022bde9adef8d773c1f32dba09e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-live-kernel.x86_64.sig",
+                                "sha256": "68da45d01bd64e9963ea558559b2ff9772e4b38c3460b844900e2b4462a1025e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "ef960a5e2e82ebde21849c0cbd4dbf73e68471d2d0bf2fd2bca9f790094c1f86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "184bd02c7cc1373acd1d155bc74872aa10e2d2d8f7fd668b2880c1089e6c71ca"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "91bab36b96df2a8616208a4f4b5f5c61959e1ceae85ddaa323c24c1621849a37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "e01c896bf0b38b97eb7f21511de8ab818175de0ad7ab3a03fb365e216ef66c07"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "5b57580bc239b6e3947eed7587abb9d623a78bc9eab8b30f92ebdd3074a3aff9",
-                                "uncompressed-sha256": "53134596856a000a4325a17ac806ab372c8f2c40b68e083ace69b965656e90aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "bab65fb4b3bcab55d2d488413db140b1b3ae442bce1e65682f10c1dbc4c0f649",
+                                "uncompressed-sha256": "dffeeb733444e30f2987af4ba4631646743cb5a94645936e533efc52a19b132c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-nutanix.x86_64.qcow2.sig",
-                                "sha256": "a7a585e757339d3e38c98798b3e167f93e11c3acc6c47e5f12096d6d5271417d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f78ccbe6923677a8d68bb12e940d647ef50378a3b319e3efb2aeda5d283a7e06"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1dba39e67a4ace9aea2052dd2a56575b430891211e05bd0c8af7aa2dfb3d0227",
-                                "uncompressed-sha256": "9efc6038a1e82c0a7bbb0b70d8860dcf7c2dc9134406e83a91624bc27361e453"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "fb6a1ab00820a20c0fcf72013cf74a65927abcfc45a268eaf54909567f143f38",
+                                "uncompressed-sha256": "b3338440c322c66ce77b3a7e6e0c53261bc1a782c482460419d8967419417e6f"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "88ba2496baf6f3bebf181a3868346146022e951f781fa8af387fd13ead48df4b",
-                                "uncompressed-sha256": "9f374ee66e8b25839116bd5bd36a0c1be4127bb5cb3040aca0338ac55b427ba9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4e30c6ca95d11bed4e8825090349b79c5a2d4c6760875860270c9f5267a58a3e",
+                                "uncompressed-sha256": "631e4a31f73eb1592b0b17317494ea2a9b0959e08e65a38641a9cb86cb0549cd"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "a0750e09ea165fb118bfac453b3e4f036157b7c70e65ff610a6c856de1579931",
-                                "uncompressed-sha256": "a373405f5b2be5c660e5a517ad9651ee4e2645bc091bc79a21fe6e7afae25155"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "6fddd09a60ed31863935281acec8c975201254d5ad89c65b88d32f39b2dda9e5",
+                                "uncompressed-sha256": "b04beb7b1010493df2ca4a80ca6fb9e8fe50349a67d0a6b09f2fddd52c436c44"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "7f032482b77428be09fed4eda9d411338730aaa95d43fb14001b8283f23e5aee",
-                                "uncompressed-sha256": "f8303d0b09c6ca4d98c5a2d93849a15ef469c78b00cf664718a284f1ee3e0cb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7bda97cc1a388113711e0f6b8be85f11fa9420014fc1abbe02afeb7bc5dca924",
+                                "uncompressed-sha256": "50240bcafd9f31c5d76a4dc5953090b160e12079fb16ee55053998043ee3c8d6"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-virtualbox.x86_64.ova.sig",
-                                "sha256": "76c169fd28c2280913f55cceb6b279c9a7fe17607796635beb77a3907a46ca00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-virtualbox.x86_64.ova.sig",
+                                "sha256": "5b4bb42e6392dc9c2d5e05309d31b191b56bbe433ce9c8b971d6ae24b307d26a"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "714cf0cfb36dcad2a41a81a0d1f7493d9847ccbc3861e5227d8da74977b84407"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "a1a421f0e4caa155f30f7336fd56311c00e90a1967319215344a66f474210702"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250914.2.0/x86_64/fedora-coreos-42.20250914.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "dd3d37d3cebced20522251664f0bd86a3e548c0e1c7a1903b976ab12824129f0",
-                                "uncompressed-sha256": "88f08de5818b375d9e90085e12c609d76ee4df94696a47a016042de8c71cf4c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/42.20250929.2.0/x86_64/fedora-coreos-42.20250929.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "f1106cd07603f2148a3a6350d6ed0e8fdeacbcd55193bfec6fd17e89720a862b",
+                                "uncompressed-sha256": "488550add78477ee90f7b3bb509ef5d206476f8c315cf3de51c501ecb42cd869"
                             }
                         }
                     }
@@ -821,153 +821,153 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-093972ca75ecaec69"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0582883f47279c8fb"
                         },
                         "ap-east-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0e94bffcbd6833c02"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0ec900cb180e13e3e"
                         },
                         "ap-east-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0f16b6e03b1cca0d8"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-00a8af64f8350ac32"
                         },
                         "ap-northeast-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-04b5ebec928dc7650"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-06899815ed77c8e64"
                         },
                         "ap-northeast-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0e4361f37792d3164"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0d5d81f7b6967f4dc"
                         },
                         "ap-northeast-3": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-06b3fe7a02fe566b2"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-056a77706417b319f"
                         },
                         "ap-south-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0f5cb05e1b351d0e8"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-01c3225d3059e9871"
                         },
                         "ap-south-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0fadaad747f21eeb9"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0d4e45187956b63b6"
                         },
                         "ap-southeast-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0e6efaefa66e7214a"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-00395e11916184490"
                         },
                         "ap-southeast-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0e1831acc483a256a"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0b399bf836c107596"
                         },
                         "ap-southeast-3": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-09d95c5c19527bce0"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0a2df3c5cb524b1c7"
                         },
                         "ap-southeast-4": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0739bb62fad7ac654"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0eef37d2d5dc153cd"
                         },
                         "ap-southeast-5": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0d1a064a92d185203"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-081d6dfdfbc693a66"
                         },
                         "ap-southeast-6": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-000d0fd47a149c71d"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-014bd692e7c356839"
                         },
                         "ap-southeast-7": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0ce7c4337b5bade78"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0e75ef567d9b128c7"
                         },
                         "ca-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-063f89fa722d11b93"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0423e1010d6ed14af"
                         },
                         "ca-west-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-08cfa56585256521b"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-096d5a612af74be9d"
                         },
                         "eu-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0274fee471c1b6130"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0f723ec040d13b6d6"
                         },
                         "eu-central-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-08d0d966f25c9db6c"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0c34f21591b353fcc"
                         },
                         "eu-north-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0c83852458ad156aa"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-04803b28bb57b204b"
                         },
                         "eu-south-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-00a8302deba00d442"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0787f8ba8683f2782"
                         },
                         "eu-south-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0f5455de04dd51161"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0d4430903efdcaaba"
                         },
                         "eu-west-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0684caaed6227e449"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-01f1e76fcf492006a"
                         },
                         "eu-west-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-050c606ca43e52d99"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0b07166f67a01bdb7"
                         },
                         "eu-west-3": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-05fd192b3c8a9ce94"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0c3dc1b9c52e8c59f"
                         },
                         "il-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0065a47c70578315e"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0f602c278b1d01003"
                         },
                         "me-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0aebc83c2f654d547"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-077b2c85845e61e4c"
                         },
                         "me-south-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0d2288f0fe471de3d"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-05a9fb4aa75b70497"
                         },
                         "mx-central-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-09a57927dd33ad45d"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-02eab0c5613d15c7e"
                         },
                         "sa-east-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-01c62e57751993662"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0621b4823323ccc86"
                         },
                         "us-east-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0eb53aef6297adc89"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0ae6b3166ab28fbad"
                         },
                         "us-east-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-0fee38da8cbe8b06f"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0fdd608faa81b8147"
                         },
                         "us-west-1": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-02c873e1154116dc3"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0f29ebe77823d3fd6"
                         },
                         "us-west-2": {
-                            "release": "42.20250914.2.0",
-                            "image": "ami-031aaa57711d58452"
+                            "release": "42.20250929.2.0",
+                            "image": "ami-0a5f67debae6dd837"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-42-20250914-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-42-20250929-2-0-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "42.20250914.2.0",
+                    "release": "42.20250929.2.0",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:1bb487f3787cf155faaa50acc5f34dc2b65ead91973ccd46af32b5536ca62738"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6f3cc02aa46899c77dd14646623e9b7444c49c025a28791b04ec3d54407b76a5"
                 }
             }
         }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2025-09-15T21:02:08Z"
+    "last-modified": "2025-10-01T14:40:11Z"
   },
   "releases": [
     {
@@ -129,9 +129,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -139,8 +136,16 @@
       "version": "42.20250901.3.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "42.20250914.3.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1758031200,
+          "start_epoch": 1759330800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2025-09-15T21:02:09Z"
+    "last-modified": "2025-10-01T14:40:12Z"
   },
   "releases": [
     {
@@ -145,9 +145,6 @@
       "metadata": {
         "barrier": {
           "reason": "https://github.com/coreos/fedora-coreos-tracker/issues/1890"
-        },
-        "rollout": {
-          "start_percentage": 1.0
         }
       }
     },
@@ -155,8 +152,16 @@
       "version": "42.20250914.2.0",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "42.20250929.2.0",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1758031200,
+          "start_epoch": 1759330800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @tlbueno via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).