### PR TITLE
Roll out stable 43.20260331.3.1, testing 43.20260413.2.1, next 44.20260414.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-04-07T18:08:52Z",
+        "last-modified": "2026-04-15T16:36:04Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "5167e32fa214ba17aa7a84f2f3d4041e001ac8a512b661039aca0be4af39ed34",
-                                "uncompressed-sha256": "258a056e07480fc1212051497439d7169a2d35d5f0a10b6e4868ea1e2fc9621e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "adb9d27b352a07576b5fa484c55ebb3e115266dfbbff929dfe48213392858289",
+                                "uncompressed-sha256": "2098e3c82c5fa76a71702d940b6f8cd8970fd4154f6fd674af3aaa9c6f3d0ff7"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "945503c232dea18779acd916c71bcfc36727327a3c867161e53aca869ed55c3b",
-                                "uncompressed-sha256": "06b03de65c9a6f68398c527ee63f7b07f33935b71581837a628e6f0b37890769"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "82ad839ad455f28e374b202d0c012c00e2beae399197b5d2c864dce836ae1d53",
+                                "uncompressed-sha256": "0c8546d3e853f03e9eb02430d01fd9411b238b0192b27c67e05b8111d8e1838c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ec967be179314f01421809c4b86f0f6dce9822d9c57f053147cb48911af1ded6",
-                                "uncompressed-sha256": "0b1b654499cab7557c11903a951fc630f8f6f57d7964834fdc3e0638ae127a25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1db9148401c63d33b9dcfc3ca0b22ec424d52d111475c5b81aca03042e90e4c1",
+                                "uncompressed-sha256": "dbd8cd762d2d4bec48f5ac5211ab8e248ab3789f9e8c8e47f5d32bdc9064cd74"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3b54933355d709a470e2be00563dc505fe9b6e02120d051d207d8f2c19cfd065"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "e52893bc25c93481b50d1c97cf2263d1ecc3a3628e4407be0bbae4db2ea3f8a8"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "9316d80888579dfb1e538785b3b3a81ab1a3d05b71141f36c5c233e5cb9ef401",
-                                "uncompressed-sha256": "0cdda8807182f54962f2f579dc28917a47d82fa68af175408ca4233d66be64ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "07c6506c5849461b9d90d39b4bb7d8bca3dd17ff7e692e834c3ebe174e0d6e98",
+                                "uncompressed-sha256": "ddaa2cf2f3834b22bec562c95036c453aa9e13f048c34cdd83671d8b1135ff05"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "7264505da1baac96a3ec4acc87cf25c8d76a02f5b96f11c9914497a361a608fe",
-                                "uncompressed-sha256": "30a495e25527da2f3f45814ae04c541978736e71eaec1500bd6afbf7ad5bb6fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "90c7bb299a1d64bfbea63b31182f98eb5c819f4ffd018a7a82bddb232c28a646",
+                                "uncompressed-sha256": "ad46956291e59ec8c8204ab7d7d8c5f051a98d883f0a79da8c07830e28d82620"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "1a3ad7e748569d2b45970770a023cb293447989380ebc3d179f10defbc9596d3",
-                                "uncompressed-sha256": "cd53cca8aef72cb91e299918b10ce1c08f0796c3d3db3cc3ce559332d802373e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "5b725bff50d44c559d5bcc79271d4640d6bb93c25fecdcaf02ecac6d9fa02f61",
+                                "uncompressed-sha256": "ef42a9341d5c740dabc6147304a21464b170a2dd3f1455417b65f85a564fc8e4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "bec4fdfa22c3c5fb7f3d0a610fd170654aecab1f6f22e94813c111e55cb06e42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-live-iso.aarch64.iso.sig",
+                                "sha256": "19c05c44d161ce9842c75ba6c9195c927bce3dc7377a75e0e0ebfa55b1ed5a1f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-live-kernel.aarch64.sig",
-                                "sha256": "e55a5f9a9177267f58d1e957f58e6b294a4552cfe7cdf72174e686edd6b474da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-live-kernel.aarch64.sig",
+                                "sha256": "d33744c96ce290dcc8649d80cbb3abe956f661e93a632ba56bc559384d128c24"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "b6c391d9c06acce35ea8ad94088112b1b1daa78924aa0f35187f94e6be8d04ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "487d918f3e31902267f0436ce8e2aeaa4faef1215cc22cc8a5e99f13bd94383c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "32ef848d82d8ab640231a902ae41b021b522c88e3099f69aa8961d7e511cef0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "e34b9104b94e031859ba3583e6c7ac233f4d026c0d725e17b951820c33b5e243"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "b056ca6b45d0011748f7a9557104417c0bd824029157d9b92170f3a7a7ddb975",
-                                "uncompressed-sha256": "99e1db51134d2b6ec6d780b58b7547938b209d2d4b15185b5628812c558dbd33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "b05c14b930bd30a8f62262cca40d6b448cb341f33811ebcdf67d7fa9a1283cea",
+                                "uncompressed-sha256": "d055cdbaf93f538778d8912f3d72e1e6e8ecd15179359046e4d209011899b55c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "9c65a8676ee1b733a2627933952e9e94b92ccc1a9d3b810552dc98d64bc58d02",
-                                "uncompressed-sha256": "6426ab0be578cfbbeac91382a0f83a366c7308f123060cfd014e834d3ff41f5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4e9029c6657736d34222d80b77226c6601621f1cc395e013e470e9e9d009fc27",
+                                "uncompressed-sha256": "30a02a8e911347013c9d04b4aa0dfce2244dcf27d4ea994a327b8e41af75cfbb"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "9caf30b0820e118f40890fb56f59699b0fe30fbcd3c580e824a6e8812501cc63",
-                                "uncompressed-sha256": "9384edf1fec278dddd4c82e5260a3a027182ba616e5f57701e966153b6571090"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "7ba92e65047353a58339d1f5bb8659fa5215846775e1304c994a0adee6f03481",
+                                "uncompressed-sha256": "d989a4fb449accb21c3ed339a4a837f9a98fba1109b0686610f634f381a79105"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/aarch64/fedora-coreos-44.20260405.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "80638dfa5bdfe50fc3f69d045b080d4ba7f012b17ab839a7770a02b7080eb7e2",
-                                "uncompressed-sha256": "2b1db6ee5d259e8a546fd263d53ddc8cdbd94ea1d137b85dd9411c59e669405b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/aarch64/fedora-coreos-44.20260414.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "79fc2dd931e507e78d9ac34edc7868754e8e52e639166f247567db62c1163b82",
+                                "uncompressed-sha256": "2d939a673d8a6f97139bcb14745a1b7b54ec8e83d0cfa3d002f332ab0cb7949e"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-01c6216454adcdf1d"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-04ab6e54f41e47dac"
                         },
                         "ap-east-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-06002daf604562244"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-003c51423a62d4f10"
                         },
                         "ap-east-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-088c243fd3cba9046"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-01f95403e40df2c7e"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0c3cd394437c19180"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-00e53b09b9bc5c38a"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0e0d953869a5ef2a6"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0a7223d60e38cd3da"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0cb2e54e9b2508aee"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-03c5a9ec538f69a03"
                         },
                         "ap-south-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-03a56443522200152"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-003978e4ecff3e37f"
                         },
                         "ap-south-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-01208945aca11e2ce"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-05cbaec0326ea0ab8"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-05954214a22dff62c"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-00713b9e039ae6e71"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0271a9251ceb9f52c"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-077eba87a6c31846b"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0887d4e21ead3481d"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-009bf84245c554e6e"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-09b33448dd5a89405"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-097a4a64ad4e3a433"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-05cbf4d64d25b6c52"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-099414f9cd43c5a0c"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-086dfacd52fc53a51"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-02a785d02dd632a6a"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0fabdb1645d7ed6c3"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0c13dacf106d550b1"
                         },
                         "ca-central-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-04cfbd9af19ed7df2"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0698abe02fc84f060"
                         },
                         "ca-west-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-08a14039ef9303dc5"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0c72d99112318c6e1"
                         },
                         "eu-central-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-015c27d1eda709d84"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0752099c259e8a13e"
                         },
                         "eu-central-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-05296fa17d5662fcc"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-08d0346bdb36e755f"
                         },
                         "eu-north-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0598dad7b8e2ff459"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-08f12691ce7da8b6a"
                         },
                         "eu-south-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-08a72e097577b3536"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-078ce1cdae682aa4b"
                         },
                         "eu-south-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0e8d43f4626d5b2b6"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-01dfba5d5f5a97a96"
                         },
                         "eu-west-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-04a24a0323bca9d55"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-066e00d5b8184a6b1"
                         },
                         "eu-west-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0cfa060b996779e34"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0cb71dba2f303171f"
                         },
                         "eu-west-3": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-027fb089fa022c94d"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0dd68c19d27e48275"
                         },
                         "il-central-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-048d0ebd79dcbaf06"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0b08da84582e5e46a"
                         },
                         "mx-central-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0920a401eb0b43d04"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-023c58d8c44fa20b1"
                         },
                         "sa-east-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-06d15941d5aba2c4d"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-027614cef8dba3913"
                         },
                         "us-east-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0bc502c2242883446"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-035369a016a465193"
                         },
                         "us-east-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-097838fe73e4258e4"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0eb10fea0a93733fe"
                         },
                         "us-west-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-022062fcfedbc64c5"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-023a185813285a81c"
                         },
                         "us-west-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0464d66b3df1d9f44"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0bf48a3df609a8ea7"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260405-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260414-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "caa1db5a5b649373ac9fcc8766e27f6a4103232cc638a950dc42a8453badc851",
