### PR TITLE
updates: pause testing rollout for 43.20260217.2.1

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -163,16 +163,6 @@
           "start_percentage": 1.0
         }
       }
-    },
-    {
-      "version": "43.20260217.2.1",
-      "metadata": {
-        "rollout": {
-          "duration_minutes": 2880,
-          "start_epoch": 1771432200,
-          "start_percentage": 0.0
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
Upgrades are not working, see https://github.com/coreos/fedora-coreos-tracker/issues/2112