### PR TITLE
testing: add release barrier for n-1 of first F44 release

### DIFF
--- a/updates/testing.json
+++ b/updates/testing.json
@@ -169,6 +169,9 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },


### PR DESCRIPTION
With the rollout of F44 in `testing`, set the last n-1 build to be a release barrier.