-                                "uncompressed-sha256": "3869428dd6095c2558dedf6ba311e24b7db5c74d7205d02fa97fecc25dccda47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "8b32233fbf1ff8cc6402fb0666ea1761832f23a3a6bbbdf915daa21ae94749c2",
+                                "uncompressed-sha256": "ea4ce62608a056c56dd236dedac9de3c4091a011f216f3743d9d33ca63967519"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "f932a92d78e6578cd02d6abdb0489ec562eacc294c61fc43744e7aa31a87aa10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "ff708f052c771061eaa45ebbe60a4f4afb233f39fd960fea30a609d55afb9159"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "daf5a8fd71682cc8724b4c26369ab4041e18631235134c70b3b804789b84a454"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-live-kernel.ppc64le.sig",
+                                "sha256": "c0feb764e6f637d851bbadf1663c9539d594728925ea69179671792ad2bd14c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "03d9314533be6427a89f2ae5a9cf95389ae837b67adf4294dab2cdd1c2738f14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "64d9d17a47e460faa928d81f51e25ddaaa87601e3fd69eff4d23e2edcc8103b6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "b7ef1ffb3fa3a37a2d8b9f65e0806fe89f510b1129d34f56eecd02e6f7c06045"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "d3482f05cead6c913ecbd9f25dd344f7aa243582e3e1db27e01597e4ad2e9ec7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "bdc8b2ce4888a7fbe221504fbe392b8e4a67b05a9e99d56df276499a5dd8c7a1",
-                                "uncompressed-sha256": "34bc59b7cceec0964bd4a3b12f1080e4013c3a73dc0716f5e7622b58d819bbbe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "e54151ba4c3a7a3e0fe10d38cfeeb7225a74c3fea96ebce91f34f4dbed031b51",
+                                "uncompressed-sha256": "77b15bef3582c085ebc1f4edb084fb5e5ac730fbd427411c2fbcf6ff05a9be94"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "c7d5ce85506c8801a0dd1793b48c28a0518d4c00f46277f3d36959f543e77594",
-                                "uncompressed-sha256": "c87c9605aa3eaf36a4e1709f23eb757d0c81559eb1c84b8f2532b39fce1f17fe"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "440258b6bdb161d32fb71e904e85be704d78651ad925b2efc9a477f72594e750",
+                                "uncompressed-sha256": "db900e02f2725f1dd481c6fda195b54b3c9fa236fafbe23db7a9a0c03c490646"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "7ec2541020c030c311b352637d8fbd073a193ac30d5a49f43a1cb41cc39aa182",
-                                "uncompressed-sha256": "0dc21adf1dbc7b3de170ec2d6573a8c8adcf35c777411efd39de70717fbb570a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "a38c3c106ed990e9b0a1771645f2ceabdefe42f7069f38068427befb57bf68e2",
+                                "uncompressed-sha256": "196e6569b76b4272b3fcd7545470a95ea18ab71849c81a50152bb9a2d0a89b51"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/ppc64le/fedora-coreos-44.20260405.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "b9d2d1305911a66127ad7534ea12ec4316f5bcc78dfd32d448930f9f9941717e",
-                                "uncompressed-sha256": "6b89b59fba4b5b59919bd95d90f1a7cd2093211c6eac32d71fab89e61c0c02f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/ppc64le/fedora-coreos-44.20260414.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "94d282e12cf1860f5de2d1392c21a7cf2eff9c8acca7c8dae9b98dad0eaaf837",
+                                "uncompressed-sha256": "15c844988686adcdc789dcab2f1aa6035801d8948c91d5cb2f6a28e4aadd6530"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "55de81f8661ea7ec85ab436d1fa1dc2aaa1f6d4e1bc447bf0cb94be24e6eda82",
-                                "uncompressed-sha256": "d5b253b8fb0c3414e8f19a8eb759d5102b254d4d8f9257294b86381843c7980f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d582b65366ba7f4e0c66dc30bce1ad3f092459e508e211444f9204cae7a0e00a",
+                                "uncompressed-sha256": "cc3a5bb419a4078263c9cf11981e76a25380aa760ef6bd8c96b7875d099b3561"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "456c530a822ce1c7ca45459d5b1d809de6d3a33654e40b50345371960275bcfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "9cbe1530a347ff413ce2778b5c7bc93de2d0326b749b0e1c0a36d5511926a67a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b5e349ed00e53dae8a1434922ee709aff96ed53220a763a62131534ebf196a21",
-                                "uncompressed-sha256": "918c5d567127cac5059d2dcf4c9ab717adf4be6a77c5d90dcb6e9c0ddb84a4aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "6117a7dc3e709552ef904757fa5b47c798c42645e2cb015d9be78bd92411b4fa",
+                                "uncompressed-sha256": "dcd851c39995017ec084fb4781eecca18546d7d68d21adf3b2e18bcef4fa25b0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "9b053d7f98dbe5f68c4c205dc4e733487f66e9b983f228a52a2d99c9095d2a87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-live-iso.s390x.iso.sig",
+                                "sha256": "1d6f36196daa08af8f4cb2a78876bfad19368946d0c5c5c7f47958fbdbeca195"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-live-kernel.s390x.sig",
-                                "sha256": "f274924e62962486a6749ad0c38214e3e92010bd761e093480a114ddd892a0a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-live-kernel.s390x.sig",
+                                "sha256": "b27bbe4ebb2f7708457b25f011ebb4301d134c5b98785bc97401b4a061c02d84"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "03815625788394c818da3e537226098c5d839954163ea94e720697a5a6c5643b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "d3378b3b7a5b95d7e5f93302785734d4ca5af564d11cbbbf8b946bb0577187c3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "5eabd24fae48fa578c9556990cc92c9a2dcc0e24bdf7cab988b1cb983c88a118"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "faea6bd301521457591b84176324848765ede63470cd93f9671920464d24cb6b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "c289b59aae44462830f9e14d990fe865ce68cc1e1d58776ae894a15a87e84aa5",
-                                "uncompressed-sha256": "d56c0626602fdd1f3ba3c0fef09b5b04686b6b9e764ae5af4ee9117c25017de2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "9244ff46af3c859349c3848c1889536fe966c86d705cb0155505eb6d64109c3c",
+                                "uncompressed-sha256": "b9ca940fb642c47f24c63b65a9024b4ce9e82a27122d1faafaca07aa93bbfd35"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "63b7652928d8d838a7653c26980c27fb2146e6de137c0eac8122430f3cd2b750",
-                                "uncompressed-sha256": "147caeef6e0306c907d93f83f35c84848a0709b9922792dc0c7871d2f345edf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "8e2d05669fb5cbca236affb8ba740cf4627e7686a5f10f9d4c4c68dfc38c4a3d",
+                                "uncompressed-sha256": "7e223e0d12de91fb65ed1f6836ea9255fe6117f81320afeb5cbb74bb471f1e68"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/s390x/fedora-coreos-44.20260405.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "5811730c29fb5bb4e00bd7a033e38c1be52a682a50bf79cdb00b9364a64ac21a",
-                                "uncompressed-sha256": "2c6f9400dd4c0fdb18544c0405167236ef920f82f88b4415c2d012cce070faf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/s390x/fedora-coreos-44.20260414.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "86cb05f78341374d81b4cfe3f1e6f5b9103fbae1c2e435791f1cfaedaaf9ff31",
+                                "uncompressed-sha256": "bb44f4641e642b776fc375723db3ab2435f0a0af4a2f1c84b961c6fec43bc07c"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a24fa42874708246edd97a3b695372341793cc025d2f9f6ceb0dd55f4920df5b"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f7efc3fe45a3045935da48bad936587e597cbb84d44e38a8ad4ef34f22307d37"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1f3e72e88d13701f1d2ad2c33eb8e54b899dd1fb831d0bda6776733a730f61fb",
-                                "uncompressed-sha256": "28a6b67f048aaea7501197e0e5e667b1a4a99c7dbf139faaea658acc02700e5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ae5e03d991920f08d0c7662236e27d5a12e4c148953456834fc8ea8f5d73d4b9",
+                                "uncompressed-sha256": "8ef955fd8d38df90401a29eed21f6321a175c9c855bde0414e8e290db460ec9a"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "913de534d5d284d797bc91a8e78b5c8a2a1ea8c6ec0e3a588d607ba7cc66a294",
-                                "uncompressed-sha256": "1d197366b354bf8936b0f58f1a8a3a2efd735eb6d7736a6f97527d663ef96862"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "b223458b357b1d285bf8933f8684e67d74624d96510118813450a75c3c0705b1",
+                                "uncompressed-sha256": "653249a034663aee1327f3378dfdfe28b82df3fbafe17c57950360a652d9fd21"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "28eba7f508f2c63b447dc313f92c9e72775e4791acbb99743aabb89a1708528f",
-                                "uncompressed-sha256": "a19d7f0558980b50150fda37841ad67a451c919b7a4d7183c29f3f6936edbbc4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "c84c0c924df8d9a49d41646f7b754ea5f90e2812e83aa9331918c4b53369d006",
+                                "uncompressed-sha256": "73e6557d8dcc1a7b4a4bd50157e132ee317fd3329eb48b504835b5b7fa9c415f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "0eca25de801246e1276e93c4583bc6610a9d1740ec8d665395848da8a0959c4f",
-                                "uncompressed-sha256": "0751e55ae5a0774a0742d96404af1f62b82c3f5304fd368e102eae2146a7b471"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e6300ea8ac0093f78ce6e28e36f93b00b5bdc69e68d8a3cf537ef64c12df6c0a",
+                                "uncompressed-sha256": "985f3aac393d1ac9bca87c6751cef536d7eed0b4d86f94cfa522dfc7198e1409"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "6c001ec2da5ea0b635e9500ee9d3e8be07b65ff2ddd5eabb7b2464ccc65a93fb",
-                                "uncompressed-sha256": "88e5667da404d5c0dd4189418bf694abd55937ca1592bcd4e7e110a829c94a52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e17063e997d8813d0b8a194c9bf57bee8dbdc0790a1bc0f94a4f5b035f58fcaf",
+                                "uncompressed-sha256": "857f1d155dea24af4e4a5601f7515ecfe60046eb82df737870393d49f9b88604"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "a8172e4aafb14ac2c7cb45a3be80389e19e4f58a158f7b4b30527957483317ff",
-                                "uncompressed-sha256": "48f92cd6339702dd466d4ae1f269ba176e0249f3c43eadfb257117eab7a0f8ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ac3617844afee39e6607489ae023109712ce684da4252b002cdd7362376399a3",
+                                "uncompressed-sha256": "b078a7ff5eec01a0de8e3961df9c7d77066d3fc4b1b183abbbd1badd87476f61"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "111c03a87109a54a2c332db0540f4f5e5fc99e14671070e23b29ff6359a17f98",
-                                "uncompressed-sha256": "f9b39c692fa00b0cf2acb5c95d2bf44a601a2956eff6838fb2269b40fbb50016"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "fdff1cb08d1e439a6c9165c45be30fae6f0762230f68d0c382663e6dea045e24",
+                                "uncompressed-sha256": "9d31160ac0b539701921dac0d874d22791a4eda145aec6faef5acf2d53d36e46"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "e89a771ddaf112d23c2d201865dcaa4fe4bad0650d9ec4f5b8c52a1ae0d53906"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "6e2ba486e8e11ef1edf960bb12cdf0a9b8ed9750e59cea673d1094aef59a70c7"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "948e17e10f26de68ffdd42dfdd09351af7331cf1b8b5f6a5ef00e03c5167be0b",
-                                "uncompressed-sha256": "04fcb48a390e9ba67701824681a487940307b36d128f95c23c0956a869f580b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "613bae10e3974bfccfc99b81083b2f71fa90a36431c23774e3a10e44fa00715e",
+                                "uncompressed-sha256": "0b96514930e9368ea11415292802c807feed853a99d4fea4880820842907dc4e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "1a47e64b289799189f704942906111113fa755f4313b1757a9970dba3ff63b50",
-                                "uncompressed-sha256": "bb59939dcf7cecaf208d91caac54ea1a9467ea1d4e0f6c38595ee20f2fc8b034"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "ce41808691cb58030933f20a15078411b803a8093c2f6087ede442ce5d5710fd",
+                                "uncompressed-sha256": "3c963e7459cb4eba758667fa64cd124d9e12f6bdc3072b023030f07b29573f05"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2e65afde535692fbf3a1e85822e43b194084f9c6cf48870ed04ddd9b28512423",
-                                "uncompressed-sha256": "2f42f4ec46528cefc52eeb5765af89acf378063f6f15741a66fba74d9e1fb7e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e0a3670734c9c104cf4a6c0eb527d1676e76df9de71ffc4f05f5d5d87132dbfb",
+                                "uncompressed-sha256": "1632c334a59e7dfd0a29e8271a680d94f05132c775dccc6f6cef827efa911b05"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "ae229afdf43ef84d5c9b3968f63dadda2914c92bb5049def193f01370a19fe09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "0d2df18906e4240d3041c887188baf68aad4c09837a0f598896c45eafb5eb8dd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "296f11ee5460c6924d1f15e833afd65065548e74dca5d8a9093a9a21aad9009d",
-                                "uncompressed-sha256": "e6517e73e49df09bef5ff60460dd7eb579bd1bf3c56bb267ce4855c26f226525"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c879d6b93af65aa89fcb45eebec4bfed851a61822ee1edf644e57691709d1aa3",
+                                "uncompressed-sha256": "599cdd0ed5fa63e2e24e54e36910f9120c1f72bf58d845ab266218a6b5156aef"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "7c2e64ff3f1165e0bdd111d747b4615f3a6e1b789b127f7771600a90ba28b53b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-live-iso.x86_64.iso.sig",
+                                "sha256": "918ecf2c78ee5bbdc8badfabe0b7abec0607ed249487c6e572caae69f5f79462"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-live-kernel.x86_64.sig",
-                                "sha256": "4b37e4e542a62c580c751787848be6c99e6f908f6712c8c6da85516b8d541de2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-live-kernel.x86_64.sig",
+                                "sha256": "1c8fb030127883eb16ff4e66418aae3b08aaa3ffa2c9e3d312d6989b2a9159ec"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "f8e1eb1e60a709fb61b60a316ed58cb89fcfc6ee61eaaa1a23c7ea1b1fcb3bbc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "316e3509aa85815be8fbf5d7e1787a4bb1b7782b40ed632ccb9e82bc81d427e7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "24dd2ebae22c5f7ddfa8ff73164b4fabefc25b44c56e937c08530505d22f7a6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "6fb98a506c2a24cae37b6be3c101b571f6f2cfb35dd3c6182050fca7ea861078"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "31a28981534e31556f220ce47d2a5053dca86a44f7f22b0ce0d08b524fe893b0",
-                                "uncompressed-sha256": "ebf817afe159a2142fa06d6524e0ccf08c79cba6a76f64aab9ce7cf9cef362dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "feb7876d2efaec7c3601cde211c33f59e873184d35e18d0de0fbbc916d4ee76c",
+                                "uncompressed-sha256": "25b492972c28e4be77af4705d210f12cfc6842bea856e1ec91de142353908bb0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "6cfba80dba2b29bffcd0f8f7f1371119619733d23a0a555a01c191aca17bd635"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "90a0efdf7ad0cdb5d499e0d3843494029e85f380f16e24f41605ff5ec87cf3d4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a127bcf16597186d17dbdde08519ed2e373ff76779dedbe06084866968086737",
-                                "uncompressed-sha256": "9efdf85429a1343d17d0afa6a53d3e19f821857d87dce80e8035bd0e863e23a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1d3ce147250356aa7f1b343e2793d4bc73098d1e3ccce1aa5a9b2427f94e5a79",
+                                "uncompressed-sha256": "f4e56b81618fedc05501bbc3bb49c3d87652e77f7c92771835fdc4cc7beb1d28"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e7298a75ed640b1bf50232581c00e1fce70dbe3fbb393d673d03f18c54040508",
-                                "uncompressed-sha256": "a1f82756258558227a917aaad4421b5ec20838929dfa20cec57e9e2d2c5c52fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "79f8975c1d9521de239a949797f89426b25f498511c7708127768105998340c3",
+                                "uncompressed-sha256": "bab9a37385c46c183b88f52dfaa61eebe8c4ca6c5d29fd45b8db566158013944"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "b1b9075c5407590e6ebe7da03284e8fe5498186f9de5a671d3023bacd2aca0dd",
-                                "uncompressed-sha256": "a10d47df03e6796ca820516bf5ad515668c5c326beb8bcd5fafd47b774c7d34d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "d3b05ae230868e5dc9a3914e435386328a04028e0b1086ef0a7427ee001ebca2",
+                                "uncompressed-sha256": "8870b3dbeb3fd2ced413479547aa5a3a87caec120197e5e37fc42e3723022a81"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "479c578c8b292fe599549d07a64759351fb7f9effa8d9aac378fc2230c87df49",
-                                "uncompressed-sha256": "6efa1e677b6c9cf1cb3ba04d07ed0713b3b0bf9c65b205e4431b7b26e5c10b0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "0171c9a407f4535b25d8916bd723e02af9efa27ec041e0609023b677e26c8a92",
+                                "uncompressed-sha256": "e7d354a2cd6fa6f4051f263bfcbe000ce27977853531ebe4c4a1d499ee93211c"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "b3fc50b058c2e7a8b5c60ddbb300dde0a3b265ce926c36c044a2010b726c5ffb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "2d855e52c0068543c1e34ba95f9d84775cb0037e9d0fb61d753b508ee14e603f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "811f19bc8867a4f2cf3f210f44c0707d438a6d25bbf0cf963550cdddff89a1bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "d32cec9a8cc4e66612147d93968a5c3b7edb81f12fb362764c05c1f0165a176c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260405.1.1/x86_64/fedora-coreos-44.20260405.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4737a759fb011a07d7527bcfb87bfaa666dde2c416a19e86b057217ea6896032",
-                                "uncompressed-sha256": "44564ae0602052f143e1b004690db1ed01baa030f03046bb478b4e6a54c740ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260414.1.1/x86_64/fedora-coreos-44.20260414.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "fc76de8c8c754e88af5a6dbaec285bef8b2a5cd24c627699afd32243fe3c78cb",
+                                "uncompressed-sha256": "451dec8bad222eb15be8c92e3b7e831fff8cd4ea38e2ff85a42f08d844bfe56f"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0ed137734e8994a2e"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-089ee4c27b4689739"
                         },
                         "ap-east-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-041a54e668b09fd1f"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-00ff4f09dd04510f4"
                         },
                         "ap-east-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-06fb385093cdcf3df"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0c4958a1534f53fc3"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-07eb5488c04df4400"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0965d9ba66f7fabd3"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0fd2e22c42a500cb3"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-02b7699de9c56404a"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-05b60bf478f0ea4f4"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0b62d2b232ec3d512"
                         },
                         "ap-south-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-09a4c247ecbda57af"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0d56e353375f1af9f"
                         },
                         "ap-south-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0a66ee32a49eafffa"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0ed2a5889326d1c1c"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-030be98edc099c70c"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-086f0d784f07fd3c9"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-008a2f92945c4cae6"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0cc7c39cc7f286b92"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-06a4f0d627cd13fe1"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0b63cf65a167027ef"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0aff148944f0efb7c"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-09e241a8e4f36edfc"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0743b631546f1da5a"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-045dda428981173ed"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-06160a6b5a24ffa07"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0328b983808367cb5"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0a2c735e63fcae41e"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-05be15f57bc847675"
                         },
                         "ca-central-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0189065d121560a77"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-062b77bc6bf1604c8"
                         },
                         "ca-west-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-03a27f09541c801bd"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-03e612ad5dda0a22a"
                         },
                         "eu-central-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0ed1f4479b5d2a236"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-029aebe612eb2a2f6"
                         },
                         "eu-central-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0b8eefa353d8daf55"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-014d048627b101829"
                         },
                         "eu-north-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0251c35423558338a"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0c5bbea17849bff3c"
                         },
                         "eu-south-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-015f2b36b0d5da7a9"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-06be260210631561f"
                         },
                         "eu-south-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0a91c6064cf0cbb35"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0b6423f15c5874ce1"
                         },
                         "eu-west-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0b9da5b839eded479"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-06b3b4c3c8703b368"
                         },
                         "eu-west-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-02b8758f7c4b4bcd7"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-04d18d925f55ddb3b"
                         },
                         "eu-west-3": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-08e6dc0fd02bb1f80"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0be8b14fdf7ce00ed"
                         },
                         "il-central-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0bafac33526f405d7"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-02b012e9812f33df9"
                         },
                         "mx-central-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0ffb1a000eed813e8"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-06cd26a5e9b86a873"
                         },
                         "sa-east-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0943d1e00672362a9"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-0c2718d230b48d6eb"
                         },
                         "us-east-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-06427b74f24175066"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-00da6c8109e52c515"
                         },
                         "us-east-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0ba73369d12261254"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-01e7ab3947045f4aa"
                         },
                         "us-west-1": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-0017a9055b1eae9eb"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-04ed147ec0b89cab1"
                         },
                         "us-west-2": {
-                            "release": "44.20260405.1.1",
-                            "image": "ami-066b3b5868cfa23c1"
+                            "release": "44.20260414.1.1",
+                            "image": "ami-07ad6732dfcec07cf"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260405-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260414-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260405.1.1",
+                    "release": "44.20260414.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:96a14c5432a7478f1affb7401f801901c88b6198cc071f7be5cb1002f8646d5f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:61a19d3df0249f2e9ea040d3ca78725aebb584eb013e1ef647aa62bd32d8375d"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-04-01T15:00:42Z",
+        "last-modified": "2026-04-15T16:36:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "d556d55e2787fb7818e90e70c4624299d315c79bd5972c17d6ed5ae96abb8a29",
-                                "uncompressed-sha256": "217d95a0eecec6f252fca5ebe0cbb96a3e9754fe36f3bacd5194d163064c93b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "d91299036115f981f3636fa8cccb7da59ed9e124051a83a8577cbe82cb2b9758",
+                                "uncompressed-sha256": "f60c739b8058e6cd0a5416f4bb85fe0684463334f9091b9082ef45b8e36136cf"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "7b5fe60693f03ba03a42de8d2302e3e9480ed2579dcae327ff982211c577d92a",
-                                "uncompressed-sha256": "c3a767579f7893edb701a0281aecc1c65b2059984ef20dbaf10d363b2717ba48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3ee5318de8d2ae0713e29a4b6c4d6aaa103a49bb8440622561a18176a80b54d4",
+                                "uncompressed-sha256": "5b0c241bb77b618e0d6bed45a3905b60431f4a35d3811ba0f0fc29ffcfc0cfbb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7cf3dd65630d9c1b26ed0c8ab8a136de7ecf8855edca556b809989787932ce98",
-                                "uncompressed-sha256": "70fa6705015d0d57641708fbc3fe47890febc8b1523f1f2824fff78da1c6f8bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "2addc4cddceb6e13058cbf160e7cecc896f9682012f2e0e179f8729b9c4271d7",
+                                "uncompressed-sha256": "126d268b56e968834950041568d2106f3045f496af10f48ceb7de155cb2dc097"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0459de9073c08a63d11e0d055e9b7a66c658083bf3912854efe344cb2e8dafca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "506e910b6457f297e5301a2a38ec0e8e31e84c5a4f6e3581019df38650bc1b8f"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "dbd80053c132c010bf787889b5972f1d628caa67fd2fbd97c3a02ef9ecdc30b7",
-                                "uncompressed-sha256": "e99cc882bbb785c74d825401ba3f5bdfbe823425cb7ff4cc08fee8e35e4cf3c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "d1f45842a80807d40b66cba48c6444a2c5ac8f30e1afc43ffb0fcf08a6024c57",
+                                "uncompressed-sha256": "66b9ad43541726f5f377f63d7ad07a3e36114532f58287473703ad498f622390"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "209f31afbf4f37aa62755060b767064ef156bf09c8df79e23a0dd91894c01f2c",
-                                "uncompressed-sha256": "11807600b02dd7742847ee4c7060e74d3052ec55eae7f4ea7aba29e1192bb7d0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "a10226a1595fda654b121352bacf6f45e0b13399d498192ea6f7fbb0fccbd8fc",
+                                "uncompressed-sha256": "9ab4dde4dc9051e2ebecb4327f36fb1b3d49f85983af945b06ba04113825110d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "3d844eb23931e8b1cefe14c832cf233cebc70880d05f13f5d637ea42c211dd60",
-                                "uncompressed-sha256": "ee5e5047068972fcd9c417e4bc386fcbee753520d2062b7f3edd40cc82112cc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e2056bacb498820718d1396a9b61f2b0af98cc90c73350b9cf18ba847e920640",
+                                "uncompressed-sha256": "fb783326a30030544f8118a3f63c0fcd1a7b6312a89cd2f1e69d46454cc86337"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "b00d324b17b925748a05476a34c56184c042280eef20c14ae80d9a76eae40aa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "17f9850dc0ccd85290491866f1262607327ca0c437c14601744755be4d13703b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-live-kernel.aarch64.sig",
-                                "sha256": "df94b830ccba00ce8565d7fb24d989410180bb4dfbf7ca7aafd79d27023106c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-kernel.aarch64.sig",
+                                "sha256": "0dce93d2b915e3a36d6b47a872212e500db0aa5e17f26b0d8417c88fd14cb252"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "876bfa58995eeadd9b2835c7311529f683c679fb23fc1f4dafcc6ffd3214df80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "ca5603f1d864c95e025117c4da12698e64da502186ea4a273c6497d9ffa496a1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "5b027beb6691c3d95d5f84612eaff423d58ab033b5f2b23b2c1a9a680c67930c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "a2b1ba29a61d21a577ad7b35c7b7fae1a88b1695afee5d558bbfc336bdae864c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "118de49274f10d5226e10f03239738d0528ac64557600809aeeea4912538061f",
-                                "uncompressed-sha256": "4fd92eb9b6fb74675638ba17f0a46687fe7e32e85cfd9aa5059ea77f5fcc1c90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "27dca990badf88ca6c47c14c620b4239a7edc5bfbbb3165e2bef4132ddcc37d0",
+                                "uncompressed-sha256": "c27b87c83b498a3841c7055066e0166869d9332973624fa8c1dc3e1c2f050184"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "f6c8571f12d8bf099b29799a7ddfbd282dbfe419330e35c1a9009538e77baf56",
-                                "uncompressed-sha256": "2b1e316076206c1e9b97d8537082f95408a0d50f6b005977bc210b748a610bdd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "294dcf999cf1557e5000e77c49b1d6e08a2dbc065d3b7e4c01aa607d82962dbb",
+                                "uncompressed-sha256": "814f73b163adb957fff7ed772946d368f5d4e5212e0ea7ba71edbed679d376c0"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "21e2ea161c74bc0ca2b81aa5b031c9a3d4d04652fe29c8ac30129cfcbc50d6fe",
-                                "uncompressed-sha256": "f81d7a3c4ee1384a836de33d96569be85712e44eb31278ffdc5facd4eb19aeef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "3dc3e4bd21a0aadaa6c775ba80b0a50107ff4dde9ca2a3383e525a652b2da2a4",
+                                "uncompressed-sha256": "7609a1f8b0967096d11b54b660f0a954790706763723dc49ab4a7d884cbbaf60"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/aarch64/fedora-coreos-43.20260316.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "306dc6e3be0f7d2eb4531071ab52cd63514fa989c9e2cc76b414b8b3a4daceea",
-                                "uncompressed-sha256": "771e8f3b123a2a618636b8a5d488f05d104ab18a9577ff0609fa0a1a72098bf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "27766f44742d782f2434695c24b6d8c4e20f34d23b1f2fb3a7b4fd615685de4a",
+                                "uncompressed-sha256": "ab9a11439a1a3043aa3777ef1d0ac8f9b2ab1eb5c3ddc29d11c839a45232f219"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0e0557ccd57985eab"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0036049c0a5cda70f"
                         },
                         "ap-east-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0953ff63e57ed419b"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0fa7be93f50e0747f"
                         },
                         "ap-east-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-02b0dad5cce86d393"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-07df8afab540c1a64"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0ce1f2ac9311d5df4"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0679ccedadf54a248"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0c040f5a6e5873f77"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0aea3c7fcf2afce3a"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0196a841049c77791"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0e9c8856c299884b5"
                         },
                         "ap-south-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0c1461a1a655e5e38"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0ae6f949ca8c7f301"
                         },
                         "ap-south-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0f84e6253e7bbe039"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-057530ef63c6aa38f"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-058e50ee46867a5b7"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-02bf708f8539d2cfe"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0467163f5c4f745e5"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-065b1ce7bfc83c642"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-07c1d2417dc866b4c"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0f630f05bc7d093e3"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-07330c35f09c31a20"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0519e036ffdcd99aa"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0a9322eaf0eb1e9d3"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-08cd71b48e06c11a1"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-03b416d0361143369"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-08da751726a14265e"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-04be35721394bf3cf"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0506a2b0f43549e38"
                         },
                         "ca-central-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-06cca5f0cfac0e850"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-09ce4bab953502a6b"
                         },
                         "ca-west-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-01810c73368bd99e9"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-05226fb75083403ab"
                         },
                         "eu-central-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-020a26e8e5fee6b2f"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0573120b5b4114cf4"
                         },
                         "eu-central-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-092f29b682dece0b8"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0219db74d0a938488"
                         },
                         "eu-north-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0d5d257470b1c647e"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-05ba21a6ae5c834b9"
                         },
                         "eu-south-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-05bf29bd6a14ce0be"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0b68a9d9c6fc9f70d"
                         },
                         "eu-south-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-087d6c0f6db1fe2c9"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0250512ccad33402b"
                         },
                         "eu-west-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0ef5fd68a421c86b7"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-07c94b0b91e55dcfa"
                         },
                         "eu-west-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0c6bbc71c0169fa23"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0b1889654f6051fb2"
                         },
                         "eu-west-3": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-01d27eef726925419"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0eaf128e95c13b108"
                         },
                         "il-central-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-071bf7e1c9e0b3adf"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0474f5460b1c60d3c"
                         },
                         "mx-central-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-06ccc3e46ff284d76"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0712266d656e24e93"
                         },
                         "sa-east-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0ffcb79c28e1302e4"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-04b01809aa5662f3d"
                         },
                         "us-east-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-075a99e955c1d227a"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-05e7aa0b3acd20910"
                         },
                         "us-east-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0bdc930cf245dae9e"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0ae6c5f0f606036de"
                         },
                         "us-west-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0d88ab60358917747"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-07cd6c60942d3d81a"
                         },
                         "us-west-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-091f6c40bb19fdaba"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0360d3f508e6ed5e3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-43-20260316-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-43-20260331-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "9913eaaeef1fa14655ed9b08cb36d00dd2b94de1d9dccfc82f86f9eb63edd5bb",
