### PR TITLE
Roll out stable 44.20260419.3.1, testing 44.20260510.2.1, next 44.20260510.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-04-28T15:58:58Z",
+        "last-modified": "2026-05-11T19:14:59Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "f1ceec6cbce9e4e1ffda00c5285fe0180797e14fc192a3263e417c52fd8043bd",
-                                "uncompressed-sha256": "aa73aabfc087592c5e75d286557a57e723dd15929364f33b63a39825eaa6af97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "d9f5a081f23b778f76a7e6f126fc13c68606f58791cadc58ca362c55ea317688",
+                                "uncompressed-sha256": "91e74e028cc74dac4d9583747e8e8a9b7faff453cfc791eb0938f54e4904864a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a975f6af90b0459b24d668ade02052d52b688c5e82bf60e99869fc66d7d14762",
-                                "uncompressed-sha256": "44b0f9cb5a42152b094655f78f5decd1242814d01753bf66b514ba1c62423dba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "79fbbd2d3bc3acec3b087fe4635a713130b25fa373497a799f97aa98d05b3231",
+                                "uncompressed-sha256": "ede096b73de4232e250c46d77a55a711093f7dadef27433c247498971a70c64d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "0f74767f9167ede9a07609dd4993878b9b175fd01a82ce007de973e3ec2b0ee2",
-                                "uncompressed-sha256": "e48d018b4439b34bb84dcb8f0fe4a6fe0b1466f7c0ebc95a6c33c9d665336a2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c9400baca96bc889e5b4ae1ae1b424a41bd3824d038e70ec494e1d89fa1e9171",
+                                "uncompressed-sha256": "9fcf18a0b32268064aa019d2b1291575de8913c1d89d36eb2316e32b716f20f1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "302e8099babfc89016ca1c2856b8c3228eb257aafa3a625e76b395a68fc3a0a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "cd954200e5a86ec0d44b1c402e765f83f664f977a7832fb8bed00f20d48f2a93"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "7454d04939e99f43d4975e05ba372dfc4c8cb35b3c8bd7805742e89a39e5a60a",
-                                "uncompressed-sha256": "0b40053dbe77ef32c86f2e9e095ba45222bf41d596b01ee749594b38fa00f3ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "927e6f0cad3b68ffbcb73e5184cf0abf8e53013e7daa3fc42a167a97e1bdf35c",
+                                "uncompressed-sha256": "0143e0f222ac9158ab8e44552a94061c42e03d47abf772ee983dbf305e72b2b4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "382f74582b737df58cd80623e1659e04fa0a3374c9c107637939f62ddf554781",
-                                "uncompressed-sha256": "68d5e04aeea70a77c7b0a1239912b04ef8892d31cdf572225d97b68f78d41002"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "4bbf0b0fef97f675094913f2003384da1479416eba07d3465b016f12dc1db0ef",
+                                "uncompressed-sha256": "423b1e6f093262b61e3a45f7632ea1a254f2093e8bf2a8875d56f00778f55ca0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f64a997af459378c6582be62ce0ffc49e19eff94ea063c739992ef4ef827677d",
-                                "uncompressed-sha256": "9a3990217efc034e32f21b92b926eadef5d67bd597916ce92b806a6a5e8ba4f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e9855fee761a74994dff0329d4f75000207a54aeb6a88c55ba3f5f79f85d3cc6",
+                                "uncompressed-sha256": "8d04c63923fee998042f35454c92e7a57ec6c0bcfe1315a1e8689d76146e6289"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "32c3a0f3cc7a500eda25bdf50316c7ce273dfbc14546870ac95a5d77882385d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-live-iso.aarch64.iso.sig",
+                                "sha256": "ffaae3c0bdd5ea1f364fc3fb5d79a7292677e9161781d4d9097316d29673216a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-kernel.aarch64.sig",
-                                "sha256": "4314e2feb216deba0d0998da1693a8ea9e432dc47c5f81cd3408d4d3436dfeb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-live-kernel.aarch64.sig",
+                                "sha256": "c6f4cb8fb2e6d8caebf0b390621a3cfc635f82abfb7cc84ddc0d30e50d94ac9c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "44b5c3b0ae03634a0bdb05e162b3709af61ae4be3956b0897a545b583e7488f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "edf62babb5a48fa9e76d65372dfac238f6850561797b29fd7fce026aa750e7a9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "68c95eaf122a4970736e735a9da795806e0652bc889ddffe37011237b323968b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "8ab4ef4a54c6128e2fcf8c281033ca8b684650a25c9bdedf97a73d2c1364697e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "5b9f61baff3b4c0aebe0bd231b6ae2f437fcc20d96a7e27c6cb9324e5075c9ce",
-                                "uncompressed-sha256": "c7fca20f7ed7ffee5cc6757a96d41ed1820b8d6bd1ba2665b3f48b87a0a93ee7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "767fb42897ad32e5bca7c0ef291ce2478182f462914aea9695cab98e26bcb674",
+                                "uncompressed-sha256": "52f559c69db8233a78a4bbda640f2ae7d810fedb4e246ad37654c9acd31f5e19"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "2dc161c65d50d1c4933c6a88b762c4bf25dbf0b0cb8fcfb0a599fde38d10dccb",
-                                "uncompressed-sha256": "640cb3b4e84b674f1ae5870851611f58a87468769e872d8f722ba26164e5c6af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "6811c1dfdc5535c9756e7cd0e14f191d282089220089c588553f08fe265ff7cd",
+                                "uncompressed-sha256": "6c1249aebec24d5a251fc0ef043953545f92baffee1fca45d0a600a632bfd4eb"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "e6da45abcf4357b03ecbccd005ea18a948b014254ebf4eb9aca2da68da9a3e9b",
-                                "uncompressed-sha256": "69107cac5e218a7ec7b579790a79915de2e7898dd2f201fd55156b61b0452ced"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "7b7ffb4d620c0e14300ee094add01786f151f8efe329af5d7e926672db554ee0",
+                                "uncompressed-sha256": "2f36c330bab10cbaa66cd4031864b463899c92b21ad41d40dae3d400bfee777e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/aarch64/fedora-coreos-44.20260426.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "6e27061d972b5ee36ef24a756d90d837d724bf114820cba39e985cff9e18b3c1",
-                                "uncompressed-sha256": "69f8410be76a3deb2d1914f2dc7a02415b40680d6ffc140a0a3268df595e9e2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/aarch64/fedora-coreos-44.20260510.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "92185655e459cbb0aad8f50649b556e0d8aad190e67e42ec289774053f8f5792",
+                                "uncompressed-sha256": "376837cce8367a44eaf2ef7a7d1406d57b54c8b3cef3a7670d0c85a824b877b0"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0bd3fc79df87e53ea"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-07338d0d9c91618fd"
                         },
                         "ap-east-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0d5c2b227cc7bb4a8"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0c3ea324e7ec2517e"
                         },
                         "ap-east-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-01404c8058ee647b9"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0342b89121e413073"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0189ac8b47ecd5ca7"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0fc9d351e27e6d796"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-08c0fb00f09bc20d6"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-04e8a095efae9d4e3"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-08ae58215231d1ebe"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0ca0f18a37e76fb00"
                         },
                         "ap-south-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0f99e5837c09bb65f"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-035f0733f7a47eff0"
                         },
                         "ap-south-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-09f87f581b2028ca4"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0e1da3094eb70e8cd"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-054e32b8a0c85ce4b"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-036ba52a08c7f190f"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0874ff675a3d6417a"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-06aa1dea592318dc0"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0c004a1027c28f176"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-07b0997b414912024"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-093775703d6786a11"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-05dd04c6ed8dced9d"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0c25ab1701793948f"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-03ea651e3c983e953"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-068e4afe4a32cdc62"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0c63837cbff9feab7"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0939aff4f5eddf15a"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-024feac2c5880f01a"
                         },
                         "ca-central-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0cd61dd6816b26173"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-03e7217ffa885611f"
                         },
                         "ca-west-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0ffcb75bd64c661e4"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-03648b2e881ce2bde"
                         },
                         "eu-central-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-02fad68235eaaeaa8"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-09fea31b5f50f0df4"
                         },
                         "eu-central-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-083a8705fdbdd2a23"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0f5b90ff542fcc2df"
                         },
                         "eu-north-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-09be4a698a80561ad"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0899ec7fc6ce25128"
                         },
                         "eu-south-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0761bc313ac568900"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0df7ef279d16f0be7"
                         },
                         "eu-south-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-04d1216e653964a95"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0e29110ce8661480a"
                         },
                         "eu-west-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-03be9d269ca003685"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0ba91f32257d4c90a"
                         },
                         "eu-west-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-01dcc2e6aa31fe12d"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-001e3b4aceadadda3"
                         },
                         "eu-west-3": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-05146b6380e2bbfc1"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-01d9c0caf6905e59c"
                         },
                         "il-central-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-034935960bcf3243c"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0fcb8534780bbd30c"
                         },
                         "mx-central-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-00c558b63a9a5e49b"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0d5d1163a8a1fe52e"
                         },
                         "sa-east-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-04cf0f09a11f982e5"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0a498e21d0dcfc0e3"
                         },
                         "us-east-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-049ff49bcf5321881"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-00de5a26d4075be9a"
                         },
                         "us-east-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0a3e50a7743592a00"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0a087d277a16eed06"
                         },
                         "us-west-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-00adf24e26bfc3e20"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0277ce1bb9b41d455"
                         },
                         "us-west-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-091cbbdf46a24feb0"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0118c52bfe5048588"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260426-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260510-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "66c64c20c7d1dbc21c21712b3f4f3c4a054f023fef90d45746bb64c33d5592b4",
