### PR TITLE
Roll out stable 43.20260413.3.1, testing 44.20260419.2.1, next 44.20260426.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-04-22T00:54:15Z",
+        "last-modified": "2026-04-28T15:58:58Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "510cd3cd083dc17d40ec2b8c725c26fd450a046747c169338b75ca484afe38a2",
-                                "uncompressed-sha256": "30b9071983bc34ddf3ce3d0e8d710d66827b9a5631981b130825306bceaed73b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "f1ceec6cbce9e4e1ffda00c5285fe0180797e14fc192a3263e417c52fd8043bd",
+                                "uncompressed-sha256": "aa73aabfc087592c5e75d286557a57e723dd15929364f33b63a39825eaa6af97"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "91549e22b8df796870d42692c746e1436bf9c91717fe58e240ec6e6c81c418d4",
-                                "uncompressed-sha256": "9df5e0e6f82a17244cb1768e479e8eca21de7c827ca9dbc563afe53922796969"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a975f6af90b0459b24d668ade02052d52b688c5e82bf60e99869fc66d7d14762",
+                                "uncompressed-sha256": "44b0f9cb5a42152b094655f78f5decd1242814d01753bf66b514ba1c62423dba"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "369ea8c6669ee73d44539ba679d13968e07512b8cdd81134d15feab94f63fb99",
-                                "uncompressed-sha256": "939a0efbc9f61e829bcdab71b958d1d650c36593988102719b07ebfdd47d6669"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0f74767f9167ede9a07609dd4993878b9b175fd01a82ce007de973e3ec2b0ee2",
+                                "uncompressed-sha256": "e48d018b4439b34bb84dcb8f0fe4a6fe0b1466f7c0ebc95a6c33c9d665336a2f"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "949855066a54c5ffb30d4be234e35b0c26e516898fb8c7ce5f7ed119fa6486cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "302e8099babfc89016ca1c2856b8c3228eb257aafa3a625e76b395a68fc3a0a8"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "c790397fc742b8dfc8d18bc16c899e726972d09e82830a6524d04533ee694ab1",
-                                "uncompressed-sha256": "3858b9825f518e387aea3f0d47ebba24e02dcc20bdb000b92659f8cde05c8223"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "7454d04939e99f43d4975e05ba372dfc4c8cb35b3c8bd7805742e89a39e5a60a",
+                                "uncompressed-sha256": "0b40053dbe77ef32c86f2e9e095ba45222bf41d596b01ee749594b38fa00f3ec"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "b2cc91e93fb2551041843b709b6eaf07eef88d4fb9bf98f3f40b8adc9fa61ba7",
-                                "uncompressed-sha256": "ea01e1ac976838b436289faf97c68092bca6bd86a1b90ac1db597d9707ac1f2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "382f74582b737df58cd80623e1659e04fa0a3374c9c107637939f62ddf554781",
+                                "uncompressed-sha256": "68d5e04aeea70a77c7b0a1239912b04ef8892d31cdf572225d97b68f78d41002"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "bd77aa300a4ddcf31e6ffb4db330b10f2fb7c78fd28aea4366caf272f74a3064",
-                                "uncompressed-sha256": "c0c9be814e6c776919d2b45e23fb387f3f99c9a9ba41f3527beb67c2e19b6534"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f64a997af459378c6582be62ce0ffc49e19eff94ea063c739992ef4ef827677d",
+                                "uncompressed-sha256": "9a3990217efc034e32f21b92b926eadef5d67bd597916ce92b806a6a5e8ba4f9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "5e15f2379cbcd91e1bb9524722af7b7016a94262a85d374e141c328262eba2c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-iso.aarch64.iso.sig",
+                                "sha256": "32c3a0f3cc7a500eda25bdf50316c7ce273dfbc14546870ac95a5d77882385d6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-live-kernel.aarch64.sig",
-                                "sha256": "d33744c96ce290dcc8649d80cbb3abe956f661e93a632ba56bc559384d128c24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-kernel.aarch64.sig",
+                                "sha256": "4314e2feb216deba0d0998da1693a8ea9e432dc47c5f81cd3408d4d3436dfeb0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "1e016a0f0a5abf016c163c9c3099f09e68f1fe070c4b07b2cb96d9db8c825a35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "44b5c3b0ae03634a0bdb05e162b3709af61ae4be3956b0897a545b583e7488f1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "09dc97df9f1e233a6539d8ab60e2f7e0a73920458c42c96a105d45b3b021dc5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "68c95eaf122a4970736e735a9da795806e0652bc889ddffe37011237b323968b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "3ca90d4aba786b5b7668e7f0e9ea45333ed4679c3b1d160fa90958b8625ff7a5",
-                                "uncompressed-sha256": "67563afff2887a3670a18123537f4a87cc142128c0cdeeeb41975a2a821524f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "5b9f61baff3b4c0aebe0bd231b6ae2f437fcc20d96a7e27c6cb9324e5075c9ce",
+                                "uncompressed-sha256": "c7fca20f7ed7ffee5cc6757a96d41ed1820b8d6bd1ba2665b3f48b87a0a93ee7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "24faeea202e5193891dbd7f3db96c2aca78845921b8b1ce6889fa8b3f9cc044c",
-                                "uncompressed-sha256": "ad0c5decc37f11471e724262824271513d58149cdd9a469f2915f474d8a00035"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "2dc161c65d50d1c4933c6a88b762c4bf25dbf0b0cb8fcfb0a599fde38d10dccb",
+                                "uncompressed-sha256": "640cb3b4e84b674f1ae5870851611f58a87468769e872d8f722ba26164e5c6af"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "6d3d45d9fa92d664a370f42d292e3c2cb9444fde7d09eb175129c27138324959",
-                                "uncompressed-sha256": "47096cd424f9e678657f999afd6ba85de6f3230afb376589ac86a0130f234805"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "e6da45abcf4357b03ecbccd005ea18a948b014254ebf4eb9aca2da68da9a3e9b",
+                                "uncompressed-sha256": "69107cac5e218a7ec7b579790a79915de2e7898dd2f201fd55156b61b0452ced"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/aarch64/fedora-coreos-44.20260419.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "020b5cf27f3ad28f2ed52fa4ee6b36c17a67af367392f1b499fd4f878e73aadb",
-                                "uncompressed-sha256": "48c5fdef0eea516c3653bb24fe5f609a34cfd202218f14702e4776eec159e4ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6e27061d972b5ee36ef24a756d90d837d724bf114820cba39e985cff9e18b3c1",
+                                "uncompressed-sha256": "69f8410be76a3deb2d1914f2dc7a02415b40680d6ffc140a0a3268df595e9e2b"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-077be4ab6a56452ca"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0bd3fc79df87e53ea"
                         },
                         "ap-east-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-02685e36b248cf28b"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0d5c2b227cc7bb4a8"
                         },
                         "ap-east-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-01fc029a688a50d01"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-01404c8058ee647b9"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-096c355a4cceb0d50"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0189ac8b47ecd5ca7"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-02d1a2f6b17da1c18"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-08c0fb00f09bc20d6"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0e6dd50172da18723"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-08ae58215231d1ebe"
                         },
                         "ap-south-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0fd1d18a4c9f58c54"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0f99e5837c09bb65f"
                         },
                         "ap-south-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0b7fba2dc46dcd8e0"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-09f87f581b2028ca4"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0b914663fa842dfba"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-054e32b8a0c85ce4b"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-094795da7e038dea3"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0874ff675a3d6417a"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0c60ab7adf9f3cec2"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0c004a1027c28f176"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0e5c2d17110b089b0"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-093775703d6786a11"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-095318a4bff016764"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0c25ab1701793948f"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-062e3a1774e9b59b0"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-068e4afe4a32cdc62"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-08b6337e66ae23423"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0939aff4f5eddf15a"
                         },
                         "ca-central-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0df73f000021b86f2"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0cd61dd6816b26173"
                         },
                         "ca-west-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-063e0612668dbb253"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0ffcb75bd64c661e4"
                         },
                         "eu-central-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-02837c1e80925c74c"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-02fad68235eaaeaa8"
                         },
                         "eu-central-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0e51fa81775cb60bf"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-083a8705fdbdd2a23"
                         },
                         "eu-north-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-045c1b6c479f30c5a"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-09be4a698a80561ad"
                         },
                         "eu-south-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-029cea419766ffd78"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0761bc313ac568900"
                         },
                         "eu-south-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0da32ce81ab0ac7e5"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-04d1216e653964a95"
                         },
                         "eu-west-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-02fe27aa6c3e000ad"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-03be9d269ca003685"
                         },
                         "eu-west-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0f6cd8c78523d39e8"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-01dcc2e6aa31fe12d"
                         },
                         "eu-west-3": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-053c100a7580f5366"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-05146b6380e2bbfc1"
                         },
                         "il-central-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0205cbc77f80a89d0"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-034935960bcf3243c"
                         },
                         "mx-central-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0390c80e9652e2c86"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-00c558b63a9a5e49b"
                         },
                         "sa-east-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-058b3ea7e9492537d"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-04cf0f09a11f982e5"
                         },
                         "us-east-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-020e4ac0a5ecb47d3"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-049ff49bcf5321881"
                         },
                         "us-east-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-03eba4d984c7ea0ec"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0a3e50a7743592a00"
                         },
                         "us-west-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-091490d56a6443a13"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-00adf24e26bfc3e20"
                         },
                         "us-west-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0d1e5ee791cf66be3"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-091cbbdf46a24feb0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260419-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260426-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "886a1714b17773888d34dcaf653de4b43d85faf63c3f176f280ac9ad611acd76",