-                                "uncompressed-sha256": "5b6057e99aff2ad75a29e65e2347d0649f833a30281926c90b9a62ca03f991df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "1cf496f536d985c5c2f41e837d95f53718396c51f7a5bc8603aacc083269478b",
+                                "uncompressed-sha256": "55e0ef9b1f7278371a1f8d61d7ba8c64c9c5cc9eab55b4e22d06e12d5f0d6e31"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "f51ab98fa66599ac85332cb025ad3dbeeb147ea248bbb3ba5cabab14f99e25ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "f8fc7df626802fc1f0de4807fa189ed259226f3ececcfd4ae21c72b227002ac0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "9925a680f814a90a85e989b8a54e670f93696c1d971476f02c28873b53d886f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "8b76b3524cd8ee8dcde6db5570276d07b15d8556ee872288c20d81e4eb8607f8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f76c576b3c56e2007e089713cecd0a8020b1b6567ab0bdf9146507103849c4de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "70e4cb8d56edb6355d772be13810d6ba41c672433dee834085d0f1b4511ff400"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "79e842a014df0f5dd0f122e9cad5127355d5bdeafde3f46a05629af267925c77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "0a8234ecc7dfd75a83aefdda903653b7fa3ae0bfcfa11a5fee2675e92bd8e41e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "83d3d287296cee0ace994c4c5743786c84ba2cdf80d6e83cb0ec28e9035a8ebc",
-                                "uncompressed-sha256": "8602bcbb556c2b48c8ddaa498b9cea8a0de6c7d13894b52ba9937d685e29c315"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "78713196c80824f3cd4c2d58ed51349508a53757f254121475948927e410bddd",
+                                "uncompressed-sha256": "e224ec3db9e4893443a4f34be93fb934c4b1002b19e7e8efa90bcd2368be88d9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "4cc9081c113125859020f2debdcfc80d89cd3c143ee3cbd190569a232e46cd42",
-                                "uncompressed-sha256": "369c98349f128b5a357ff3a75beb20e7420860029cb8ba5bf454d5c922c1458a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "19125abd2dea53f3d9f6cdcf2724917c55b7ddd58ba3aa8db22d4cafc924171e",
+                                "uncompressed-sha256": "a7f914f7ba18b91edb64bae93cccf2bd3c519526fe1a919ac3b93d0013b99ccb"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "57292b6730563e8ff4ea87ceae527eca396f4845a7023767be02fedf9b23c174",
-                                "uncompressed-sha256": "5d1daf1e33b5f56d01aaa616fbfe7b94266d0d68e097be5f2e672b003043de1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "b9d2759573bd8b346276e8addadb659c40ce0e891735c2a285a16c9d5ee01a02",
+                                "uncompressed-sha256": "a39d8a077cbd63438fcf361ec47fe9a80735ca4673bdb89c9986b466c4a3bf98"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/ppc64le/fedora-coreos-43.20260316.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "47f5d506a4f9c8ad000b2d6f5c56065916e8efde8c29bfa2463d1ad755149e5a",
-                                "uncompressed-sha256": "bd24e9ed1b4579bb6d2ea9f00ad8ec5c4b16bf9d5a98cba3d3cd3474bd5fb502"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "d87af5e84c304735c19e6c99449607b7bab356dab1f581a055885235605eac78",
+                                "uncompressed-sha256": "73711c2925db53f0c85770329c5108a0b349bcb7be63ba61c7becfce500e50f7"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "2f017c9a39af17ef874f6a8d6e0e18d471102965a1439af48d2313ffc72b9a4d",
-                                "uncompressed-sha256": "ad6244a1a0a3dbed2a925fa733e67adb679fec0fe00e943afb087db8c19884af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "c1e8ba0248f70c02fd63526bdc77c0b541c4a80d1603fc37dddb5ee59a688605",
+                                "uncompressed-sha256": "cfcb43a67310e0c3436220b27f97605df0b63d999edc48c231c3c268ac535d7a"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "400d18f9e0f66988d197b729d89b5b763c9b37b1793172771215cf9b64894d1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "d36f65cb4bc8408c461e2247e8c5d8f0d6d1842e73f3212831e77763e6e1052f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "f5ab97b06eaf76e54372893614ae1aa9b1b38ae42c80b7e76a4270d907289d1d",
-                                "uncompressed-sha256": "95cf1ed48965b9bf6f94819675ef950242d557de328b0eb712a19c2e97a4191d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "672ffcf5fc870ab15046f2cea6eab157ffaac1e2ee825921a9b2a88fd9f9c7a5",
+                                "uncompressed-sha256": "bddb0c3447b8fbb1de495268b5aaf5f6f75d63badb2587d17e327e472b2091dd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "4c0a23b9b9b9ea101a475ad3b1b602eaa25b83ba56221331d9e86addaa0f6f7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "7fd3f1c5be044b69f19ac65223864adafbe28669811fc84c4fae95c61ac2367b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-live-kernel.s390x.sig",
-                                "sha256": "caaccc7929fb81de1bf3438df47f2c059beda2c6755a17013ba3e91c7e60a4e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-kernel.s390x.sig",
+                                "sha256": "6152473eafd2325db8e5ead468841f6c96e8b3e2557184ffd6d4f5adf51531b2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "613ae47f10e171023a135dc2986fcefaec5a33f32ac45abe32b1c902d86d41de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "ef950f1d9a322fa976581c09ccaf8701dd5e0b0d185dcea56cfe94b9e88a79cc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "51b46b2bdaa609e8ea11e553b751cb5b4b073fae3ebfa6a6d1beac1dcd05bf55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "f93034b163d3807f929d74740b096c0ea70fda3ff3701ec3230089ed576bb509"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "e30d431b4c9d7b3117b6a44b24405de50edc591c4da99e0999538a4d2255fe07",
-                                "uncompressed-sha256": "0e1d5e2e82b211a3774a3be98d707948d6c5206dc1a72ca749503f34495af490"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "33d59603317368f8de2fc5253e0795d9c3d949601349a9298b3481172be5acdb",
+                                "uncompressed-sha256": "3c8aaacd52afe75bc63b683fda65a78d1f11287b9d962dd0966dfc51d8b52437"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "2500709852e7dd0c5d642546678bba63e539139297c87bbe063262ea2b8cc4ae",
-                                "uncompressed-sha256": "80d4557a24dbcc579daec5405eaa75d6abc717cf1271e536f11232c2dbadc020"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "8280cd9c77e92f5eeb1a52a50e1fd8e0c3a0db61bd13a053f7251548c15fb71f",
+                                "uncompressed-sha256": "151531e069f8c7848d81884fca600c30f8f45ad15f2c1e484e03a8168f89c592"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/s390x/fedora-coreos-43.20260316.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ecb0b7a1f4bf4d724cf0a3a86ab4cb49bf2a83a121ae9314f7f283365d9cbd8c",
-                                "uncompressed-sha256": "8f9504f1ad4ed481d55fcd5137a9579bb587e870ef8910b0e431e1c91c857d26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f106b13e53ab2604ae8692fbc39202ff98608d9873d2d8a59b2a5641c5676a1b",
+                                "uncompressed-sha256": "4731615d0ab0aced42b37b4f8633a4234a420803311d61b01b5c9e230f675f9f"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:41f7e46c1255d70f8e2fb808a7356567833c74047dae330ced459cb9d0f88fbe"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:847839f0923c8b5672bc36cea0b4270ed22b6fd6e6d2c7a3e5220b77f76076c6"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "b17e98fc52d6425b19db401a5352cea8e3f8c3fa7f5d7acce94420abecc41e04",
-                                "uncompressed-sha256": "b2cf130f8e4ea4f33c8b671a547a889846580f2a918e412f3b238d9ea1da9230"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "de9564a59d29d3234fae6a46e68ae493baf30aac687206280bf2994cf5aa3fa5",
+                                "uncompressed-sha256": "5f10ddf4d0677dd7baa01a5879014ad6fdf542ade19a194b663a183133079905"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "d415df50958b2782c65cc54ae07e03e6dbf7557af402a39722fc5b9fcbbec710",
-                                "uncompressed-sha256": "7d0c151bdaee3a8f2127a83581ec1fcc74644e2c9f7f3791d7ec9f7098af4952"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "2c8bb34f5ad83ed071750ac2b96ab0ce940e5c550dfcf6be390e64a522ec5000",
+                                "uncompressed-sha256": "85609fe84e6a4d3830a9daef55e3460ea548afd889db50bc049392eae92d8a84"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9fb35e5fae122f0e7182fe0132b8d942afdf2f326ac8e13b4dd41bbeb390093d",
-                                "uncompressed-sha256": "535b97ec0ab48d9e7036543451124c07568a6e145bcb58c871501874f3bfedb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b13bb5b12416743830fba7f8e3acc0e043704d0fc73dfa16a055ed4acfc1f7c9",
+                                "uncompressed-sha256": "773a3fa67a04bf9529104e1abc88d27d324143b7c6db603bb0dbd61069ece23c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a55aa5ce6e509ebdb1c2653452bd7369af9af518f1872542d0d67d311f06e6a6",
-                                "uncompressed-sha256": "5c3a6c0f20e94104ad12f2db8bbe1ad20c3c2b4f66d41f4de283ee534d0c2407"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "54723f004d3a6b0b6f17c27f6a65479ec4b1af1ecda6eb0c94c510663595cfbd",
+                                "uncompressed-sha256": "93a3f68b70d146db00a54ac576a6e4ee009b890a55153f125d979a16be4b0101"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ca825b1185479d5fa4391d75cd93ce4d3dff8dc3e364b2b69fde774880a6044f",
-                                "uncompressed-sha256": "cf498a0f625ba0a05b88ec29a249b07d85e47e77cccad174bd61b4b1e7507add"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "38b383bb0d4df7729202b5b6b7336e07178a13b2564f75ed1b4d9ab1d1a12b98",
+                                "uncompressed-sha256": "11d184ed6de5ed0f0c81d678b4a1eeb86c4ee913b8b683f3b221d65a29b36df1"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "25182e5b50b8a25852bb1df2179cf68754ab82d0b0bc2363b8dc1e3af2dadeef",
-                                "uncompressed-sha256": "b13c578fe82b7d2f5a8fba5a93013b1e9b106847447211b118e4984fa89e6ab0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c538ef3f197b535124879e6799b7c30f9a298e3106adb5ce77299afe60816a8b",
+                                "uncompressed-sha256": "4c280843abddd1b54f49a7e5c4056f399232527834ff242ee73147b33f17d2e9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "d4e47098976282bcd1a56fee0e531710ba0f42fe934c5e26c0430879002d99a6",
-                                "uncompressed-sha256": "765787d3ebb7fe7622983314dc1ad10e9f8e54094a5c26ffd9534e9029664c38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8452258974889383ace2142a920c8209bd9f884ba891bf3800e0879173c49a05",
+                                "uncompressed-sha256": "531f8a88cd79d2aeaeda646992816413a6b0c7347746aeef96721cd96070e5ab"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0bf032727c11eda349436b066e3fc432c620f69dbd8b9249e37c121b7dbd26af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "65d1276e91c8521a85c05a8e2e80dd828f0280c74db532f98a7b54bd52020ef9"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "c1a91b4da1447ef63758df71ed9baaef65def102ead8b847c08e47beb4d9efc8",
-                                "uncompressed-sha256": "b0c00ae002aa7ff8cb7a7737626c1f69eaca48e7b409cf54aeb9636f7d85a969"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "283e47f4e98b63c710ec4615aee8a0e1b6bc88c4296b0af71e345bd11441e1d6",
+                                "uncompressed-sha256": "f406b60ec74f6c198bcca9156caaf4d8b4504f3029948548f862e19288568e16"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "d4a83a0076f51aebb3fb243217e7602dc7c2d4173d9728adb4e830df6864e83c",
-                                "uncompressed-sha256": "5233ac7c1cb9bb1cfa797946e34092b4903b41820be4c2f170edce0f2e7595f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "834b9b6249299d7b81dbb72e22d4ba7f09c1aa3915363d5a6023daa112709c31",
+                                "uncompressed-sha256": "05554bbeeacea2e9c3399d479a2329d5565e5835842ab44804d67b15afda5761"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "aa72277fb52f8fae72780e8325797439e0114cc3c6c26f9e697346f75843b473",
-                                "uncompressed-sha256": "90d36e135f45e17fd99d2603daf5e6021785d25d639f7368062be42b51521178"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "39e99bee847a10e01051b22d0237aa0a1ef67e3de1afd7a849ac1baa0e1bb8bb",
+                                "uncompressed-sha256": "d765b5585a227ab2710118eb5eeeb9dbdabec8ae87fb6f4790b7308c90952c57"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "3b4da06e5709301daa99f2f144e12e10e373f599e2c2266f86bf36224289a75c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d3eb52807612dea40660d42965058099db825209133a024673134bcb9b3a7b56"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "bf21134a740e66a0f887f1aeb3519fabe8097485ee7cdace0f90a27d9bb5dda1",
-                                "uncompressed-sha256": "2fe44ca8003405d68906d8e3e219cd9d3ce7cf6066b466f021549fe4a1f802a5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "629add2f783cfd5db8a5a0dd8f08e3cf88b534ca7654cad426630b921ea5a2dd",
+                                "uncompressed-sha256": "a1df63ea7e197de89a137d05d18c79411c108ec68c0c357e9e68cac9e9d0d5ba"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "2984c8d02637209e4b06337818516110edbd935fc9fb4464422b4f3b4d054388"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "9b4e7500782fc5ed8b17d3474397b6a3cfab9143413ae5e167f11168e817c06b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-live-kernel.x86_64.sig",
-                                "sha256": "7088d096c19562fef701e08835520fe05671fea056db61fc445a941c5272ce8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-kernel.x86_64.sig",
+                                "sha256": "80bdd497f1ff9531fc8a11df4494a71155e7e1bbdf1bcb7d5ba55b81803e5a7f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "5ce01fde1a8eb21b633e7a2dd4f70ed1999165fb3a2b17ef955d76582fe8df77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "54cc160e111ed28a68e43302dfcd8074958b34bfd244ba87f6b56685044d8731"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "006433bfb6cebd43dd5071c35bfa99c1677bb103c6d525bd4af1f23dc58ea692"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "580434a14e843dea4a044d76d78c9665665edb568a0ed5861d198a1567c49d0f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "56a326247c3ce67e74eaf494ec25bab8a35dffece0f31678c8a725692aa20c9c",
-                                "uncompressed-sha256": "03dd334c3b2a9c15a83ad230aa7f657cf014d64a35d0f2f064aed6f3309133d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "75b8f34a970d5a024fb41cada4e020cc42c7e03218e0dcd14f8469eed53ce5ad",
+                                "uncompressed-sha256": "4c57f094aede97140af056bf395557285dad8a69babd5ac16eec8fd3cc0eda30"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "1ebd2da179adbd9d6b36fd4adbc0496952eeab7163b97cce3c4d3a2276191996"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "0125f494581230160c2a4952828356e1be5bff5d020cf6e5739b40cf41062aa0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4f84ccde318f0f5d888ba688085d1d9da53d1e743244846a40e359dde76683a8",
-                                "uncompressed-sha256": "c5b0d4c68941899aa2d9c966211f660446c7969b0fa71c5c5b6b7a76b0de2ee8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1afe5ef0e6adbcc554f1d36641383b19f61c9f467c39b4a039ce31189966430f",
+                                "uncompressed-sha256": "832355c8cf5941f03d3caab19a3fc03bc6399d0b6daa3a9908b6396ca2f7866c"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "93c90112bdb7b7105583e7c9ccd288c158e2e69ba2bd814b3e835758031bf066",
-                                "uncompressed-sha256": "813df811c4048532d2a505bf72d215c2ee0f94a561c52dd94e30b27bfcf2821c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "83b1e76016f2467184757796edb41acdfff064dc5622b80707f333a92b69201e",
+                                "uncompressed-sha256": "2a241cb885a25d64b3306189153c565064b9b682ffc510284fb6743360822b2e"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "7e762be5d0d8467cfb26e74df7e3a7e4c833919177f975f10654932a418aae7f",
-                                "uncompressed-sha256": "b42ef99830423e9d94a9906ffbd00ef27c24ecf19f513f63cd52d548276e7f31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "9c75e6f73299b02cdd854117e5966fb6b64a47e5f85e839ab79e9cad656451f8",
+                                "uncompressed-sha256": "b9cded968aa0a6c6cb6095f5d5744b373661ab5ed8834c8b6d485168e0c98ff4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6b17466db4d649e19cd7175e61066ca9548b01791e27f834cb363480f58aa546",
-                                "uncompressed-sha256": "cc740d330bd846e13d20ae4a6f3f7b7f09cf1b543f753859af9ac1882917aed4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "719c9436e559746d80bc57e04da9e583f7e807bbca5fc7a5203ace7cf10a7361",
+                                "uncompressed-sha256": "bc494a31b9e37f1fe7077b622c1162bcc0f54738c2bc361e4ae9d9db65b216b4"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "adc80ed8a029da9f3c12af060022c0ec495606559cbc79cfe7ab4a952b8ea4bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "b98fe17d020690304e50cdb9303091a57abc3ebbe571fef23b63ba2c0999015c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "8693b054f902f4ef9c3d204601eb82f033f6452457fdf117374f9428c67a8faf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "184ce01988132052c3ac5c69d3b88175bd4ddc6887bb7c0cf27b7a5ed4ea795c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260316.3.1/x86_64/fedora-coreos-43.20260316.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "ca1e858fdf9077a7f17700461d081406854145bfcb7d9e79f05d4f151071423c",
-                                "uncompressed-sha256": "5ff7de5d7597eab126a821d9b309183a68ec51de692f0df72aff66de851d7e1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4919e23603b6a2f185b0f19233d77530c4d7a93c99961cbadf0adb84ed5b61c5",
+                                "uncompressed-sha256": "b71575b0bf26ef34497c530bb4fd2e0a34c5953a0fde699ef80d6684862f1aa1"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0cd8819857f0451d2"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0224c7a1182bfd327"
                         },
                         "ap-east-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0666ef068c905999c"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0e05adaa95c4df02b"
                         },
                         "ap-east-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0286bf5a67f6b2b37"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0465bcb3368941b8d"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0678360c605dcb490"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-08517f6da2e041e3a"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-01fde7704975c85ec"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-03c79c0f7ecc7d7fb"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0fae0a3314172108a"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-05495f51bd62d94fa"
                         },
                         "ap-south-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0b40aaa7809bb1502"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0603e5c627b21be9d"
                         },
                         "ap-south-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0fb140b86c79f36b7"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-019b87917a1e007dd"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0f0791edb6e282e55"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-05d8bce1e45dff23b"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0459b9d7405df3456"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0e8d933798b36fb9d"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-01c2d591a30341a68"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0bb6f7b56d9bb8d88"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0a91f90159816c01e"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0391faed6900f70f1"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0f3b1b173fd0cef47"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0d8a43ae8ebd2899c"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0482f7a4858b9462e"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0c4acf71fb19e5f35"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-04d95571d22b7d4fe"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-035a17f706f42494d"
                         },
                         "ca-central-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-005a7e32dd9abfaf8"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-010bf018891e184a4"
                         },
                         "ca-west-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-047ff815196d165dd"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-05d69e578175358d6"
                         },
                         "eu-central-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-07f1eb0930a654b71"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0e494d958c7ae0956"
                         },
                         "eu-central-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0f2c7d7cbb08b17d0"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0e18961001a758773"
                         },
                         "eu-north-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0ab053d116b12ced9"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0008f4f0899bb1018"
                         },
                         "eu-south-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-03015db0c87ccacdd"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-05cc5ca011ad33e9c"
                         },
                         "eu-south-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0ea2ea2402c4e7286"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0c57f76fed0208c3f"
                         },
                         "eu-west-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-06b36165015abe6a8"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-016bdabd19a960ca0"
                         },
                         "eu-west-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-03df90e07a079a565"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0a074aa2d9ac6b64a"
                         },
                         "eu-west-3": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0176853f6229e530e"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-081a9224cf9dff2f1"
                         },
                         "il-central-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-01443fbbf946e5713"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-053a561d1c2e74228"
                         },
                         "mx-central-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0d1abbe8a97f11c6b"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0142ff64d1017af00"
                         },
                         "sa-east-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0e4e2f68b3834d465"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0a51c621e45c1a35b"
                         },
                         "us-east-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0ff7e21a5c82e791b"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0586e72674556059e"
                         },
                         "us-east-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-001c86acdab2b0efe"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0769407fc4b43c361"
                         },
                         "us-west-1": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-08e043b77ca5bfc19"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-0795e47aad0be8fa0"
                         },
                         "us-west-2": {
-                            "release": "43.20260316.3.1",
-                            "image": "ami-0e4ec01bee0cd7881"
+                            "release": "43.20260331.3.1",
+                            "image": "ami-04684d8c0699a49f3"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-43-20260316-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-43-20260331-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "43.20260316.3.1",
+                    "release": "43.20260331.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:be09474ec885c92f9aa4493afe98afaa4f645dbc1b88ee2e6efdb88f0fc98d13"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:30566b2b63c228b4590117b457e28761b8815bfebbad38514f37d5ec6b0deff3"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-04-01T15:00:44Z",
+        "last-modified": "2026-04-15T16:36:04Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "b0af039563e8fa80a68ebebc857da910a6fa4e82c5bb13b482f3cce90695a293",
-                                "uncompressed-sha256": "bada5b236292243d31f95663a94719020123bf4e39b593cbfae92c65e53544f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "8583302b10a5e5cb95b8f3c75fbdbab37804d38545c1acd73c39793455afd83a",
+                                "uncompressed-sha256": "136832a4403751c6fd9714bb8041075ee96aa5d1e16540497b903221e487881e"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "8548758feeeae3f55b35d906388202b6b766db7d4c9474be0ad1a3e0dc52094d",
-                                "uncompressed-sha256": "7eb229f4ba8e37f9ea0db811694199237c0af1881deca17084f8d02b9a322d40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b3719b7dbca8e20aa2537fa584ddbaab8507792da184217ac65611e4d5e4708b",
+                                "uncompressed-sha256": "7a252b9fe80d9d6d9ec73fa83806ec29d93eb81d3bc56dd5e64649e7652f6b3c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "aa776ee13be33c9af4aa75cf090bc23f0e391d02c9a757dbedca6709a88505fc",
-                                "uncompressed-sha256": "307c5904284e60fc3c75145815d0f4ed0a3ee9a1ff80ec6229de5e4db0c39f67"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "eb18aa4486eff05bdf07fd51878425bc6e8fcccb36ce47023fb27ef30ab32d5e",
+                                "uncompressed-sha256": "41fe818249339fe34c7ac6250578e066682a68bd42dbc42090f02bb1f74a447e"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "9d0ed7ab363258078938d75bc1bc9fbc440ac10890c2fea8ba9314a5c5c7d3ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "48918e2c0da8891f65f0e0cdd702a1c36b7eb98120fe2f634ae256e9a65a1f30"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "9f6f1372554ee8ce11105f5782fbe6b7a9b79b1bc855de1f1d79d8c6c15a1177",
-                                "uncompressed-sha256": "a2e8486d55b8774041390d2cafe1be9b573e9b6964537b39c70e1b919a69f0ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "da68675ad3610539ffd9a3747a83c910e33d5deecc0bbe52cda5395d0dfa9e7e",
+                                "uncompressed-sha256": "ed750edf46b5dbbf7bcb6a52e0fc31aa9381f79796517c02d19f98c0bc2d57e9"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "29f2838f037b38ba91be1617f5068796df9b87ffa1a5451eb82a70a5670bebf1",
-                                "uncompressed-sha256": "aada03d7e7631bfc053c5580b1d75a56dc143771923c2871b6f7f4a05f077472"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "55e798f4e096b82625232bd172bc0465b78b22372074b4425bb3b625f103c777",
+                                "uncompressed-sha256": "958a1ef08dd8313b83e2414b12a86954c40151caee367b77d296792860dc748c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "4b081059f8a7731aa7ad0807ad50d3815406a0c433c239852e994f8681077ac2",
-                                "uncompressed-sha256": "564593bf1ef6c9ef218bbb7ccbb7d82945000c7f09cdd467d2574c3b565636fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "15c954a6af123681bb44fb151b0939e688489b66c449f88c414a91d46046b0be",
+                                "uncompressed-sha256": "943b3d2d226f203c6253d3818343b9504a42161c71ede61385237e563ee746f9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "2a2353e208c73535ba64602244f0f57fb6be811e4eb695120776217277fb4aaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-iso.aarch64.iso.sig",
+                                "sha256": "941dc1018ce08cdb1421edc3cfb14e34053ab244229f148f7f2989c39cec889e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-live-kernel.aarch64.sig",
-                                "sha256": "0dce93d2b915e3a36d6b47a872212e500db0aa5e17f26b0d8417c88fd14cb252"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-kernel.aarch64.sig",
+                                "sha256": "a6f43e9ca8727695a0697918093f7b36cea847d9f6a373fb05c2db7633197772"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "7183fba4f92c3187978b6ad5f3aa12956f3593976185a17ae11b1cba7df14d8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "391066429e2e18b0f92cf84cfa1d2312813ef4626da579bd7dae5ed805fcc397"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "1c6a0eb5998c49278b0512d074e06b12de95d8d1eff9b3f3db4977d5f4219e64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "d3b62009777d3e0a9e0bde1e879ab8231bae185538f45548155d1306dcce2a76"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "41be37c71627da782eb6e603bba7930a5040e772dd2cbedd6597e9900a6653b5",
-                                "uncompressed-sha256": "27bd15a687a528c2ad26a5502d190983ed2c2110e356a4474520b13975f75bce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "496ef9c9b7d6281b15dd75ae861f3fd4f550f9db457b2960a051583cf68be3e8",
+                                "uncompressed-sha256": "c76d0d9c76a6e556b545ba7a545a92ecb2da04bfd80704039ddee434a67931a8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "a509a8356000f6a6f626c843df0b6068b1c27dd50d917e69ee58c73e3c1a28ee",
-                                "uncompressed-sha256": "84dbe85158798f5eadad278984b53780e52a31aebd3efd1a621e2e597e6cf968"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "08445ccf7e028f796fbe1635948f29b679598c737d96d29aad719e0d7eb99a9a",
+                                "uncompressed-sha256": "dd665e8390c2395041c990a9d0faeacb9fd51715c16a62ec31e1172e0be4f6a7"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "c7eb093e630b0335dd07676bf2aad2db6666e1e4f9ba146ffa4350ecf372d04c",
-                                "uncompressed-sha256": "46a2b7ce97ca387870d44d388b15c0d3e3a3f6c87a7dd9be57a3f7b648ddc22a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "8593105afaf4a38e8b60ea8cf37b8305720397ec1f437298a5f8daad937d2de2",
+                                "uncompressed-sha256": "3b8ed36e1e28bc4bcdd2dba5d130832c15f5e2ed827d37c4bb96fad1002a81e5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/aarch64/fedora-coreos-43.20260331.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "10420af28f625f597e281fe05c728c97f877e4ca300c044bbf6e6dde54651a40",
-                                "uncompressed-sha256": "4de22cd1ce4fd4af3f337b25d072b2a5687c5bc296f7ac3806ca332bcc12b2e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "730f329dea1bf1adedb8795601ea4a7d95fb01df058310958fd215e5305ae12d",
+                                "uncompressed-sha256": "e4f2c58c3aaefbb04ecad3a5d582ba8cf6b41106ed203d7cc2659f647128be60"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-079115679723d1cb9"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0d89d315359f9b220"
                         },
                         "ap-east-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0f37c3e004ef4ef13"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0c1c18ee12cf41469"
                         },
                         "ap-east-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-04a66dfa4c3f7c04d"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-00e17ee62d0bbf63b"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-07e49029536118728"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-08754903b3976da67"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-03e6a63c0ee72fe48"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0df0882d4879550fa"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-08d5e30db1e69ec6e"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0b06b9b22861813ba"
                         },
                         "ap-south-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-083b236fd49916e9a"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-029a477311755952d"
                         },
                         "ap-south-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0fb44aee87a96d5ee"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-006fc78aa6390fafd"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0fd1d7f8a8cc183fd"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-09690d91f2201e35f"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0ca194f6bfbfd3665"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0a43ff21dbd797bd9"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-06095319cefa28d85"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0be180a174033d9c6"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-09e9aaec9900ef7b2"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-08068cfe3c71002a8"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0634b76af43e93b5c"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0de86fa5f4540f8ee"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0e9e0f0dce2a32ec1"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0a1dd3ea1f647d0eb"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0d7f1b761392e8271"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-087b4a091322c231c"
                         },
                         "ca-central-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0115ee17fb6da56d0"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0031dc0f59f4641c3"
                         },
                         "ca-west-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-06cf2537e7500e1ed"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-099329eb2e73881f2"
                         },
                         "eu-central-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0d73cfc688f00b4ac"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-019f474eb3674ea7e"
                         },
                         "eu-central-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-006f3673809b5d970"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-01335611cc21ff77b"
                         },
                         "eu-north-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-06fdaf0ae8f50f67f"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-093342faccd8d8d49"
                         },
                         "eu-south-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-03ebd998132937427"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-01912fd0d62b00e20"
                         },
                         "eu-south-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0dc9c356200623a83"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-069ca7a8720a70975"
                         },
                         "eu-west-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0cddea0f9c526a3b3"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0c0448acfbfd8d73e"
                         },
                         "eu-west-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-059c985016810773d"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0a12b632ad6523ec8"
                         },
                         "eu-west-3": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-072fe7ac24ca8dc57"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0eaabd64e957eea3c"
                         },
                         "il-central-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0ae9986c5c01101e1"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0aa6a695710f4871f"
                         },
                         "mx-central-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-00470ef88532a4dad"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0e30e90e99b514857"
                         },
                         "sa-east-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-089dd1cdec858ebf3"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-07dc9c0326c92d01f"
                         },
                         "us-east-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0184f011e6da9f2aa"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0b629950387f60177"
                         },
                         "us-east-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0b7afc65c8b82c994"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-003f5ade2f12d2567"
                         },
                         "us-west-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-02d02fe2c7ff4f7c8"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0767cd64867407b14"
                         },
                         "us-west-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-036f030b8d840b09d"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0f7b88eac24fd347c"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-43-20260331-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-43-20260413-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "cb8002cc6e140d5a366b25175fc2525c0fe776b26a087d70ead1b2f72a0fcf43",