-                                "uncompressed-sha256": "614f31029521f7b2eae19f74e057df1284e88eece542fea6dffb79d4e61eca54"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f94d10b7647f7ad8f9ac232ba4b32437057e216bb42a344fe74593ab5a05feb4",
+                                "uncompressed-sha256": "d6340b677789f513844116a2939a8ce8f42442563f87383cf4329653c9677fd9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "36d35c23c09bd21b59940cad7b79708b604bd0678cb5a9c55d5d95a84df27ba2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "b5bc0a76e4a630dd144fdcfae1b3a120b5eb89aa3a0f6c882424a9db98f8551a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "9887efd41811df6c8c920dd2ce39b9718f83a3405e6b50f183ff98452a6d77cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-live-kernel.ppc64le.sig",
+                                "sha256": "241319874c6eebc6aaec8d4b5513320ced31e528f1094b6c2514baeab907599e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "dc01282bc7c048c29a467496db7ef2396c8394c0dfea379a23186a85c417b6e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "8a52d38fe69b581b61fd240523b5284957c539ce3f311890d76f3980f35c0117"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "da547b61a150ffaa815d5a46284d7d6d24aa7278bb8d9d7b8f75d2e29c27f7e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "819da56a2513c69399470eeab5a54cd29ff7fbdb779ebf4c2985ec5e082b0690"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "845b0cf184759052ed184edb0d554bc1981bf0530b60c4892290881660fe1b57",
-                                "uncompressed-sha256": "c544fc1ecb5bf17f6e8f56e17b78a92d541a53f40a9084df11997d7b705c6887"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "740908e26cab3c6dd570dd980ff06ce482db9218579b239283b2f27a62235ce0",
+                                "uncompressed-sha256": "e745a5a7f26030e6cd4b4b319c07579aeefc86982c2fec3ac495f5c78665a218"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "f1ec90bba773a9b77193be889b1918d56502e19005fed6b82a8f9e6d3a61baad",
-                                "uncompressed-sha256": "cf2f9155b8c499e95c668b04bd8891a01b9e3d5c04739eda688cf0cc9b01b6c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "4f241351012fb7d5a460f67ebf78bf0aaea587f02bbf468ce4a7496aa1aae12a",
+                                "uncompressed-sha256": "b27550a0edfdefecab643102ef89230f9fd6389436a984d7681eaa4bc05313f9"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "270874f28498631c56591de69c552e38d7ae39c7fbde153ef1d6e05cc7585666",
-                                "uncompressed-sha256": "0e40da8c1d80c8ff6ebe4bacb92b8e27baeb3555a2bc416f6b529ad67cc602a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c4f613b2c813601e733c897843e655b67fd8cc0855d718b11df9fcdd29d0df97",
+                                "uncompressed-sha256": "4781093f31988b622f68a4744d6bc8c8ebe29c5f69ce512e9c4c727ba8f9059b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/ppc64le/fedora-coreos-44.20260426.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5dc8e4c9835f2fda366f0acf32198fcfd134ad214f1a2177dc7e81314cd9dd84",
-                                "uncompressed-sha256": "e4b87e1db2edb6c9631800e68d7d124ee96d553ba7d76382a14949a10b57686e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/ppc64le/fedora-coreos-44.20260510.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "d4a402ae9bce0a66aa865e8b5b0014ce8f149739d3056362a06f634ebb323fbf",
+                                "uncompressed-sha256": "19aabad3596f742ebaa5d7b312851b2b87c796a06098ad742de056c9f8a13858"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "0a7c267024238286a4976c88f46cb53585912e786b31b2dcd0c4be735b753bb6",
-                                "uncompressed-sha256": "7c4c2f632cca958dd23e4b972fabcf53503255637c24100fd5e3f2dd824234fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "28aa7647bfd6c15c646d1ae6173402d98be83d28da6da4fc6d9783a9d4e0582d",
+                                "uncompressed-sha256": "9866966a94ec97719324dcd8f3b74bef4add561af9f45cad2cc6e775b1f20903"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "d7eaa53a6a41110bf817cfa8a8e7653690de8b6e8fec3c0653a57b71c7cbd665"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "4436ab6c83be9e1910e8625a132c13332ee80d91f0209ff41e3a4eb7e3d28c3c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "cc07b000a1ca0376a28d1dd668104440e3c6ffda5b328b6143ef5fb537564353",
-                                "uncompressed-sha256": "7021e743ac155e4eb828f6b1ae9343c1b9c7b9657b73e0d2dc447ef0d6dd4707"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "bf099935c88a6c3fe4c84d88cf6ed0a9916c8ed6e094237dcca7f68045bfd1da",
+                                "uncompressed-sha256": "2ae3914bc49d79066fb257d26cbce1f83ea2efc4a8cb3540c916557e09008e29"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "944cba56acc25aaf328a849b4f6fa4dbd1347fb2ce529e45e9eea0f21df4b836"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-live-iso.s390x.iso.sig",
+                                "sha256": "dcc3bec778491d9b9fc9d9364cc40147929e57e78918845f7bab3107b2d0132b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-kernel.s390x.sig",
-                                "sha256": "235da68228c9ad07d2092f6acedd90860f202e6d2bbd55c911be07810584ed3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-live-kernel.s390x.sig",
+                                "sha256": "c56869c60af0525883adb4189c5bc9420169827737bf5e9f742c01e9a7b3a684"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "d3611e1b22b2fdef15ff1c1fca44723dfef26974ec6ecaffec7e6a935928deb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "304858052f547fd6fdd2d48371f6aca713ce7e2b2d041d3ff72340796fb40b6d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "16102dc5ac31787366047a31d3907633d5833d12a6b9ef7f42d065a69e39b5c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "879bad89d25590d25429eebb29f13285144c5d4bdc994e25f822a9d2ca1b1359"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "b19afeeaf223e6523cabffe89939e03f113413017dd21cb28b7c4e926cff196d",
-                                "uncompressed-sha256": "794fdbf5f5f8d0fe15b09fb4f266fd4e128b5ff5efd8a78d28405ecd27fb5358"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "2628e4b2fdbd23ea09872490f07421ca0ce8394a51bd7f2ac5a64af30c305834",
+                                "uncompressed-sha256": "3bf9568b8c9773f566539d2cba697bbe0a39d52ac1a361ed019fe4df45751d06"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "380b4ee91076c24a863c98aa57c2c7d4a646d76c4e352c21da6988ad78116ab8",
-                                "uncompressed-sha256": "db93e22afecbff6c7b302ef9b5e749bc5c5a7096951f5f81fecb24243c00a115"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9151a7bfbfedbd13af80494d38272e071ed995e5d4aa49bf7d83f2d43003c8a5",
+                                "uncompressed-sha256": "4efe0931d9fb470bc2395fa0d2f0c64ae854a9b6173f415e204a33fbb291c8af"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/s390x/fedora-coreos-44.20260426.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "7b5d2e58d91cf398869c810cd7d0c4105f9eea617d136fb72b1187e925055839",
-                                "uncompressed-sha256": "359cc44b1ffcc7a2f9aa9726c09881c8ccd4570e8629decf1956be7b400df28c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/s390x/fedora-coreos-44.20260510.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "cb3395763f7d8faf460535fb76a6b9ac8edeb0c6a35e2361111b5d2ebfc2a130",
+                                "uncompressed-sha256": "f78adc65f6a499a70d4b00fe91c8ab9dcd58e3f20bdb44ad5a7184720824796e"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6a546f459d0c48c7fde10e5ee57d4a0b61d8347a7218f54dffd5c1b5e20017f7"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d900680e6be159c1bbde9bf7d15bbe8d6050f5f93bf60351d4f7658fa4a08682"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a34e1f716a919d07b0b5e9532c11cb123871b8af85adf1357f686c5164f5dafd",
-                                "uncompressed-sha256": "8f882dff9237e6967c7a1eba3f09343a1f98ff44e410ccd02b2725ecc5be2ab6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9bc55d369ef175416664139670f161f36122df2736e1e9301e4aef04eae9668a",
+                                "uncompressed-sha256": "6bd571566b14eff4ab446dee0f70fa4a3ee039f4d0a530cec44c0247b9de416b"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "598d62feeeea84c794c9db636e029cf0d53997fae5249470c73021cc60d2f927",
-                                "uncompressed-sha256": "a2cee4447c610a60530e00c2d53ac92962cd382e3011feac57fe929f88e8cd80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "142afb2098d45fafdade5f572c154fa17ecdf096be7f6e3774dcc13d706ee4b3",
+                                "uncompressed-sha256": "086094e4ec02c96fabd19d24955185ebf0c95b99d959656e767caf17e4a56b44"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e6cd6da18fe672b7ff5b53cfaa0f177bb2dfb3e7299f866b1659bb5fe4bef185",
-                                "uncompressed-sha256": "6bdea822c35f60c79a9d732b0f4cb543fc120e5617de5c3dd59fb71ad31cf9f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "79d68a2f8bd01b0d62de145f8d944082625d4a57d3b0a11c95bb10e52e5b843c",
+                                "uncompressed-sha256": "e5ac8494d2349b6deee9af6fd2d0de9e2f2301e20261cd7fa724a409e58934b9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "b2432f647ecf314a72d4ede305e93eda3127519d478bbfb1f42233f0a15387d2",
-                                "uncompressed-sha256": "fac6a66e1b630c6960e8ef403d617f2cd67338482079327c1b798c0ecbd55dac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "954004a054c7c8bdc119acf8e500166757b28f697be6abc8d1539bd0eef9287b",
+                                "uncompressed-sha256": "80e529cfaaaa2f88154f3f22b428c297af894a377f9695b6b50cab7c9438b440"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "e824c908ad5a2958cb3a7f74ae5f0f17ba9276566f124b74a0909495fc2b4468",
-                                "uncompressed-sha256": "f80967e5f0f7f47cebf47f9fd0947082cf76d917cdec6bbaf6667141192a8898"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "03c9e745920de1f518052148d49fa20bd528384fe254898aca1351d2e9446d10",
+                                "uncompressed-sha256": "807739e2748493c2b010be7c341914a13d88ce04d8dbadd56804cdda70250893"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e5846721fd5d77e78aeb7d978b360abbc01195ce7c31123bf24af32c89e16259",
-                                "uncompressed-sha256": "27d53aebdc021e0be7b84f3d4288ee1b6b6758a76dd9ed3adb5864018f2acb65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "2aba55fa11702e4a6a40d254fe1f11d005ed5fd6e008288ec2db099cb69d17cd",
+                                "uncompressed-sha256": "0ea5317e0170c7ff42a2cef44d914810112743e184839aa26ffde0fcf5c7dfcd"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8728b854cfebdd9484c8fb2c4dba7e95f5478823aca6733fec9ebe801937018d",
-                                "uncompressed-sha256": "0182a7345425825fec258261a70d25466ac5eb63bfec23d10279d49997926cd8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "46f205f85dc88288e9c7545ab453efb459334a6367cb71d50bf72abea14481a2",
+                                "uncompressed-sha256": "8f64b766f165a7644a4d4bd812705197f34bd89d149e4d3ff04f2b20fd82451b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4d658c5489666a7b9fb63cbcd9a2d4fc3633a9051295126429630402d88abd9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3115cb9c74abb729622a6e330c20e6e267e4c291c3285107b0bab54b2106da99"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "5a35032254f7c0b6ef3aa900d0f2a81beeb94138be1f126cc5646b2dfb125097",
-                                "uncompressed-sha256": "1f173c8bdc326b130929146c21ec547d43913cd5dd34f090776297bec6ad405a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "817ad2a172e20e523ba50831a0dab5ad1b865792d5a1b0cad026aaef0e9e9ddb",
+                                "uncompressed-sha256": "817a620ce171afa5c6a33bf46ad92e2e7042c491a6727e48c982dfd26ad3e709"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "7244915eb25fb397c04a4af1a3b2cb55a74bb0c2c9b9cd721ae85e7836bd16d9",
-                                "uncompressed-sha256": "2f2934e6b69d7e3d7435288231113d9ae87a8ea62e9784df3c22a422959e32c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "bbe48b06cebfa6f8eacda53b5efa26d0153745722d3fc72e63c36d9d1065d731",
+                                "uncompressed-sha256": "1bf53936ef5d9f3efaab817ca65c9ee66efd2e6980e1e7bc7ce7b3ae3d82b4fb"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d3cbbf8397558e7d42202f127a40503b4158ac65b9d34af22df22a00fb5db1b9",
-                                "uncompressed-sha256": "b2688122f6b5a2ac6309668a0bd89c01c8264670a7fa9de7408248d01423bc5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "fe55c4701d888b4ff4a798a6bdc2be5a3017361ca66d070007ffd87420c7133d",
+                                "uncompressed-sha256": "7bc20064b2e4a9af4411b82cc2aa22262eaae84c8ccce38a31192cd54867cd0c"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "65ef9b19cbdee938b04800f52a9a39a30fa6906bcb38834f8ecc1d25c9647a33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "d597dab3282a7c9858383ce0106d8a414645f0bf7023d11387527abfd7d08a12"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ad5e77a66068bf00f50b12e150e9c426bba529a58063399946cf644b254771a6",
-                                "uncompressed-sha256": "e6d0df41c125e7b2c89fe98f684a294ef3b05c8289542062104db91ca4b37fa3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2aa46ae5337d568ed8737fc1cac7e472b4d7c2c30270e057481cc69e0189f472",
+                                "uncompressed-sha256": "0c57be89115c366a8247166fee0011c3573f4a4a2aff7862376a92a8c7dc0c98"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "69230334972949766ff04c6fc16722878aedd239065d39589a83d3f06a4767c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-live-iso.x86_64.iso.sig",
+                                "sha256": "8c040aa7bd103d5e8fa733b29872e64bd69961e07f3d6cea17f2b68d8f036415"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-kernel.x86_64.sig",
-                                "sha256": "1cd64153afa5d746103a25739923ff2413e912365940cfb2d614cbc9fe3eee7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-live-kernel.x86_64.sig",
+                                "sha256": "b44573827dea811f5546d185a488c6efadb0e837316978e314ff511cec6f91a8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "87661e734d321d8e362e779209519ef5a559d1ffccb42c9bc80a5eb7fe0eefdd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "2f33a924cc0c307ae59dd48f387721bae88f2f6278f9d1a8e0a90502733a0a96"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "d67cce2b389e7f623c0866c5c58050b4830cf6fc399926335ac1f9c89653ab44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "db6ecd245dd59e1c57a6674c11679239d9e1698729eb0e6d156072b530c13bd5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "fb121ba132e47d4fe85f7b8005b082be7b5e84d0826cc985e6759f68479491e1",
-                                "uncompressed-sha256": "48d13a9ef583d6701dd93a727fe61cc6967273c7da5b7e4ddcc89e16b1b5a675"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "286dd1f861812387b970451e28cf4f03c292c8efc2344b5bd35fe717730d4de5",
+                                "uncompressed-sha256": "c1b6215d4742011233781c09dc26341e97a5c7a5dc592044e8dfccb0b4bc403c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "69cd54d11e1736baa9b9a1e3e71185f42e7d4363e83d0fd9e8ab83074c54dff1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ca423bbe76e226ea9e7f48a28a9c7f3f1c77a288451f86bac5bb427e2eb6b4fb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bc2255635f5f333231d0ce8c9f29fb808471c0f058500c78c3f15671ad63c87d",
-                                "uncompressed-sha256": "4b0f6526de440749266a3c0b4836e2b39c729422264179cf95bf4035406ae93f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "49d27079ef43614c32f148b98d9fd5be980440802f71e96f21f9141fcce1f293",
+                                "uncompressed-sha256": "de4e2b1711fab685623641df1988f032d6a1aaeb84c7b6b52de6955e2f0f22f4"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "050fe66c964da9df876f6ec1caad7b28fa1e29377cd8b63b526d6eabeccfa3f9",
-                                "uncompressed-sha256": "831a3f08fc27944e26991fa59f7886e50e015103dee36c1f660c759365aee91b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f64ffa642fadca27b44f833ae03cbe1fafa1d28a05f9515f4b22e08c3abc630e",
+                                "uncompressed-sha256": "f605689805d8116d9f62919c0662a155f098717547200bfff6106cc68cf645bd"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "4fac3bf02d241c188078e6a3f2d41d9de2f628a40b315515fe85f657587b805e",
-                                "uncompressed-sha256": "296e8e048b0d1d3e1eb72645124ec89511ab8b462517fc4782af6110986cf8b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "798d7cd7b29238d271da8a3afff4fe190b065fe03cb60c1f0f660f40a82252c9",
+                                "uncompressed-sha256": "0934a89d78197be7b3136b80584e7433f72ead32d6546f3918b15aa0ad235c00"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b034d90075a62105cec4daeaa53a98f2f1d61e798c2aa22b4765805008701a8b",
-                                "uncompressed-sha256": "e298b73e7ad49374cd42ad3e8cc5af8be72cb8ed9713091e43345d9c77ce4d93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "2b9443b759e62e940d9726b95bad03b6fd87ff13706f6b5c304e3c55bb178601",
+                                "uncompressed-sha256": "b26728ca09616884f6ecd0f1b3bc3cd9763cbdbe67a76761fc2e0b7f8d939df5"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "f360e1e93922824fae695e9d96ad15830bdf8e72abba82e9bd02774fec57d931"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "5b7d9517181040ec98fe66c186e1bee17c2884368491223ef64bca99bfc947c1"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "240e773a9caafae707bfa8fc6c1f423af8acfc71668ce28a924b3f8134e1ca34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "e1be26ce9b61ed738b786a51d2b4863b5897b4327271ad3c847ec222b90cf4e4"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260426.1.1/x86_64/fedora-coreos-44.20260426.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "bb6a9f35a1a2712477d79d453c149f7f32a3988bced6137465bdccf1d1178ad8",
-                                "uncompressed-sha256": "3fb7264062b069140023987ec5688d9169fd2a6eedffce594b9e397e5bb55f51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260510.1.1/x86_64/fedora-coreos-44.20260510.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "8d721b4668246af0d28b8ebf681c2bbd635596ec3a581998e068035219943f40",
+                                "uncompressed-sha256": "a496f14194d8176db37d445939ae7a24c071569c8e91118c3eac5caaaf08e3d9"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0685f12d2c6d2236f"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0cec18b270e10df60"
                         },
                         "ap-east-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0785d62ed7ae3c623"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-084c8772e48293959"
                         },
                         "ap-east-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0067be2f6f308f423"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-01c1fe4d3720b8538"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-00d3a872b5da42ca4"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-016756368b296e071"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0e6cdc3f46812e8d4"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0d4f825f9530fef98"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-06e6bfdfae7e3d95f"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-088e12a9e1d7dff80"
                         },
                         "ap-south-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-01bfaf6b8343482dc"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0d29c14ba7dfdb053"
                         },
                         "ap-south-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-06a432ad0e6b6563e"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-00f25333803d1f310"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-01ee417429a43927e"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-06a9c86b90799dd20"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-080749ae1f7f71dca"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0071995ffac13f2b0"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-004768e5cb54aa375"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0c0e6e9a27f2189a4"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0186088ac662a4056"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-09924900d7b831f93"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0a0efd84ed562a142"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-08a6b54746f7ee27a"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0a00519efdaa64865"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0b82db9d4cba23f4f"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0fbd1823ac2c52ae2"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0c97cc0a9582eb343"
                         },
                         "ca-central-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0a0e29b002fc4df44"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-04b401a3a71f7f97e"
                         },
                         "ca-west-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-044f83a0abb670887"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0a5319d24f2107bd6"
                         },
                         "eu-central-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-03467b328f017b647"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-015d394d035c3ec0f"
                         },
                         "eu-central-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0228a1e6e40266d68"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0fb52bb09095d788c"
                         },
                         "eu-north-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0bd38ffc703a6402e"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0b8d3dde82b148260"
                         },
                         "eu-south-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-005e51bd96cbbd757"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-020e7f7fe2bda4169"
                         },
                         "eu-south-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-00e8be49203b6ecdf"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-00f94eb71428a5b95"
                         },
                         "eu-west-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-09812c19119c1a5e6"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-03be7721c2b770ccd"
                         },
                         "eu-west-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0d6f17ea35fd64866"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-02f68f5e3fadfc67b"
                         },
                         "eu-west-3": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0ffef2bf54252ec08"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0f38e3a7edba83d36"
                         },
                         "il-central-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0e95a5132b50854b3"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0628b3c1d42345da8"
                         },
                         "mx-central-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-09770b320e15efd15"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-007368c14e9cbc297"
                         },
                         "sa-east-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0a580992509dc1316"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0eb25bce3581e268f"
                         },
                         "us-east-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0abd6f0676b5c45df"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-03ed80bea95aa9eb0"
                         },
                         "us-east-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-035eca47716c4ac7b"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-00aea38c3e0b41e24"
                         },
                         "us-west-1": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0305da33e4b063b1b"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-05a88c0f9691e9b08"
                         },
                         "us-west-2": {
-                            "release": "44.20260426.1.1",
-                            "image": "ami-0a8dd8da15daac086"
+                            "release": "44.20260510.1.1",
+                            "image": "ami-0080d0a9b0f655da0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260426-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260510-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260426.1.1",
+                    "release": "44.20260510.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:110eb2d72c9022fb0fa2606f81ce48c0fb6bce605995b41bc340b9a5faa81fb8"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:19632d194df443c21ddee1e50064f5d4bf414d8bf3ecdbfd6d0461b91e853d16"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-04-30T20:29:35Z",
+        "last-modified": "2026-05-11T19:14:57Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ddf258ebf916806f2301dd562b67f8bd2405b7ba836594f3488096c462c45d30",
-                                "uncompressed-sha256": "1f4b6c03aabd3beb2a2a95c9e95f57ab272df8adc93c87562cb121550a43f5ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "74a8cabcf2eb4e366982921dcc1063f2b13f3636a9fc1be61303a6eab81ad9eb",
+                                "uncompressed-sha256": "3a26e4d14157481323d4af4118dd01c27b9b428cea6aedaa529be16e8750922d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "fbcad06fe676ef08411b3175fa933bbc9a7cbc7d46d718d5b4636a344920cb4a",
-                                "uncompressed-sha256": "c27d20ce884a5d810659c14e35b699e6cec84be057dacf8332d048a96533d7bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "4c2666741a183e9d2aa5f2e20cb3db71b6aa91bbc2d05e30d827a3d4e24cb564",
+                                "uncompressed-sha256": "819e7ecca580ff1f6c813ab4d9867ed8432959ea87c9778c4a68b563777df84b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "bdfbf5fa7678cc56a11fdd15ad647c001fb698ea93cd1772628cb003409fddd3",
-                                "uncompressed-sha256": "0f56f7f92dbd6089d2afdba028cf7f857a795ebc9ccef1779a89aec7f75e1e9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1113eb0ed2e6b417cd7ab1d599c73887f2539e3518001c4a5c4c8fc9ee685f52",
+                                "uncompressed-sha256": "eba7d5535b21778306171b5acc8bbf401283c87bd534b8f42b2770da5a36dc30"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3507fea44205b9b4dd1587ddb80cb7588c5ef22790b38ec1ec4646fecd14af9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "acdef25e63b2674f45e8577eda6d2472956f8cc9db30471bb838fe00de1b7d9f"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "a67626165456ca685cbc8f470f42d5da4cb7633bac2f9533008de8f329f30b4a",
-                                "uncompressed-sha256": "fc6b5635809c49d807e83366ad8922980da760b3f83063c4e921eff34acb18de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "521a3a4af37d213b796e1160997ba9671054a394b8a92933f6951f4856bdf265",
+                                "uncompressed-sha256": "563d5f570056e88fd8bfd2f594d4b00f2541ebe81589c1157265990c1143b824"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "643d96e592bd15c41f3117d2c39cd9c2445940f00eb6b5b681e2e78944a3fadc",
-                                "uncompressed-sha256": "26b512dc285564cbecea522cd84a7f543a6a842a8caad241152f3776a5a1f482"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "874c2f62bc7764b45873ad59665ec269250869268ade429039e1007de45d8a68",
+                                "uncompressed-sha256": "15ef7140684ebc6293c8be3cb3be50d5c918f78ae6f55244dc5e6e556ff54b57"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e4aab6648221591d54b7722adb3fd08ca02ad80a70825a24ba3a6b0a3181da76",
-                                "uncompressed-sha256": "8862dd7bae8b89309bb57c0faf1f44ef190ed1e60fb3b6417222598a1707bb7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "7d15434c7c01e5860564bcd7bb13986271de27a314de576dbfbd58321e2db801",
+                                "uncompressed-sha256": "9f67438669f61acedaf641898a94b347a8b0c8b8fb849417e02c281165de3942"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-live-iso.aarch64.iso.sig",
-                                "sha256": "f8eb9aa2f8a982842c862207907040c4b63bf77e24df9bcb93190b24ac4ae1e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "5ca85a2793f2dbe763443006eeadc07ac712eb0c7fb0b237de895289bc0ea612"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-live-kernel.aarch64.sig",
-                                "sha256": "18ed060e184141f12d8e251949a2385157ea5615182a5b96cd7236ddc0d42949"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-live-kernel.aarch64.sig",
+                                "sha256": "bc52e2f9dec570e965bdabcee4e51d4d482dd12ca863fd72196f7274d6ac27a3"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "31b8b4f98919b3564f9dffaea836c362bd62c267330471f387f80bcce39aec3f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "ea80f805c8254a4bb5d158f7dcf7b49b9fcab65198e5c94f5546eabf07f2945c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "4efbde7fdebdb24a69a22b5346decfa15c382b088e45cb6c8b7580c777a140d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "f09aeee8ac394aa2e170560612029c19d4741e41c67796168ce9a514597e5b79"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "8c2a2afaacb15fbabee478d2470e685c4d109734f6031fe08417c541e60a27e7",
-                                "uncompressed-sha256": "1b7b9ee51b75b5aff05a9a12fbd936a84896b83ad58bec65fdc4fda6d6b0c994"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "289ff4d0344ec275c53e934245f56b2ac7601e63c25aad6e5eb50debb412023f",
+                                "uncompressed-sha256": "601d16988bb7d7a223e6726ab9e92fe8dad5a55a89c0e9bcf063ad5bec16fac0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "5460573fea85fdc30513b2cd38a807c6f7865cc576a9f0bf2bb0a3ac9f240de6",
-                                "uncompressed-sha256": "299c600e53fcebecb09c8f5a051067648fb9e9a03935cfb935688f21f68e98ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "54b4bfebb80dac90e5e23afc9e82c77ffc3520c13fac789c38b292798837ea6f",
+                                "uncompressed-sha256": "ef781e5532d79524b2a61e3b5b773a2f4584e52de474535261372dc28aa3e3bd"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "99c56f802d0ab775024bd443484ae3a65cff91263cfcb8261776a780aaf8b2af",
-                                "uncompressed-sha256": "42611bf1c29e11e6184a9f15b5c90eb5f6ea5c645d7a485c718006da4acda32c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "f15d2d4247753a318fe2e87fc9166d2ecbed71ac789c3af38ee841de96ddef39",
+                                "uncompressed-sha256": "1c2c76d9528f39ce5c563ad5739bf4420624ff26c6fd8fc08f581b302b26e34d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/aarch64/fedora-coreos-43.20260413.3.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "1d1826e753fd51a34e1b53e1b922583b893e5cc2578a4ec95e5e924c66c01f22",
-                                "uncompressed-sha256": "5cde5a234fbc89ea1d81aab32572f4510bb89a2f5ae436af6918d6ead2a825b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/aarch64/fedora-coreos-44.20260419.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "d7a66a4a69d83208ecfda180650d5681da6f572bed9c491057862be1d77fa0f3",
+                                "uncompressed-sha256": "b65510a2e2628f49baa66703b4a549b2f004c13e66607724a451069b8ab3c6fa"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-07a6912da316f2296"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0c58b323a3aa79e73"
                         },
                         "ap-east-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-06579ee3230e43eeb"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0ab97175b7f4af207"
                         },
                         "ap-east-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0088e2d85fbb6d5c6"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0b5d6656a915ef0e4"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0cb7df27c318d58a7"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0ab1d285dd3d681ec"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0a92100ca1f03b6df"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0169f1c9098406fdb"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0b2b1eefaf9042ce8"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0186b12ed2394780b"
                         },
                         "ap-south-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-00e59862c23ab1572"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0a4002a3ae0aa70ea"
                         },
                         "ap-south-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0a5cd1c0dde1d54d3"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0a69e29f1a01f7079"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0b75e000acc514e71"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0e69db73adf266803"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0438132f9c2e519c5"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-03b417b3a7a517a0c"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0ad4a64be5b666af4"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-00d0c39f3918f182f"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0cf5693ad816d4e12"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-08526ae8628bb5d26"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0f5272418019c8b9e"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-08b80464673c4aded"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0dda9f43e7d199733"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0ed606fed3c5031d3"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0d4da72567346b547"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-097ce2caf2f6c47b1"
                         },
                         "ca-central-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0541c1b447e3315f4"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-07fad35718577a1d1"
                         },
                         "ca-west-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0b7965b4621f52632"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0e0805b9d8ba6ec52"
                         },
                         "eu-central-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0dc797bc9c76a45e1"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-070ce65bf7fc6e41b"
                         },
                         "eu-central-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0b0b340a7b1abb897"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0e2eecef99003ebb9"
                         },
                         "eu-north-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-073599d47b1f50229"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0e8ab0cf258c8a2e5"
                         },
                         "eu-south-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0cfd82bd1896f943b"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-037ec0d26a803eb0b"
                         },
                         "eu-south-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0069221e07f843e02"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0920a69404808aa55"
                         },
                         "eu-west-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-09c3d47db4302d1ab"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-076a9318fea431a30"
                         },
                         "eu-west-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0d259cce32e3a4c0f"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-03dca160af1ac349f"
                         },
                         "eu-west-3": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0875b10000200e390"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-049551757f210d645"
                         },
                         "il-central-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0474fc4cbea25e52f"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-033e10c9d15481c1b"
                         },
                         "mx-central-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0b8deaf5e1ce2235d"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0845f760f239ef5da"
                         },
                         "sa-east-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0c61571fbe375d41f"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-01ad983e12b14b02b"
                         },
                         "us-east-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-06ef5260728a52025"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0ac656fd0ab335997"
                         },
                         "us-east-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-08bb593dbfdcb945b"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0c30ee4d484179036"
                         },
                         "us-west-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-02c55bf398fe83a8e"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0a4974fa0a16edfdd"
                         },
                         "us-west-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0d3e319721e86b80b"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-024eb1dc4643da167"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-43-20260413-3-2-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260419-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "e18f2b1634557f3d2e1382ef5e3d1d519cd4f19dec345ecaac469e2513cac9dc",