-                                "uncompressed-sha256": "33afc9dc34014b3cc7e90effe05ca1559539b5d5899757564f6f1e24e4852fa4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "66c64c20c7d1dbc21c21712b3f4f3c4a054f023fef90d45746bb64c33d5592b4",
+                                "uncompressed-sha256": "614f31029521f7b2eae19f74e057df1284e88eece542fea6dffb79d4e61eca54"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "1cfd1c09daa3d9a3f886669e507274b0232aa11e3a5263d262058d6bb925ff47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "36d35c23c09bd21b59940cad7b79708b604bd0678cb5a9c55d5d95a84df27ba2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "c0feb764e6f637d851bbadf1663c9539d594728925ea69179671792ad2bd14c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-kernel.ppc64le.sig",
+                                "sha256": "9887efd41811df6c8c920dd2ce39b9718f83a3405e6b50f183ff98452a6d77cc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "2cd2d6fd8e7072b92d757d2b80ae93e719e12eaac7f5b9b2ca8d70a62395deef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "dc01282bc7c048c29a467496db7ef2396c8394c0dfea379a23186a85c417b6e8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "c70857842d4cb0abfc1c96c8fd63cc2c892ceaba82f881a9b65b2fb6a7402549"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "da547b61a150ffaa815d5a46284d7d6d24aa7278bb8d9d7b8f75d2e29c27f7e3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "72a8aba87a2cf70f8f676982f55ec011f48793d7c0dfc2e24f9c7108c54459b7",
-                                "uncompressed-sha256": "61c4c265fe6f34cc65099db6590d3b2cb1a9e0f0c0b38391e621faa93a23856e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "845b0cf184759052ed184edb0d554bc1981bf0530b60c4892290881660fe1b57",
+                                "uncompressed-sha256": "c544fc1ecb5bf17f6e8f56e17b78a92d541a53f40a9084df11997d7b705c6887"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "eef25ed3d79171e617f8606212e3919f2cdaef8a07dc13b797f590900530378a",
-                                "uncompressed-sha256": "c53c79ef0ec34b46606e8990b2b6ac5409157cbeee89692b9299b1a07a85ec40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f1ec90bba773a9b77193be889b1918d56502e19005fed6b82a8f9e6d3a61baad",
+                                "uncompressed-sha256": "cf2f9155b8c499e95c668b04bd8891a01b9e3d5c04739eda688cf0cc9b01b6c9"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "c914e6f0910cc325c6e26c90ebd1574d252e387420298522d07ab3ecb906f8f5",
-                                "uncompressed-sha256": "896c5ca9296fc815197716b3b0b65edff6f0a2770ca5e0284db335d9c861389a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "270874f28498631c56591de69c552e38d7ae39c7fbde153ef1d6e05cc7585666",
+                                "uncompressed-sha256": "0e40da8c1d80c8ff6ebe4bacb92b8e27baeb3555a2bc416f6b529ad67cc602a8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/ppc64le/fedora-coreos-44.20260419.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "dd663b89b41441decb3a7a599d8bcb29f82ce948cb77667f6591ba94b071a85e",
-                                "uncompressed-sha256": "a2673c2361bc9f8fd980bf46ab7553490db8ca573cda51c1f9b1e688db91730d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5dc8e4c9835f2fda366f0acf32198fcfd134ad214f1a2177dc7e81314cd9dd84",
+                                "uncompressed-sha256": "e4b87e1db2edb6c9631800e68d7d124ee96d553ba7d76382a14949a10b57686e"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e081d5ee705e0d78c87805ebf0ec39daae1bbb47ef1fdcb07f4906026d2a6cdd",
-                                "uncompressed-sha256": "34daab78b3da22acaec7313d1f6b234b8598f916b40ed860f6ba339207cf1e18"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "0a7c267024238286a4976c88f46cb53585912e786b31b2dcd0c4be735b753bb6",
+                                "uncompressed-sha256": "7c4c2f632cca958dd23e4b972fabcf53503255637c24100fd5e3f2dd824234fb"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "03faf34b9ad74a9c4a2185a1b4a73d26a364221a2774092939c6a7a4c64f2aec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "d7eaa53a6a41110bf817cfa8a8e7653690de8b6e8fec3c0653a57b71c7cbd665"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "d64c58e72dc23b2b68a6494fe171e29be9f5619e7bd0bcdd8ee2cd876f600d0a",
-                                "uncompressed-sha256": "c958d451c7257bc978080cea5df34c3fb4557faa6eed26474423eac34a58a279"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "cc07b000a1ca0376a28d1dd668104440e3c6ffda5b328b6143ef5fb537564353",
+                                "uncompressed-sha256": "7021e743ac155e4eb828f6b1ae9343c1b9c7b9657b73e0d2dc447ef0d6dd4707"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "3c737218af70ec25563cc2bae1c1eaac743ea015443e6a433580d283d2e2c3c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-iso.s390x.iso.sig",
+                                "sha256": "944cba56acc25aaf328a849b4f6fa4dbd1347fb2ce529e45e9eea0f21df4b836"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-live-kernel.s390x.sig",
-                                "sha256": "b27bbe4ebb2f7708457b25f011ebb4301d134c5b98785bc97401b4a061c02d84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-kernel.s390x.sig",
+                                "sha256": "235da68228c9ad07d2092f6acedd90860f202e6d2bbd55c911be07810584ed3f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "dcfb4fc315592c82b00f460270f1c248fa12dd5f82d21b12e5d9ae6b4d94d828"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "d3611e1b22b2fdef15ff1c1fca44723dfef26974ec6ecaffec7e6a935928deb8"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "1fcd7725b8c02b0070094b23e4282692c781fcb4465a68a184082100f4a39016"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "16102dc5ac31787366047a31d3907633d5833d12a6b9ef7f42d065a69e39b5c3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "c614ccb7852cf54c63c6ec8b570ca6ee64cd1227b80219080cac11e0e5c1387a",
-                                "uncompressed-sha256": "29286456a37cc7db2c7bd320b8d7a911e5651cc3c91bff231efd189960c566ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "b19afeeaf223e6523cabffe89939e03f113413017dd21cb28b7c4e926cff196d",
+                                "uncompressed-sha256": "794fdbf5f5f8d0fe15b09fb4f266fd4e128b5ff5efd8a78d28405ecd27fb5358"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "0aac27227b9d29b877b4f91d70fb798840516200b7b832bc01627b84d1c8ad76",
-                                "uncompressed-sha256": "17ebe46659dde2c803a8ff79b5f3d6159c7f6078e447b202d739f5223001199c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "380b4ee91076c24a863c98aa57c2c7d4a646d76c4e352c21da6988ad78116ab8",
+                                "uncompressed-sha256": "db93e22afecbff6c7b302ef9b5e749bc5c5a7096951f5f81fecb24243c00a115"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/s390x/fedora-coreos-44.20260419.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "91ed9e913e5334d39a1421b2909776aa4c0ae9c01a1748372bf0372ea0cb9d1f",
-                                "uncompressed-sha256": "060e2edd5d56906023da0f7b87f12b86fe9edc4cd34054b85229958e6dc52bab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "7b5d2e58d91cf398869c810cd7d0c4105f9eea617d136fb72b1187e925055839",
+                                "uncompressed-sha256": "359cc44b1ffcc7a2f9aa9726c09881c8ccd4570e8629decf1956be7b400df28c"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:03d9802b3623f07da2fee9e1d6ca3a07f501733859a0f86c44e17d02394e0383"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6a546f459d0c48c7fde10e5ee57d4a0b61d8347a7218f54dffd5c1b5e20017f7"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0674d24f45a901fb2b68acae068bdad40b361f00b5aeec90ee3d49325a44a731",
-                                "uncompressed-sha256": "9146a1a516d04d0084a420e78d3d31f4ad5ee7455f3145110e4e892f05e8ea06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a34e1f716a919d07b0b5e9532c11cb123871b8af85adf1357f686c5164f5dafd",
+                                "uncompressed-sha256": "8f882dff9237e6967c7a1eba3f09343a1f98ff44e410ccd02b2725ecc5be2ab6"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "8b093cd0e594656ed7f3fa68c6638a3a22a568c4de4f8bf815d947fd39576531",
-                                "uncompressed-sha256": "73937cdf97420777ed4393c0c91e67e92ce5d86edf6fbf06e8f232a745396cd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "598d62feeeea84c794c9db636e029cf0d53997fae5249470c73021cc60d2f927",
+                                "uncompressed-sha256": "a2cee4447c610a60530e00c2d53ac92962cd382e3011feac57fe929f88e8cd80"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "82cd13786662f1e7fcd90e0af6d697b87784b04907b9617dd4a5153301f2ba66",
-                                "uncompressed-sha256": "87f9544af42282b9b20e95e2139600ab881421b9281db1badc0be8434435dcaa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e6cd6da18fe672b7ff5b53cfaa0f177bb2dfb3e7299f866b1659bb5fe4bef185",
+                                "uncompressed-sha256": "6bdea822c35f60c79a9d732b0f4cb543fc120e5617de5c3dd59fb71ad31cf9f4"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a4d8906e809f64739800db66d106309e25d8a39eb6e9aee322646bd0bc2489e2",
-                                "uncompressed-sha256": "153f224b896a0fe3e9bfae7c52cb92902a0ead6988bbfe0dc5230110e120cdff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "b2432f647ecf314a72d4ede305e93eda3127519d478bbfb1f42233f0a15387d2",
+                                "uncompressed-sha256": "fac6a66e1b630c6960e8ef403d617f2cd67338482079327c1b798c0ecbd55dac"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ce7e26ff1e48ec345c09937e8b2d32012622733c4004b477f6195c54351ab4eb",
-                                "uncompressed-sha256": "0fbfad3462349d40b058dd70a219907b77f898ff6df10b0686605104755e929d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "e824c908ad5a2958cb3a7f74ae5f0f17ba9276566f124b74a0909495fc2b4468",
+                                "uncompressed-sha256": "f80967e5f0f7f47cebf47f9fd0947082cf76d917cdec6bbaf6667141192a8898"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8a761f2789c7eea6bd61c7be459faba2fbe4838caf845a6a51f262f961acfd55",
-                                "uncompressed-sha256": "8c2c9fadd5389d84102bdba8340c680b12ea657e1ac02ced5fb9d30aabf23e0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e5846721fd5d77e78aeb7d978b360abbc01195ce7c31123bf24af32c89e16259",
+                                "uncompressed-sha256": "27d53aebdc021e0be7b84f3d4288ee1b6b6758a76dd9ed3adb5864018f2acb65"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "524dbedc84ba93eeb7a4655555c5d128acf6607a1f5d096a77d4ab6e73d1dd6b",
-                                "uncompressed-sha256": "eddf84f923713dd4e249b44ad2b62f8f05ba2c44438354aa4d6c3d27e8dc3e23"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8728b854cfebdd9484c8fb2c4dba7e95f5478823aca6733fec9ebe801937018d",
+                                "uncompressed-sha256": "0182a7345425825fec258261a70d25466ac5eb63bfec23d10279d49997926cd8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0aa0ca313742b3d9ea1c77079d0720d297fee2c3588f7d95b95417d415baa691"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4d658c5489666a7b9fb63cbcd9a2d4fc3633a9051295126429630402d88abd9b"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "a74e8e8a7dae4d8a5171101a2706c935ef4512042533c43ba1277e900f0d3536",
-                                "uncompressed-sha256": "2258c0429e102843ae5a9f6c2cc525454cb21fdc354813ce96733e46da06eb3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "5a35032254f7c0b6ef3aa900d0f2a81beeb94138be1f126cc5646b2dfb125097",
+                                "uncompressed-sha256": "1f173c8bdc326b130929146c21ec547d43913cd5dd34f090776297bec6ad405a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "d533c98548cb3194bb289147bf8f87ae1c1ee07b3f9119b2f06ee5a84f471159",
-                                "uncompressed-sha256": "a3bdcf7f7f5ede2679a242f9e67934d00fe747968f47b169a3b092c6e1b7b051"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "7244915eb25fb397c04a4af1a3b2cb55a74bb0c2c9b9cd721ae85e7836bd16d9",
+                                "uncompressed-sha256": "2f2934e6b69d7e3d7435288231113d9ae87a8ea62e9784df3c22a422959e32c2"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "866c4de2ce3b00b3329bde747f6ddf045d6c819b73647aef15d96867f0694215",
-                                "uncompressed-sha256": "fc2c27da336cf1c8c0f801db0f47b4b1bf36a08838068c92e21e858624cc3407"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d3cbbf8397558e7d42202f127a40503b4158ac65b9d34af22df22a00fb5db1b9",
+                                "uncompressed-sha256": "b2688122f6b5a2ac6309668a0bd89c01c8264670a7fa9de7408248d01423bc5b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "b4da7d340bf15a75fc19f6c8d54449aa42d35036dde2db2ddd7c4885baf83fe9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "65ef9b19cbdee938b04800f52a9a39a30fa6906bcb38834f8ecc1d25c9647a33"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "bd8f4b284c4e0447a4ad42019bef8c951cd56bb2b60ff2b4ecee87e26c8b9c0c",
-                                "uncompressed-sha256": "189ddee8a9e4bd3bfa0557c288c86dd02b3e89d3f1ab2a43d34de7d2f78a457d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "ad5e77a66068bf00f50b12e150e9c426bba529a58063399946cf644b254771a6",
+                                "uncompressed-sha256": "e6d0df41c125e7b2c89fe98f684a294ef3b05c8289542062104db91ca4b37fa3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "da744a31cc6e39ec32957a233d7c98dc0c7f99a99f806b0dafb919cd351becaf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-iso.x86_64.iso.sig",
+                                "sha256": "69230334972949766ff04c6fc16722878aedd239065d39589a83d3f06a4767c8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-live-kernel.x86_64.sig",
-                                "sha256": "1c8fb030127883eb16ff4e66418aae3b08aaa3ffa2c9e3d312d6989b2a9159ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-kernel.x86_64.sig",
+                                "sha256": "1cd64153afa5d746103a25739923ff2413e912365940cfb2d614cbc9fe3eee7f"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "49a544f90fb598cf8e69750eef04be038a8490821b53f10cf66737daf75fd7b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "87661e734d321d8e362e779209519ef5a559d1ffccb42c9bc80a5eb7fe0eefdd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "ac3e8cad5dde9aa943cfdceaa48777c74818084f5a54efb1159cfd65fa210639"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "d67cce2b389e7f623c0866c5c58050b4830cf6fc399926335ac1f9c89653ab44"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "500261540f2edab7147d1756f53f33724ace66e2756e424d7b6b9cb518671313",
-                                "uncompressed-sha256": "4b4a5f49bcd9250e6f4d89e6dc9849172379ce3e51ba6323e68d67211acc9c93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "fb121ba132e47d4fe85f7b8005b082be7b5e84d0826cc985e6759f68479491e1",
+                                "uncompressed-sha256": "48d13a9ef583d6701dd93a727fe61cc6967273c7da5b7e4ddcc89e16b1b5a675"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "19a6d93d2252bff85186dd57276829444b9ba3de70a03d812edb43167301a93e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "69cd54d11e1736baa9b9a1e3e71185f42e7d4363e83d0fd9e8ab83074c54dff1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "dc13adadc18ebf8c1d6dc47d07d15289f61a54482b33602a43197b8db2322deb",
-                                "uncompressed-sha256": "d61bb0719296a2d77da407bf0b495a5eca0f0e27bc11aa67af83f4acdfc98b64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bc2255635f5f333231d0ce8c9f29fb808471c0f058500c78c3f15671ad63c87d",
+                                "uncompressed-sha256": "4b0f6526de440749266a3c0b4836e2b39c729422264179cf95bf4035406ae93f"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "8e1fbc5eac208b4d569fd64cd1164e23d37f2f201bd3071778686e0087e19091",
-                                "uncompressed-sha256": "b65ba735a6ab7889a5085ea82894a22222327ed0bdfa47234f093ba861574609"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "050fe66c964da9df876f6ec1caad7b28fa1e29377cd8b63b526d6eabeccfa3f9",
+                                "uncompressed-sha256": "831a3f08fc27944e26991fa59f7886e50e015103dee36c1f660c759365aee91b"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "5b21e6ab2dfe376427bc4173b59778077aabe9c03bff8e0dbdfb2d1fe91a8011",
-                                "uncompressed-sha256": "d376509b06dde9bb63b5dffe4e630a263347899361ed20af93dfcf0236c5b728"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "4fac3bf02d241c188078e6a3f2d41d9de2f628a40b315515fe85f657587b805e",
+                                "uncompressed-sha256": "296e8e048b0d1d3e1eb72645124ec89511ab8b462517fc4782af6110986cf8b9"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8a90340a666492231ae720e3d3a9c49c9d77f4a7bab7a325874fc7c37b7fdbe5",
-                                "uncompressed-sha256": "b37bfc0ecaad3e214ea64620cdef82db6e6815fbce93e5a1a99c4cfebcd68fdb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b034d90075a62105cec4daeaa53a98f2f1d61e798c2aa22b4765805008701a8b",
+                                "uncompressed-sha256": "e298b73e7ad49374cd42ad3e8cc5af8be72cb8ed9713091e43345d9c77ce4d93"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "3a39b534120df4a1e0e682fbffe64b6d07f43ac612400949946f7f904461ecd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "f360e1e93922824fae695e9d96ad15830bdf8e72abba82e9bd02774fec57d931"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "34d2552e77a0248b65a4910477a1483313d33116625bbd3b55a55e8c081433bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "240e773a9caafae707bfa8fc6c1f423af8acfc71668ce28a924b3f8134e1ca34"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260419.1.1/x86_64/fedora-coreos-44.20260419.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "81b6a2d7ca3006c023f2e714c8e78f7c753a60310ed9bbc731eaedb4204b9878",
-                                "uncompressed-sha256": "dba016fd6a2f258add7332cf14cd5b23b931480691f1bd155e05d95c4ff9a781"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "bb6a9f35a1a2712477d79d453c149f7f32a3988bced6137465bdccf1d1178ad8",
+                                "uncompressed-sha256": "3fb7264062b069140023987ec5688d9169fd2a6eedffce594b9e397e5bb55f51"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-077b748af448364e4"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0685f12d2c6d2236f"
                         },
                         "ap-east-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0cbcfa58a63274d95"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0785d62ed7ae3c623"
                         },
                         "ap-east-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0155995fa4d170f99"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0067be2f6f308f423"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-00496c5371c57cc9f"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-00d3a872b5da42ca4"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-078ced7014e6d873b"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0e6cdc3f46812e8d4"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-089b7de6ee4f0d186"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-06e6bfdfae7e3d95f"
                         },
                         "ap-south-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-02f2f14c3cdc5e4ef"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-01bfaf6b8343482dc"
                         },
                         "ap-south-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0da3e1fa5c3c33708"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-06a432ad0e6b6563e"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0a06a2bdbc09c6efd"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-01ee417429a43927e"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0bda0bf113c8fcff7"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-080749ae1f7f71dca"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0ac4db7797a0ee0e0"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-004768e5cb54aa375"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0e2155cd8411c7614"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0186088ac662a4056"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-06e3f8bf199c35a64"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0a0efd84ed562a142"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-060c43f517307e46c"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0a00519efdaa64865"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0e0de838069883c1a"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0fbd1823ac2c52ae2"
                         },
                         "ca-central-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-04ed8180c3981b6c1"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0a0e29b002fc4df44"
                         },
                         "ca-west-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-08b2414dde6f8bb1e"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-044f83a0abb670887"
                         },
                         "eu-central-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-033f7cc1c48780bec"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-03467b328f017b647"
                         },
                         "eu-central-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0a596854788c55195"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0228a1e6e40266d68"
                         },
                         "eu-north-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-08dcfe91d75fba5d0"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0bd38ffc703a6402e"
                         },
                         "eu-south-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0f402c77c620c1020"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-005e51bd96cbbd757"
                         },
                         "eu-south-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-09457db3bfe6685bb"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-00e8be49203b6ecdf"
                         },
                         "eu-west-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-00d5503dccafe15bd"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-09812c19119c1a5e6"
                         },
                         "eu-west-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0a80052937c9cc9f1"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0d6f17ea35fd64866"
                         },
                         "eu-west-3": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0d52e6bc6cc913d23"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0ffef2bf54252ec08"
                         },
                         "il-central-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0345646d7507f53bf"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0e95a5132b50854b3"
                         },
                         "mx-central-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-046924aa14004910c"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-09770b320e15efd15"
                         },
                         "sa-east-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-00bd602046e71e1df"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0a580992509dc1316"
                         },
                         "us-east-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0e90172f700b8356a"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0abd6f0676b5c45df"
                         },
                         "us-east-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-0ae40d16167d29eff"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-035eca47716c4ac7b"
                         },
                         "us-west-1": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-04170616ec14a7aa3"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0305da33e4b063b1b"
                         },
                         "us-west-2": {
-                            "release": "44.20260419.1.1",
-                            "image": "ami-085bf8367f8556525"
+                            "release": "44.20260426.1.1",
+                            "image": "ami-0a8dd8da15daac086"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260419-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260426-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260419.1.1",
+                    "release": "44.20260426.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:235a0e03dd5d226680b9131da21e7d00664471b497e2962be3f992d662f92c68"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:110eb2d72c9022fb0fa2606f81ce48c0fb6bce605995b41bc340b9a5faa81fb8"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-04-15T16:36:03Z",
+        "last-modified": "2026-04-28T15:58:57Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "d91299036115f981f3636fa8cccb7da59ed9e124051a83a8577cbe82cb2b9758",
-                                "uncompressed-sha256": "f60c739b8058e6cd0a5416f4bb85fe0684463334f9091b9082ef45b8e36136cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "2ed3ffab18e77272021b7b375ab5a33aeae7150abdc437bcb22217391f7acd35",
+                                "uncompressed-sha256": "8912e56e7e37b190118725dd388a5f2b2cc95e1531971cbaae078be237ed0dd6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3ee5318de8d2ae0713e29a4b6c4d6aaa103a49bb8440622561a18176a80b54d4",
-                                "uncompressed-sha256": "5b0c241bb77b618e0d6bed45a3905b60431f4a35d3811ba0f0fc29ffcfc0cfbb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "38e5219021aa1ea58a42a8986293e8a35d0f87af9b731addc39a7854bbc2f3a2",
+                                "uncompressed-sha256": "356e596ebc648a443c0785305f0345c545a70da53ff343a5fea094ad12b2c1d1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "2addc4cddceb6e13058cbf160e7cecc896f9682012f2e0e179f8729b9c4271d7",
-                                "uncompressed-sha256": "126d268b56e968834950041568d2106f3045f496af10f48ceb7de155cb2dc097"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5eade83c5eab85d8b6f0221a5ddbf584936e4ef3af8b9bff640e8d9a7d509302",
+                                "uncompressed-sha256": "79fcc751cd1271ff5236f167d52133221786eea1cd4f5b094418991cce32b436"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "506e910b6457f297e5301a2a38ec0e8e31e84c5a4f6e3581019df38650bc1b8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0b289b6f28ef535a91d823420cf0a9895356cd1c2fe8c2caee9685e10c73c76d"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "d1f45842a80807d40b66cba48c6444a2c5ac8f30e1afc43ffb0fcf08a6024c57",
-                                "uncompressed-sha256": "66b9ad43541726f5f377f63d7ad07a3e36114532f58287473703ad498f622390"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "a370a35a783157ce8cfcedae2ac512cb68910c8874647eb933eab3a097306176",
+                                "uncompressed-sha256": "d5b3cbc631a109c0bd4a1ff88250e3ed34ca911f551b705aaf947e8a48ecc9cc"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "a10226a1595fda654b121352bacf6f45e0b13399d498192ea6f7fbb0fccbd8fc",
-                                "uncompressed-sha256": "9ab4dde4dc9051e2ebecb4327f36fb1b3d49f85983af945b06ba04113825110d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "6765a25de542f41f78c523999d8f6163cf92fde7e2b068fa1cbf32f4de3e5eea",
+                                "uncompressed-sha256": "0a06ccb54acdeda2a0fd8d17e1576fbd87c922ab691a2888b0c060ed3770ae47"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e2056bacb498820718d1396a9b61f2b0af98cc90c73350b9cf18ba847e920640",
-                                "uncompressed-sha256": "fb783326a30030544f8118a3f63c0fcd1a7b6312a89cd2f1e69d46454cc86337"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "999f661ead61939aa4403de0576c8af866a0675b462dd75929a33980cb4d478a",
+                                "uncompressed-sha256": "b9ce5d60f48b61914148f828a3dd756352ab0b5d2febccec13e0bcfde26e4665"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "17f9850dc0ccd85290491866f1262607327ca0c437c14601744755be4d13703b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "812fc3f99892eff98a123255148ceb0c52b5dfbeb33ff592b2929aeeb129d172"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-kernel.aarch64.sig",
-                                "sha256": "0dce93d2b915e3a36d6b47a872212e500db0aa5e17f26b0d8417c88fd14cb252"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-live-kernel.aarch64.sig",
+                                "sha256": "a6f43e9ca8727695a0697918093f7b36cea847d9f6a373fb05c2db7633197772"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "ca5603f1d864c95e025117c4da12698e64da502186ea4a273c6497d9ffa496a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "6be881b6291180715232d3e86e95a010ad4cc633b4424164e67b5c28e2d2b3e2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "a2b1ba29a61d21a577ad7b35c7b7fae1a88b1695afee5d558bbfc336bdae864c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "1b681c5c59213b2c156a502314b91f408c77f150678bb9371de728460ac490ac"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "27dca990badf88ca6c47c14c620b4239a7edc5bfbbb3165e2bef4132ddcc37d0",
-                                "uncompressed-sha256": "c27b87c83b498a3841c7055066e0166869d9332973624fa8c1dc3e1c2f050184"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "d9f80934afcc0db676105d5d008e74d64db5263402a7750fae1ff5423fc6e4a7",
+                                "uncompressed-sha256": "e2a0927a2401f2c8ec4ba2a3b13a352cf5fa5a8948301f91fbd3e8c40a78f9ee"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "294dcf999cf1557e5000e77c49b1d6e08a2dbc065d3b7e4c01aa607d82962dbb",
-                                "uncompressed-sha256": "814f73b163adb957fff7ed772946d368f5d4e5212e0ea7ba71edbed679d376c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "06f577333d01adf28537ac854f10a8763c43df20ea3a4746db21f62a77ec5263",
+                                "uncompressed-sha256": "7d9f3f7db413fbdf93324fe99f889dd7566ba29835b435839f706bcb98b01f33"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "3dc3e4bd21a0aadaa6c775ba80b0a50107ff4dde9ca2a3383e525a652b2da2a4",
-                                "uncompressed-sha256": "7609a1f8b0967096d11b54b660f0a954790706763723dc49ab4a7d884cbbaf60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "fff2f50073ccdf5d4d277b1e7517440403204318675ec7c39e09a0590f126ff7",
+                                "uncompressed-sha256": "e8ce902332753343f83ce860a7a11256ca7eb98110bfa9280fc57d063ad76e9f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/aarch64/fedora-coreos-43.20260331.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "27766f44742d782f2434695c24b6d8c4e20f34d23b1f2fb3a7b4fd615685de4a",
-                                "uncompressed-sha256": "ab9a11439a1a3043aa3777ef1d0ac8f9b2ab1eb5c3ddc29d11c839a45232f219"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/aarch64/fedora-coreos-43.20260413.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d1c78e2b8c7e43fa97164858afe298a65a958ef31a9499dc0a094d6698f53954",
+                                "uncompressed-sha256": "c5a87fb532cb5fad76eaace9234ad1571a84eaadec4bdaae3ba1e6b690d591b9"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0036049c0a5cda70f"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0f2942f9a5a673b87"
                         },
                         "ap-east-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0fa7be93f50e0747f"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-01907e984e6bbba7b"
                         },
                         "ap-east-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-07df8afab540c1a64"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0fb3630d86cb1f534"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0679ccedadf54a248"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-03a5b93f53d3535cc"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0aea3c7fcf2afce3a"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-094a2482d22b974aa"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0e9c8856c299884b5"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-08761dff0d5c1653e"
                         },
                         "ap-south-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0ae6f949ca8c7f301"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-08667a3028494c2e3"
                         },
                         "ap-south-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-057530ef63c6aa38f"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0c5cab59b732878e1"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-02bf708f8539d2cfe"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-02bc825fe4198fcde"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-065b1ce7bfc83c642"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-02f10756bdad20df2"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0f630f05bc7d093e3"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0e556b39aaffbb472"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0519e036ffdcd99aa"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0c9be30c108c9e462"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-08cd71b48e06c11a1"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0dce16f50ba4f879e"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-08da751726a14265e"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0446ff3ae0cd952fb"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0506a2b0f43549e38"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-099a5fa80f982abc4"
                         },
                         "ca-central-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-09ce4bab953502a6b"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0030b1ecbd18efda7"
                         },
                         "ca-west-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-05226fb75083403ab"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-064ff75fec8beb518"
                         },
                         "eu-central-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0573120b5b4114cf4"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-08c3fb8f399a3727e"
                         },
                         "eu-central-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0219db74d0a938488"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-00555e07aae98198c"
                         },
                         "eu-north-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-05ba21a6ae5c834b9"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-07000accf4a241194"
                         },
                         "eu-south-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0b68a9d9c6fc9f70d"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0b8fdcf4f927b37f5"
                         },
                         "eu-south-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0250512ccad33402b"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0c557057a934fe493"
                         },
                         "eu-west-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-07c94b0b91e55dcfa"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-026249381088b782f"
                         },
                         "eu-west-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0b1889654f6051fb2"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-07828878a6fcb0e2a"
                         },
                         "eu-west-3": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0eaf128e95c13b108"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-02bd8406caa29a020"
                         },
                         "il-central-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0474f5460b1c60d3c"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-007d202e3658c509f"
                         },
                         "mx-central-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0712266d656e24e93"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0c976507914d5a4f3"
                         },
                         "sa-east-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-04b01809aa5662f3d"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0cf04c2188012fa70"
                         },
                         "us-east-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-05e7aa0b3acd20910"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-080ab5ec8378c84c2"
                         },
                         "us-east-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0ae6c5f0f606036de"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0d6b99367efca2250"
                         },
                         "us-west-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-07cd6c60942d3d81a"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0b2c6f4dcd8379108"
                         },
                         "us-west-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0360d3f508e6ed5e3"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0328b9952a4cb16e0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-43-20260331-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-43-20260413-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "1cf496f536d985c5c2f41e837d95f53718396c51f7a5bc8603aacc083269478b",