-                                "uncompressed-sha256": "ea6b6bdeb0ff8a5b3562f2d40389055f07b9f2cf6b08ec0fa827d2f2873701d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "6651c530456397708a97fe3d296ac31372257667d297a000e887777fdd42ea08",
+                                "uncompressed-sha256": "8bacf65ad47c81ffcd1b03d41bc4e21b684647982c416fed2d6b94130f6391f7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "af8f2ba06b5f9417cfbceeaa098611d1cb48057286c8e69f5b209929664f4618"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "9726d103fb2011f681076b3eba3a8a7db137ffe74464c77defa02fa0fe7ecc74"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "8b76b3524cd8ee8dcde6db5570276d07b15d8556ee872288c20d81e4eb8607f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-kernel.ppc64le.sig",
+                                "sha256": "cf1f306404fc5de1fa0960dd66fda240633f944c9d95300d132bc4d00d613301"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "b2f5c474f707612e11e0cde89643da86d97c8f0aa840e8b6d760b0a56a5aba59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "81a1644fba565a1321baa2389ec01e44a8462b29a5697863c10c3f765837547e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3dc84ceb969f86dfcf466b5b2f984afd481ccb38ffdadcafca88d239368ac1db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f96dbc858924ba31417d1695f9c7d6e9d7769297d3dace90e2c06423133ab683"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "103295cc39486bfb21547453666c74c6577d8605b77927d7cba21840bec3b50c",
-                                "uncompressed-sha256": "7bcab0e80655b9ac58033e975b6753be25bb206594ba997fbaf602f3210126fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "1ae0b1c86804b8e236811b75f8ebf77f13230fd551e6f6783bbd32a24fb2b02f",
+                                "uncompressed-sha256": "3b865a151accf504bd484bd7c1618b6502bddb771d68554246063ad9c9afe387"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "0c37aaaf729a605e89672b4cc4507b917f11b4b848259518b6a99be9405499ba",
-                                "uncompressed-sha256": "d51e738caac6b05ff8510e00883b7ce362b421230d6c487fe5c13f320357eb2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a18f2a632e7cbda85a92e0b948aed98d4caa0e6f2a9ee377feef3d469780c824",
+                                "uncompressed-sha256": "e241e5b922255709172540f0b2b7ecede6c6e16e492e75e20721d4272d07b14e"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "5f9c6e57b4722bdb91dd85b2bfc065981f80894ac18e68159765b2f9e05d9d3d",
-                                "uncompressed-sha256": "32de6ee90f915b7bc486bb66b8231209de400074d2bd7e7d49790d6fa938fd9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "3c484b3ec6694a0d2506190567d306d5cd091b8eba9c95dc7706e858f8f91e7b",
+                                "uncompressed-sha256": "5fa0470e7543ac69fcef098530184eba71a6ea99814e31be55afd43ada0e519f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/ppc64le/fedora-coreos-43.20260331.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "77022895dc0ba598e1e215d4927bd2e460bbcb26ff3cf46b05b942d429a3ed9f",
-                                "uncompressed-sha256": "7e94a81e65d729c723a6a01a0ba4776d23fe4749735ed4a4d74e131683510d3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "f0b309660e4c84d87df2565879ca713144fee3f1b298a38df0da5976158de415",
+                                "uncompressed-sha256": "bca956fa7beee32aa67ba2d90f96be7961d58873ba6b55d56dbea2249a94ab2a"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4583e2b17cef432a302f1f73dcbb80dd4d36725fd9c0d4121a30f54aa1e1e47e",
-                                "uncompressed-sha256": "597a242c411f9a85a0c63c0beab08b239f6b4946a30a5ed48cd65e75a05289f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "a3eca008e7a6b6ee7f24db9f5efde5cbeb72d142fd2c200c25f3155fea712986",
+                                "uncompressed-sha256": "7e0e016b3da875eaeddbe6754c6c12e2b7501d900fc0f0183ff135328eafe497"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "1fc3afa749f4cb431b9c9d4b74d4acee85d91e1bd7ef9f7efe27903737f57715"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "1a06a626d78b844416ce421a8c52dda1d323a740dc5f5007fe784e0790606c6d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "d2cb615b502a52b15a6d773b91202b5fa3c4eb24adea9935a69bbdb3e020a3f1",
-                                "uncompressed-sha256": "6a670d480fe61717cb413090ed79699b41cb653274a2aa2f17b7391e8e991438"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "22093e63e5ff38ae746a3c7cfb4b77c95a72cc3ed41be6d2cc524e794e07ebd3",
+                                "uncompressed-sha256": "c63ecad55cfdc9350ac3cb3bcafa3034c2497c3e4649fbb33dc5dea8739b96ed"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "c42ea158eee0259aeb66419eec5a4e5829befbfb4e3926af06a9a6d429c4a165"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-iso.s390x.iso.sig",
+                                "sha256": "af19c23c274a478232bcd1c6ef986fef396a79282a0c372073ea426b76aec39c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-live-kernel.s390x.sig",
-                                "sha256": "6152473eafd2325db8e5ead468841f6c96e8b3e2557184ffd6d4f5adf51531b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-kernel.s390x.sig",
+                                "sha256": "5d43ad6a4819ec0e0a82d09bc84be2ea45fd5246f8287fe4c587b3bdcac843d6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "e9f9791b522facb982991a3639186fd6eac38bf107fb57e5edd2969b895c22e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "fa9a21f9d29a995cd6ee1298db2099e81b1080e7ec700156918f22f067ec69e8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "2c539a4aa264b81d5fc453f6d111d15c59cf8cb1cdfc6d0bc58686e64d41cf44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "07a9405a4e7626dbcb1069d6db90e0dd545750ff527c5cd3bf1ad197dc406b95"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "485bd4be29c9dae60df3235a8a6722a429b720490d525eebf950b1b5b30a4dfc",
-                                "uncompressed-sha256": "fa0120b1a8c2e5f3ed75995870593b22b5ba57913b13b4b4783c3280e211a43c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "81a336b50e5641b701cf4bf0699b0d8642d1c1d555b3436f17fda2d4bd48dca2",
+                                "uncompressed-sha256": "e1d30c66295eb9db20e6c0d65ed35b0ed254e3a46863a082af001fc6dfd5558e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "6e3bd6344bfb3e82835237c7a2c1419d70de913b011ddd22408d76f8afadf8fc",
-                                "uncompressed-sha256": "6a9c1ce7a024a2598170a85de71f99e4f507334cdad46ce476582a563f2112f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c45d30818322aece4036f65a6c9cd9c817bdf9430445ff28ba1e4ce7b1ce4d6c",
+                                "uncompressed-sha256": "9441685732b378cb945faf527e94f3b8c20966a4e082d4763a380d71e25fc8fc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/s390x/fedora-coreos-43.20260331.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "192097a76c3fa86dee4e44c606b7bea7ff218272bcd7ddfdd8bbb1a65a1da37e",
-                                "uncompressed-sha256": "c0903fe1c36de0b1fb9ac84d06a6ca4c8ebe8b8a1687e00cdaa7125108e2bb55"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "17b0a4fbefe253ee142ac711ae38a8c15aa98589ab05363a72c9debb1d62969d",
+                                "uncompressed-sha256": "84e23884813d6348df0393399087ad1646452d12af3a6627fa0cb9a0c9742e3e"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:61fe4382ad6d313b027d40e6360d9da598ac18bd7b550dd6f9d2650ddc622d45"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e30570462384ada83d71807b1a284deaab8ffc8517824eccbe4e2b3ab3232ef3"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "71c996c212fc54d48da7c1f56ab2e4a6dc1bad213ff65550742a61ecc07f75d3",
-                                "uncompressed-sha256": "892276f3ac58906d8aa9e69b663e1c60d75b534e87b2b39bc7895200226236f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9e048bd9d906df8152f32aaeeddfe159ac1084370d524b59517dc899615b31f9",
+                                "uncompressed-sha256": "eb3fd6357a286ec2735eccc9bf2306436c05dcab72cfee460d7c88d0db520e35"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "6cef640b3928972504b1a9a2d3f3fcbebda0e1f9cfff2d8aa7839f26e11bbefa",
-                                "uncompressed-sha256": "804498a83e8597d0e583c39c160c8c395f0716b16b03f24214c33fa84326b58a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "c79c57472525eea0c3a8f73e063379dce564c8708d2b63f75a11f1d2e97f79b9",
+                                "uncompressed-sha256": "8cf0f64679df9f92674248c2aa231a23466967d43209d5bc064012f1d46b5d56"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "7137db51a182bcadf005a370bcc4ce104584ca5a1c8b8f8ac93db5bae85636e3",
-                                "uncompressed-sha256": "d40823b403d00db022b8080268fc3e7d2be556d73158feba4b1b50d1d02d4a95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e8c99d8f135199e8e9b6429bfb9c708059029f93ac3d329c905b600b493a595d",
+                                "uncompressed-sha256": "fc03eb3164b6d8d9ce2c5831231f9342a004358a7408802c29c048e44e4946a4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "d1ee7569a3fe5c0605d5f62c2437fb5afb452d364ef9cc6c7fbacc8174afb54e",
-                                "uncompressed-sha256": "92e4211f4d46c99cd5ef399cb0d21d8d6e50464e1c40bcfe7eec4b56054f1647"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b0baf559a11944173a8cbdfe6e722e2c02eac21b478c1c06c0c73c5994ea2c73",
+                                "uncompressed-sha256": "2d5ba34a380b9c778bd37142fdf609037912d33b22c6e217c2f5cee2f67871a2"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "5887a6b91d437256ca4424e387d3f78cb184035778c5eedf8f93e684257e219f",
-                                "uncompressed-sha256": "f8bdde362f6ef99be480b8e39a2d07e08c8008810b42ad607c1c183988e1b730"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "456024924b6a82605a171d43f4ce62e594408a415fa08fde983f3be174e3ea9f",
+                                "uncompressed-sha256": "05c903ba118756a806fe47e5b069aefa7bba89b7ff214a558eb6d6d6ae737943"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7d894e228d324e94f32902119ea1400da813b3526bf4a38e8d6498671afebff2",
-                                "uncompressed-sha256": "f77c14cb8dc295b89a7bce6877cbf74161a422be31ab0984c0ff7e7971f0877e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f7d93b794d0e87aeecc9649c8f7118407ec3fe2e25305a62d6db537911804ea3",
+                                "uncompressed-sha256": "b8ea9843b34988139079b284ccacebc7a1ef7fbfbb5a3c2020d99c4cd0088f85"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a0a4dcab809b4c40b8e53f00ffc600b68fcf1b817825a8eddc12a3d0e805958a",
-                                "uncompressed-sha256": "20df293e7f3ae386f08f6130a1c85a960188dd946a8292a791e2e42daf9123fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "69907649d81b74d9039f08d81ddc488b731b4d69f25f79145f337a7bf8e165c1",
+                                "uncompressed-sha256": "3daa917ead03e94f8d58b3b3bee2968bcad97819651a7af6dd171e55e34424a2"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "38bd3aebd78b824763f38eb7dc0f6cef9daa82c6d8e3d1c8c9aa3a80d1780c0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "43af47717e7736f4a38ed0ea511621f855280752dcc208e414e53993f6a5bbd4"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "2ba2f86343abca7aafb48f6232918eb1cccf31bb7d585905e430a84ddda89fc8",
-                                "uncompressed-sha256": "ef236d2e4d1c16b2460fa859c6a7dd38b25d91b75207429739b37d273d12471e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "a1e076fb65aaf838a134c89fa2d5787789c166e23c0702e3088da456989473e5",
+                                "uncompressed-sha256": "ff43421e1d4132ce29b2755d931d1190434f499e2ce8cbdb552ff923e047df7b"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "0e6bfeb962a56eb952d851c68e02cffe717f7497d3b816dc70a4ed97f8406956",
-                                "uncompressed-sha256": "7f6f0c568e435666a3e50cbf21b3fcf3431144b809193d406c8360afe26d65db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "06ce14a5c03b7b00a949fc343d3c9a3118731ec62fe1d354b52cd3ff6b0d3d76",
+                                "uncompressed-sha256": "73d2535c093992464127a3a52626864053c9c6776317da04d53412e53eb8e811"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "11ffa5bfa6198d780bd8f293af67d525f7206d7836f8126c5fafd2c1f169f617",
-                                "uncompressed-sha256": "3bf057eb8915eb1973c80997d7043f31eb9031e15b66f9c7ab6fbd707b40f28c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a17dade0e08483b38478136bd7f91f6078ccad54b8bf18fe60f97c8aeb534d5f",
+                                "uncompressed-sha256": "96d563c9cdd66df9e694ac1cac4421ff0fd0d033a497e021e07a97843b300cd5"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "5c07492230f5beed8b4b320acea9811f774c2dbfc6dfcb110eebb6ac2df8afff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c3897752215a3d2a5925fc3c59e0c078f3aaec64f1014746c2181f4beedf7894"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "6642665492ec974eb0e7f18fe03779c72366a22b7b023e4ff508b3d4f415dc66",
-                                "uncompressed-sha256": "3d8c71eb40d0750ac9ec49c09af9b2c59b2e7b5dd13da0b7f50656403f43804a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "caf8e4881732248f1507d6929a224240ac3f0b3e3c9e4bce85b05c111378be98",
+                                "uncompressed-sha256": "9b13278cc8bcbe80aed0ee196b24950c5c178e65a8646c249001e576257ce7dc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "e69b829d77683f6db6641baab5f3d8500967aa7413ae68bd1f803ce28aeee30b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-iso.x86_64.iso.sig",
+                                "sha256": "b18bcf4173212e5d55d4b42e16f1c3ced0033d80cd434fff760d44e3aa38bea8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-live-kernel.x86_64.sig",
-                                "sha256": "80bdd497f1ff9531fc8a11df4494a71155e7e1bbdf1bcb7d5ba55b81803e5a7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-kernel.x86_64.sig",
+                                "sha256": "85c9a2a025dfe976a0da98157c7956208ac72388f9eb01d246a69549df27a993"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "50d7329d4818eefb0a1a54a491327cdbd6c9248dc69bc1bfaf6b4dd392b5371c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "88f16df1445c104a2d7222e5cef47083b7ce0a81021d5728a4ec953a882b2bea"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "722bd95cd218084db4ede1cbf7e47a683825b419274d03bac4109d73a889c0cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "add8421dd922dbbca5a5b41dd733016165dbf3abbb612a877dee13765acfadb1"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "0fca0e984620dce1bdea23a18e5fd80086c8d4737f59939ac7fe8311942c2d59",
-                                "uncompressed-sha256": "7aa4a4988a0196d3ad54bfd7e689d55e609b0dd35a015a3efd346b7906e67187"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "62fe0ff35df5c0c05d0a9938a887da63d298843c64a0f953d6e3825f2e1ca639",
+                                "uncompressed-sha256": "ceb3ccb7a1d30b3436a886a2f8952888344917b7c7a84a01272a70e23264b288"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "231750fc866511e7d285751e2ab9d2e7a0aa3323f3b15dd6b9e36534a7b560ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "35a4b518158ea47e864293380fe7cd036c591744f0b0cd04b2a91c97589672c7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "74d5249d04025fe82b07bb8df87260b03d05d46d2c959954bad89950297f11ff",
-                                "uncompressed-sha256": "aa617983741c7370de39c3ff6453505fed353adae1dea64aefc81ea76b2439fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "9d917c9fda2d6b472fa40e16a6e57c9d10be5cd854cf79353d8947b39f3a8561",
+                                "uncompressed-sha256": "3d250366741b2423d7412816a7c9354e0a16453eda37eee45d6da19b1dd25234"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "f5299b3fea04c850a6d40fff71d8cb1958ad0e1003e804f9f7cabc8a3730f247",
-                                "uncompressed-sha256": "85e23c76d7c82df1770998c41de5a51ad53152a2edf8ee9748fe09ef5f9ebb06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0e7a4d70047a6ea5253812e86bf0dcdba2dec1a434e0d827b90bb2fff5e595fc",
+                                "uncompressed-sha256": "5e20e7de69f1ac08ee42d4314ea315577e3b8e07c1c93e446964f8c6ba2c24cd"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "a7bb43e7230490c17062ccb4527a7f9225e1f5897f293a8c8853253274417a17",
-                                "uncompressed-sha256": "d1ce04f84520abac11518bfc5cf4601a7acc56a45ed789de468f13f7536aa5c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "76a879c0bc80283b01932d331e4dd3895c056436370bca12994b0613fd1d0a96",
+                                "uncompressed-sha256": "1b7b70a0d324231b0fa367f812f6e89836c0f58d13eea993f6e59da524d0003a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9390f9d20c78cda5a61b47520197505ddc57798c92dbf10f3cd3a458b816e03e",
-                                "uncompressed-sha256": "703bcf485410165a5b6f57e0edf5a0375e33b3ce2d2ad5b619709282aa15e3a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e6204a1695c0f7a3496e14364b104a2ec4c04f2967d5f41b744cf6e4dafe359c",
+                                "uncompressed-sha256": "e86cb2e00bf9b6eb767c9da68dee6e487428121a3e2c68d670bc15677935c6dd"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "e0df075bee2176a502430e4861977aeac9bb6c105ff63c768a6c885b4758b724"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "07615358b4326e2f6ae6008cf9107458ba528b61684d550ed87f7b76ba706d04"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "610ac4a8068d6b5c061b4c4e19309402b05fda1275ba02c73ed4f850175d628a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "de93f7ae799e7e62df19adf6d4e7cd90c22e74e1233dbc3ac55d9e899d1e3e14"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260331.2.1/x86_64/fedora-coreos-43.20260331.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9837861bd258c6ca6a76c2ae28b47e4e5e20df49daab07df4746752adc281687",
-                                "uncompressed-sha256": "d45e979cb698a5520bdd9e6b8109cbf7b2c7cbafbceb670fac074bf78c135341"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a44d09de0a1caf50fff73a1433a9b128e3c4ef23a06f7c15d30ad90bf0c568cb",
+                                "uncompressed-sha256": "52142f97d4caec69e3cc4f4d738b00774b86694514652ff4bd6006c32fb837a7"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-006d35734c9d98a94"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0d4ca0b574fcd40d9"
                         },
                         "ap-east-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-09ab1268281c48c1c"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-02dd03e7582e5c396"
                         },
                         "ap-east-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0e69ffcd1c647a688"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0c5d286d6a407047a"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-028ded3e2ae2e1aeb"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0d10d8754aec5258f"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-05c7a518d3bcb5f4a"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-088b479a7a5fe4398"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-014c9dc44b64cf091"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0948a742fb9bb8851"
                         },
                         "ap-south-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0559f80f48584d3c0"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0ac19c9646d48f025"
                         },
                         "ap-south-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-08c6bfffb1dced794"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-058e6e06ff0cacd01"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-093a542651b065e17"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-08e275d0db88ca1ff"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-02ef42751c2a35d2d"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-03b602ae9af2e9bad"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0b0a2114c8ba21636"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-03db3028e9987245d"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0dd95f9478534206f"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0e2b9f630d970d829"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-044ab8eeef4251115"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-05c445f8530414fa4"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0af4c470846638dc6"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0a795169c07bdac2b"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0b76e7c5c608f1fa7"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-01a2386f8cef004a4"
                         },
                         "ca-central-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-03208191dad4c9a45"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-06ea44f22bd23aec0"
                         },
                         "ca-west-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-00074f9363dbee9eb"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-09f5f7eaa318fbaff"
                         },
                         "eu-central-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-006921d41ba7b367f"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-074d6b6c99624691c"
                         },
                         "eu-central-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-09c5873a72d341c88"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-005ed2a423443d192"
                         },
                         "eu-north-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0f31d6445101aa484"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-09a42bf2447c0b16b"
                         },
                         "eu-south-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-00fb76aae2ea073b3"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-022db59a8f73e27f4"
                         },
                         "eu-south-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-04ce61e1f2837454c"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0f798b6e10df56f94"
                         },
                         "eu-west-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-09a4b613fb95cf7b2"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-008e8769e4afc70ee"
                         },
                         "eu-west-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-05f7ff1c827edbaaa"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-06f926c339a4639c4"
                         },
                         "eu-west-3": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0872a9f002276a98f"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0e3b57fe30e196cc5"
                         },
                         "il-central-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0e4940b7f0a527c71"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0665eb8a400f39925"
                         },
                         "mx-central-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0ce945419edfd6523"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0fdec8acfad7949fb"
                         },
                         "sa-east-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0792b0ccfc74d4c2e"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-08dba74a312cf7576"
                         },
                         "us-east-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-02c107a132405a662"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0fc8e08697893b990"
                         },
                         "us-east-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0deaf424c259eb812"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0da231aea24d6b572"
                         },
                         "us-west-1": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0e0d3c417499fcd0d"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0805a4e1c24e3a180"
                         },
                         "us-west-2": {
-                            "release": "43.20260331.2.1",
-                            "image": "ami-0381559b7eb7aa67d"
+                            "release": "43.20260413.2.1",
+                            "image": "ami-0afcc2341ae968188"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-43-20260331-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-43-20260413-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "43.20260331.2.1",
+                    "release": "43.20260413.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ab1490a27298c03a154aaa308b8e6c38e54aaee6769421b07bb6a34f606585e0"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2dd373c32fe33fabd20fcd7f7cc049d855aba6d82b541472cad1801e5630423e"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-04-07T18:08:53Z"
+    "last-modified": "2026-04-15T16:36:05Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260331.1.1",
+      "version": "44.20260405.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260405.1.1",
+      "version": "44.20260414.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1775595600,
+          "start_epoch": 1776276000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-04-01T15:00:43Z"
+    "last-modified": "2026-04-15T16:36:03Z"
   },
   "releases": [
     {
@@ -149,7 +149,7 @@
       }
     },
     {
-      "version": "43.20260301.3.1",
+      "version": "43.20260316.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -157,11 +157,11 @@
       }
     },
     {
-      "version": "43.20260316.3.1",
+      "version": "43.20260331.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1775138400,
+          "start_epoch": 1776276000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-04-01T15:00:45Z"
+    "last-modified": "2026-04-15T16:36:04Z"
   },
   "releases": [
     {
@@ -165,7 +165,7 @@
       }
     },
     {
-      "version": "43.20260316.2.1",
+      "version": "43.20260331.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -173,11 +173,11 @@
       }
     },
     {
-      "version": "43.20260331.2.1",
+      "version": "43.20260413.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1775138400,
+          "start_epoch": 1776276000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).