-                                "uncompressed-sha256": "fbdee7241c8af2adc598d61ed9672a6126b7f4b015a42ccc73b2ada67c59f5f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "4d5af7f7215dce315d353e2a54abae15f0d4bbcf9a8be7529fad20563c3f08c2",
+                                "uncompressed-sha256": "2aeb75e44b49eb63348e95c925f8292aaf726a301aaf31c4b0531efb12d99962"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-live-iso.ppc64le.iso.sig",
-                                "sha256": "4761fd0466adb0855cc413eac619f40179bb22c953cde68467358279ba9290f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "8deb1f076a46ad0fac250438365c7f4e5a3a4211f88bb5fe963a1e5e5ea20190"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-live-kernel.ppc64le.sig",
-                                "sha256": "2d95b261cfa53ef8922824b9f84a49ddcbe599c1e30009959a1df29c29dfd128"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "f61913fc0386884771272ced9a1d68434d9e5e11ece2fdf4dbb446d753d3827b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-live-initramfs.ppc64le.img.sig",
-                                "sha256": "64dd18b9d944389c769f8c677a04618669688e9b0f4b56b1f81497d8929836c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "ae21ce7fc3fdfab3cbdebc6a0f1adf7e71c969058f42a4a4de52140e2d128415"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-live-rootfs.ppc64le.img.sig",
-                                "sha256": "1f799768d6499862f7be5df68899cd035c11ff14dd9beb787bf14cbdb1cb2a0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "e6deb8d3deda15112e28dc0dc5b787c66307c01385c49aeec1f98d4900a80289"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-metal.ppc64le.raw.xz.sig",
-                                "sha256": "f9d945065a49e02f153eac1082d95c442d89ad67a91c6040b6f2f6736350dd63",
-                                "uncompressed-sha256": "c78773fb5b14d875a635609b05a6d13e67d3e393368469296cc164a8f40e55ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "caefe4a09caf6b0e0060fba6e3e22a163bdd8f4059960296309a00a6227b9194",
+                                "uncompressed-sha256": "720bdfbe33a2ea74317e6020036e889f0ff8918fe16086a33a481af5a1c2c1e5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e67f7b6fa7bc95114f71998c07ce6b2e6bff1fff816c3bdc434f919098eab508",
-                                "uncompressed-sha256": "32772317f1d7988dd38eb887fd8c4728d2cbbe648d3a3b715e6da29cbeba4549"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2fa4206332e15180c5e76c57522bb8eb51202359cc84d999d48b425dc7db2071",
+                                "uncompressed-sha256": "6dae46cf0de84a0327c41cd3a7f9bd29ebd98059dc035eee5f3868b0a38f903e"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "64fe930eaf6b7a0aa830f486e5cae3c9332d443506863a0a86f4e79537266009",
-                                "uncompressed-sha256": "7bf26f8f3d7e28867c51b151bf9eae084264fbe4a38115004cda7ccd21445afa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "7ebd478c3ed858006a8240a29db043d740434294dc98f47c3b9dc304ef5c55c6",
+                                "uncompressed-sha256": "4f287eab4cfa2adde1206096c82f716a24d598585da177fe05707183d70ba3ed"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/ppc64le/fedora-coreos-43.20260413.3.2-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "6b9e37ea0294945e79b8adc520e0a028e54a10ce027f1c7aaa5d7f9592a68d4f",
-                                "uncompressed-sha256": "633e01e0f60c420f762d7ac984629cd9f6f3774b21720691b158959e4801db81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/ppc64le/fedora-coreos-44.20260419.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "048ae7d8e32fa03aaa09d000052d0c57556c4528d8e69fc91c107a0ef4a841d9",
+                                "uncompressed-sha256": "55f273799bea5f43b06b296d6f02c5400a5482ce783f1c6538113a660b18b26d"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "d1a3a19a21802785580579c979c14a7723b49e7cf8ef39d4960a97acd1b57734",
-                                "uncompressed-sha256": "1ad9c4581bab2da5cb51bf0b81bf1947734f9a8ac70c6a78961bccaef454346a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4126cdbf7ab9e7b4d927697007669bd0b9fc9c3c105f9c7f02b03fd09afecbdc",
+                                "uncompressed-sha256": "3bc0b6fa6a4552a43692217f97a8148422d7810939a4ac6b76f9eef9bc9731d0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "1669c4bde6fdadd8e1b8299f920a9bfe5501a6f25ea9d9b56b545c671c532074"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "bfb613d3d123daa5c3ee73e84e19b89b068ec19ce8238dad61c97a649cc426c2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b7473e93a0d916c77366eea41a37c75a612bb76bdf31c33c4dbcf08be5cb092f",
-                                "uncompressed-sha256": "6744c79c176c2c6ad37194e864ef485a1b8b86022ee6b4c834b634a040c1f002"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "73dcd40c5272f5d96599f919b59c850df29f425fdc7638eadaaac4cda747226f",
+                                "uncompressed-sha256": "64f1f5a2d6224e8c1480b80397189a744494d90527921640bd51f6f6c86f619b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-live-iso.s390x.iso.sig",
-                                "sha256": "079396f07e8254c6b4242981f009fff87a1b79fcc17a62a1b935c8ea34136e46"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "77e44e8bfe308d9af6ed31ba294be083362c383430d0349cbdbfc3696ad2f4ea"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-live-kernel.s390x.sig",
-                                "sha256": "6235ea26ef98125ada8e1c9deed893acd0667a8c721ba972cab65eface3dfa82"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-live-kernel.s390x.sig",
+                                "sha256": "920c863ad4ea56bcef958506ab19439f2cc214484dca0ceed8e1fbcc234ae2dc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-live-initramfs.s390x.img.sig",
-                                "sha256": "6c642c15eb098413a95c451e5a99671d4db9766332b8ecda1f8748174d998223"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "18c401013232d6661085d682bc53831de81929c52e9dbe29c0b7b7d9603aec8d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-live-rootfs.s390x.img.sig",
-                                "sha256": "729927722dbcc69925babef6c661081042e0e402323d00d2729fc68734fd7c87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "f42800340352168912834de5f7ba8efdf046a70af266c3956530469c2eb5fbae"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-metal.s390x.raw.xz.sig",
-                                "sha256": "5bed99668aa5655298592456b9445bea35f942bf6d651b14ad264fcdee8b9b5e",
-                                "uncompressed-sha256": "1699212c93296df8351c20368670270aef2a52535d30fce9a92de24c3219ce11"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "8b33ecd996a5d7d1b1a94f00d0f25e42f663401eca24e7eee6ae3a3531eabd11",
+                                "uncompressed-sha256": "dfafe00c3611d71b27e210e7fcd2f89cc84c10df8b31f994efbaba54dddf3411"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ab11de0ad210c10cfaf51c146808696e30cb6ab5fdbe64f17e600fcb75d28b97",
-                                "uncompressed-sha256": "ae333a3b7d57763a115d5764579805b809684177378fb4ae388df81f2eb9f429"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "83f86d3b66bed5fdd382b86ec72095a63315d35f195c1928982c880ae5e1ace7",
+                                "uncompressed-sha256": "6a308b2b1dd4465e25ffdf7471e905bc238e02036a2d1165d05d7570a7bfc80c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/s390x/fedora-coreos-43.20260413.3.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "f5bc65c104d7ec97e474048cc60fa6d05d22f46e7dd58e04666a96cc76c9735a",
-                                "uncompressed-sha256": "dd96b2384d3e1c522b77637c3637b2ebfd7b294a4471c6a213c75a87a6ee20db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/s390x/fedora-coreos-44.20260419.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "416f1229e35eb7b52eb385e40207f44aeb2de6067e919d28a22344e40b80b9d2",
+                                "uncompressed-sha256": "ec2f006467b8f77ae82115d0392cc9bb81c863b65ab6b27ffc5b7f9c2b123eed"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:23e1e75b1d7a3aa84cb8c96e024c446d32cad86c89441cb23e10252bce4a1558"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:75c5a3e96be113f87e46a50f64dd5337a4a4d13ba523feb3ab287633d0d0250a"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "69439ae76fd9f6372088bdee8b03ea613d62d7c26d3fd400bba6bc59955d916a",
-                                "uncompressed-sha256": "e74dbc5f1b11977afb873c188522ce4e04072302bdc5e4923807e9c5d57a9087"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1cfef1d00ff8b1dd79e663f18633d8dca6b53c4bc74e1f34e86790f56620d8d7",
+                                "uncompressed-sha256": "fb42a6bbe96a016f10645b4fe01d65b566feb07d44f4329d16d30799053c97b5"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-applehv.x86_64.raw.gz.sig",
-                                "sha256": "59c94570d38775f75984c242f96bfc6f0d79ff05d0deeaa7b22fa85409bd9416",
-                                "uncompressed-sha256": "11655e1bda2800bd5d9e98355a33576d6576ba53b88f1b9e442d1b8719806107"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "1d6eec780f51db6fbfc3dfdc4730bb8682427cbec15e34822eea5c3c1557bf68",
+                                "uncompressed-sha256": "5773d5fedd09da8f0b20218a280f9591b3b25b09392a2b10f1bfbfa660a759c6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e37e62d3d674e8720c9da6b3910f5f69602f21d9bb9e0db072c4b3f3ec1ed791",
-                                "uncompressed-sha256": "37c4343645148f170bfe9cbb8c4c0565d12b10f034f673e606125cf7f091306d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "fee897bed1ce22f6e02df596d6f38d8c60027d4b364ec7d69c94e231a3b6e48a",
+                                "uncompressed-sha256": "146b53ac880a7a29df216c2fa52df3fa02f7c1519e72a82a575fc250c780a350"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "df7e04d53ca6a28d55b070fcd9faa87a7ed7451c8025d88f559b7bd51d64f57d",
-                                "uncompressed-sha256": "cf82166c971ba14309d495563d1647b48623ed946fcf87c348ee6fb4abfc4f7e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "6babcb243512a4dd80f9f913b59562117802e19e60d39f89c13254c01ce1f54f",
+                                "uncompressed-sha256": "d4f06d4ed5569318053dd042bae921ccf2fee1f3c6a6391bf97af54e872f182d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f9b7831e4f260a9f8f51d836fd7f22850c14fb5ee81e305f9f78d494d9ea4a47",
-                                "uncompressed-sha256": "0074420b657cf23e1700cfa7bc2f676dac8d0102f15641cd41f5627e149f5a37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "738209f630560082e763498448ee885b562b832fb42e36214d31bbd698d6aa97",
+                                "uncompressed-sha256": "9efdebd2115dddb97d624d176f60d5d75eb2ff4b85f5fbc3084b37d5c889b026"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "5f4dff756b69a604adb87c52e7f6afb1d0991d7c7292d4fdfe1c252f9d378f3c",
-                                "uncompressed-sha256": "be510c386dc29b35789f731206323657de091e35a8845a1cd9682121cd88e2a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "103030add47ccf48980783dcc230fd2b91342a5d4e7c85f5a8b919828f845b75",
+                                "uncompressed-sha256": "593953c80bbd3bce08a5683d03dcbc46822b1f25b6951b61d8a8505382f93564"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "1713873625bcbe0aea8f3f4f1e184d9ea91542c9b6fe2fd77d2e4745b037becf",
-                                "uncompressed-sha256": "67e6e7be1c11380a151ccb3252a4851b32632939cbfc9e4f5aed1a737138cfe3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "3f3539f698ee8f5159e9d0379864d07aef4ff2b790d106c549fe37abd63619c4",
+                                "uncompressed-sha256": "76f7c92de5585556acc53947a98be9afd8f5716c204f4b08e165f170e3d18166"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "3522a36e0e87940ade6c6a3bd26b54ee536ada950aa6ed41b6b7c73ca5185262"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f361c734d051071fb315eab933618885b1c4170b068f46638376627783f1352d"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "281dbe7769bbb5bb649d8fe49efb7937e4489c2d4340237c3d0084a14b91bc1a",
-                                "uncompressed-sha256": "56f46d526bf7202da2bdaa22262d2927aad661579f8f4e098986bc321d7a3ab9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "87a983d2a1546452b13b4293d7ce78683caef2806e8a72d23db0de505d3f4f8f",
+                                "uncompressed-sha256": "bf0a22a1f3e18f666515af2687601f0f4edfb31cb9d673b2e5abf529580bd780"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "3232ea9cf92f52235a35eedfc61f00d512d4df15601edd69dc723065d273e056",
-                                "uncompressed-sha256": "b7a5aea857cd5ceb33e55e15cd8901a97759fe0d5f957ac374823873ad1ee8fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "38276358b22fc5315632f7f57d63312b1ded3e6e567402ebdb45e092a02906b9",
+                                "uncompressed-sha256": "b291c2023f964825048e0db2a70273ec6ce44ec7302cd9e2f406b39cbfc8357f"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "09d6384ae5ea60a4a2bae74110e684a087c30e49fc3f1a1410a270066473c2b5",
-                                "uncompressed-sha256": "9daeabf1f693c554aa2783e3a7ec0902781aea48b5b56e85e010181d7a5019d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7d6c4d385af6fb256e562a09acf34ca2b4a08934ce3c07a5bce7c42f4956ce01",
+                                "uncompressed-sha256": "e81e63bff7149921d6dcfe0938510f7ca6abcabca15101535705ae510ce2df91"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "58404350fc6b01e5843d2e9e7672bb1d52e14b92c032a1330186cadfc95a142b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "bb907bc11a75e770cb8e2a6791249547675ab052a70332d80fb994ab75c3e4fd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e383a605892fe0882873fea3183b41103832499244f6a5ad26ed508d1ee112c2",
-                                "uncompressed-sha256": "905d247b7a8aea054e5ef6776fc12ee19ca8f4f99a02ec8defb986630023afed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "dda018b9a683dcb2300aefa1b537eb1a95042535fa0ab353d5340d1d0c35ffd2",
+                                "uncompressed-sha256": "8ddb10624e0af154f7828d81b2e2617fc650d778fc48c2a73373d973cfb6385f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-live-iso.x86_64.iso.sig",
-                                "sha256": "7ee90cf1efd437055259c7f75aba8983c487d42aa1f3b27426a66460fb704ec5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "22f2062e42df5f9a8170a557a0d672d65e53cb1b79ba28574ab31868252bf59a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-live-kernel.x86_64.sig",
-                                "sha256": "c734236eb8402c0c60ff760a3b093fde7a2a5f1eb66e6955c548a6c2e23ecba9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-live-kernel.x86_64.sig",
+                                "sha256": "29851d5cd1bdd2c6867f80f34b858cf865a27927cf5a5794f5702a7b9370f02e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "33da2d1765598d3009b1289f71e4fc077d5043b75d773191f2632aec95fd2732"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "8020500f83d6194246e3f665477924f26acbeaed416efe141889ff36c4af90b0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "a53b7157c3e963bc6c3db1db96408cb5890f84716497d2d9ee041c1b0c74c59d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "dd2ae72d867384f2fa957b9b28f9645c32b074728e856646f9972cd58acdfbb4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "6cbc54b76cf40ee17fef0fd9877be3e19b8cf855043e9fdc6bda7ea502ee68c0",
-                                "uncompressed-sha256": "97328e3a72a576a0e3938e760df3d711b3b27e621fdbc3cc695a8e2d116626ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "f06d17cc3d57f1d8e66b06a4a9399cd20cad7a8531710ba0e53bc78e24d7bea6",
+                                "uncompressed-sha256": "2b64f8fbc76009c44158aec84b14b6534876e9d35b4672b025a7a61259051a8f"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "89876ec319132047fbfb1fc02e995bf55e7640a1523c426dff37f4c443c8042b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "820f7e33ac464188598c09a3b95ad7f1b105ab71539996605907425d0d059e66"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4cda78d974f3073a1e436cc25757bb3932d8ee8f171e4e7b17f3b682c2df3628",
-                                "uncompressed-sha256": "1fe31c931631dfd17e3d0cd28fa226f905864466ecde0bb4a0ab4ea7df8952df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "d4099cc488e286ca4fe30331f44190ec7e4ec34a2d0b8c033fd3535683c1407f",
+                                "uncompressed-sha256": "23697e1384af45c88255473cddf2c4951ef959b2f40cc2c1848e479f0c176b02"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "609e6eccccab25a325165062349de1b79b2234e5b79c51dfef6a5cc94ee98b4c",
-                                "uncompressed-sha256": "aca80076c1b9032c748083c65b54850a9b3ba45e52de30e1279572f2c9159daf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "74e0f11d5770f8301bd138cfe4076e3ee13e7f3e5dd47c4a0cc4558123b6d61d",
+                                "uncompressed-sha256": "3908b95d9fc943d5524373bba9253580a7eb2eff85daede42362953d320b9d5a"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "5e3ea22d7300fac6b41f3a67b1d5ff9e2bba9991c16c342c6ff98ce4add143c7",
-                                "uncompressed-sha256": "06328c94bf7b6e0a3119ec67f565c35e8cd9e31ded8a078b9e8d04216181791a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "985ac19443adf25db55d25c2090d915452ce3c9849f9a6b2c634749439b3e4b0",
+                                "uncompressed-sha256": "64946e94a2b2ee544a14afbe2db9974afa1f13ce185c41ddf918fcaf76059518"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "35e3ff5829c96c2aa2d9fb3ccabe464c1df88e385621aa1347c911656503cae3",
-                                "uncompressed-sha256": "0dda59e14fcd3771be3c640da46b43ccf2a6ffa6373b121ee56d348276435928"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "4988775076f6b94f33c47243e2f0fbb3ecd412b6cd7ad492faa98d2d705e9035",
+                                "uncompressed-sha256": "c786b948753297949616320a109f656b6e9b5aad18e8ff9d09431519d0460fce"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "ac05c64b1c4d2b5fc1b28c1400287bee2dd7b5bde052325b08f65fe7d995954c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "3a6a5a124ed18b8ab91498cdee7c251233ed08d6b9cf0827b55056e1704f281c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-vmware.x86_64.ova.sig",
-                                "sha256": "40f916f205184b6f9ccd5957d89d9f01b0fdabd5c4ac4b47a4f961133400f653"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "d73fb45e51f62d78129f4ae4887915ba62abb043418707803aa16b5eb95ae133"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/43.20260413.3.2/x86_64/fedora-coreos-43.20260413.3.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "03bb1a0f113a717292b2d4131d1569607ba023305d83e483fbe1bd9ebafcb7ca",
-                                "uncompressed-sha256": "a11e30a0922a77289f8416fa5b8dcf20af6aa5f6a59e2264434981fe8d7d1513"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260419.3.1/x86_64/fedora-coreos-44.20260419.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "1a56ffa0a51d1e3636a3f7e73269cdcc12c3e60aa668051b7c17d180b95d0209",
+                                "uncompressed-sha256": "33b403abb1420be7cb8cb05361cc70faa5455a20e64ea31beff6eb890cf4308d"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0114e305ffd77b561"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-02cd0ab72664c682e"
                         },
                         "ap-east-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-07ea8c700d259c3ec"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0806e73e46252f82f"
                         },
                         "ap-east-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0302ae4dd574597a2"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-059a3f1fa1fe6599d"
                         },
                         "ap-northeast-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0f13cb8d77688a342"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0e095bcfb4e92c1ed"
                         },
                         "ap-northeast-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0332e47d97e5fcc88"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0bbd3b72c87ae829b"
                         },
                         "ap-northeast-3": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-03fc3856d2ce95a4d"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-084069062eb038c44"
                         },
                         "ap-south-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0ace2f68b80dc46be"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-010188f257f00f362"
                         },
                         "ap-south-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-034514d8b682303ad"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0c5d596fce63cd465"
                         },
                         "ap-southeast-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-050c224f5c6c7fe7c"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0c99181e1e9d3b3df"
                         },
                         "ap-southeast-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-02bb383a425838445"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0f0527f89e5dc4932"
                         },
                         "ap-southeast-3": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-07d3b88e0009eee05"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0f49aa8971ce2e6dc"
                         },
                         "ap-southeast-4": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0afa509a29eaf6faf"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0a80d3f054fc71ed8"
                         },
                         "ap-southeast-5": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-060c58867946aa5ee"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0132d948b782069ef"
                         },
                         "ap-southeast-6": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0943b437cbfc7c8c9"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-07394d915abd20079"
                         },
                         "ap-southeast-7": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0c5462d7151c87130"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-07dccfd7d4b5988ca"
                         },
                         "ca-central-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0c8040950e39aa308"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0bd8fc56aa223b319"
                         },
                         "ca-west-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0c63a611fa94a9dc4"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0f31e5c5d74738a10"
                         },
                         "eu-central-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-04520c1592d01a178"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-05a904ed1eb67b1b1"
                         },
                         "eu-central-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0ee41774200204696"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0a9923a7a838be59a"
                         },
                         "eu-north-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0c9986208c8342ba8"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-074502b7777a6db55"
                         },
                         "eu-south-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-076877d0f56bff622"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-006f6cd24cbb8809b"
                         },
                         "eu-south-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-020f7824fc1080e6e"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-085bf4464fdc6a860"
                         },
                         "eu-west-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0dc04d208bb702353"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-093b0fcb88b96c026"
                         },
                         "eu-west-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0e896f425e161368e"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0345ad5ea37e7b66d"
                         },
                         "eu-west-3": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-08cdcc9b1a3f702dd"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0b157ebab2898ce7e"
                         },
                         "il-central-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0b0769c59bd802f51"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-099a60f7e4ba41826"
                         },
                         "mx-central-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0bbc495b08bb571dd"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0957320bb650d8393"
                         },
                         "sa-east-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-00d42459a6ae05966"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-01766397e9a02677c"
                         },
                         "us-east-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-058f6194fb2d07709"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-084678d8f0cbfdc6f"
                         },
                         "us-east-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-018b6dedd82169937"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0717ee56c207e5b33"
                         },
                         "us-west-1": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-010eb678ea3214f0c"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-07990516cea0bae6b"
                         },
                         "us-west-2": {
-                            "release": "43.20260413.3.2",
-                            "image": "ami-0b08140530144c31a"
+                            "release": "44.20260419.3.1",
+                            "image": "ami-0e42f07f052af2738"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-43-20260413-3-2-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260419-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "43.20260413.3.2",
+                    "release": "44.20260419.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:52e40863ef9a6431b337c7cc5d42323e0909cdfffef86d94def09196a16baec0"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:19eeb6a2fe3cb0566572e4ec08287e90d3e5fff969b8e63df05c4fb7cc5b4c11"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-04-28T15:58:57Z",
+        "last-modified": "2026-05-11T19:14:58Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "85785cdbe34d18d4509e973706485eb49a0bcf5f96ae049e31f1342af3f36222",
-                                "uncompressed-sha256": "940c6e2763afda161ca169857a2a6c22268d191bc6490764e5da30eb07c3617a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "8394b1bc99c9f943c0a7e01480bbc8fffd70ea44b3d16b9f6a69d71c9cf65806",
+                                "uncompressed-sha256": "da1887b6982ddcc65d95fc6468dce41cd86897b00eff56ad6cb09b187ec554f8"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "4af62bf9bc2921455b4254ff9094fcb7bb37a95a81f23bd884ce3e51cb2c603e",
-                                "uncompressed-sha256": "1ccf694083fcc6efe6fb211ee8f3e7385278a81553b0ebe4b916926cd7327423"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "e84d45a3f432550500326228419a63a960f9e761bd235ad51bb307edd2ed48a7",
+                                "uncompressed-sha256": "4f58a62f81d85a74e39804b3b5591248f0c503afe56f2956748268cc3f83b169"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "3611c47ec8ded2cad68f0bc12a46e489f1be0f2be5966e7a99813a140a332f76",
-                                "uncompressed-sha256": "9c7e366e01f02f16e3b324ebc7b97cd54efefd6e15c72694cdfbb7788a09e999"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "1b06e2d8da0366622d4460c641721299b900676f6a4e8414c92ad7f27a328fbf",
+                                "uncompressed-sha256": "4c9bde76099ccb24bb3467aa2e7f996122681cd99fb147bcfcaed41340778de0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "91d5e49fdcd111550a562128eeb7ffdd134d1afef1f46876bdb9598fa3b2a98d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "7ba96dad0334b9c567b9721b6befe17b944600a36920c7aabd4f0a637344dd57"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "a9e301199f36748d86c3054e92ab4ada598bc5b6f2117bc6118d58c40678674d",
-                                "uncompressed-sha256": "9f1344964dd6ed82532d3b52a8a2e336d7a5ce0973c228f08b1582249d58a45d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "404c6740df0fdfbb12987cef16e2c163686cd21e9e570a30af877a1da97f188c",
+                                "uncompressed-sha256": "e93fda2dccf43650acf3d9f43646da73b5f55ba80c6720746fa117e3e3d52003"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "1b61b139073987cf43cca05e47b3247d160a3cc76618c874faaf8e9fc4039875",
-                                "uncompressed-sha256": "fb9a7811e3c70837134eab1f30e9db7aaa9734c5734154fb4b003e00e9197250"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "985849873ce38e6c3ce56ef3f577cd6b31dcfa4f3ea2fc6b8079961c69f5e024",
+                                "uncompressed-sha256": "4f04225b381a805991ed64bfb255e5126b229d02514729ca13fc042384127fa2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e296068f32866347c4de0bce1dd5b1b0b3d49af93983e99a246fcc2cc3ecc802",
-                                "uncompressed-sha256": "f3da1ebf813f361f4f9a7c0cdad8845a1141f80d1af9deff7d62871943f9a62d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "fc0488a0586c32157b15c5a570c42b1539e22a8152cc8afbad5e742ca9e1fb6f",
+                                "uncompressed-sha256": "41ba9a11c8fbc94f57530ff637af42d17fd391732f4577dbb11f31eba35dd960"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "b74898e5efd410beba1fd05dd3fe6bf3d40f4d89dc4d48080b3484eef11efa71"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-live-iso.aarch64.iso.sig",
+                                "sha256": "605ec55dd591d3287f9536f0da898efb9ad1b01142231e6ac0ea4ead74b0846f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-kernel.aarch64.sig",
-                                "sha256": "d33744c96ce290dcc8649d80cbb3abe956f661e93a632ba56bc559384d128c24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-live-kernel.aarch64.sig",
+                                "sha256": "c6f4cb8fb2e6d8caebf0b390621a3cfc635f82abfb7cc84ddc0d30e50d94ac9c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "aa74d35bced7afa6fad2619f6e60fbd1f37c3f316ea62bc7c841a557f17605b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "ece0f3f739ed01f28859004cfac8ecc093b597502681061e949845f28cb32155"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "066214ecd78ceca2ead31ee2db76bf4aeee5fba660cb0d28e8b1ca3d8e5816f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "7cfd7fc54a9db6151f76c0fa036d457fd1b924a89bbd99604383d6912a2e26c5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "313ed9eca8fd5e30750529891f17c47d09ffbfbb71a8fd2f2c96512cfd51d796",
-                                "uncompressed-sha256": "e615feb4fcc765ee98c6aa87e8b13ee1055ed33c010aba92cf1571e757601f9c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "1551acf3e2758c37efb7788498c29daf5c1c6f75f2050b6d63927be6d183d6fc",
+                                "uncompressed-sha256": "624bcd8cb4a8955e8858094e28c876ac5edc73f1ff4ff5634c4acd7bd213310c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d7f9236f58e0491f1627451400c4fd6447a17ea9194e244ddcab82691f7cb54c",
-                                "uncompressed-sha256": "4a8bb476400451f15da49e63c92feb2dc89b6ab030c95874ffa7b750036750a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "ab8a635a4cead6509e676fbcb64cba71a2762ffd30271accf91221494144b04f",
+                                "uncompressed-sha256": "4f26a78bcb24eacf704e9467875244eebc2ecae4430259e2c59a8aa4f9aee83c"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "3106b74bff4d13d88d707aad438ddf8beec325d526b4419a95f1e3a9829acbcd",
-                                "uncompressed-sha256": "1e8506c8fc3a727ecae328f80b75e6124306403ec384b8ebe02f778bd6eea5e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "3821e2dc8f42065042741e7d34cd8177e36ea547f894984a489a9c74a9d39e26",
+                                "uncompressed-sha256": "3f7d4b02893809eec340cdf47147dfce619b01accde62cae449940966313179f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/aarch64/fedora-coreos-44.20260419.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "18bf6a4c47ae4e63919c2eab2755a02be52a886f3eedadd1d96f5381aebd69a3",
-                                "uncompressed-sha256": "427c5572129ca86a455fc65f0106c0938de1add7116fd82afbcf6c353e9abbc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/aarch64/fedora-coreos-44.20260510.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "94919d1757d3828dda6edba67cb5ff321474e6eead8d4862aa30cddb7d59f64e",
+                                "uncompressed-sha256": "cbd97bb7a4bab620b1023695b7a6d4add72c583d307e15ec99054b99152b1960"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-05b5de1d9d2d167b0"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-08b7e5a90a1282105"
                         },
                         "ap-east-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-066c927d30749696a"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0ea3916d3ad359468"
                         },
                         "ap-east-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-02069e9cd1ac29f2a"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0b3523f17bdb5ff96"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-015d2f8015a239187"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-03284f2bbeade4eb4"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-095c3645227603049"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-00f6dc1a3adfb5c6e"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0a0de244b8f7b538b"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-036cf6ade5ba29114"
                         },
                         "ap-south-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0de5f3c866c024a75"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0c27d3a6a15339606"
                         },
                         "ap-south-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0e37ae4f5c195ae93"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-03d442ca4f1c86fa8"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0c3dbf99d8901fcda"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-01308704648ce420c"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-07749c3773758da4b"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-095aaa12a59e40ff9"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-04873507bb7d179df"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-05416a77f66d33359"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0fa6b76824e4438e2"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-00d97b31debfc4c4e"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0a1fdac8e1e5b6e7f"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0af42da30efffc67b"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0ca383ea84b86e610"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-00f7000909cb583f2"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0ff11928b01fa7b20"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0bf27419a57b3f4d0"
                         },
                         "ca-central-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-067e5735f4b65c237"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0ceb82fd5e1911303"
                         },
                         "ca-west-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-01fdfc39a6fbe4db2"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-07ee84b87da26eb1d"
                         },
                         "eu-central-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0e78da9d6b726f48a"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0125987a9ae68141c"
                         },
                         "eu-central-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0bfe76c239f8c2464"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-072b492df6531ca00"
                         },
                         "eu-north-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-05428de302911f7b6"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-08c207bf68312862c"
                         },
                         "eu-south-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-05a50361e1f7c6d8b"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-05475c26b8242734a"
                         },
                         "eu-south-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-003d2f99a432373bd"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0651f1212688764fd"
                         },
                         "eu-west-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0d22270ec428501a2"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-03955cd86960e43c5"
                         },
                         "eu-west-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-042409e431e9a2003"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0afba2705a06da529"
                         },
                         "eu-west-3": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-09dbfcb0ef7762d7b"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-057235743747d5e7f"
                         },
                         "il-central-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0a88975ca30da8a0f"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0836258a583410be5"
                         },
                         "mx-central-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-021de6db2488b7baa"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-054bf5027a89af263"
                         },
                         "sa-east-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-078662a50e6ccc41d"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-007b5f832628eeb65"
                         },
                         "us-east-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-003d287a5c64f7216"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-053db2d50e9f2959e"
                         },
                         "us-east-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0ef9401ed4cd2c997"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0bcf0d40f8604ee1d"
                         },
                         "us-west-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0de808eeba7f7628a"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0b1cc0204d6c2c396"
                         },
                         "us-west-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-09802ff6a81e1375d"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-00ee91418566e764e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-44-20260419-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260510-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "20ff3645ad68d874aaa38d1bccd6aa91e220d083e9432a8abf8ccaaab3265960",