-                                "uncompressed-sha256": "55e0ef9b1f7278371a1f8d61d7ba8c64c9c5cc9eab55b4e22d06e12d5f0d6e31"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f94c46cbec3cbe124f2a4c5b416e5294d9c44b048bb7f41f79012d39f84d1126",
+                                "uncompressed-sha256": "ad92024d2e8caa1bd3e401983f40bf9fa2f53e003d2fbb9d2c2338643cc1e32f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "f8fc7df626802fc1f0de4807fa189ed259226f3ececcfd4ae21c72b227002ac0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "18b9481de95a809ccdff47e754a28f7cba76d607f74b0af74d826a6c127845d1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "8b76b3524cd8ee8dcde6db5570276d07b15d8556ee872288c20d81e4eb8607f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "cf1f306404fc5de1fa0960dd66fda240633f944c9d95300d132bc4d00d613301"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "70e4cb8d56edb6355d772be13810d6ba41c672433dee834085d0f1b4511ff400"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "557ee11fcc48bc2dcf326a2b93170dde8baf5f91ab7c3ede53dac0e5f31ba811"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "0a8234ecc7dfd75a83aefdda903653b7fa3ae0bfcfa11a5fee2675e92bd8e41e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a29f8cbe0bc51577c1e2854d298742b5645b1a27959db5ffac6c310b3e9d9809"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "78713196c80824f3cd4c2d58ed51349508a53757f254121475948927e410bddd",
-                                "uncompressed-sha256": "e224ec3db9e4893443a4f34be93fb934c4b1002b19e7e8efa90bcd2368be88d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "0ade7c414d86f5897ea0de113dd47202b2ccb91fcd620e3b11ac1f99752fef6f",
+                                "uncompressed-sha256": "4155864e52f7925812d684547f6be222b467e996a7e2965a024cbf8cf214465a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "19125abd2dea53f3d9f6cdcf2724917c55b7ddd58ba3aa8db22d4cafc924171e",
-                                "uncompressed-sha256": "a7f914f7ba18b91edb64bae93cccf2bd3c519526fe1a919ac3b93d0013b99ccb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6ba10a333bc55eddc0968f14d85435e2f9619906f0d38bb9d5e6bbaf36d33af1",
+                                "uncompressed-sha256": "fe6006f9c6fa37ed8fb37d8feee652e7912d820d7c284ca2587554ae23cc0f4a"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b9d2759573bd8b346276e8addadb659c40ce0e891735c2a285a16c9d5ee01a02",
-                                "uncompressed-sha256": "a39d8a077cbd63438fcf361ec47fe9a80735ca4673bdb89c9986b466c4a3bf98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "351d96b3bf401d5b362e0f0b4cf5678be8d54cc11e830a062271acb57df71d6f",
+                                "uncompressed-sha256": "516236e8956c4a87f43bf74ddabcedf9454c82c55b3ed4551c3247c12bc03c60"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/ppc64le/fedora-coreos-43.20260331.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "d87af5e84c304735c19e6c99449607b7bab356dab1f581a055885235605eac78",
-                                "uncompressed-sha256": "73711c2925db53f0c85770329c5108a0b349bcb7be63ba61c7becfce500e50f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/ppc64le/fedora-coreos-43.20260413.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "4eced18187f5c55e3c777a00eabc4c8f0aadee33d31593ffbd6fa72cf04559fd",
+                                "uncompressed-sha256": "b0ecff5dcdea669fd03879832ddd9e34d5d44a095e2dde5880d669288be84f1c"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "c1e8ba0248f70c02fd63526bdc77c0b541c4a80d1603fc37dddb5ee59a688605",
-                                "uncompressed-sha256": "cfcb43a67310e0c3436220b27f97605df0b63d999edc48c231c3c268ac535d7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e2b663e1c2c5fb8dc271310e4a965c90edf1f23eb561304937fb928b54c19223",
+                                "uncompressed-sha256": "942fed45b9615ab9ddde4e6125bb327afc97bbaaa4d79fba7ad739dd0266b3e8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "d36f65cb4bc8408c461e2247e8c5d8f0d6d1842e73f3212831e77763e6e1052f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "8b83778d11d63bf01fdb07fc741b0d52570a866067dde485ad62d6310e65e6fd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "672ffcf5fc870ab15046f2cea6eab157ffaac1e2ee825921a9b2a88fd9f9c7a5",
-                                "uncompressed-sha256": "bddb0c3447b8fbb1de495268b5aaf5f6f75d63badb2587d17e327e472b2091dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "8e0b8965dbdb11ddae08386dcbcab661a460c1a5e11203ec3134ddde9b8f50be",
+                                "uncompressed-sha256": "b258832542aba8d19d39740d1e993dfd8d4aae1066fd2d73501d7fce1d3626c2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "7fd3f1c5be044b69f19ac65223864adafbe28669811fc84c4fae95c61ac2367b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "18147c3eaa7091ed11b5b7433995d7ab5f4a1b50625a46a50d6e42e063e54414"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-kernel.s390x.sig",
-                                "sha256": "6152473eafd2325db8e5ead468841f6c96e8b3e2557184ffd6d4f5adf51531b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-live-kernel.s390x.sig",
+                                "sha256": "5d43ad6a4819ec0e0a82d09bc84be2ea45fd5246f8287fe4c587b3bdcac843d6"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "ef950f1d9a322fa976581c09ccaf8701dd5e0b0d185dcea56cfe94b9e88a79cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "966092d07c82ba82a7f37bac1542945c3648933a34b25575b1a313ab713ef293"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "f93034b163d3807f929d74740b096c0ea70fda3ff3701ec3230089ed576bb509"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "e66f9ccbc24dad0cc279065fd59a70d44bd580131f506214e187eda0c656f0b9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "33d59603317368f8de2fc5253e0795d9c3d949601349a9298b3481172be5acdb",
-                                "uncompressed-sha256": "3c8aaacd52afe75bc63b683fda65a78d1f11287b9d962dd0966dfc51d8b52437"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "89e250bd9bd9f538873aba08f4bdd6b45cdb3655b120e6688756f6797207f4fd",
+                                "uncompressed-sha256": "a989fde7bc1de5fdafe2752b6f2b222b55cdf3832f7bb205650af2973c63248c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "8280cd9c77e92f5eeb1a52a50e1fd8e0c3a0db61bd13a053f7251548c15fb71f",
-                                "uncompressed-sha256": "151531e069f8c7848d81884fca600c30f8f45ad15f2c1e484e03a8168f89c592"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e460ffd61f3e1a0d27af5e92c3d3885b60ea6f234dc9c990ae105ab0c5ffbbfe",
+                                "uncompressed-sha256": "d4589888636c976273faa90a8fb1dd8853befe1030ea5ecb73296b8fc057d1c1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/s390x/fedora-coreos-43.20260331.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f106b13e53ab2604ae8692fbc39202ff98608d9873d2d8a59b2a5641c5676a1b",
-                                "uncompressed-sha256": "4731615d0ab0aced42b37b4f8633a4234a420803311d61b01b5c9e230f675f9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/s390x/fedora-coreos-43.20260413.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "10b6cd5f0a07d8b99c139b23f1e2f52fec1022278b8e998af8dbdaee5e6583df",
+                                "uncompressed-sha256": "6816366ead445479667fdf4e591d684444ae7d165774f2f1b3ab6ca8b1143c89"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:847839f0923c8b5672bc36cea0b4270ed22b6fd6e6d2c7a3e5220b77f76076c6"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:548d8cbbe28d2a1ed0c38464f1fbfdc29074f6f986376d9fc09d99a1776d4dc2"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "de9564a59d29d3234fae6a46e68ae493baf30aac687206280bf2994cf5aa3fa5",
-                                "uncompressed-sha256": "5f10ddf4d0677dd7baa01a5879014ad6fdf542ade19a194b663a183133079905"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "efde182a10ca4ca41a4ab95d756d03a81639ac58ce488ceac133136ca5e15546",
+                                "uncompressed-sha256": "0f2b91a9b1cc1a8415e29d38308aa752db3427803f77ac49b24f3687eb7b722f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "2c8bb34f5ad83ed071750ac2b96ab0ce940e5c550dfcf6be390e64a522ec5000",
-                                "uncompressed-sha256": "85609fe84e6a4d3830a9daef55e3460ea548afd889db50bc049392eae92d8a84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "48a26991056dd8864c40cf4f83d4abfea00f4b43c8b2880acb0ef1707daf812e",
+                                "uncompressed-sha256": "0c9a9ce87b4fab0fe21d10c3fb3aba7575b7d0c7480a6ce1e1554a5feae34110"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b13bb5b12416743830fba7f8e3acc0e043704d0fc73dfa16a055ed4acfc1f7c9",
-                                "uncompressed-sha256": "773a3fa67a04bf9529104e1abc88d27d324143b7c6db603bb0dbd61069ece23c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3d7d5625270b4fdd8b5fe87e3041dbb5ae11a1657815becf77aa898959c91e30",
+                                "uncompressed-sha256": "d928dba51714e103be5c1bb1abcace03b7b5d9ddd805fdb5acc1faef78badf91"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "54723f004d3a6b0b6f17c27f6a65479ec4b1af1ecda6eb0c94c510663595cfbd",
-                                "uncompressed-sha256": "93a3f68b70d146db00a54ac576a6e4ee009b890a55153f125d979a16be4b0101"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e75593188f63704ea0be0ad5363e37c76972d1feb215490a3b903dbceba1cd96",
+                                "uncompressed-sha256": "927b219618efcfc35b29ca723fd48ba900bf702b186f8ae91f21eab1459406c9"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "38b383bb0d4df7729202b5b6b7336e07178a13b2564f75ed1b4d9ab1d1a12b98",
-                                "uncompressed-sha256": "11d184ed6de5ed0f0c81d678b4a1eeb86c4ee913b8b683f3b221d65a29b36df1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d237f2fe4b1dfc626cbfa3c057ff95b869ff6eb23738f9e48787c481a26530c7",
+                                "uncompressed-sha256": "b99828aace0e6e0bc7194b123d26cda72a9232bbab47f6b1c6d593ef5b29b141"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c538ef3f197b535124879e6799b7c30f9a298e3106adb5ce77299afe60816a8b",
-                                "uncompressed-sha256": "4c280843abddd1b54f49a7e5c4056f399232527834ff242ee73147b33f17d2e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "5c1e1fc45f01dea738ff5b71f8a422abc1b9172ae06b1ccf350416674d8f82ad",
+                                "uncompressed-sha256": "478711874f1a00010d0566ff808deb725e09b5cdbe7389884c60ede4102fbbc4"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8452258974889383ace2142a920c8209bd9f884ba891bf3800e0879173c49a05",
-                                "uncompressed-sha256": "531f8a88cd79d2aeaeda646992816413a6b0c7347746aeef96721cd96070e5ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "d0bff0ca907bcca82d2b00c4f5f560982e1732f1ee14aada015029feaa53a631",
+                                "uncompressed-sha256": "29026e2e4988544ef6c814956e4df38423f7e98f5c62a2fe82214b4fa8ca18f8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "65d1276e91c8521a85c05a8e2e80dd828f0280c74db532f98a7b54bd52020ef9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "c09dac65d10392a5dd2bf1b7a07ceaed480f21ffcba86fe59b2ef203bedcfe19"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "283e47f4e98b63c710ec4615aee8a0e1b6bc88c4296b0af71e345bd11441e1d6",
-                                "uncompressed-sha256": "f406b60ec74f6c198bcca9156caaf4d8b4504f3029948548f862e19288568e16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "8804e329cfa7a22c6693f1d63866d714701f711ccfd1a03430a695becd7d3a6d",
+                                "uncompressed-sha256": "9b91ae9fba5223ef47fb5182828430e2ef35c4d21351ac91ac1457dbb1278bea"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "834b9b6249299d7b81dbb72e22d4ba7f09c1aa3915363d5a6023daa112709c31",
-                                "uncompressed-sha256": "05554bbeeacea2e9c3399d479a2329d5565e5835842ab44804d67b15afda5761"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "65ad3b467a1505e5024d4b8ab62555ba9b337bd1d7780efbba7f7e481c134a08",
+                                "uncompressed-sha256": "275fd66b2fb1f34406f93df01649fc5e29e18b1bdf3d5332ff79b25185b39623"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "39e99bee847a10e01051b22d0237aa0a1ef67e3de1afd7a849ac1baa0e1bb8bb",
-                                "uncompressed-sha256": "d765b5585a227ab2710118eb5eeeb9dbdabec8ae87fb6f4790b7308c90952c57"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5caecffa49a88bf1e3a2c4beafccdb401af7859c43c997264056a116d5110f8d",
+                                "uncompressed-sha256": "62d7f2a0e6c7e292edf2aa1d0e72a499257bde9f9bf24bdd59ba2afd4e7ffa89"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "d3eb52807612dea40660d42965058099db825209133a024673134bcb9b3a7b56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "0793ad2cdd92137e714728181165d7f3d4a31128698ea61a62e10da5789a4400"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "629add2f783cfd5db8a5a0dd8f08e3cf88b534ca7654cad426630b921ea5a2dd",
-                                "uncompressed-sha256": "a1df63ea7e197de89a137d05d18c79411c108ec68c0c357e9e68cac9e9d0d5ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0fb6329cd7cd7770e1f1ad8e0618986df3611118f7fe6d5a26375de4ffe9dcfe",
+                                "uncompressed-sha256": "6d4994c9d2482f9b202345c12827762ba7fc32060b4e89257e66766032153b9d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "9b4e7500782fc5ed8b17d3474397b6a3cfab9143413ae5e167f11168e817c06b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "62a89769ab64eacf445e13dc3f963b48ba1b36d5ef1c53cedd934870bc134f86"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-kernel.x86_64.sig",
-                                "sha256": "80bdd497f1ff9531fc8a11df4494a71155e7e1bbdf1bcb7d5ba55b81803e5a7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-live-kernel.x86_64.sig",
+                                "sha256": "85c9a2a025dfe976a0da98157c7956208ac72388f9eb01d246a69549df27a993"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "54cc160e111ed28a68e43302dfcd8074958b34bfd244ba87f6b56685044d8731"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "d196d8c26971a55f210890f094fd9fbb80fa2160541583c1f8f7b6cce0afe928"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "580434a14e843dea4a044d76d78c9665665edb568a0ed5861d198a1567c49d0f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "5f808f67e548c9ace4a7b498ba57e3e69b8d38c1f743a4499ef68dc85aca230a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "75b8f34a970d5a024fb41cada4e020cc42c7e03218e0dcd14f8469eed53ce5ad",
-                                "uncompressed-sha256": "4c57f094aede97140af056bf395557285dad8a69babd5ac16eec8fd3cc0eda30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "369c94286a03c9bd21fab2a4e2c84c202c67d3afe65af639ccc7133f59d7bf81",
+                                "uncompressed-sha256": "6259503670af301d76e9942ed17542f5e84675b670c7387b0508ab76231706a0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "0125f494581230160c2a4952828356e1be5bff5d020cf6e5739b40cf41062aa0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "8041d5b64f1981698b66650ae483ac8dcacd3ad0f1f18fd93bd375d2944b135b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1afe5ef0e6adbcc554f1d36641383b19f61c9f467c39b4a039ce31189966430f",
-                                "uncompressed-sha256": "832355c8cf5941f03d3caab19a3fc03bc6399d0b6daa3a9908b6396ca2f7866c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "5e5419ecaceb7f9a41f2a49336c10b163239a5491eeb8ca9af3518bc562f5b85",
+                                "uncompressed-sha256": "9a4bbd7589882d96b51050e9b1526e62bdfb1ffa444d4f66971ac7265c2337c5"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "83b1e76016f2467184757796edb41acdfff064dc5622b80707f333a92b69201e",
-                                "uncompressed-sha256": "2a241cb885a25d64b3306189153c565064b9b682ffc510284fb6743360822b2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "987d4dcbffe8caaaee15a5d25a621011c30c856371c1964830c0eb05bbb3b0d0",
+                                "uncompressed-sha256": "0f070539a33694cf076cc854a9e6716fb0d470c25b4b79c238d83f59ba841b3b"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "9c75e6f73299b02cdd854117e5966fb6b64a47e5f85e839ab79e9cad656451f8",
-                                "uncompressed-sha256": "b9cded968aa0a6c6cb6095f5d5744b373661ab5ed8834c8b6d485168e0c98ff4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "a84c8d19e7b4bc4a2b850b7a067c21540c5b44b791444e52d5ead4a1ee985702",
+                                "uncompressed-sha256": "e63b17912b0e68955336de4c3f1b95541be1370c8828bb9cddeea8a1392c5a37"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "719c9436e559746d80bc57e04da9e583f7e807bbca5fc7a5203ace7cf10a7361",
-                                "uncompressed-sha256": "bc494a31b9e37f1fe7077b622c1162bcc0f54738c2bc361e4ae9d9db65b216b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "fbfdeb3558552d08898070050b397e38210b3c5ae19005fbc3fc2107e1526f19",
+                                "uncompressed-sha256": "7e9cbbc0aa9b05f16b93003481bf580b242ac3b7632b021ec7e784e3b2cdef85"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "b98fe17d020690304e50cdb9303091a57abc3ebbe571fef23b63ba2c0999015c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "7de6722579ffb3d5768cf328cdf8c23baa9cb23fca7ebb6f07d86e5e880cc66e"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "184ce01988132052c3ac5c69d3b88175bd4ddc6887bb7c0cf27b7a5ed4ea795c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "c5bb3c57c345caf48e9f622531231242510cfdbc7ec326597d9a8bc2144d0cb1"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260331.3.1/x86_64/fedora-coreos-43.20260331.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4919e23603b6a2f185b0f19233d77530c4d7a93c99961cbadf0adb84ed5b61c5",
-                                "uncompressed-sha256": "b71575b0bf26ef34497c530bb4fd2e0a34c5953a0fde699ef80d6684862f1aa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.1/x86_64/fedora-coreos-43.20260413.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "73dba04d6c3670009abf10c037f7d7ba8e5fbef901101603117947a2eb524176",
+                                "uncompressed-sha256": "c2e7b0047fd8b81480bab13795b7f75b8d8d456f2d0fb66de85e087d060c3e56"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0224c7a1182bfd327"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-04455254f4c64a265"
                         },
                         "ap-east-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0e05adaa95c4df02b"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-04206cf5657020dbd"
                         },
                         "ap-east-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0465bcb3368941b8d"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-000efe4a6299d94f0"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-08517f6da2e041e3a"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0dfc0862c203caa4e"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-03c79c0f7ecc7d7fb"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0cdc40fee8309387f"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-05495f51bd62d94fa"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-020ab6d49274c0a96"
                         },
                         "ap-south-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0603e5c627b21be9d"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0e272b989877722d7"
                         },
                         "ap-south-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-019b87917a1e007dd"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-052c27e6062fc8d63"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-05d8bce1e45dff23b"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-04dd00ed3ba8caa48"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0e8d933798b36fb9d"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-061f4cd212cbf4deb"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0bb6f7b56d9bb8d88"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0c46e3787f5c11ac8"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0391faed6900f70f1"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0b18213fb2774b601"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0d8a43ae8ebd2899c"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0519638e7477abf66"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0c4acf71fb19e5f35"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0124cf5c0bba14e4f"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-035a17f706f42494d"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-01186b77e469d6ada"
                         },
                         "ca-central-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-010bf018891e184a4"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-04eaa89d585b70f80"
                         },
                         "ca-west-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-05d69e578175358d6"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-04ebf39f071620aa0"
                         },
                         "eu-central-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0e494d958c7ae0956"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-089c47f0110560fdf"
                         },
                         "eu-central-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0e18961001a758773"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-051410ceee11fa6ac"
                         },
                         "eu-north-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0008f4f0899bb1018"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0ce3be20ee126e255"
                         },
                         "eu-south-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-05cc5ca011ad33e9c"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-05ca3b5f3d821dd2e"
                         },
                         "eu-south-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0c57f76fed0208c3f"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-025833c926f592fc3"
                         },
                         "eu-west-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-016bdabd19a960ca0"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0e2f437db83d7ca09"
                         },
                         "eu-west-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0a074aa2d9ac6b64a"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0a636df9d6ad09f81"
                         },
                         "eu-west-3": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-081a9224cf9dff2f1"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0ec4d85d63a3c5adf"
                         },
                         "il-central-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-053a561d1c2e74228"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-04cbca9129b1102b9"
                         },
                         "mx-central-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0142ff64d1017af00"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-012d942036828cc40"
                         },
                         "sa-east-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0a51c621e45c1a35b"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0038f81fb39603559"
                         },
                         "us-east-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0586e72674556059e"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-0299424562da4244b"
                         },
                         "us-east-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0769407fc4b43c361"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-057e380e26a15d909"
                         },
                         "us-west-1": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-0795e47aad0be8fa0"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-02f866a14ba5368f1"
                         },
                         "us-west-2": {
-                            "release": "43.20260331.3.1",
-                            "image": "ami-04684d8c0699a49f3"
+                            "release": "43.20260413.3.1",
+                            "image": "ami-008515d58b940ca06"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-43-20260331-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-43-20260413-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "43.20260331.3.1",
+                    "release": "43.20260413.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:30566b2b63c228b4590117b457e28761b8815bfebbad38514f37d5ec6b0deff3"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0b948dfa337bf70798b16cf8c6af5938784f9e9a84d04d1051650e68a4f8f770"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-04-15T16:36:04Z",
+        "last-modified": "2026-04-28T15:58:57Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "8583302b10a5e5cb95b8f3c75fbdbab37804d38545c1acd73c39793455afd83a",
-                                "uncompressed-sha256": "136832a4403751c6fd9714bb8041075ee96aa5d1e16540497b903221e487881e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "85785cdbe34d18d4509e973706485eb49a0bcf5f96ae049e31f1342af3f36222",
+                                "uncompressed-sha256": "940c6e2763afda161ca169857a2a6c22268d191bc6490764e5da30eb07c3617a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b3719b7dbca8e20aa2537fa584ddbaab8507792da184217ac65611e4d5e4708b",
-                                "uncompressed-sha256": "7a252b9fe80d9d6d9ec73fa83806ec29d93eb81d3bc56dd5e64649e7652f6b3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4af62bf9bc2921455b4254ff9094fcb7bb37a95a81f23bd884ce3e51cb2c603e",
+                                "uncompressed-sha256": "1ccf694083fcc6efe6fb211ee8f3e7385278a81553b0ebe4b916926cd7327423"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "eb18aa4486eff05bdf07fd51878425bc6e8fcccb36ce47023fb27ef30ab32d5e",
-                                "uncompressed-sha256": "41fe818249339fe34c7ac6250578e066682a68bd42dbc42090f02bb1f74a447e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "3611c47ec8ded2cad68f0bc12a46e489f1be0f2be5966e7a99813a140a332f76",
+                                "uncompressed-sha256": "9c7e366e01f02f16e3b324ebc7b97cd54efefd6e15c72694cdfbb7788a09e999"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "48918e2c0da8891f65f0e0cdd702a1c36b7eb98120fe2f634ae256e9a65a1f30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "91d5e49fdcd111550a562128eeb7ffdd134d1afef1f46876bdb9598fa3b2a98d"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "da68675ad3610539ffd9a3747a83c910e33d5deecc0bbe52cda5395d0dfa9e7e",
-                                "uncompressed-sha256": "ed750edf46b5dbbf7bcb6a52e0fc31aa9381f79796517c02d19f98c0bc2d57e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "a9e301199f36748d86c3054e92ab4ada598bc5b6f2117bc6118d58c40678674d",
+                                "uncompressed-sha256": "9f1344964dd6ed82532d3b52a8a2e336d7a5ce0973c228f08b1582249d58a45d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "55e798f4e096b82625232bd172bc0465b78b22372074b4425bb3b625f103c777",
-                                "uncompressed-sha256": "958a1ef08dd8313b83e2414b12a86954c40151caee367b77d296792860dc748c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "1b61b139073987cf43cca05e47b3247d160a3cc76618c874faaf8e9fc4039875",
+                                "uncompressed-sha256": "fb9a7811e3c70837134eab1f30e9db7aaa9734c5734154fb4b003e00e9197250"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "15c954a6af123681bb44fb151b0939e688489b66c449f88c414a91d46046b0be",
-                                "uncompressed-sha256": "943b3d2d226f203c6253d3818343b9504a42161c71ede61385237e563ee746f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e296068f32866347c4de0bce1dd5b1b0b3d49af93983e99a246fcc2cc3ecc802",
+                                "uncompressed-sha256": "f3da1ebf813f361f4f9a7c0cdad8845a1141f80d1af9deff7d62871943f9a62d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "941dc1018ce08cdb1421edc3cfb14e34053ab244229f148f7f2989c39cec889e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-iso.aarch64.iso.sig",
+                                "sha256": "b74898e5efd410beba1fd05dd3fe6bf3d40f4d89dc4d48080b3484eef11efa71"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-kernel.aarch64.sig",
-                                "sha256": "a6f43e9ca8727695a0697918093f7b36cea847d9f6a373fb05c2db7633197772"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-kernel.aarch64.sig",
+                                "sha256": "d33744c96ce290dcc8649d80cbb3abe956f661e93a632ba56bc559384d128c24"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "391066429e2e18b0f92cf84cfa1d2312813ef4626da579bd7dae5ed805fcc397"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "aa74d35bced7afa6fad2619f6e60fbd1f37c3f316ea62bc7c841a557f17605b1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "d3b62009777d3e0a9e0bde1e879ab8231bae185538f45548155d1306dcce2a76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "066214ecd78ceca2ead31ee2db76bf4aeee5fba660cb0d28e8b1ca3d8e5816f7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "496ef9c9b7d6281b15dd75ae861f3fd4f550f9db457b2960a051583cf68be3e8",
-                                "uncompressed-sha256": "c76d0d9c76a6e556b545ba7a545a92ecb2da04bfd80704039ddee434a67931a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "313ed9eca8fd5e30750529891f17c47d09ffbfbb71a8fd2f2c96512cfd51d796",
+                                "uncompressed-sha256": "e615feb4fcc765ee98c6aa87e8b13ee1055ed33c010aba92cf1571e757601f9c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "08445ccf7e028f796fbe1635948f29b679598c737d96d29aad719e0d7eb99a9a",
-                                "uncompressed-sha256": "dd665e8390c2395041c990a9d0faeacb9fd51715c16a62ec31e1172e0be4f6a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d7f9236f58e0491f1627451400c4fd6447a17ea9194e244ddcab82691f7cb54c",
+                                "uncompressed-sha256": "4a8bb476400451f15da49e63c92feb2dc89b6ab030c95874ffa7b750036750a2"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "8593105afaf4a38e8b60ea8cf37b8305720397ec1f437298a5f8daad937d2de2",
-                                "uncompressed-sha256": "3b8ed36e1e28bc4bcdd2dba5d130832c15f5e2ed827d37c4bb96fad1002a81e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "3106b74bff4d13d88d707aad438ddf8beec325d526b4419a95f1e3a9829acbcd",
+                                "uncompressed-sha256": "1e8506c8fc3a727ecae328f80b75e6124306403ec384b8ebe02f778bd6eea5e8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/aarch64/fedora-coreos-43.20260413.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "730f329dea1bf1adedb8795601ea4a7d95fb01df058310958fd215e5305ae12d",
-                                "uncompressed-sha256": "e4f2c58c3aaefbb04ecad3a5d582ba8cf6b41106ed203d7cc2659f647128be60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "18bf6a4c47ae4e63919c2eab2755a02be52a886f3eedadd1d96f5381aebd69a3",
+                                "uncompressed-sha256": "427c5572129ca86a455fc65f0106c0938de1add7116fd82afbcf6c353e9abbc9"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0d89d315359f9b220"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-05b5de1d9d2d167b0"
                         },
                         "ap-east-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0c1c18ee12cf41469"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-066c927d30749696a"
                         },
                         "ap-east-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-00e17ee62d0bbf63b"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-02069e9cd1ac29f2a"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-08754903b3976da67"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-015d2f8015a239187"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0df0882d4879550fa"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-095c3645227603049"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0b06b9b22861813ba"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0a0de244b8f7b538b"
                         },
                         "ap-south-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-029a477311755952d"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0de5f3c866c024a75"
                         },
                         "ap-south-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-006fc78aa6390fafd"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0e37ae4f5c195ae93"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-09690d91f2201e35f"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0c3dbf99d8901fcda"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0a43ff21dbd797bd9"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-07749c3773758da4b"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0be180a174033d9c6"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-04873507bb7d179df"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-08068cfe3c71002a8"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0fa6b76824e4438e2"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0de86fa5f4540f8ee"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0a1fdac8e1e5b6e7f"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0a1dd3ea1f647d0eb"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0ca383ea84b86e610"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-087b4a091322c231c"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0ff11928b01fa7b20"
                         },
                         "ca-central-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0031dc0f59f4641c3"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-067e5735f4b65c237"
                         },
                         "ca-west-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-099329eb2e73881f2"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-01fdfc39a6fbe4db2"
                         },
                         "eu-central-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-019f474eb3674ea7e"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0e78da9d6b726f48a"
                         },
                         "eu-central-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-01335611cc21ff77b"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0bfe76c239f8c2464"
                         },
                         "eu-north-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-093342faccd8d8d49"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-05428de302911f7b6"
                         },
                         "eu-south-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-01912fd0d62b00e20"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-05a50361e1f7c6d8b"
                         },
                         "eu-south-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-069ca7a8720a70975"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-003d2f99a432373bd"
                         },
                         "eu-west-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0c0448acfbfd8d73e"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0d22270ec428501a2"
                         },
                         "eu-west-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0a12b632ad6523ec8"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-042409e431e9a2003"
                         },
                         "eu-west-3": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0eaabd64e957eea3c"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-09dbfcb0ef7762d7b"
                         },
                         "il-central-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0aa6a695710f4871f"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0a88975ca30da8a0f"
                         },
                         "mx-central-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0e30e90e99b514857"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-021de6db2488b7baa"
                         },
                         "sa-east-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-07dc9c0326c92d01f"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-078662a50e6ccc41d"
                         },
                         "us-east-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0b629950387f60177"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-003d287a5c64f7216"
                         },
                         "us-east-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-003f5ade2f12d2567"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0ef9401ed4cd2c997"
                         },
                         "us-west-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0767cd64867407b14"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0de808eeba7f7628a"
                         },
                         "us-west-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0f7b88eac24fd347c"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-09802ff6a81e1375d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-43-20260413-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260419-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "6651c530456397708a97fe3d296ac31372257667d297a000e887777fdd42ea08",