-                                "uncompressed-sha256": "62ccdf866dce495cfaef01d19cdad26d6630c356e545df0f5c17c2035dcc0161"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "184729496d23ad14747c84b23e6112e1fd55ff25dc701af28ec11b069bbd8901",
+                                "uncompressed-sha256": "2a18f83a81f5cf8e0dd02bdce7cb0e1f70f79268e80b98746c65d7fdf367b882"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "46a848ef5c2272aa6fc7c136889d926e5a892bba44ca07291d5e187bee25cc6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "ec9820d4d1f9a48888c51e46cf221dbdfeee5a221e9f7c4e9d41cbf52489b626"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "c0feb764e6f637d851bbadf1663c9539d594728925ea69179671792ad2bd14c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-live-kernel.ppc64le.sig",
+                                "sha256": "241319874c6eebc6aaec8d4b5513320ced31e528f1094b6c2514baeab907599e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "2436a6e656dad5dea39e8ee51b168f731fac20dec7468d6190d9685838f3acc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "9636198ba1a48d6a0d554b990200aa57ca88b946cf21162dc2557516058bd2a7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "bd6f3158f50e5a99a71f9a0125abf4daab590030b744c2121dcbf002059310d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "605d7e084a62ffefd72923aa47b1b2ee1111f6c88a96a6f7b9ef3347bae12474"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "4ce8ad5ceccfe24322872ea7482db8f795761c4969d6fdb11b23ae970631d5ba",
-                                "uncompressed-sha256": "7843445c014fdf3da2bfdb5f9cd8e2feeba670d7199de9cc6f8ff11a28f30ad7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "1979a717bf10504093897d4d2dd69b468eeea29aa679c6607a28a6b50c8fc927",
+                                "uncompressed-sha256": "444f717a4da5a129bdac0c1af4c987417e576070d96a86d3efc1c9cd34e1e3a8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "b306efd27f6fe6b0a9f87844cc32aa6eadf8a98a20a2c639d70a18b41317af65",
-                                "uncompressed-sha256": "91a747b9d08fa27093ce80021717fee8594eb14875076f77fd4ac49e1f0f2c77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "9685084d58a64434b271ef09bb45e2f8659e8b24f12812480d9a48ff1ef4fe0d",
+                                "uncompressed-sha256": "e63116353b1370d33e6e00900850d804f93fe296b9a525f572953b9ccb6309fd"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "223ba322914e33b6fdb02338943a290a31e57e6ce0f32afe2620455d7e98737a",
-                                "uncompressed-sha256": "2fe78c5b6bf84cc302ac841b5e867d0293aa22d37f69c38f290643008fd69b75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "1dc5d15fe54919f687d1dd471ef3fd3ea49ad88513312a6f09cde660dec0cb78",
+                                "uncompressed-sha256": "a1361a623225f2e2ad9e15db931275a6185547146a1f20d0a6ae191c1a0773d0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/ppc64le/fedora-coreos-44.20260419.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "93a78ad7b4204b17ecfe7280f7601b9b59f13cfb28feccbc60640a778fd7ccce",
-                                "uncompressed-sha256": "2ca105108b4c5638366d8b06c96f004042251265c22e68332aad3e12910ed147"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/ppc64le/fedora-coreos-44.20260510.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "8b5b86557657b4cba83bf6b68dec552b6fd8ca1cb54ed43cc7fcec0148461837",
+                                "uncompressed-sha256": "70b73f22b45173b3c1a31ee43771b49c9b0294e89b53c926fb3fe8f6319b2b9e"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "941ac3296c29003bccebd641d6bf31cf282fe5a4be694ed01788942c5957261d",
-                                "uncompressed-sha256": "b47bcf941ff156286654d7b109705bb59c4057a32d332484160e563c2c4b5b20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6828cd2fcd571af4ae25fa802bba10bcfa760006a22aabba5b7bef0b8c9cf4a2",
+                                "uncompressed-sha256": "6656b2bf57b6cbb5c610beb2b02d93f96f18beae90d1445688419bae147f6c7e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "b2395c6cfdd477e151790d4a80985bed7ea5f8bc510350dca437e332a733543b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "987fa9c21a5646d007cec6fc570c23f09c6a88db924e829caee38890145b62b9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "74daeeb6e4b09dfe9ac342504aedd98dc4834f60db4318817971c8ac0e0a459f",
-                                "uncompressed-sha256": "d84a455b8ee7a2c033903a904bdc7cfb81e9cf537468e8830b9c4a2b90406eff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "56792793d11a03f8d3f9170173a0e99b760a42960573f9cd67eac485ba3bf3a1",
+                                "uncompressed-sha256": "f9927fe00801cc1a03963afa735c3306202b9f64f876705c0da14386988f6065"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "06cc982a2bda3ede186d582982ecd1b6b44ba13dea29327aa6a4d78112ccd9e2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-live-iso.s390x.iso.sig",
+                                "sha256": "e7bab1e56914dd41ff6ad98e8dd2feb49383c7ff6f67eec82211bc6545ea08e8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-kernel.s390x.sig",
-                                "sha256": "b27bbe4ebb2f7708457b25f011ebb4301d134c5b98785bc97401b4a061c02d84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-live-kernel.s390x.sig",
+                                "sha256": "c56869c60af0525883adb4189c5bc9420169827737bf5e9f742c01e9a7b3a684"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "0b92ddd69bc8a253868d91a0484571525c7aa96ab84744850beb395643d36861"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "04aff3fbf1b54ca019f4016748016956ff625208ba2612d86b3bfe6888d2fae3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "080385b982c7b7fe6c26f9645f921994a13ee58a4327c190cba5e004bebf4030"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "16b8c98e886aea4fce130fc027be6f7ed8b107a0741b82c8717256450a0db11d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "d6ce4dd72ba1ab4c82c10bcf1ae721c20ddfc418d866c291f259f8bd136019d7",
-                                "uncompressed-sha256": "b79a82fc51801f2e2948402af186fe21178e17e372e61846c4c46865576e4f20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "e0f22e1f815ef6c9d80af7f82b4cce03f2c95fc7e89a1d4e441b64dfe6d4a091",
+                                "uncompressed-sha256": "a6e454b4941abb37bcbe8919dd481036f79b84489875a3de30ee9ea9d56ae289"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "edca5bfcc7409493cc987392ec6212afc9d6f776070366a5c5b8685b327be36e",
-                                "uncompressed-sha256": "99493fe8809011dbf8828d64c254e587d14b1d7a2e99a29c1a4540649019dc01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "15e1800fea6287d9a5e78121c7f5b516d9e5038c7969da63eeaa5344a15085ff",
+                                "uncompressed-sha256": "90c9fde7ab0521939a4ac764c897117e81e7a45f2e74c4388646d69085c38351"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/s390x/fedora-coreos-44.20260419.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "953d84a0c68c8137f7e443b81c0da39fcac013900b80ad84ad4893e51cb320cc",
-                                "uncompressed-sha256": "1758e76f413742511a33bd54b33254cb037c839627cac512fee8eda10debdd91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/s390x/fedora-coreos-44.20260510.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "f597a0af873f215130522d042b3e121ea73feaf6f4815ff4119c91bfeada8ef9",
+                                "uncompressed-sha256": "954fd3386504b29f9c231e1eba5e910e6c9acbbbe282a92ac258745b01e23354"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6b8dc46fc09ed1d1d38ef4cb67e3f9e606ea10af908b2fae6bcbda80b8f8ec8e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:bf048d43be1d09e1103883c3a1ec843cfb58a6fe43963edbd1d04660716336c8"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "92534b88c3df4edfaba3cc9e57093b46e2c9fb9e5bf4f60ec45a1c86e4475912",
-                                "uncompressed-sha256": "df3007dc23ec815a80250b4d2e80f78c29d10b0a7a1d6e8ff5b4fcce64f34b8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "74c13a07d3732a2192a29e186f4ea0b7f0b71e652fa1b91349b4bb89593b32a1",
+                                "uncompressed-sha256": "ed81a75401250004bb681da89873541ff4fc257da2f991568af904330710f5d1"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "7292567fe13f364c853b4e831f57094351081d4d5b59f38026df8f96fca5f7e8",
-                                "uncompressed-sha256": "6c6aa7791ac9adc486472039b7183adf2f871799e09a63a07ff04fc179e23e75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "8e2b5240d341125621645515f077a88b47c97f9f9917880b6285bbdb57cce4ae",
+                                "uncompressed-sha256": "2b434d0151374a4a37616d9936dbfdba7f24c1fb83fd70ac402c7a33761c42ff"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "e9bc3fe38432b303d38d77b479c8947703f0523728de15ec9f2e592c25d49ad9",
-                                "uncompressed-sha256": "4cf2a10201194abddfa048304de633db4f3583de5e4d140d49785fa538239c84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "0a6f2370341d489da525d3a31a2b737d729af0fe80d1f5c29111a27945c932cf",
+                                "uncompressed-sha256": "65a72728b82b0c4904c011ee115ba2622961ee524265efe2155b0a1f1d012e56"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9a5779a66ae6758792f981cb9ac98021f83c89dbf60e5d009c5dee410ed6d0b1",
-                                "uncompressed-sha256": "10e4ba146a79416c28c891c6e0c8158accb9e4a7bda8525a5054733ca1570e25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3ef9fbe23e5770c30150f2dfd1547feab4ff2d2f859b210555b0b455144ba993",
+                                "uncompressed-sha256": "28d88fd70a4dec44f00a6c4993657d5adb2324ee167988fe3f56b73c72cac17d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "0c81e092cff2fc621f227ad07a5e01d78b96cf51be0274f1d58e2325f09a38d0",
-                                "uncompressed-sha256": "9353c32d51524ac9ad0c1c755ff8c7c044491d39fb63f968621d8bd3a2e761e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "9431fecf2c323392a0c6b49eca441da9be506cae68c4a1a7afc03cd675b0bde3",
+                                "uncompressed-sha256": "65ee4d969e2d236894444396f1abe0f30dc86781df4aec8d1934acbca5a0bbc0"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "c79ffc16862b093ee7359881eacbba541abca30b225f679383c2ec4b16b20528",
-                                "uncompressed-sha256": "94fee00bd539222ebb965239054ead324295f6c3efdd549c6ca3b2c46ef96a63"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "09f14c334311c988c5b4ab62726f7963a86c71f3926c05a40994acca5c7a72f2",
+                                "uncompressed-sha256": "81b938a5f9d057b7fe7c322950ba5bda8bbe0cada728a3cdaae565c3e345687e"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "026b6c5d3f04743105325f21ea9ec5b7af10a2a295af5fccb0d0092f5482611e",
-                                "uncompressed-sha256": "bba6a416f86ef5303ee7598af2a39f501ac65190a316b8f0316b4b5441fb5043"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "678d49e4633af317c1257a15c54653f5179abb479dd930e8cdf36ebd80886122",
+                                "uncompressed-sha256": "4c6b6ca9cc0bd1fc381a40c22eb6be857377f3222825fa0d33a5142818b27da4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "fd4b349b9f25a859235577f4859268c5bf49e3dcfafb9a276a13fe6b33141f13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "73db6efd5e00bd1a4cd60aca3562d5fa0d3b4db96d8d87163c5b76c4ff1bdb11"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "ea3e3c374ef2f95cc05f04c319dd6c9be7acb82b250808ca1c0c3a6abc7ae594",
-                                "uncompressed-sha256": "5d6e673da35a3d54068c4cc31374ed2fc60a76fded852a6d9c86ac395572304b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "8b0fabc38106281de1f75a79aa13a8a6f2adeccc845b5ab6e453ec4ba5b22f7f",
+                                "uncompressed-sha256": "eb6b08e978a709af182fa81bd1a5cb6e0ba3049b000ed4314b62b1f837648443"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "d6391c4d23815cd51ae344a85d83a43cd7658e3e55f8ddc4584cb387f47e7754",
-                                "uncompressed-sha256": "792c4b5d096def677f8d222fdb3bea549b605f0e90464f7c9c4b237ade9b1d5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0f0297cf95692ab1ced086a46578c74f25f9a8716b9e844b8879d10013822c47",
+                                "uncompressed-sha256": "b76a73291ddb3de9c653dd53b7964b14b893912aed704e1f54a6b5912349cb7a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1666d78f3df33a2114859d1b00804c20085536f04c8d4e33e49bbb019a5c25e0",
-                                "uncompressed-sha256": "667e814306755bb463a6e429497aa57c6e96a2794e10b526597ea883f4a20830"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "71b22afa49a54ca9c550592fc5e8be61a49875e0340eedd8def8ad81c98d6971",
+                                "uncompressed-sha256": "a970e0f9dab7f12b5ba4c078d07f6c1a7338617063fde4e29b816646502e909f"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "316f54019b3894ed89afb9c206fb77bc23732cfb99717e5a6655b7e32eae0a3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "9b3a79ef5003b44d8cd84d2d1a274f421c49dbd2562280c0590dda411dcc7aaa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "1655f447b25e9a638dd5da11b495d451f3b572fa85f1a3059ee890fea3308929",
-                                "uncompressed-sha256": "4b439e3f02c97f8410b80407a4efc0434601352d684c31119bcbc52661518029"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "aaa1f3d9a43331291f350e0a34785064b27a8d4bbd05700504cedfe8fca93274",
+                                "uncompressed-sha256": "0846937aeee8a423cb7c4cb79a5574f3a48f3d70f15c9c4c016769ff6c03792d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "232b420907e8d1e7fb37d456cd5ab79ebacc67b44d95b1c074012f550c22a906"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-live-iso.x86_64.iso.sig",
+                                "sha256": "8e2fc7af16d1f2c7ab3d7a6133c523d34a6c17a376184706c13ec422d2c45149"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-kernel.x86_64.sig",
-                                "sha256": "1c8fb030127883eb16ff4e66418aae3b08aaa3ffa2c9e3d312d6989b2a9159ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-live-kernel.x86_64.sig",
+                                "sha256": "b44573827dea811f5546d185a488c6efadb0e837316978e314ff511cec6f91a8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "e35a1484b110a2f72893b0753d641372f4dd7066af66c6c9118bf8225b9c1567"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "5fb48ba27f7b276c3f339846f8759ee6308ed0ffec7205819101bf8508ab15e4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "631c6b248e1a7d3d0a51ff83dee6079eaa2ec2d99794968a9998a087de5c7888"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "9b334432ac0e8255ff16f7cb651764d7d775439168ad14932943b09d61f29869"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "7b85bb95b6a6d37116b80eef69f3369a0466d1840fafbcd8f295049b268ea37a",
-                                "uncompressed-sha256": "7ff6f1ad0ad013e41d09ab3ef81bc9925f36307a66bf4929aa5a3714321a5f50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "e7b379c7eb312566e693017e690aca052593c15c1177fe90c66d3e57b38f3628",
+                                "uncompressed-sha256": "a5c25a0bc617282cca6721327c9e4d47ba385d34052730cc5c8e47d7f8020ea1"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "d5c4ed62e5a438db7fe7a6353c8a9cbd48bb374931e38a969035045f3918dcde"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "95abc811c5a944baf1791ec480b9a50912ac8e484b213276e7cf4d9dcdf1b08c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "19cfe83ed68e4b27bd3ed65c9cd5b1a42b08828bff95944ec0abaddce62cd9f0",
-                                "uncompressed-sha256": "af5ac97060cad510c8b673a4ea077b89be88afcdb2e525ea5eab72b6139b0918"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "256adcbe8e8601c99fef3e97c8418c610505ddc3852d1b49af97cb92b1edb02b",
+                                "uncompressed-sha256": "73f505fb986f80796af7efb4c5965648085cacb94d4222e1881a67f4996226f1"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "262b659bc0b1889403b00909a58636910715638c88487ddb11b62d3fe9092259",
-                                "uncompressed-sha256": "b7ee5666d9b117330a3badd87e3c85f4976885e7cb7cc81c8dd790fdc4a0d9d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2c1709bea00523fadb9ebbabff1d4aeb002a8bdcba146a35aec42020421d219a",
+                                "uncompressed-sha256": "50c7c7e6e8cec4d093cf8692c4bf20b976ed419c2c48e80be538ac6f62e684ca"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "8c8583af19d0e08294f6009a338b91eb407f2834809d164761b45ff4ffbe745e",
-                                "uncompressed-sha256": "e47edc54eadfc79b44c70bde9b2439b0b3ba8b013bd6f8f4df5c1b6f04d75592"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "d54b9aabb439b69ef691893d1cd4d0bb95d0456220465839680e49fe0bfc5fc0",
+                                "uncompressed-sha256": "0a2db24f81741e1fb650b95a151031df1c5366832b6c2727f78bb2f7ae356bf7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "56c1d862e20ae74c000ba5e7e721dbe7cfee870d1f95977128c0e14c43d6bb6c",
-                                "uncompressed-sha256": "c8069cea41fa13369cdf81b253830f24b6e977effbb861de0b1e96322f45e3a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "17b71901835175d796f3321dcf09a7a07db3245a0a31794b0a3bd73511bab81b",
+                                "uncompressed-sha256": "9caa4ed69a49c49256472331e47113b82fb7af8e0d18629acb22b1b5ec8de619"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "54ed9def85e607af5c9335c9f504e8b259221ae65e16758ca28ffdfb0a529c13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "03760543cc1ab7a119b33934241bf8ffb9cce319b6c85a3ef398aceb1612cf03"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "2aa67c21cef7eace3a80a1f07028e4f3222d0c18f7384389ebff6b7f47a493ae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "2e7187a3233ec01bc28e31f3b6d3719ebb84910e4f0d564d903aa18f618f1442"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260419.2.1/x86_64/fedora-coreos-44.20260419.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "6725a63b46d06baea9da0b02eade2ad12b62ab7429670f7f3aaf3e9595615c12",
-                                "uncompressed-sha256": "bcaa83156db940d672cdb34d5404f3131d71dff18cfba889095cb7ed06b412fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260510.2.1/x86_64/fedora-coreos-44.20260510.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "41f997ac6a1b889c8e76d14adf4eaa7ad52af3587926c5e46d26010e306041c8",
+                                "uncompressed-sha256": "581c01eac798b6175841dc7ad8565a08f5bce49d874d0eb698963a195988c696"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-054b9a3782b7eeb17"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-076a3949afd32ff2e"
                         },
                         "ap-east-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0f681770fa53b39e5"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0907a66c639a36ef9"
                         },
                         "ap-east-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0765c3d69b05783df"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-050981e3ee8717149"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-016071409d7f9106f"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-07ea108e22c62bfdb"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0b9bb8edb8e15495f"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-03bdff6d45461642b"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0640b6693130fb0ec"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-084747e1962b1a975"
                         },
                         "ap-south-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0497cfe5fb6c5036e"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-08fdaf3a8bd2535db"
                         },
                         "ap-south-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0e3fdad284ea10cc9"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-06be2d6139d5790b6"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-07878e7a95d56d54d"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0dc0f63c94234a64a"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-023330bb35a4ba95a"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0032b460cc564e647"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0026ceaced15b2db8"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0f87b4df3835e10e0"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0e8c2a8958e643a93"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0226127938f5ed14b"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-028a7eaad9429adb3"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-04ba6e036dac44b07"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0c3784a625e339d77"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-08b3a3015f6414fae"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-04a75746e574d8a2a"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0f21d6197f40f3cf8"
                         },
                         "ca-central-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0276a26a5db1417f4"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0bc544984c2631254"
                         },
                         "ca-west-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-08a2140816fffe2f1"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0ff1095a943a121ec"
                         },
                         "eu-central-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-05af65f19534557eb"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-006f789803738340f"
                         },
                         "eu-central-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0110471861939d095"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0b3389ce05c1b0657"
                         },
                         "eu-north-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-06fab6164964e86e7"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0e51ac3960f0adb44"
                         },
                         "eu-south-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-05fc47eec9d1ddd56"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0287e30636dc5eb3c"
                         },
                         "eu-south-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0d0258534a1ada6b6"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-09a51b91c25c58d9a"
                         },
                         "eu-west-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-057636ec4cd742e1b"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0a7516181e2c75e51"
                         },
                         "eu-west-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-031172d729cc99c1b"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-08cba40ef0eabba5a"
                         },
                         "eu-west-3": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-07967ff12bcc12fb4"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0aa47349360197783"
                         },
                         "il-central-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-01c1fec8d1c0bd7df"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-05a80825311606c87"
                         },
                         "mx-central-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0cdb9f6c58e49d909"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-031fc673469258ea8"
                         },
                         "sa-east-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0554a4fb3bda1e781"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-08b19c4bd1a17b674"
                         },
                         "us-east-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0718cc02131cc3af9"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-075586abbe9bd3c65"
                         },
                         "us-east-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-053972dcda24c6645"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-0dffb820aba5a9a90"
                         },
                         "us-west-1": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-0fee2815615832077"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-02b8ee7d518fcce7c"
                         },
                         "us-west-2": {
-                            "release": "44.20260419.2.1",
-                            "image": "ami-07588803cc18d42cb"
+                            "release": "44.20260510.2.1",
+                            "image": "ami-09a4774b721ec0a1f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-44-20260419-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260510-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260419.2.1",
+                    "release": "44.20260510.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5e28b035f7558668b77fbfe714f80d13b473d851f132230d9f6628df7fde53f9"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:52c7e2912de61c4745b4bd33c632d4bb465e33b6a5f7cd4f72a2d873566e24f4"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-04-28T15:58:58Z"
+    "last-modified": "2026-05-11T19:15:00Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260419.1.1",
+      "version": "44.20260426.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260426.1.1",
+      "version": "44.20260510.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1777399200,
+          "start_epoch": 1778529600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -153,6 +153,9 @@
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
+        },
+        "barrier": {
+          "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
       }
     },

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-04-30T20:29:36Z"
+    "last-modified": "2026-05-11T19:14:58Z"
   },
   "releases": [
     {
@@ -149,7 +149,7 @@
       }
     },
     {
-      "version": "43.20260413.3.1",
+      "version": "43.20260413.3.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -157,11 +157,11 @@
       }
     },
     {
-      "version": "43.20260413.3.2",
+      "version": "44.20260419.3.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1777586400,
+          "duration_minutes": 2880,
+          "start_epoch": 1778529600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-04-28T15:58:58Z"
+    "last-modified": "2026-05-11T19:14:59Z"
   },
   "releases": [
     {
@@ -167,9 +167,6 @@
     {
       "version": "43.20260413.2.1",
       "metadata": {
-        "rollout": {
-          "start_percentage": 1.0
-        },
         "barrier": {
           "reason": "https://docs.fedoraproject.org/en-US/fedora-coreos/update-barrier-signing-keys/"
         }
@@ -179,8 +176,16 @@
       "version": "44.20260419.2.1",
       "metadata": {
         "rollout": {
+          "start_percentage": 1.0
+        }
+      }
+    },
+    {
+      "version": "44.20260510.2.1",
+      "metadata": {
+        "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1777399200,
+          "start_epoch": 1778529600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).