-                                "uncompressed-sha256": "8bacf65ad47c81ffcd1b03d41bc4e21b684647982c416fed2d6b94130f6391f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "20ff3645ad68d874aaa38d1bccd6aa91e220d083e9432a8abf8ccaaab3265960",
+                                "uncompressed-sha256": "62ccdf866dce495cfaef01d19cdad26d6630c356e545df0f5c17c2035dcc0161"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "9726d103fb2011f681076b3eba3a8a7db137ffe74464c77defa02fa0fe7ecc74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "46a848ef5c2272aa6fc7c136889d926e5a892bba44ca07291d5e187bee25cc6c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "cf1f306404fc5de1fa0960dd66fda240633f944c9d95300d132bc4d00d613301"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-kernel.ppc64le.sig",
+                                "sha256": "c0feb764e6f637d851bbadf1663c9539d594728925ea69179671792ad2bd14c8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "81a1644fba565a1321baa2389ec01e44a8462b29a5697863c10c3f765837547e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "2436a6e656dad5dea39e8ee51b168f731fac20dec7468d6190d9685838f3acc0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "f96dbc858924ba31417d1695f9c7d6e9d7769297d3dace90e2c06423133ab683"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "bd6f3158f50e5a99a71f9a0125abf4daab590030b744c2121dcbf002059310d8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "1ae0b1c86804b8e236811b75f8ebf77f13230fd551e6f6783bbd32a24fb2b02f",
-                                "uncompressed-sha256": "3b865a151accf504bd484bd7c1618b6502bddb771d68554246063ad9c9afe387"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "4ce8ad5ceccfe24322872ea7482db8f795761c4969d6fdb11b23ae970631d5ba",
+                                "uncompressed-sha256": "7843445c014fdf3da2bfdb5f9cd8e2feeba670d7199de9cc6f8ff11a28f30ad7"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a18f2a632e7cbda85a92e0b948aed98d4caa0e6f2a9ee377feef3d469780c824",
-                                "uncompressed-sha256": "e241e5b922255709172540f0b2b7ecede6c6e16e492e75e20721d4272d07b14e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "b306efd27f6fe6b0a9f87844cc32aa6eadf8a98a20a2c639d70a18b41317af65",
+                                "uncompressed-sha256": "91a747b9d08fa27093ce80021717fee8594eb14875076f77fd4ac49e1f0f2c77"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "3c484b3ec6694a0d2506190567d306d5cd091b8eba9c95dc7706e858f8f91e7b",
-                                "uncompressed-sha256": "5fa0470e7543ac69fcef098530184eba71a6ea99814e31be55afd43ada0e519f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "223ba322914e33b6fdb02338943a290a31e57e6ce0f32afe2620455d7e98737a",
+                                "uncompressed-sha256": "2fe78c5b6bf84cc302ac841b5e867d0293aa22d37f69c38f290643008fd69b75"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/ppc64le/fedora-coreos-43.20260413.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "f0b309660e4c84d87df2565879ca713144fee3f1b298a38df0da5976158de415",
-                                "uncompressed-sha256": "bca956fa7beee32aa67ba2d90f96be7961d58873ba6b55d56dbea2249a94ab2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "93a78ad7b4204b17ecfe7280f7601b9b59f13cfb28feccbc60640a778fd7ccce",
+                                "uncompressed-sha256": "2ca105108b4c5638366d8b06c96f004042251265c22e68332aad3e12910ed147"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "a3eca008e7a6b6ee7f24db9f5efde5cbeb72d142fd2c200c25f3155fea712986",
-                                "uncompressed-sha256": "7e0e016b3da875eaeddbe6754c6c12e2b7501d900fc0f0183ff135328eafe497"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "941ac3296c29003bccebd641d6bf31cf282fe5a4be694ed01788942c5957261d",
+                                "uncompressed-sha256": "b47bcf941ff156286654d7b109705bb59c4057a32d332484160e563c2c4b5b20"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "1a06a626d78b844416ce421a8c52dda1d323a740dc5f5007fe784e0790606c6d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "b2395c6cfdd477e151790d4a80985bed7ea5f8bc510350dca437e332a733543b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "22093e63e5ff38ae746a3c7cfb4b77c95a72cc3ed41be6d2cc524e794e07ebd3",
-                                "uncompressed-sha256": "c63ecad55cfdc9350ac3cb3bcafa3034c2497c3e4649fbb33dc5dea8739b96ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "74daeeb6e4b09dfe9ac342504aedd98dc4834f60db4318817971c8ac0e0a459f",
+                                "uncompressed-sha256": "d84a455b8ee7a2c033903a904bdc7cfb81e9cf537468e8830b9c4a2b90406eff"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "af19c23c274a478232bcd1c6ef986fef396a79282a0c372073ea426b76aec39c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-iso.s390x.iso.sig",
+                                "sha256": "06cc982a2bda3ede186d582982ecd1b6b44ba13dea29327aa6a4d78112ccd9e2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-kernel.s390x.sig",
-                                "sha256": "5d43ad6a4819ec0e0a82d09bc84be2ea45fd5246f8287fe4c587b3bdcac843d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-kernel.s390x.sig",
+                                "sha256": "b27bbe4ebb2f7708457b25f011ebb4301d134c5b98785bc97401b4a061c02d84"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "fa9a21f9d29a995cd6ee1298db2099e81b1080e7ec700156918f22f067ec69e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "0b92ddd69bc8a253868d91a0484571525c7aa96ab84744850beb395643d36861"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "07a9405a4e7626dbcb1069d6db90e0dd545750ff527c5cd3bf1ad197dc406b95"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "080385b982c7b7fe6c26f9645f921994a13ee58a4327c190cba5e004bebf4030"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "81a336b50e5641b701cf4bf0699b0d8642d1c1d555b3436f17fda2d4bd48dca2",
-                                "uncompressed-sha256": "e1d30c66295eb9db20e6c0d65ed35b0ed254e3a46863a082af001fc6dfd5558e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "d6ce4dd72ba1ab4c82c10bcf1ae721c20ddfc418d866c291f259f8bd136019d7",
+                                "uncompressed-sha256": "b79a82fc51801f2e2948402af186fe21178e17e372e61846c4c46865576e4f20"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c45d30818322aece4036f65a6c9cd9c817bdf9430445ff28ba1e4ce7b1ce4d6c",
-                                "uncompressed-sha256": "9441685732b378cb945faf527e94f3b8c20966a4e082d4763a380d71e25fc8fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "edca5bfcc7409493cc987392ec6212afc9d6f776070366a5c5b8685b327be36e",
+                                "uncompressed-sha256": "99493fe8809011dbf8828d64c254e587d14b1d7a2e99a29c1a4540649019dc01"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/s390x/fedora-coreos-43.20260413.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "17b0a4fbefe253ee142ac711ae38a8c15aa98589ab05363a72c9debb1d62969d",
-                                "uncompressed-sha256": "84e23884813d6348df0393399087ad1646452d12af3a6627fa0cb9a0c9742e3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "953d84a0c68c8137f7e443b81c0da39fcac013900b80ad84ad4893e51cb320cc",
+                                "uncompressed-sha256": "1758e76f413742511a33bd54b33254cb037c839627cac512fee8eda10debdd91"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e30570462384ada83d71807b1a284deaab8ffc8517824eccbe4e2b3ab3232ef3"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6b8dc46fc09ed1d1d38ef4cb67e3f9e606ea10af908b2fae6bcbda80b8f8ec8e"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9e048bd9d906df8152f32aaeeddfe159ac1084370d524b59517dc899615b31f9",
-                                "uncompressed-sha256": "eb3fd6357a286ec2735eccc9bf2306436c05dcab72cfee460d7c88d0db520e35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "92534b88c3df4edfaba3cc9e57093b46e2c9fb9e5bf4f60ec45a1c86e4475912",
+                                "uncompressed-sha256": "df3007dc23ec815a80250b4d2e80f78c29d10b0a7a1d6e8ff5b4fcce64f34b8f"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "c79c57472525eea0c3a8f73e063379dce564c8708d2b63f75a11f1d2e97f79b9",
-                                "uncompressed-sha256": "8cf0f64679df9f92674248c2aa231a23466967d43209d5bc064012f1d46b5d56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "7292567fe13f364c853b4e831f57094351081d4d5b59f38026df8f96fca5f7e8",
+                                "uncompressed-sha256": "6c6aa7791ac9adc486472039b7183adf2f871799e09a63a07ff04fc179e23e75"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e8c99d8f135199e8e9b6429bfb9c708059029f93ac3d329c905b600b493a595d",
-                                "uncompressed-sha256": "fc03eb3164b6d8d9ce2c5831231f9342a004358a7408802c29c048e44e4946a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "e9bc3fe38432b303d38d77b479c8947703f0523728de15ec9f2e592c25d49ad9",
+                                "uncompressed-sha256": "4cf2a10201194abddfa048304de633db4f3583de5e4d140d49785fa538239c84"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b0baf559a11944173a8cbdfe6e722e2c02eac21b478c1c06c0c73c5994ea2c73",
-                                "uncompressed-sha256": "2d5ba34a380b9c778bd37142fdf609037912d33b22c6e217c2f5cee2f67871a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9a5779a66ae6758792f981cb9ac98021f83c89dbf60e5d009c5dee410ed6d0b1",
+                                "uncompressed-sha256": "10e4ba146a79416c28c891c6e0c8158accb9e4a7bda8525a5054733ca1570e25"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "456024924b6a82605a171d43f4ce62e594408a415fa08fde983f3be174e3ea9f",
-                                "uncompressed-sha256": "05c903ba118756a806fe47e5b069aefa7bba89b7ff214a558eb6d6d6ae737943"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "0c81e092cff2fc621f227ad07a5e01d78b96cf51be0274f1d58e2325f09a38d0",
+                                "uncompressed-sha256": "9353c32d51524ac9ad0c1c755ff8c7c044491d39fb63f968621d8bd3a2e761e5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "f7d93b794d0e87aeecc9649c8f7118407ec3fe2e25305a62d6db537911804ea3",
-                                "uncompressed-sha256": "b8ea9843b34988139079b284ccacebc7a1ef7fbfbb5a3c2020d99c4cd0088f85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "c79ffc16862b093ee7359881eacbba541abca30b225f679383c2ec4b16b20528",
+                                "uncompressed-sha256": "94fee00bd539222ebb965239054ead324295f6c3efdd549c6ca3b2c46ef96a63"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "69907649d81b74d9039f08d81ddc488b731b4d69f25f79145f337a7bf8e165c1",
-                                "uncompressed-sha256": "3daa917ead03e94f8d58b3b3bee2968bcad97819651a7af6dd171e55e34424a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "026b6c5d3f04743105325f21ea9ec5b7af10a2a295af5fccb0d0092f5482611e",
+                                "uncompressed-sha256": "bba6a416f86ef5303ee7598af2a39f501ac65190a316b8f0316b4b5441fb5043"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "43af47717e7736f4a38ed0ea511621f855280752dcc208e414e53993f6a5bbd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "fd4b349b9f25a859235577f4859268c5bf49e3dcfafb9a276a13fe6b33141f13"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "a1e076fb65aaf838a134c89fa2d5787789c166e23c0702e3088da456989473e5",
-                                "uncompressed-sha256": "ff43421e1d4132ce29b2755d931d1190434f499e2ce8cbdb552ff923e047df7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "ea3e3c374ef2f95cc05f04c319dd6c9be7acb82b250808ca1c0c3a6abc7ae594",
+                                "uncompressed-sha256": "5d6e673da35a3d54068c4cc31374ed2fc60a76fded852a6d9c86ac395572304b"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "06ce14a5c03b7b00a949fc343d3c9a3118731ec62fe1d354b52cd3ff6b0d3d76",
-                                "uncompressed-sha256": "73d2535c093992464127a3a52626864053c9c6776317da04d53412e53eb8e811"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "d6391c4d23815cd51ae344a85d83a43cd7658e3e55f8ddc4584cb387f47e7754",
+                                "uncompressed-sha256": "792c4b5d096def677f8d222fdb3bea549b605f0e90464f7c9c4b237ade9b1d5c"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a17dade0e08483b38478136bd7f91f6078ccad54b8bf18fe60f97c8aeb534d5f",
-                                "uncompressed-sha256": "96d563c9cdd66df9e694ac1cac4421ff0fd0d033a497e021e07a97843b300cd5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1666d78f3df33a2114859d1b00804c20085536f04c8d4e33e49bbb019a5c25e0",
+                                "uncompressed-sha256": "667e814306755bb463a6e429497aa57c6e96a2794e10b526597ea883f4a20830"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c3897752215a3d2a5925fc3c59e0c078f3aaec64f1014746c2181f4beedf7894"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "316f54019b3894ed89afb9c206fb77bc23732cfb99717e5a6655b7e32eae0a3b"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "caf8e4881732248f1507d6929a224240ac3f0b3e3c9e4bce85b05c111378be98",
-                                "uncompressed-sha256": "9b13278cc8bcbe80aed0ee196b24950c5c178e65a8646c249001e576257ce7dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "1655f447b25e9a638dd5da11b495d451f3b572fa85f1a3059ee890fea3308929",
+                                "uncompressed-sha256": "4b439e3f02c97f8410b80407a4efc0434601352d684c31119bcbc52661518029"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "b18bcf4173212e5d55d4b42e16f1c3ced0033d80cd434fff760d44e3aa38bea8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-iso.x86_64.iso.sig",
+                                "sha256": "232b420907e8d1e7fb37d456cd5ab79ebacc67b44d95b1c074012f550c22a906"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-kernel.x86_64.sig",
-                                "sha256": "85c9a2a025dfe976a0da98157c7956208ac72388f9eb01d246a69549df27a993"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-kernel.x86_64.sig",
+                                "sha256": "1c8fb030127883eb16ff4e66418aae3b08aaa3ffa2c9e3d312d6989b2a9159ec"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "88f16df1445c104a2d7222e5cef47083b7ce0a81021d5728a4ec953a882b2bea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "e35a1484b110a2f72893b0753d641372f4dd7066af66c6c9118bf8225b9c1567"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "add8421dd922dbbca5a5b41dd733016165dbf3abbb612a877dee13765acfadb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "631c6b248e1a7d3d0a51ff83dee6079eaa2ec2d99794968a9998a087de5c7888"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "62fe0ff35df5c0c05d0a9938a887da63d298843c64a0f953d6e3825f2e1ca639",
-                                "uncompressed-sha256": "ceb3ccb7a1d30b3436a886a2f8952888344917b7c7a84a01272a70e23264b288"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "7b85bb95b6a6d37116b80eef69f3369a0466d1840fafbcd8f295049b268ea37a",
+                                "uncompressed-sha256": "7ff6f1ad0ad013e41d09ab3ef81bc9925f36307a66bf4929aa5a3714321a5f50"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "35a4b518158ea47e864293380fe7cd036c591744f0b0cd04b2a91c97589672c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d5c4ed62e5a438db7fe7a6353c8a9cbd48bb374931e38a969035045f3918dcde"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "9d917c9fda2d6b472fa40e16a6e57c9d10be5cd854cf79353d8947b39f3a8561",
-                                "uncompressed-sha256": "3d250366741b2423d7412816a7c9354e0a16453eda37eee45d6da19b1dd25234"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "19cfe83ed68e4b27bd3ed65c9cd5b1a42b08828bff95944ec0abaddce62cd9f0",
+                                "uncompressed-sha256": "af5ac97060cad510c8b673a4ea077b89be88afcdb2e525ea5eab72b6139b0918"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0e7a4d70047a6ea5253812e86bf0dcdba2dec1a434e0d827b90bb2fff5e595fc",
-                                "uncompressed-sha256": "5e20e7de69f1ac08ee42d4314ea315577e3b8e07c1c93e446964f8c6ba2c24cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "262b659bc0b1889403b00909a58636910715638c88487ddb11b62d3fe9092259",
+                                "uncompressed-sha256": "b7ee5666d9b117330a3badd87e3c85f4976885e7cb7cc81c8dd790fdc4a0d9d6"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "76a879c0bc80283b01932d331e4dd3895c056436370bca12994b0613fd1d0a96",
-                                "uncompressed-sha256": "1b7b70a0d324231b0fa367f812f6e89836c0f58d13eea993f6e59da524d0003a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "8c8583af19d0e08294f6009a338b91eb407f2834809d164761b45ff4ffbe745e",
+                                "uncompressed-sha256": "e47edc54eadfc79b44c70bde9b2439b0b3ba8b013bd6f8f4df5c1b6f04d75592"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e6204a1695c0f7a3496e14364b104a2ec4c04f2967d5f41b744cf6e4dafe359c",
-                                "uncompressed-sha256": "e86cb2e00bf9b6eb767c9da68dee6e487428121a3e2c68d670bc15677935c6dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "56c1d862e20ae74c000ba5e7e721dbe7cfee870d1f95977128c0e14c43d6bb6c",
+                                "uncompressed-sha256": "c8069cea41fa13369cdf81b253830f24b6e977effbb861de0b1e96322f45e3a1"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "07615358b4326e2f6ae6008cf9107458ba528b61684d550ed87f7b76ba706d04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "54ed9def85e607af5c9335c9f504e8b259221ae65e16758ca28ffdfb0a529c13"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "de93f7ae799e7e62df19adf6d4e7cd90c22e74e1233dbc3ac55d9e899d1e3e14"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "2aa67c21cef7eace3a80a1f07028e4f3222d0c18f7384389ebff6b7f47a493ae"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/43.20260413.2.1/x86_64/fedora-coreos-43.20260413.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a44d09de0a1caf50fff73a1433a9b128e3c4ef23a06f7c15d30ad90bf0c568cb",
-                                "uncompressed-sha256": "52142f97d4caec69e3cc4f4d738b00774b86694514652ff4bd6006c32fb837a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "6725a63b46d06baea9da0b02eade2ad12b62ab7429670f7f3aaf3e9595615c12",
+                                "uncompressed-sha256": "bcaa83156db940d672cdb34d5404f3131d71dff18cfba889095cb7ed06b412fd"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0d4ca0b574fcd40d9"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-054b9a3782b7eeb17"
                         },
                         "ap-east-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-02dd03e7582e5c396"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0f681770fa53b39e5"
                         },
                         "ap-east-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0c5d286d6a407047a"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0765c3d69b05783df"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0d10d8754aec5258f"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-016071409d7f9106f"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-088b479a7a5fe4398"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0b9bb8edb8e15495f"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0948a742fb9bb8851"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0640b6693130fb0ec"
                         },
                         "ap-south-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0ac19c9646d48f025"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0497cfe5fb6c5036e"
                         },
                         "ap-south-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-058e6e06ff0cacd01"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0e3fdad284ea10cc9"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-08e275d0db88ca1ff"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-07878e7a95d56d54d"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-03b602ae9af2e9bad"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-023330bb35a4ba95a"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-03db3028e9987245d"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0026ceaced15b2db8"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0e2b9f630d970d829"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0e8c2a8958e643a93"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-05c445f8530414fa4"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-028a7eaad9429adb3"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0a795169c07bdac2b"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0c3784a625e339d77"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-01a2386f8cef004a4"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-04a75746e574d8a2a"
                         },
                         "ca-central-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-06ea44f22bd23aec0"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0276a26a5db1417f4"
                         },
                         "ca-west-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-09f5f7eaa318fbaff"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-08a2140816fffe2f1"
                         },
                         "eu-central-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-074d6b6c99624691c"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-05af65f19534557eb"
                         },
                         "eu-central-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-005ed2a423443d192"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0110471861939d095"
                         },
                         "eu-north-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-09a42bf2447c0b16b"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-06fab6164964e86e7"
                         },
                         "eu-south-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-022db59a8f73e27f4"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-05fc47eec9d1ddd56"
                         },
                         "eu-south-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0f798b6e10df56f94"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0d0258534a1ada6b6"
                         },
                         "eu-west-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-008e8769e4afc70ee"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-057636ec4cd742e1b"
                         },
                         "eu-west-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-06f926c339a4639c4"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-031172d729cc99c1b"
                         },
                         "eu-west-3": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0e3b57fe30e196cc5"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-07967ff12bcc12fb4"
                         },
                         "il-central-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0665eb8a400f39925"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-01c1fec8d1c0bd7df"
                         },
                         "mx-central-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0fdec8acfad7949fb"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0cdb9f6c58e49d909"
                         },
                         "sa-east-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-08dba74a312cf7576"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0554a4fb3bda1e781"
                         },
                         "us-east-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0fc8e08697893b990"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0718cc02131cc3af9"
                         },
                         "us-east-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0da231aea24d6b572"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-053972dcda24c6645"
                         },
                         "us-west-1": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0805a4e1c24e3a180"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-0fee2815615832077"
                         },
                         "us-west-2": {
-                            "release": "43.20260413.2.1",
-                            "image": "ami-0afcc2341ae968188"
+                            "release": "44.20260419.2.1",
+                            "image": "ami-07588803cc18d42cb"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-43-20260413-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260419-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "43.20260413.2.1",
+                    "release": "44.20260419.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2dd373c32fe33fabd20fcd7f7cc049d855aba6d82b541472cad1801e5630423e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5e28b035f7558668b77fbfe714f80d13b473d851f132230d9f6628df7fde53f9"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-04-22T00:54:16Z"
+    "last-modified": "2026-04-28T15:58:58Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260414.1.1",
+      "version": "44.20260419.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260419.1.1",
+      "version": "44.20260426.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1776952800,
+          "start_epoch": 1777399200,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-04-15T16:36:03Z"
+    "last-modified": "2026-04-28T15:58:57Z"
   },
   "releases": [
     {
@@ -149,7 +149,7 @@
       }
     },
     {
-      "version": "43.20260316.3.1",
+      "version": "43.20260331.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -157,11 +157,11 @@
       }
     },
     {
-      "version": "43.20260331.3.1",
+      "version": "43.20260413.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1776276000,
+          "start_epoch": 1777399200,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-04-15T16:36:04Z"
+    "last-modified": "2026-04-28T15:58:58Z"
   },
   "releases": [
     {
@@ -165,7 +165,7 @@
       }
     },
     {
-      "version": "43.20260331.2.1",
+      "version": "43.20260413.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -173,11 +173,11 @@
       }
     },
     {
-      "version": "43.20260413.2.1",
+      "version": "44.20260419.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1776276000,
+          "start_epoch": 1777399200,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).