### PR TITLE
Roll out stable 44.20260523.3.1, testing 44.20260607.2.1, next 44.20260607.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-05-28T10:34:09Z",
+        "last-modified": "2026-06-10T18:13:12Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "770546686ae207567d1540f90f9cce22e2e436a0180b3f0c422b0b72318fb69b",
-                                "uncompressed-sha256": "55633670ab53ef71a042d402127b01a35cf53b4dee21dbe0c315abbdacaf1b8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "097ed87bc761c6ce0e3030665e6e19e5566e2477f34e5892ae1959b2fdf2215c",
+                                "uncompressed-sha256": "211ee638e8323911689601172be375beaad93080e7e5a70fd430097cd796adf5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "253237c29b544cff3c1c4c6f54c44f27279de5e9f80510e388e09f4f518ac30a",
-                                "uncompressed-sha256": "c297bb7b95528cc568f53720885b0b708b1c9fe3163e613faf58c7b3498e3445"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0721243eed15552627f8e7da21a79e634e58822b01bd05cd87935d25a563c8c7",
+                                "uncompressed-sha256": "11e2348632f658010b7962e1dde06cf0488b1ff7e6f6d3465f56cff1dc18672a"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "54d8dfaaee1959c7e999b0e03f9b25d0c21fe5d22956ce6f2e2efd2b5d0d92d6",
-                                "uncompressed-sha256": "f91888bc5c5730da77f61d647f5fc6dc1514acb8a1d290b860db1912e5b6414b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9419a1bfb3c6a9695babd4ea93148065f918fd5d5f3ec0ccaf8c5f68f2f57db9",
+                                "uncompressed-sha256": "fbb2979a18dd57ed11ca248c0a2f3381fa1471d8f834925dff35f1b440667cfa"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "7f40af84f94eec348424418319b034e879bee2c3a183ad8b22e59a2a4f726505"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "c977231b72fa25b6c62e999e42321c135cc7716ad3dc8c401127ddb43b2081be"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "54377599ee8c34b956edf251f6153d0ac310aaf74c94c32bbf6e1a0397fd1daa",
-                                "uncompressed-sha256": "de5b3aa19aa56ce49e6a740726c0bb7299d4f2bb434be3222a449c03e316a6b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "4d79998fe2755a8d580fd57674543fea113067146aedce4913def2a38a270a98",
+                                "uncompressed-sha256": "9397e514274ead75481d392d9a267ee05197558860234d0c72b70e7ad3dd3404"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "85efb1302ea62d63292c9110860bc9fe451e826853c2a9b16a7e627ff1c43776",
-                                "uncompressed-sha256": "5b4acaf77907fbcc002f0c3e7a8daa9df4138a67291b8ea705bb5cc034b29933"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "4453d01f53a48c4f472e109705297699d2ef4a9ec2e7690acea47743e0e85f54",
+                                "uncompressed-sha256": "b433ecdd5cd7d3023d0e0c01319dbd35011e32bc58893b545d3cf73e9bf0f73a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ece32c8a7ea7aaf878aa59c7ee242e1880dc52b95f98648e55e8fd8e04ac9ef2",
-                                "uncompressed-sha256": "cde734fab73bcb7229f7eb31a014fcb91798c3a077ef76b2051a3a86fe67c267"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "eceed3a2653a678ba37f56131c406a13d5d07b47a0981996fa701b66b7b3716e",
+                                "uncompressed-sha256": "d40ead4cd4d277e493498b2716f348e3a20a884ec97786bfc9d5912937f3bd7a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "bd1e8f534fc46f69b297ccf158be39a6e5257c89b1fd67f53192fd18c1c4c520"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-iso.aarch64.iso.sig",
+                                "sha256": "f7ec8debead78de78e56c1c399c2a8e52df3ccece6ea783c56c8562909e1aa08"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-live-kernel.aarch64.sig",
-                                "sha256": "d0ebda524533aad795045189ce8d421a30ba687929b537b7cd1b71ebfb129893"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-kernel.aarch64.sig",
+                                "sha256": "8fd6c12d431111bc017a228b3b30f18905e3a156c1a1d882e7daa2c5a288dd15"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "313cacf5ad895a391f8bd89a171c5b887222e6d677b4e8c2c690e90fb124f650"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "b030da0acfddf7e43124ceaa3b11c04eede8920ce03fc46ee93ce6bbf60f8b43"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "bf7739a92baa57f00f8e8969400f9bf3abcd153c5fdf23c9e944756df24f00b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "0808009a59ef84a32df344555c987de2fd0a71cc05c2ed45074f365048b23806"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "38f9e41bff3c13322367dd5548bd97b146cfcd5bcac0a835c5a1a02916961789",
-                                "uncompressed-sha256": "13cf78b4777704fec967a6642c430d6cc9e03504c84b0e9fb5df178fc73fcd1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "161045da24c20d3e15d30055b96a0ea6e131cbd036c7ef66e9b31cfd84680c35",
+                                "uncompressed-sha256": "f70d250c28170659fcf4fe754905974df04bd7172c3786d173ba9c454026569b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "287088d77186a036d8a6dea1efa2c5c6f3f25167a9a4ccbbd14fe1042ad4eade",
-                                "uncompressed-sha256": "85af66ff79b7b129923de15cefef2a9d8b139872f04daaf63a3df27b0001f6d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "df85b62581d0c9649647fb711cc0c1922f328e8cc963f3a4feee22ae8002f338",
+                                "uncompressed-sha256": "9d21783d1f4460e031b21c2755a946b4e1d35c98dd26ac53ea60c2494f0c93a8"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "05abdb910505f364655051461ff583f989e984b7948680f35149cd592c37fcfe",
-                                "uncompressed-sha256": "f786e9d868ac63e335e7b6057cbce7438efe0578f5aefea18f8d68072bb070ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "89de46a50518e1285ed60b9345b7ffd3c4c178a2f7d79fd1919401523ee9b4f9",
+                                "uncompressed-sha256": "634513c70060c753cec6d3407c210a4b41522619260c015e152da51e579b3692"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/aarch64/fedora-coreos-44.20260523.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "13b15fd8531819bd23409abc3ca8fb1bc71b0ea348533ccf10686034ca97e694",
-                                "uncompressed-sha256": "6b6dcf8ac0eb65185ff6f578112efe2d934ba07dbe25f12179b918101c5d0699"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e624e79657257c4c68cf4c4d5d249ea9333617978023fa12e4f83a6986641d32",
+                                "uncompressed-sha256": "42020affff1303bb52ba388d7e83bec226caddb974a51420db7bf30e41c81bd6"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-09a8f3e7413e1f030"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-05f887b29ae0b74a1"
                         },
                         "ap-east-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0792c60e41677c484"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-00cb33f74bc71402d"
                         },
                         "ap-east-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-05824cb60dcfe971e"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0fb95c30bebad244f"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0409cb758a71e61f8"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0276c54f97f25216c"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-091aee8f95ce2c69e"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0324a368206e2c758"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-097d556860f959adc"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0a8050d0bfb0549f0"
                         },
                         "ap-south-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-04b0d70d2195a9b82"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0f6289f8bc1da115d"
                         },
                         "ap-south-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0ee4f9eeab80f38fb"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-035de6ad66804ba41"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0bae03f1ec3613cd8"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0b54e848778cf6dbc"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-008e41f59ac901515"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-07654b9f2dcf7057d"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0f8013f5f311d5c2e"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0794c8b1b538e94f1"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-099773fdf09ee80dd"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0fb8358018377e747"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-033b42d2035bcdf37"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0826082928e3b75fb"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0ef72cca559d9e209"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0f47bcfc1062f1b54"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-01e9ed43210b2c6b8"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0f1b3a99529b00e55"
                         },
                         "ca-central-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-01840d7fdbcc33920"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0dc47040f72f91468"
                         },
                         "ca-west-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0cced31ca66ec4e16"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-091971c3c9244d700"
                         },
                         "eu-central-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0917744f18198adfd"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-012584363906ca43f"
                         },
                         "eu-central-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-031e6cbd351fc4441"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-00e959acd09ab65d5"
                         },
                         "eu-north-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0a482e2b00f5cb942"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-04da158747a9317fa"
                         },
                         "eu-south-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0ca78aab3a4a27680"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0277de25702d868c7"
                         },
                         "eu-south-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-09582fcd984261854"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0e11cbcb4f7ee2c0e"
                         },
                         "eu-west-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-072e43b399bf63602"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0c927fa388603f671"
                         },
                         "eu-west-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0074b761e73b0cd35"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0d702d10bcf7c9164"
                         },
                         "eu-west-3": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0a06344dbc943898c"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0cf8923cd75ea75e7"
                         },
                         "il-central-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-06de09840da111eef"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0370f087f5ba838e8"
                         },
                         "mx-central-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-02bb096e8e98284aa"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-01f26a3371e8f5c2b"
                         },
                         "sa-east-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-09c3805046025d1db"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-05c3e0076db3c0e31"
                         },
                         "us-east-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-050981a6155a43937"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0023af1678aceb2f2"
                         },
                         "us-east-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0964cd78edae667a1"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-098a0292534d61ba0"
                         },
                         "us-west-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0c407bc77ffed9f7b"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0a68a59a497e0150d"
                         },
                         "us-west-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-09910ebf54815fdfe"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-032da03760dfa109e"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260523-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260607-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "30e49ad20840afd7a8eb25d52caa5a35e474aa7921e7d3fb9a3820f4f8f772c8",
-                                "uncompressed-sha256": "27c4c86f25fee5398de4a5e3af7f69477013a715776fdee5417bcb2573e60a04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "0e1e7850bd28137ea3c8d2fe0600aee3ce83fdb7557bf5e22b60f0f9495b4fe5",
+                                "uncompressed-sha256": "8ab72695bb73aca0349fa2a8e451d6b4ac6909cd2226dea944768d7281956e1d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "33717d9c9042c54cd0711c7f0db525d40d7bc68ce895afc867d3598683b4ec37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "2091af7f7f6493a4c577143ea9818c74084b02632f878fe42d2a3648d34124b9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "c8a5f3231b5204a152711d3f583ca104a8522741ccd05f5d4e88392e745dfa1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-kernel.ppc64le.sig",
+                                "sha256": "d336b41fc5a1e6c545212b65efc75ad40a2c5ccc83a247e59783eb0beabb5247"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "f4ec1ae19b2962403abd11372907e7b52cce6fc6687593bd9da693e04942536a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "43368737949dfd93fb34665c10a3ca2e8c270ea822e99995af9475b2280d50b0"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "3ab29195445f203d4bd5dfc81b09919b99dd42710cc3a9de6071894a29246661"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "31eeb05eb3db8ac1b526ebd769115c1020e4ef4101c28f01a85466888ad6f033"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "ada73921adbe5cb2be5c8b22a1dc88c5b5e60ff404ab847d8ff54a4a2fb5fc81",
-                                "uncompressed-sha256": "730074e77419a60cd4e54b3b4abd23ee0e0a3abbec412b8a7b65b0d6aba3dc24"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "3d314c255b537f58c3ba89629f694ddcf761dab5d0d4702e9e8ac1b570a784dd",
+                                "uncompressed-sha256": "43c9622eafd60d9d1a423b6884b0f716db8a751c6d7868ed93a9493664b0163e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "9f96d7b59627a3ce15c8d1b25d3bedbdc49440bc879919b4b926caadd56d6ad2",
-                                "uncompressed-sha256": "37ed5243820d7179f9580765155a46e2062e5f7297a56b2df321e8421f4e42ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6ec69af10da3a759b6cf98bdacac1e88baef02f97e31fcfd6473fed8c92e6246",
+                                "uncompressed-sha256": "d561ec47de91a350b5979ca8fe0c2c694aff1301465b9e8329e4a2bf893d4ef0"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "95fcec1a4c7b9f0dabc6d94284e206236851a00284ca003eb866d29a3a18e484",
-                                "uncompressed-sha256": "fc7b5ab3a60eadc84ab6a342f78b09afc7b1742591261a79297db7e3337b1267"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f399b3491697e157cd6b7242b96e65de407c762f0fc659ea6586b5c702e9bf4c",
+                                "uncompressed-sha256": "4362c769dc0e8cfca8b22e850a1cdbd88d7cf598b087beba4b63c2562fb6300f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/ppc64le/fedora-coreos-44.20260523.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "acdd4abdce322d5f5a672ea506d48a9969517990e08846e9098321a2dbbe54da",
-                                "uncompressed-sha256": "ee5c543ee91655b2d1a7a8d2a9ec3077e15b349e707832dd34c64a3c467938f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5296e4a9d1c79c1e1d2e0695344cbc0d21660c6e6f7c8450a878d8fac5444967",
+                                "uncompressed-sha256": "bacf7594930392ca05ea13a92d17a6558cd0bb8896f5f1dabf7f9b6d32600e88"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "77a1059b752c3c1656ebcf50df12b1086b2b5ec4119e1674838a0d907f8ab7b9",
-                                "uncompressed-sha256": "aa7492482ad780af97aca403092672279709497ba0f5207802ee25ced8d50729"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "9a256d54c09c47ac9353c4920c9063ee329074ba1c9fb9760ca63053d74eb008",
+                                "uncompressed-sha256": "74925808ebd819e24c2846ccecbccfd0cbbae21438d7f31919ecd1223d9d54e8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "cdcc94ab45f624e09fa4d29ea727b9b89842b9c1927de869cefe576cce32b263"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "42feb5e69b16b0472851b6df138011ee60eff09c1ed9b97ee35dc8aa062f1d79"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "80255210ff880dc4263e93d3e93f8f07eeb826128514f5a04d4a8b29792c3386",
-                                "uncompressed-sha256": "34161550e11b1f164b679fb75ba2c130089770a2b969aabd07dbf846aa4a2e7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "70b955f766804918be02a70565ef71fb12ae086c0d353bbf6d53870a927a9f92",
+                                "uncompressed-sha256": "89675682c13eadfc3456194832f037a53991cfdbf564551430deb1bbf267ec69"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "92dfda77d3f0b86674a7af5710a0565057789fc1133e771c9dd025d9ac8dcb33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-iso.s390x.iso.sig",
+                                "sha256": "9a31e6fa96a284e09b67c09646c04a8393b9ae244b29a830af6bb74333016773"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-live-kernel.s390x.sig",
-                                "sha256": "f79763d82d6246fa460c3c80146f1b5a469c09babd62108f54389439ee63ff86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-kernel.s390x.sig",
+                                "sha256": "df85eeb1bfcab7a28106ba565d8975616cddcdf175d961848584ee57f9dd723c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "b4064a2a58ed689930d7f5a1e008b74b35480b00026cde40ef980657a4c3a306"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "e84767a45e6943073924ae3f876768ef95322c8e5493c3b5cecf94efe5274ec1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "329a0afaa6664ffa27d61a42247db7b52e24ada44cea52d861074a25a65fe309"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "fa7583e79b1d28e81332dc3c61bdb252aa75f93c0ba1061d2b991e2eed35540d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "92ed44fadaaa05622744530dec7c95d5fb00e1fc8ed339b615f6550d18cbacdf",
-                                "uncompressed-sha256": "d6703878bc125add36034b46f2543755aadba725f6fde1ed21b760b063649bb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "22774bc9712f831594d136967d895a2cb67811c81fe1456bb225b396eb1189c9",
+                                "uncompressed-sha256": "ae9b57f2daa06585861ab8ceb2a8104699aeb95552808f77b9c3b1c3c52c95d5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "1e5a4906e220c10f7132dfe6b47d2e0e8eb56fcf4bdb9c856627819ab4edeb89",
-                                "uncompressed-sha256": "03d94e81eaa88ad00285f1c72670b54536ebca30df16e32b43bed0b68df00b9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "968432f68c603b7b4a83896e7082379ab949b492978665332c6ed84d4bb1450c",
+                                "uncompressed-sha256": "184cae56c5a96c8710473f5523305a7b9cb1dcd252268f9d99a4b14732798b4e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/s390x/fedora-coreos-44.20260523.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "fa76132cda28b2a8c34957c9b5604d9a3b0a6e6ecc73491295995e530fdd5a8d",
-                                "uncompressed-sha256": "5b2d71fc41dd2e8650ecaebd52c1c15d38bf95bb003d949c28fafe8a999c9ed6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4b8fe94c140bad31baba17c1e041b5fa7ab56a5d62533f3a50c2b5eb978998a6",
+                                "uncompressed-sha256": "f022e137251fb7a6d4f050a9f4e867d39b80321aa8a887357b6148431526b282"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5e9bd6742827845fe6661816cc353c207ed68b1b5b15ce741b7284c296954e6d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0eb4d09463bd0730e16898fb7ac263d5a5daf30b6add0785ec70823120f53f56"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cf4f1d3378120f4c21af87648ed36be0c2dfbd9b83efcb09be506e01bb6d2938",
-                                "uncompressed-sha256": "2b798e787c1230c21a5bc79def793ce1467db9eac818d43b7bbefef22d7261be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "10e7db3bea91b38c3c4ae64fd7c83e7bb2aa08a87429fb478cf7b4584af1c639",
+                                "uncompressed-sha256": "9f44b87aa510056c37091c44c1ca7441eb33231b20c6b1f90246eb4605873b35"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "a231280ff21189bb046701f80488c5bf0924c25a98e31c82f8857799f1ea4294",
-                                "uncompressed-sha256": "b1adbea1f661e2b7ae5f13a586ec49d44711624c244912d0d4d3e562bb325d39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "6dd00e660d22ab643e8e9dcf983d6f42c598b23ed13f399def0074f2823a7b92",
+                                "uncompressed-sha256": "3701102be798ecb399b6df9aad0f6ae1b5c4d59d9c74cabc95d675aca9918ab4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "fc6712a49b50df3ad0d5b4766ce12a6ce390bb467dcbafed07c7154469959536",
-                                "uncompressed-sha256": "cf05c48f27f90172b85134181d3791300e6f834bb753084c31a6f33662940afc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "69b969c4cb3f16e86f295d239404af609e6f4c95964bc64b6574c6ce0c194500",
+                                "uncompressed-sha256": "554620f8860499d953e97b6a26838c330981b1174e1602db13af5d2109cbbf76"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "dc38064fd4c1da49e0bf1a36652615514a6c2d41e6fa4d3f4a6ca1d15c17c5a6",
-                                "uncompressed-sha256": "11713743c40b019f656663f46854df33a7af57f0de42e3cec4556aa147eba9a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c91f78adda35a883b957c0bbba552ff12fc9bfba3c2b4ad1d088180d0a739952",
+                                "uncompressed-sha256": "11e1f8886f46e27654f8fede6de43636bcbb6f42a6f70ceb3351fd2e0e788103"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f769f32b66d56ba5026527ec8477517abe3390ebaf8d15bce0db936352cdb031",
-                                "uncompressed-sha256": "6fe5f15da5260e1f6db84c193f5ae3c1af64f920d10ea3e6b4e33ecbbf8d2427"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "924b9c3de5164e9e40feff6c3dbab4f4f61124276cb75fefdd47b237e809799f",
+                                "uncompressed-sha256": "6bdb1a57a39d656f0354ad22f3eed4f8319f9a8ded16eadba4944867d16b430c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "5a2070146c6ea9285504b1f8f80536dcb5f41e534a502915b88a51f3c891ff36",
-                                "uncompressed-sha256": "ad4ed85b6aa82869a6e08b6d5bfff2b88001cb2323d8963eb7e8eb2950424bb3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e81b0958e50e3fca1d52691bda87b94e78902939002a4698fc0fd8df78cac58b",
+                                "uncompressed-sha256": "80a8f2845b251d8ad61ea0a2c6640dd9a5fe7f567e9b95507310e622a1d7742a"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "9d7bfe41dd91768d23ca6d6a0c86da90923569a8d0b073c68ca61f1434b03df8",
-                                "uncompressed-sha256": "6805db746161f6f37a07a2ba80ede0e48de45674ca50573529c6ba57a68e4615"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "a57a1693eca1c080d4df6874bb11b8266567220ac7a7100a364c64455bd7143f",
+                                "uncompressed-sha256": "d2e8dbc653c8ef73d9fda6f75ed900df25a6b0a52b27bb93f089b736979d2731"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "36c4f95c376a8f0759067a8092e2036622b7343547e2e3545c8ef8ac86b5ec41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "44914cbd8c49e800d5441a3c966d7e9e100bed9cf745b5802fe3a4b75b415264"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "22178b8f2a5bee794283d68653cc51f404e7bd7a087c77c14787c79dd6520095",
-                                "uncompressed-sha256": "e288f99e437fe68cdcbd98d63f7550f79ae8a15f0c5fdf7affb569965b9533c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "29b25cc86eef361addb9c73219ed1bcdcf4627e1d659fc7df296fa589eb685b8",
+                                "uncompressed-sha256": "204a8f9ce0f4069fd14d756e4dbad75ef3f5fb92d8a25dc5560a0d025ebf185a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "300493b7bbf8c39318e390bd5c018ed5052750a77dc15ea71ca1d3840cfd3a61",
-                                "uncompressed-sha256": "fd062420a425bf8e2ab4397aaadfe6eb82cb116beb6370f8a46398a0fe34b217"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "646efd56c7db7e0a9deb6c1f50d129f494f04833f602c02160535e9b67c96581",
+                                "uncompressed-sha256": "cd7df0685f34e416be23f33657f24ec234ea2f0c00c2edc913e9ec908689510b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "ab56889ce8a659687eb3a98c8f9780b951cac2ad18ba66a3d0dfae05e1f2b6ef",
-                                "uncompressed-sha256": "a5a7877e3c5071f0afc4e204198742621bdc3c7f06f7a18b2ebfea4406a53176"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9ac98959e72b257f012e23676d937a33e36a588f7a3e8b586443fe3b68821798",
+                                "uncompressed-sha256": "d59924d2fc6e3f07206b4137d58c18043ae48a81ec754a248d21eb88dd20717d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "431ac926a867feca523df397a16ab1e1fca675c6d6967b9b66ea0f0f2e4437fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "5666a0c82440c3bfa7c402467c93d58797687ac58a795a0bd09382bf81c43493"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "15e701d11d9a01b89e58dd328ebcf6bd04f308705dcaa92e7a537be20818a991",
-                                "uncompressed-sha256": "1d44692b8bb3ff985518100964d8b2dc97ea8377e191b14e3a903d0ef22a0980"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "bd7976c4d6ec87e23eeea6fd7698e79613694d571c92f97988d8dd190baa00f3",
+                                "uncompressed-sha256": "945d94a7aea22107eaa283846b1d79683699949e7ba9e28ffada08400c882a65"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "01a518279a5f7892fd7b8bc6bbb338667c0fece7fd5607bd6f4a92834afa081c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-iso.x86_64.iso.sig",
+                                "sha256": "25a68d1ccb28d019ff7e8f6927dad11f8d8c0324c729e7acfc8d5a55501dbd5b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-live-kernel.x86_64.sig",
-                                "sha256": "601d29ee241a50cac84361e03c7f6404b53d4000aae77f7c89709ef9154e8f27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-kernel.x86_64.sig",
+                                "sha256": "05e5f16566f0bea5d21fafcb623afbfde63b668675d90ef2730afe4f93f47a38"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "0abc0dc2b84b1c039c5385ce8515fd86f9ba57fa10242376de1271402c78c0c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "b5440f25800ba806ae2444296ddcbac7d3dd14b626d4530950a31937cac89eef"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "112c82c60b0f5e4224bd858705918fe823f785ac85a9eb45dfbee5ebd9528d0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "69c75dad2be87d9743a929bd1c42441b953d6b5f9d320a020c59f0731c0c0a5d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "02669302242b2f8ec28bacb7b7403edf21eeadbc09419c594bdc7f9efd54955e",
-                                "uncompressed-sha256": "01144f06d874bad8b1f4073a246ef1dd99daa8c47db05aef2e9e7dadf5168d51"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "59f08e20e2ab4486911e18caba04b933cfea24725e4c6f2c5d73428051538960",
+                                "uncompressed-sha256": "d10dfc85cc047210abd0a363078741a9f9049ca99bf7231d2b80e23741432682"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4a53e305a71d6ca174667657b9a711fde7904883900a158cde629e5a706d3ac3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c28ad712ddb94adefe25e1c6032a5b833c0fd32f76ef12947ec1da973b7e2170"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8dc53f8dcea9ab6713b83dd7a4b1145aa246088ae0fd35aacf4836782a9144fa",
-                                "uncompressed-sha256": "8e1d9b77483468179aa3b7271d7bfa7c2d24ccda1b918b215e0a1c28417ff436"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "88d21c15b52833aab832ed8bf434b8f46684a685de4d215c19b3c0eac4f83d18",
+                                "uncompressed-sha256": "58df440693e9c2cc24123b1c3422e61d2f0a902b729fb08742bf101bb44a4a2b"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a2d36364e07ce9bec095f2eb0fd755c41bcc4d8ac08f1a42595265e3241dc668",
-                                "uncompressed-sha256": "e71a7f2f77aef2323624508e60680af5b7ed2b864048746ec812fad33e87c858"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "84002a4abb5e65d7d6c076771d83a8823ef5ac449c7b4df6f68e925f27d22005",
+                                "uncompressed-sha256": "94b4640a34f1d572e98a307347d4b06ba0f2bbc61eb52d6047831c285cc2f3b7"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "6f3692622d298c82c9ebf6333367d0171c4face8d9f3e9ac84cfa17bc82fbc11",
-                                "uncompressed-sha256": "52f6affde5d29d72d1e0d3a4b4410e961276253bf5bbe0da1ce3c1df5e13c7f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "5b566ce88fd0e1c86847cc0f922965305bf5cecf958428dd591b2c9f0eac0d82",
+                                "uncompressed-sha256": "fe59c9d4ac59b0e635f9e083cdea0997eea11412fc0f25469f4a32664b5856c4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "aa81c719d854b38318d4436d6535eefbcb8a44390db4913e05adf928b08c7642",
-                                "uncompressed-sha256": "115432c63b23ec6fc19f6081801fe2de08d97d050722e7fab4459c7388e9b029"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "3f669a0f237da175a367c441d71e5fd414185a8c7660f5ca6e458fb4fc2ef866",
+                                "uncompressed-sha256": "e11602af3d0a215c2a9ce9bd73016d30712b8e7a88b3760dd08a20e96ecc69b9"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "95ad01885cf467d46e7642985ef4af3231f9b0a20f6382ebf23a15760aa72316"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "fec9e6e1a87638f73c74ff9dbf9c3e4453ecfb5807fc17275708a2830ebb7b48"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "97147ff5b3c4f8d751c14294f1a4a60982a3a91e91f52c399a54995ad5c31a1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "1fa62c510c81c176b03a165ea38eeb5f6ed743e8b747ef1074f09fb918baa4db"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260523.1.1/x86_64/fedora-coreos-44.20260523.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "bd590e41f323b041d093e34f76daf994c3e6c51cf217cbec0a6cd15044d9c138",
-                                "uncompressed-sha256": "db2e0c28de0d564fce2b306bb25fcbf8a9565081abad6883d2b6b227bcca8b5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "eabaa195aeb9c4aab23664c015b873c153536646e0321eee3bc268978e168f76",
+                                "uncompressed-sha256": "993d1475cad7c437bd39251ddc971d3ddceb1ed846e9d7584a02adec5ec0cd3d"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0ca90dd57e73a3fe1"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0d15a66f14bdc571b"
                         },
                         "ap-east-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-08dbe3a71e7940ce9"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0622d1586dd7f7f0c"
                         },
                         "ap-east-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0f29d80cf908a669f"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-050774f83e1b64998"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-06c0088bc6e49c901"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0df6d54dac269c6a3"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-01e4c0a02de0752c4"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-051924bbf194d4973"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-03748c976d6488d2a"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0f408333270e1794a"
                         },
                         "ap-south-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-080637852613cd75a"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-00a1d075a5375aa8f"
                         },
                         "ap-south-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0bceb2b2a975ccee4"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0abd57d6247f82edb"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-05d01f430a45fb95f"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0daff1618fd0096c4"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0698c909986e7c448"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0d094c2dfad0e47dd"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-012686c842d2ccc0b"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-086cc3c537b2c3aff"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0580ed893e63a735d"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-031a0e1096bbdeee8"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-057f7eb3c0a160793"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0ae52acf8fd254a96"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-03a13111ca3f45f79"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0f2b473b17a22b22a"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0bbc51908abc790f4"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-03bdc20c67c581a8f"
                         },
                         "ca-central-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0430bc9e23f47366d"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0474295522258a5ed"
                         },
                         "ca-west-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-03620d089e7da2ea4"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0739b17a5aac82b28"
                         },
                         "eu-central-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-047f002fcdabce11c"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0713195370423e30f"
                         },
                         "eu-central-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0724bfceb991a516f"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-03b23e8f1482c019d"
                         },
                         "eu-north-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0355897beff26aeba"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0af1dd97544769f29"
                         },
                         "eu-south-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0b51501d7c394d532"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0ee95142a1b3c3bde"
                         },
                         "eu-south-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0e6c20741d6c12ff4"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0096da6fd87aa6ed3"
                         },
                         "eu-west-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-03bc33914be2210d4"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0252270f3a94e4a44"
                         },
                         "eu-west-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-06e8366cb3fc7f6c4"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-00fed975a9a012015"
                         },
                         "eu-west-3": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0e2294be695d549c4"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-07d606e599821e31d"
                         },
                         "il-central-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0a5fc7576c7eb00a2"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-009fefe963011730b"
                         },
                         "mx-central-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0c171b83fbedf92ca"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-072f66ceb49dbd747"
                         },
                         "sa-east-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0a27b5299b658c307"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0328a4f83b417765a"
                         },
                         "us-east-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0fe7d47da84b8d5af"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0b8aa540b676d57ad"
                         },
                         "us-east-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-00feff0969bb8134f"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0a13be469abfc296a"
                         },
                         "us-west-1": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-0b2db5f194f435c75"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0f105cb3eb91d0bc7"
                         },
                         "us-west-2": {
-                            "release": "44.20260523.1.1",
-                            "image": "ami-049667a12b3adf126"
+                            "release": "44.20260607.1.1",
+                            "image": "ami-0b0500b75233f1347"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260523-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260607-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260523.1.1",
+                    "release": "44.20260607.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c33d87a790d2f4029af1209aba61997f71f60368f78899bd03cc83aa616a7cf1"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:671263ced9fb8ec4136dca7aeca43130917dafcd1f3f07a081255f55126481c7"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-05-28T10:34:07Z",
+        "last-modified": "2026-06-10T18:13:10Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "413374599e5514a4cb45379616ca7a7c286f6b808736eb559223f3b35ad15be4",
-                                "uncompressed-sha256": "7af2356b0f70b838fedc4ddd8c28d424245d55f80b42b1be39ae90473d6d77e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "1be595f017149a4eaa9f588e996f284d39bc3fd57e18f549ec3b72ccea35cf62",
+                                "uncompressed-sha256": "917058c6814828696c3f343cea4ffc10ebdc23a5e00ce1a26446ad49153ca51f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d75f2222e3c1b8366c52599457e5f3360d4f45145db9b942798a170772e407e0",
-                                "uncompressed-sha256": "0ac327795fc0aefc9885362a88584b5df7db1515286ebb50f4217f78a19bf2a6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "acbfdfb95e2bc8c217183222565693ca4745604b33baaa4cca5e314edef594da",
+                                "uncompressed-sha256": "49bf38f4f04c2cb196f6e8784ec7586b6a0d46a288993e3b72f9d7b31fec6aa1"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "41184d450ce300913c954d58a45e78042da2a7e6bbd25d473747543dc7fdbac8",
-                                "uncompressed-sha256": "88ce75ddc8e789654de8c6412f5f4af990c4a6dce7e052aafe251583a012711c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c71c1d25d61f33af338a7b294b4fe1e9e501fcc7017a60a86252a573b776c5a2",
+                                "uncompressed-sha256": "1dbfc4fae548df52659359ec0312c1c007817d501f83c10d1fa10e7ff293c47d"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0ad577b9fd5a2cbaea2ffbf1bceb96b0bba2f753a4a2036e254ddc5950aef443"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "1e3eaa11eb8a55d24f5c0d2302d483d51f43a6f014cb1851283b169fcc04cc75"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "7685e693c68015a42d3e07a149d13b70aa44613d138930e841dffd089bbabf83",
-                                "uncompressed-sha256": "ad7a2eaf51f3c9375fa95bdaddbfd281fedf59943717d158bdcb0f39e3f19880"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "85029e763cf9e68ca096f86d8bb11440c79e6be69ff89e002da7c2156194af02",
+                                "uncompressed-sha256": "f853d0fe2780c750429122741406b45075b0387c226a442e019c09fef3a91b25"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "692c870d0512ef02b3a06999b14f79d1a94cde2da188fe15c594b06ced59f95e",
-                                "uncompressed-sha256": "1e4ef9e5d4b092a7764dcb01c223c49844ff770a781024cb65944ed0ba12312c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "de1f05ea43bb3dda60b4836ed30a78056b1587e8a639f85dd010941e6c2b745f",
+                                "uncompressed-sha256": "222b0706281cb48a417ecdce5c72e40699268636b6aa15f45b922b6472062bc6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f5cdbf3694897a39f928643546306f2380025ae7ae5e9b05d369cea742fd9b15",
-                                "uncompressed-sha256": "d9dc4f085eda92f2954af7aa5738bf79d189148ead836373c1e72d6ad73ecfed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "8824344de6e69d774d38227acb5dd1bac1431687d5b5a2d9226aa15eef59d6f8",
+                                "uncompressed-sha256": "728e553ff3b7057f68b48eb3c4f3719bba1e355728ffb9cb3cf7b2c9528e6333"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "f360ddcaca763ce9fc5dd3422e11040983ce07902741cabd00bd43106b15037e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "850b01ce4ac8bfa94e2e38b2eabeaa202427b27e6ee62c6d16c66010c86f7584"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-live-kernel.aarch64.sig",
-                                "sha256": "c710e084b3a07e34fdb4962a93dc4019c241d275d8a6ab0327f68f5f6f81279b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-kernel.aarch64.sig",
+                                "sha256": "d0ebda524533aad795045189ce8d421a30ba687929b537b7cd1b71ebfb129893"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "7344ee7eb4b3c96f3da20468749978edbb9f65f35a82d22290d8e8068736e522"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "88d9ce43912c1967a330529383556bdbcef32800a36c184a581d0ea6402efff1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "cf709096a9e6b4302182a44a71d6b70d2d3998dfdd0aa775d6e49f7c470390b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "09e4f63fdffb76c32946fde8f41b8bbedc54d9a4aca452216b2766b0f1636b53"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "0e2fc212682f68b44a0b07f53622a8a06a8805ea53ba96a38c230eca3e2aa3e3",
-                                "uncompressed-sha256": "f9e60eafa1f822fab10c6cae9237b4075bbe656d5b2ef6584fa9622810a8e2d8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "d9d5f6d99f005d51504d4c24a4e72cc00de79d6f388f3364a63cabdc482ac421",
+                                "uncompressed-sha256": "9343ccb8451c7a3388551ee0cedf4e20d32f4931532a26d874f64b7ea5c23789"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "0b02335ca57c99c5210583c8a2f58cd5880e974cd68a18f68db1c25adc0f46f0",
-                                "uncompressed-sha256": "ceb5775599048d5ad69c2aebb7e8e9361a6d905e031e7c7520b4035551dee46f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "0a8bfd00164275be86dbd8ad4d61565e35fd812995cb6ab747f62d605d65d941",
+                                "uncompressed-sha256": "8189032e624e5a12dd4487fb04aaa1c2bb8883db2cd05fec51796efc0ef90554"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "af23a1fbfacfe7151973448e280be8d4a5e21e3ff71f6730dde061a1a2b1d946",
-                                "uncompressed-sha256": "519b1f1eba96ff1ec3fc1bbf84a817ce73dca992f898c489f695536c7d3cd86c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "bf3c0167e1168b729feb480e0c9ed9c601edf3791c99a2de75e803a8346e90d3",
+                                "uncompressed-sha256": "3517058e43732dc27d42a94148ce8f6ca7660588684d460b6a8b8f64fe619ece"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/aarch64/fedora-coreos-44.20260510.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "78d5e45a05049fc6731fb2d7c5075cc0a084de263b33b0f5762753ad82e906f5",
-                                "uncompressed-sha256": "5671b881acdcd2ba16f807d532808baccc1f32d0b4c40c3777b96b45edf14f13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "8afa8aafd8c53a12cdf9fb31d126abb7f4269fed780cac7f30f088b3afc19c9b",
+                                "uncompressed-sha256": "02db86bd279d4417b51b0c29b3c87db1eab4054629cb6cd8a86746196d95ca27"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0ed0cb85f6bd110b0"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-077eb48d760e6ee19"
                         },
                         "ap-east-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0bfffa6062b9b16e4"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-077b0692025af7c35"
                         },
                         "ap-east-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-027161b05bb598358"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-01d0dbf78c1468a3d"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-000df8300399448d3"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0cd40bf31f8062f70"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-00119cf8ca6e4aac3"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-09e36e03939a2f556"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0c0338a222e28ae8b"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0f358969b5dbf91ae"
                         },
                         "ap-south-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0fbfc94ed16343b94"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0a2e7009edf08a0be"
                         },
                         "ap-south-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0428ccc12714cbc6f"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-05006d466c02b80e2"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0e8aa72a636db6e47"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-02baa2be2919cf625"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0610f0d9aa7999e93"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-04eb94521030888d2"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-09e12ceffeb7d24f2"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-08c366ae826aaf38b"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0e9eb7aa48c429b50"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0c0895a8a522a09e7"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-048ec5ca3210b4fa1"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-043a8ef2a7fd39b3a"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-07bf91fa5b16aa094"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-03f01ec46c29c57aa"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-07c51b7b4fd238669"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0da3c2fc3faa3e5dd"
                         },
                         "ca-central-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0904283d1d29e84db"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-01b41b03e586be5e6"
                         },
                         "ca-west-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-01dae37968827c1d2"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-098334f56f6cded7a"
                         },
                         "eu-central-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-064ef82961a865bea"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-015af216ef72d93c3"
                         },
                         "eu-central-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-05754662acd7a6ad5"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-055653a5e94e05246"
                         },
                         "eu-north-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-07e7ec428b9b45b3c"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-04f04dcf0a3832fef"
                         },
                         "eu-south-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-041138992b30b4723"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-01b01896f4ee0614e"
                         },
                         "eu-south-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0c1496a0de6b812ed"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0943d11852557f362"
                         },
                         "eu-west-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-04ce683f4469c2c6e"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-079d74064d51338d9"
                         },
                         "eu-west-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0f13fafa1a8e5c1b3"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-06affeea02fa5416b"
                         },
                         "eu-west-3": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0ed39e658849bbb87"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0fed4ec8b4fda62b4"
                         },
                         "il-central-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0898740044be03691"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0579b7c11db134e79"
                         },
                         "mx-central-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0e6cb967083b2f9cf"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0877b91220701f029"
                         },
                         "sa-east-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0eebe20e0187f1464"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-050e4f154995c90c6"
                         },
                         "us-east-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-01074b2a465823a11"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0810e323926a36833"
                         },
                         "us-east-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0eb678575ece973d3"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-08211606875693329"
                         },
                         "us-west-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-03b088e1cf30dcb45"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-045f8da9224da48ca"
                         },
                         "us-west-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0e869d3253b575c61"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-064762e6c461b4cf5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-44-20260510-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260523-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a6586863cc5978e39f394048f2a5ea29ea54f5d0f338b1e1bfb6676b912497a1",
-                                "uncompressed-sha256": "d93d4f0132d65747c29e3162726635ae46568eb23bbc38a4162edbd7a53fe3b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c47925eb65718fd93a0dbb1d177f73a3746a57427b2bc0afcf05f31c25ec0c63",
+                                "uncompressed-sha256": "1dd3602635bbfbcd47e7c274afd332b35060423dca4c36ad982028ffc4bce128"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "4e4db95f35eec2b505bd06b505d0cdd1bb0976dfb64ca93a0f60a2b10fffba0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "6ffa3d83ef6cb140a60c36797150b373a1449bedef4eda6a2600762585c62b00"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "3b9570d2d6ff54d88fb3d143a6b1899fdf163ac76196c325c9fae34e3e969357"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "c8a5f3231b5204a152711d3f583ca104a8522741ccd05f5d4e88392e745dfa1e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "a4c3b2a017f77f3f7c9c1b7a894848547d61f20b32241a9854a63393c070ef02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "0ad559054c3ec63e838dfa34150b23730e108f8ae419a338df8aebae8b9e176a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "d5705f688a456c84a8388fc4d481476ce9cf8556e65ee637a4b5213778ff8b36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "e8c992e1b7f830e1a1b9ee5b450a4f30a918125269e53f9d2e09592e56ff0f5d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "8aec71a2e593f874ab9623ba92f90da81339b5e773908b849dc04cdcf621531c",
-                                "uncompressed-sha256": "c8c4c558d342f12034c8f29a6f9f7ca7833c8b60eb98b395a2aefcfcee460be9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "6976a5ef920c7e3a5b62dfc888c70d572af6284cb18a95d387b7b3396f46199b",
+                                "uncompressed-sha256": "c66cae39f41ed14d9f2f921c24ba3dea228fab385beab9304a482c2dedf8143e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "1fa8f38722d4351f690a496042e9a404a868ff2175e3f84eee9f52d31350ac91",
-                                "uncompressed-sha256": "0698362f105f0f3a3bbe21cc895181b4f3b45d7a30feee3a4d3fbae1580612e7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "019771f1a06634c08a788d5b39fa722cbec49111abf21afccb505f837a5769ca",
+                                "uncompressed-sha256": "444ecfe01044e940febab7e56367424e6171c47752f8d5b39b64c8ebe2857e32"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "d0958c4ff3c03e4c52c2f5f96198a26943bcaab4171ffd1f614b1d17faeeeac8",
-                                "uncompressed-sha256": "2be93010b00c3ecca23b2a2a294770bcd8dd3428383ad66035017a014b2e8f08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "5af99103efd6c1a4db4518e7840f5d526a76fa6ba9377e6e628568b0a559e1a9",
+                                "uncompressed-sha256": "f3d018dd25d663e6798258ecb1166d8a8236f3105908069792349c92bbc5df49"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/ppc64le/fedora-coreos-44.20260510.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "f65dbdb889b3e55645d3a5c9134c7315f910258ff5f731b896d53e0b07b67d36",
-                                "uncompressed-sha256": "6873e2093c5605498aad1d89bfdc2ce908e3867091556b8bdbc7ff328e52d105"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "af50734dca3579ee07e6029afcedc843405527657036d0b98932ed2d60d6f050",
+                                "uncompressed-sha256": "e73e33de9260033f1a4fc6dec8f593eeb2d761f72c4b00b7ad6dab8208944f07"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "8a57974520e2bbff15fb740d582614dc0517402334f46b2c5def5b8f837b7c27",
-                                "uncompressed-sha256": "9a0ad7f30fc37d3ce4f9fefbfa3e87350d3926fd0898d9f8aeadd06ff0ff901d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "93d0c0acb8e0dff162875e4e0f37e6e286b44ed610daaf2de171320132b959bd",
+                                "uncompressed-sha256": "325db3b7402977591ccf1adc32abf50d7b1658197cfccba8ac00fce009322594"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "8b779d305c2e7bcbe305f61758bd4c54d329c12df818e3d239ebc13daf9e85b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "1ee79810123bed11db8df34b468f2f0dc2db1cc3efc7db6fc74b6e553beef029"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b9176e55e05c2ee822aadc332055a7260d254c7ffb1de41ab371ae1ca61f32d4",
-                                "uncompressed-sha256": "d8a511f177a551be5dc18bb053cb97d78bde2adb9dc910a4ed74a07feea38f02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "012874e795503a2a01331e7ff02ab302c8eef7955ad72d9aaaa147eabcce1ae8",
+                                "uncompressed-sha256": "79b81412a0706f6b57c361eb88f3cbc974d9ddd5a99b48fcaf39818c516b149c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "23a603f4748ea35498bfb2e1725b1623c49c180afce59bb57a25d56796b96557"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "bb30e6063e91e65ebdc8f6a82c83f1163ae89fcd6e97d0ecafd63ec3a0a0f860"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-live-kernel.s390x.sig",
-                                "sha256": "84712327a0ea6a93c3c21621af121250db5bf6f813080c020713e52ecf518c84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-kernel.s390x.sig",
+                                "sha256": "f79763d82d6246fa460c3c80146f1b5a469c09babd62108f54389439ee63ff86"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "75e77a68319d2d9a46c6d54eaf6640d2c658ebf21a55c5eba92b3a2d08d12e92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "43ddf858053b0b30483bb940cd1e21987d00e3a1df5dce24d33a83284e7bdf6e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "f528243b28f6e19dad2b0265e666f48b41344c0aa6a016130100cfd446540166"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "3f04b781357948ee430674bab8bc88d410803ae7d31a62c39e9ed511e2de2eb8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "b4955d7208f30fdbd6756e65603b156524eb579e98dfec26a3375cf3f465aa6f",
-                                "uncompressed-sha256": "41b63cc451e538d33fcca62b40362d7e1a73d37dac57926483f0a72f9bcf46b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "04be998bca47aede47857ce45e1da4558ed3248ef180ec0ffc834d824f98edf7",
+                                "uncompressed-sha256": "4ca135aede8ff89daa7b349eb30e8dd9dc7dd7d4e890093a9be0372ea215b8b3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "f06beaef89c4788736bfe277bf61f3e0a2ab684fb559a68b01f554211b5c3602",
-                                "uncompressed-sha256": "91f804f746992d45a71bf42eb0edb0c069bc586934a80d771d31e8aba15bd6e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "736e8ce9b8841ba82c17a5c69a28b46df587056bb2f16e6739a28ac670dd7da6",
+                                "uncompressed-sha256": "742d608b6552ff14755596e1d2e059600854e087fe245e66a71755ffb46149cf"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/s390x/fedora-coreos-44.20260510.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d642ce31d466c9f0ca9464b16977a785948db2fe6c0d08e0d8813e52f64d2d2c",
-                                "uncompressed-sha256": "f07a08fb465aa1a5a92bd127f6df4446279ca5425542b5b327c5b187bb46ac1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "a4e6fd7179a787b36f7f80382fc1fa602f07ead1e0b04fd9dba3eb62cd2ec5f4",
+                                "uncompressed-sha256": "5f5b58c8a1b111cd015ab8c5e344e527c80112352fb746133e7bf41d4fb598cd"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a7d1dd55b1fe5731f1010f7d32e17fc8bb17aaa96b0f577bc23957ebe8c5d3f4"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:04241601f06967df871bcfdd363321cc2489aec468f0d1acc213b2c8e796f9f0"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cd128d3c8557d4c26eef3bbaa59747cbd3e46adb81c9d8829b6cd2567ed94edd",
-                                "uncompressed-sha256": "ece5f754d6a421c2550f5be1c2c6449cf9dc5e63007f839092704052b2183e48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a7ef1cabe9d8fe1ea3b53d25c397dc0e1e6d6827894278c7b3e289c1789eae71",
+                                "uncompressed-sha256": "2e35348855371487db841fcf4525f17f6eadd0b63724c9ea87cfe022e415035b"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "1812af7fb376ad05c74e7804269916fe5e42fa7babe69008ffffcfba98343a70",
-                                "uncompressed-sha256": "6b2a01dc0c9ac9746234f2bbc99d6e2bb6b537d1dd1ede283a2f33f97bb01922"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "522faf91243dbd2d34d4d95f84eab1058c04ac6f2e2cd63ff99793d12ba9f7eb",
+                                "uncompressed-sha256": "e1f4f726b4e2738368a96f7c65ed4ac0c2fba6594cdf84c4fac6a3ddb4d2a75f"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a3380634270e6e772d64ea5971efc6e5098b4524a24226d5dad7489002e79e19",
-                                "uncompressed-sha256": "fb9ae2b36702cc7b4bb97aebddb24d0e8678eae8ac2588ccf48970adad437c44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ed1108284febe762eb0f8e0d4089bc8196026b2684f16aaa31100bfde32512a9",
+                                "uncompressed-sha256": "c22a602ebaef7a7e87ad2dd3dca11d977c01d1867830d3ca395bbcc659d40c75"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "6f010695025c12ca022bdabf75e624992bd45809960d5eb095eb71bffcb47455",
-                                "uncompressed-sha256": "1263cf378229e685c88d0e41e7a4be09de9aa384d53373b3900cb3348f81ce9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "09f6663c645e43d97b97ef50547f804bb35443d8e74a9c8bb4969a0a02168520",
+                                "uncompressed-sha256": "4f849036b7bb393bf6420f97fd34601e211f3f510bd7bd14ae7d18aee61787f1"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "b0a05cb46cd713b19a1c6d38ec20290ba5619c6f56412431f6b65305cb4d4d7e",
-                                "uncompressed-sha256": "f31216cd7689ebe93d7e23181e434561498f4e64e9d96165f918d5496122521e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "1526d567ab02f4a9b628460f5b6ae18cd3e28a66f7e2754ac8bd3aca74758a50",
+                                "uncompressed-sha256": "6adcba78db7c22b9e5637ccb59af61e6270bc99668422106c8bf08e593eb00e6"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "57a00caeebf03f98668dff099eb673bc103109e275f05fe3a7c4bb338aeee7cb",
-                                "uncompressed-sha256": "5154506454cb7b4ecef73f2d460a40354eedc238899f6efc8d7464bbe5ab142f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "db0513b6485af91cc1d834c3b826defc2a00050af33d984ea141befe06def4ab",
+                                "uncompressed-sha256": "5f9d38b4a4d9bdc3d3d8ae4a819738a744af23a08e741c5bc781f7d9481e95de"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ebe05ea57499dc38346227e11ab27f67244fbcbd3e0d0091aa701bf7281cfaf2",
-                                "uncompressed-sha256": "a9c832d69dc6a3e5db50d24472c96288def75e31ab203a8fdfbdcc9b4d3a5a22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "29ca0feb192e8003d34b3948ff3f451707f2c10fbeeebafa836d9625e6cb8ad8",
+                                "uncompressed-sha256": "5f715563a1f7fb61db0254631f50196edc33e926def752d228cb76b012d44eef"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ba8b5b35d5f01fade8da1c7fcd861c84485fb817cdf4ecc5bff936f8213b3d6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "805e1a6ba66b2fd5b04ed8fef293c395bb26e85e6cdd13dead94567dbb757035"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "6c5cd42a1a69d453ac00b7860c9792c5d73842a4d2d3a23d86bec884f046783c",
-                                "uncompressed-sha256": "4e44241f2d3839e0f4dff7e660ce66115d30de24c09af641eba2e3c59980b3d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "2c664c6a3826704dde713948850258b8ea93c83469f5c23cd21f7cc79b7fda30",
+                                "uncompressed-sha256": "8a87b13425df2e094266575b57471a2501d8ae5c4e6d4ea070fe502d3dfbe4f4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "c6db45b45c50c65853b05c0876a45d0b3ab80047dc7781cad03bc7c59a2c8a3f",
-                                "uncompressed-sha256": "14df160d27f7d5e3ef52a1469b8c5796764330056b4a735f01c6da64476e40b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "62eb4c0b8f79c3e3750a3f438357a3d2489e91f71705c2205d3b25a0a5dfcfea",
+                                "uncompressed-sha256": "85f661a73b13cbbab136c7760470f36ef28a9c22f6ab2782c6fc435815f5840d"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a4bb17454d57fd3003fd01fa9d6dcee151f05cd1498afe94a5973fd74498e66c",
-                                "uncompressed-sha256": "5e9bd3299d4a0cd5690c6365783d564adc4fbcb7bc45ad976d29da95de30daef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "070d445d188260420342616a11585b731a9fef9217d8f5b15d05571cb85baa8e",
+                                "uncompressed-sha256": "d359d2aa530d80a7a7916c00f147244f76ceba0560658d0578f20bcc2ec64ea7"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "7ecd1fb1968a8b5f02a1bdd1658eb6347b02fc3df5e34ec3f0950e4804ac1e0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a73f8bd3a0b69a30653735d5e21954eb446bb07581a0549fb8d3094bea66f007"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "5421b1f1ba017f6f1259388c26e341fc0f1e82c778c9e76b5e51f738eea36f50",
-                                "uncompressed-sha256": "ff24be6101f8d28ebd8afa2e71e5b13c74b62311237c559280229ab548ff40f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "d2b12e1bace6af53fd18e2264540c15290d2a5f451d365030c013ac06f343279",
+                                "uncompressed-sha256": "4dbd878df702406f184bbb63fdd5378b2236edd25b47767a4f8dfa6bf7723918"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "3aad07f702838a0918787484bc9854d8340d2d6df56ba366fe2ad640e97c4925"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "1b231a04c6ade01eec35d48ec78b337be6b2552969a2ec3460a3599cfc18f6e3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-live-kernel.x86_64.sig",
-                                "sha256": "81500e1bc3e6d5208e2b6e928078a2a104d1f1a7b16de5d9514c61b00567ba7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-kernel.x86_64.sig",
+                                "sha256": "601d29ee241a50cac84361e03c7f6404b53d4000aae77f7c89709ef9154e8f27"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "bf461cc17a44e20c30e218d1d96fd8274eb9b71dbfae40ff5439deaabf80b20a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "3229adf819a8d0ab734902baeec799c500b9c91baf6a82c6089c72bdd63d5d33"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "fa5d5beb837cdc4cf521363649334e789db2c8eb6d65d85ba9395428e994cff4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "81851dacc308412bea80e116b2fff6d00d7e4b0202cf44477bcd4e1e3d6c6211"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "f34482698e4ff206f1ae92e730c8d3ae7f7ca32468c7cbaf1051f881ea8d4e9d",
-                                "uncompressed-sha256": "39194b7a675c529707e977a6ba645b94889eb73d733b974990fa1f6550bc6cbd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "7515275337e781f29f614bc463961c0d515cd3e514bdf0920e81da85a44e8c07",
+                                "uncompressed-sha256": "886cf49512c2f381cf99ace417b8f25e182de4dd317bf03c2de1c66aeaa97b0c"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "8410140cd65158a4d7b2a45d4f9f814561d54f2f4a03c06a76649703b24130da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ecfb1ca061c2168e6d7641e7b1489b6860201c9b1fcb8a1e56507ae1988e40bf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "2c35fcedbaeaecc3a06731ea7a1770c9488270d524d910fedc70428570bd8fb5",
-                                "uncompressed-sha256": "acb1cec3a7c89feebf8f7446a240b7523635bb1c0e4795f1156a5d85d57f841e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "082e2bb48914922b96e76d963b24c715343ffc27c5cf586dca147a92c765bb95",
+                                "uncompressed-sha256": "990f66bfaa842782c8f85d65ffd782197673a32a0fee13a231613b7600a2396e"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d993bc86efb28d32c0cfe263e7c6336ebe0dbb4cda9ee3f24f6d36ddf4bc2b4f",
-                                "uncompressed-sha256": "a02808c2e8dde479aa02fff81332faa5cb0f80d039a76de47e1c71dad6ee15c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a3d861e2643fd29cb8286ac6670277fa2fc0c4aa95bd8e3f61401929af84c86c",
+                                "uncompressed-sha256": "e25e4640ec1ea3eb49a341fde4c4eb863390566b32fad3d6dd645bcbbafb3fd6"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "25947778de855807a73b2e4a98405559baee5744794e5e38e3a9fbee9978ad55",
-                                "uncompressed-sha256": "a414e06f8993f2f240d69c05393237b96baf23f6c897e8e824a986a4544f1145"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "683aa7fee0dd35659fe5509b7e0b1a46aa3aa1aae14a566dc356226372c21bc7",
+                                "uncompressed-sha256": "b2d3644dbed6772a0c21002b101ea5da5108448619ccf11b8c0e2e3994ac3bf5"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b8f0ae906a1ff357b9f5e62eb7f64ee19a42d01a16d9ac4d2132380601aa84da",
-                                "uncompressed-sha256": "37e390dc7955de13707437c080fac48769eb8445684f29beb66207dd818bd47e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "b62d2628784723c342be8761e6d02900413f94670e7d41cf498d4c35c8befeb7",
+                                "uncompressed-sha256": "39c88898cabe7f5c9dbad15eba0833b89b5474df4efcb47be0f856c1a409c8c7"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "f2e46ce54aff1fb81d0be3087b59cc804df39fd2d50ae1657f8223f7f3ec601d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "711ccce82f400bd28c5ab94397446b6616c6de2e31f37edb2ebf90b1db464d60"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "63f52f4ee23158cc8213e13bca7a3e1acaa0b10436117d91fe2bf6be6e7023fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "790e7643142249ea5b4fda19cbdf026eed858aae398ae7186eec27c492620653"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260510.3.1/x86_64/fedora-coreos-44.20260510.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "169bd1520166a88eae304b20fb6a8636782eb21b8ec8ce36557e665a2dedffe6",
-                                "uncompressed-sha256": "2da93a319fd081addcc796fa2a9a91889572e4030cbd7bd1ed1bf15b9559eec0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "503399255ae9b0b3561c535470491aa3aea7fcd0588fb320ead0a8b4dbab16cd",
+                                "uncompressed-sha256": "64871b91c5056df647bbec63c43dbd1bc7e33e0eb8a33983b75547ce404ec806"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0fa9bbbd9e1f1559b"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-09b309c3dd9dd9a02"
                         },
                         "ap-east-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0ffabfffc7cb1553b"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-01aac37ef2f86bb22"
                         },
                         "ap-east-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-03f6574201cbbe25f"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0bb7a0fbe4b0f6bb8"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-09817b6d608c01fd8"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0f86b6227542f0284"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0a283d03585ee9893"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-02c299de047076913"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0e09b6f9bd7a45176"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0558e0b09c646b466"
                         },
                         "ap-south-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0c2e9080a379c5ff1"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-04e8b77be2430ac59"
                         },
                         "ap-south-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-02fac2f5ac6fccaba"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0e16809846bf89c42"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0d9e001cf3babb963"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-004f9a514405a94df"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-03aaabd0316ae62f8"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0c0283fef53ea38e0"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0a4f49b214374537f"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0ec0549d62df1f920"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-03957e5c0a8b8a0b5"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0fc83de0d19b5d8d7"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-01c5166d75e5c68bb"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-08aa09a9ed7b8b286"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-02b9066c260a9302b"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0d48287491c2d78fd"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-04ce6939b2f447ceb"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0553e75cd4a0ef5b8"
                         },
                         "ca-central-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-019a9aee6f4d2c57b"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0cda90c90dd2f2525"
                         },
                         "ca-west-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-01ce9b25356326c39"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0ad98358e2aa905db"
                         },
                         "eu-central-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-01ff07409b7dd58a6"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-02fd4b588390c1b5f"
                         },
                         "eu-central-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0ad7e2c7b0444d66a"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0c4b1fd8eccfaa37c"
                         },
                         "eu-north-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-068b501cee0377a85"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-00428175365466f50"
                         },
                         "eu-south-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-099f5db41754cebec"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-090ed417d3ec00e58"
                         },
                         "eu-south-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-00a8431788a9c4e87"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-01851193866a3e61a"
                         },
                         "eu-west-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-020c9205813f25482"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-083427e92d287e833"
                         },
                         "eu-west-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0c536f612d0138c10"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0b7b91381cead50a8"
                         },
                         "eu-west-3": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0ca0d73915e0d11e9"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0f19b835054ef1e31"
                         },
                         "il-central-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-03448e68dd02916d4"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0d2a5ca2c845558fc"
                         },
                         "mx-central-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-0c080fe87867b9a8c"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-01bab265f1134b136"
                         },
                         "sa-east-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-09cfd89e451ec5509"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-090e24bd2823bdb82"
                         },
                         "us-east-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-009ece630b82481fe"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0f1333d7c6ecd788d"
                         },
                         "us-east-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-087427c9a4c709a57"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0fd76d4060c7a268c"
                         },
                         "us-west-1": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-020eea818c5619547"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-0c7a75bed141eb382"
                         },
                         "us-west-2": {
-                            "release": "44.20260510.3.1",
-                            "image": "ami-07352756dfd323ed6"
+                            "release": "44.20260523.3.1",
+                            "image": "ami-094727d01fd475c35"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-44-20260510-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260523-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260510.3.1",
+                    "release": "44.20260523.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ebf77e940fbcdfd03eb17ffbc5fd033126c2e937806095a28d4764fad9062a3a"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4744fb2b365b83b2935c79490374ebf89117a3e8eb09dd262c43384525417d75"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-05-28T10:34:08Z",
+        "last-modified": "2026-06-10T18:13:11Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "9702189283337db3d705914fe3860532a4cafcc97100c26ba003590083371140",
-                                "uncompressed-sha256": "7b6b2198421e78ff940d5322861cdb78aec48829066d06d635780e1e974a2c74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "ce42a398e5f4ff9286cafbbb970ae3055bb0226ceec3380e55338c1f0d8db704",
+                                "uncompressed-sha256": "5c7484ec1d4845c627239e32599090ca3b5db6914d18730e2d1085c71a93c7f4"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "e2fe942c91a2c5da01c1a0e806fbc537400279132d0b3023a98e98870b64dc32",
-                                "uncompressed-sha256": "99272efe41319dbeca4f4cbe2bca61ba5695a09057b9ae4b1df080c4a7472649"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "066b6af1c572437e249b00880507d8402005821a34a2221c164ed549cac283e7",
+                                "uncompressed-sha256": "dc54bfe723e382d83ad9e999d4638d3a8ac03e8e5f57587bfca67621441dbbc0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "464f53f12348f67cf503eaed55c4ca16e830fdc19dd3c6af79c558f5a985fb88",
-                                "uncompressed-sha256": "3ae8d9cbcd2ad9cf5c644249101e4e6ea583f555a5fdcc35d7f56cb1e556036f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "dc7b19e2668ce8e5fe1c5524f0498e005e681fe7659c29f6eeab6a9f7e6a82f4",
+                                "uncompressed-sha256": "a4e8a9fbd9c9b9501ddee795e4c58ad07d569692dd55b8cb8a71855f4119a6d3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "94ff48ebc0f652971b49fe3621ceffb46b0c1ee02082abfef265c69728cb239e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "205e30c342cc4356a37489b1935f23648957de77f00a0718f2f1abeb5ad117b5"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "a7d3ea954a8d5537da2ba8f97e47c1bdf58cb418f2375c761393a969e1075751",
-                                "uncompressed-sha256": "fb5c5d954f95b3e145c8c24a7908acbfbe13ffd900b4f56a8d02e5517a008f04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "ae429c5d36a750f5af6fc04d56f3bddb0df696b60eadd0badb80102ef1b81f04",
+                                "uncompressed-sha256": "a4643d1ab98a2a06120bec54127a8040ed260c4ae8ffe41c1917f35d0422741e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "b701ef51fdbf5bb7866636f0556cfa2fe6fea59f41225476071b4c31fdd6e511",
-                                "uncompressed-sha256": "923722e1e1a4fc28f5c070550f988f5772b0642ecde9d20415b411d63306df02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "24a2af618d43710a88d7d479573412499bfc472b40f48894d563c0b1c83e9f4a",
+                                "uncompressed-sha256": "5b16f1f491192671b2bcec180cda96bb200dd8fd99a9fbaf9ed2da18c67119ea"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "46023363d20ca487b6738e3ab0c389ba3ba2c269521d4a56733c81ea9571819d",
-                                "uncompressed-sha256": "ac23c583c982cb396617e66c80d1e615f833661397e11e7154231ae58699182c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a73daef49726747d2d42db5f49cc34cc203f6f225f73af6ed84686beb73c0a7e",
+                                "uncompressed-sha256": "ad3bef720f1735b12fcd90e2c0a815927668fba03a2c4de05d79c4b4d2c334c1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "ce19766a0493d035165e1fa64ca421494cfbcfcc1400f48b7331b42e5d6d6fc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-iso.aarch64.iso.sig",
+                                "sha256": "9d8516e4be6da960f127055c44d6f9b6153b682bc4a31e1e2dbe6497c5f3cc3b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-live-kernel.aarch64.sig",
-                                "sha256": "d0ebda524533aad795045189ce8d421a30ba687929b537b7cd1b71ebfb129893"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-kernel.aarch64.sig",
+                                "sha256": "8fd6c12d431111bc017a228b3b30f18905e3a156c1a1d882e7daa2c5a288dd15"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "e1d593c875d9a83622089dadabfc0c0488566657736e79a854f8c469ef66af83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "c8d9d99cfcfd94826ee213a7d60199418c7e5cb8c2f9cc5a183feac30219b50a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "3fe924610a4bd2a5e2d73e28524289349000c751c57dd9e3ce6e3c1079ffb8c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "3bc1cf02ccc01d20d450a87a919a630e59618f1b5a84df382db53e541cf069ee"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "74c93c63cb2d0596e34f441ba7be2c380ced3cfa201a184c2a2aeda2d1535011",
-                                "uncompressed-sha256": "1dd0bec2bb26a99a977a34b88f0e603b7d2b45f69047160ec8b712f17838881b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "f86c43ed01d6e27631e6c2bea8be057f7c2bab0915dab0afabf6a535eb2559cb",
+                                "uncompressed-sha256": "6fb84671d271ed172938442cf5083183229c5e5f076508e5f9c567cbc2fdf0f6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "ba8330e242f6d123ea523f38378397c627b154408cf8830ba31b5b9dee470aad",
-                                "uncompressed-sha256": "1b916772e0e680b71a8b830dcef50c87cdece3fcd45db6c6d29d9c210e64a2f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e81ef254c415600d4eb89bfdceb992e394136bc9af48c6b458622d2cbc93ca75",
+                                "uncompressed-sha256": "5f594a9620bfb3f0ffc25643a14a948accfc87eb6f6dfa3ff0d11283f7941152"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "2be4f8824632ab41c7d963b1e40e40acde3d98969358be23548804da9405cce4",
-                                "uncompressed-sha256": "612a79ec6f7ecf17290a6e361bbbb5c0dc830d7b0355433b57752a5380795f94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "34d256313b2f9efdb6160dc30c3d8646275b4cab60d4b292618b99debed2a058",
+                                "uncompressed-sha256": "6d1aa3d7d0173481ca387ed0bec96f6fa6efc6bfb70fc722c3d5ff52cd4171ad"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/aarch64/fedora-coreos-44.20260523.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "f590a6dc17c1b8756608eab50deca23022d47d2b5af409ad27cf652a66e539bf",
-                                "uncompressed-sha256": "724a378800728d08d31b1626049f24d4833f160ddfc786e60b6a4bbe0bd45791"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c30610766481294971832aed805a43a7110868886770802a6b8765133f48dbde",
+                                "uncompressed-sha256": "121a5addf6e1e74fcc3944c372144306becc49f5a68839094c5008a76be99b36"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0fc33131d93136d1d"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0c98ee04ef7cf92d7"
                         },
                         "ap-east-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0d6e0563f83065887"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0c7bd8ee17412665f"
                         },
                         "ap-east-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-07b71f526bfcc20a1"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-067412b0619ba528c"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0bf9fb3ef3736c86e"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-06362379d742a90d0"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-000cc1abd06ea2cf8"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0b42e2a50472e35ea"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-086ee7c599435cbfc"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-068db90a0cfe48a11"
                         },
                         "ap-south-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0c5f22dd13f0ec446"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-047e99040c8ab9277"
                         },
                         "ap-south-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0672c45b299ee1d1e"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0316b2c54af66d6dd"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0ae2a498d45291882"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0f6db4bc48baad329"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-02941764f0d1d654a"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0b586b07a2eb2b9b3"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-06566befba8d0408b"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0324172df393216f2"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0826d44647c2204de"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-00ebad98700185035"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-05344fa834f2024b9"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0d0874ff7860f5346"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0b548e64a64b773c0"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0010373f9409be5d3"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-069c261b937e07941"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0adcd451700f6e462"
                         },
                         "ca-central-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-057c92bfdd625f765"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0054c065fe458748f"
                         },
                         "ca-west-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0e004c6081c911d21"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0729b44e905f0977b"
                         },
                         "eu-central-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0b600fb9a329437b1"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-06b738d2982a3a0c9"
                         },
                         "eu-central-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0f9db86b2695e5090"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0ea24b21a3a3c3c4f"
                         },
                         "eu-north-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-06ed20aaaa1052561"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0c180248c90e15ae8"
                         },
                         "eu-south-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-04846884b56cadbb7"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0536fa3e8694542f7"
                         },
                         "eu-south-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0db9b02a7185ce6af"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-02c11639134f7b5c1"
                         },
                         "eu-west-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-013fbf3f36c408721"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-02737d42fea716c0a"
                         },
                         "eu-west-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0c6c31f292e6876d5"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0d21d09664d1e2067"
                         },
                         "eu-west-3": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-098baf938bf33f681"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-052c1fbfdc2fa7b07"
                         },
                         "il-central-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-095f913608eea9134"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-08962c617b1f926dc"
                         },
                         "mx-central-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-047384eb888857a7f"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0fcd522aaa066d3b9"
                         },
                         "sa-east-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0083583de10a5a456"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-04c424fde93ee27cc"
                         },
                         "us-east-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-038845ad6ddd8fd5c"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-03bc637634f90c536"
                         },
                         "us-east-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-050f074d9e54cbbbc"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-01cc372e84ee7681d"
                         },
                         "us-west-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-06802134bd5819128"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0e987e72d75d95440"
                         },
                         "us-west-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-078f1974505a1dfe0"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0e181e7acade58482"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-44-20260523-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260607-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "98ef98158199acfc92d4cb61c8ce3f8fff40de44a57f662db86aec8fa34f406a",
-                                "uncompressed-sha256": "e07a57a28f28096f74c8a716ecfd833fa2155aea6cf0049d424345bc9f3f96e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "f75b83ee510ffe9d427865933177091ed0353c0f825644e3a321618c27975153",
+                                "uncompressed-sha256": "bef0498519913a4c41c4d88b2a9e125700b77b1dee7163a3712c0cc97249afa7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "640e87a8796b25f1f3ef91a1474752eeeaf9c29c9c0792ce29fef55ad53a9d92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "49f2c3e6374f5ba5a4bbeaa163c1567c3139aad7fc0436670d0ada8f45aa36f0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "c8a5f3231b5204a152711d3f583ca104a8522741ccd05f5d4e88392e745dfa1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-kernel.ppc64le.sig",
+                                "sha256": "d336b41fc5a1e6c545212b65efc75ad40a2c5ccc83a247e59783eb0beabb5247"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "6430539ff6fa5f57fffa6b6c3372e7d07621a2035fdb7e575158df967b545c04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "a260e316949eaeac4d0eccd4847aff264ca6124d292daa0f29670f15e6492d93"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "0731bc193a4fe6746d33482dd4f6dd372490418a61d7aab5e526417c9a701875"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "0bba1bd7f470938158920e496e5fcbd9f272e14c245f3283b75db1154ec519ea"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "86c9660602ce5d8b49bb944e1af8bb5122673636fd088f6860c59db401b6cf3b",
-                                "uncompressed-sha256": "687fd96d897b546288d544473c6adade5180f7d8bcb624c96cd90b2fe8477af2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "0250dd321bd5a4cbbc26585325863536fc05af371e857ac0567cce6d277da33f",
+                                "uncompressed-sha256": "ff4f3950a92b049ed1323e496eff9dd8671a824ecc5abe9594e500cd75247c5e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "8231ec54d7eb9af1322ba4a4ca293d79a904f54ccd721e11ef035e8293bc00cc",
-                                "uncompressed-sha256": "8ceaeb6dc4c4b2178554523f3dce9fa79d8568d7f875f81860f2172c5a9161d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "ae8dc60e1183a3d10855ab3bd6c67bb030c8fe2ebf61598d04ce953200b8f9fa",
+                                "uncompressed-sha256": "7611983006c2cd8694fb9a92d1d276bb775434ec7e94484be04618683aeaa819"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "8bc0519ffad93aad02ab81a10bb4c9341766d1e3ede45045775ff35e76e7d541",
-                                "uncompressed-sha256": "c472b5a96677967f17374822a6fba813d41c8095973f06e1a9d77e67d11f7a03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "b1e1cbee6b3eb4f8f7c59084db716ff0992dc95e8f1ef10a1410e8601025e2d0",
+                                "uncompressed-sha256": "950c07dbe1ee5fc2092a3341c533fa826d65b3a33089903541d7ff7236d4f784"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/ppc64le/fedora-coreos-44.20260523.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "e3a4633244a1ccb4ba339abe728fa352e70fb03ecd636744e92fb182c62345d3",
-                                "uncompressed-sha256": "daac7bbb315408fecb7618f8093b108d9e0bf9c923ea2d0717b818f8eb7a3a4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "b7ee504974d7dae22341059e60331dde4f749c6fc50d3ba95b1a50f57cd99566",
+                                "uncompressed-sha256": "f4737107b1999b108a47531fc4de4220b0275cf396b877875e04a65c7f65b00c"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "91063d2fc39d0f8d926d9ef1b042124bdf6e81a97ffa1abc84ea56a76ceb39ca",
-                                "uncompressed-sha256": "8e7a2390484aedbaaa17e107722dd4b3305d49c15c5efc48b3b66c1680899f33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "841f251f9a0dc54510d24ab1f359a8e4c862286526c892d5018dc7ba36f4d7c7",
+                                "uncompressed-sha256": "e52e73c92bf31e96a1f6cb15cd328119c4219b13953efdba7e49c13c4ebc23cf"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "bd11211c5647842b273bdea6429216fb669f95dae95e74497213fbd5d6cab125"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "e0ccf28c74e3de697e9ed4b4df0cb714683fde462560084c864756a5c48a3f2c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "060e1827d2ac4919f663f806ec286977af7a08bff7245b53c3cca121f8fad64e",
-                                "uncompressed-sha256": "a3939e26532696ccc33593060427d99a219bb6dbef1892d5509600acfda8ed29"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "9eb385317687bb8a4a9f7c93d67dbda90917396e8b1c9f922a344d55cc4f395f",
+                                "uncompressed-sha256": "cf1dc0cbea147708043657b394f71bd2998f5a40f0ba681cabe24b6bde27f1dd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "2632acfc6049331097df6b417a03485dd457965c5f6c38b423e1373e5ac7b6db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-iso.s390x.iso.sig",
+                                "sha256": "de37151d934d218960cbfab5ed0b609006cffbf733695fc5a688c12777240d25"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-live-kernel.s390x.sig",
-                                "sha256": "f79763d82d6246fa460c3c80146f1b5a469c09babd62108f54389439ee63ff86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-kernel.s390x.sig",
+                                "sha256": "df85eeb1bfcab7a28106ba565d8975616cddcdf175d961848584ee57f9dd723c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "af3dd01cfc2142be8bcf88b5c2a450b57701d49d36d8871d498b1bf54f6119a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "b6ccc7d4ebe7756724616e5620b61394f55d7cd12c51957baba98bfbc393d7ee"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "dd4aa08ec38a945d1fa68a0ab00c7ab81d0a58da009d517a5051802ca3917a75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "acf6fcce805ea884c762feb7238d97c032077511c8806db10cae39b0a290267d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "b2909445eead28e16b3e7f1af5ebf7e9318a3e9913b8a014eb2586e6459a2c31",
-                                "uncompressed-sha256": "38ba9b33bf446981b7d7da50c3469cc7ec4fc7b293b7c93e7cbe9e88be8ad317"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "9678b076b7e3b2f973e5f13bf1b3b3a0fa9bc9cf8377551d621295103fdd698f",
+                                "uncompressed-sha256": "56fbc91fee0961dbe7f35845e2853904c36dd6abd5016a8e2cadbfed344582cd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "b964713d43df4b21666330f0ac07b1d97f468e4c62cc0746bd213099d6c51aea",
-                                "uncompressed-sha256": "5427e9a1c2ed9cff52432996d07cdbd37d9d0eb2ebf34a63b77c66bf3d23ee43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "65446f6707011da9da9dfed22ad38c573a244d5ce24db8cccfc9732fe4fdee69",
+                                "uncompressed-sha256": "5b3efda37b351b6064ce20ffae2856c1b2af40e6a4ab160d982867b1b01e4f33"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/s390x/fedora-coreos-44.20260523.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "173c56f2691e0e76f44d368f814c57ebef60f13d683a45807c89218f8919ce95",
-                                "uncompressed-sha256": "99bfc1f4edd2347e0d920bc460136d24fa88a83b494af1f344d0987d57dabc9f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "297b470530b5e16322b7d99e35b2babeca9af31ded2feac0f3e341350ac7aa84",
+                                "uncompressed-sha256": "0feca3fa5af499f5b972acbec7f6319f6bfc77008ab06d0c9c4d249163446b1e"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:f7671ba4324072b1365988c071768120b7c6cbbede5daa868acbdacb58b47a8d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2277ac19b218e1d696739cc255e7479cd6968407b78e4ab248364d729672b837"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "3b5d12a6ed70d0c2793553508e490027e09b57e2b9863df85cf029ebef8bdb55",
-                                "uncompressed-sha256": "20a76e7a4e8eeca024078c8ff47ec97f2f232a0c4ecbb371688551a2c2063845"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "5cda373aba353379912a071ac8618c4ade0a51d650b809a85bc02f6af5e26f34",
+                                "uncompressed-sha256": "8b7f57ca9650fccc3e11e1238e9941ddb974a253d599e44640fd0dd91c1959dd"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "6d458854486aa356da1e8d1ef93c31794242bedb9ea7d17fb99445bb05442fa0",
-                                "uncompressed-sha256": "7b7f578c73861c077aa04b5558d2ce6a6375a9068e6f91dfae51486410f8bf34"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "af3a338d44bb6f8840276e65b4300fb690ed03f07a1ed543ce112e10c7b86cc2",
+                                "uncompressed-sha256": "1411bb78c5a1ea0c03ca04167b169bcfbfb414bfc62f989dfd5c64527f61908a"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "04163b2601a10db5c577d73f1f4e83d302b3e7d6688f12637e66c06acb8b199a",
-                                "uncompressed-sha256": "daae79600d7e28149e7cfaaa3391961c4cc82448132e05201de0fa724935c53f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1d380c971ce27361cce9e12af27a723e6a1f401503cdc5dd3dc62c91644c5bd4",
+                                "uncompressed-sha256": "15da98cef337e3bb7260ecc6f0e576bc9f824f460176eec104c19476a47053de"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "f28fb4daa6af5dcc910617ecdc395a423c6eb7a61ea6ffc46e36a8ae57a9242f",
-                                "uncompressed-sha256": "8ab3b7f91d19a46271a8a223bbbc4ae98f34fe3a4be7edce9de8b404a5513671"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9459ca60c0e7bdea43df6209631fcc3c3f03fecd151bf729c2682b03e4b364aa",
+                                "uncompressed-sha256": "6aa99eb11510920745f92e517a0354e027b5be5e10f55341648743ee40d4d737"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "9e25be5b61e890355cda497eb233461871b0b2987b26a6e650afcdca3be079f0",
-                                "uncompressed-sha256": "43d14e8698081cdfd3b391a4adfb7240a70ca5c29a634bb56c06dc1acbb40d41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "423266ccedaefe3ae52ad1536686a634f356038a6fd821abe660fe6a51232de6",
+                                "uncompressed-sha256": "bc31bddc1f9d9f6061ef520504c8eb64a0e8449100a15941de222b75375c7bea"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "fc8d2a9a99b5f4bc46be8dd8570c0abbfffd3ebafd81409dcc17e84cbd25fdd8",
-                                "uncompressed-sha256": "d4bf1433d28689654e67181180629b04b848632cbcbac761f8826b1f2dc77380"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "8fbeb03d205f8a1b4cd0a943b5b9d798f9e287a2b889ac289ccaaa731c018107",
+                                "uncompressed-sha256": "89073aced75ea18a8e80f2d590c8a6b971de2f9ee45e93fae042de6585ff0e75"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "18315a72737c4d001d0e1cc0a0fee1d0dfc1367854644b49f38bc9396182a4d2",
-                                "uncompressed-sha256": "e59dfc3aa6ccd9ed6156521b3c5299a8e3d269e0eb9d68cfba2bd780d4098b8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "7223d266fe9f7c0f9e437d3e70413ffa0aef031c486817f2ae93d47e9ff0f781",
+                                "uncompressed-sha256": "115848b0c69d713536883dc874e88c10cbfedb505a5eb6e16b73816c8420f9e8"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "908448a1ac84ba4320ed961d6465526bcfe7c28b7deb3b92a3b7228e8838bdfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "1a0f40557fba6649404196828c279371a64f2e4f79bb5f0665afd4bae73ef817"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "4fffd609789420d723c1b6bc60f626a6279b128126396c0b0adb802e5833f7f3",
-                                "uncompressed-sha256": "4478e7c17d0e6b20d77fe6237ab78c47208332ce8567a894a96b23cc14c2cf98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "eb6d3999e887a0a6a7e602c0dc6570cb214ae32144e935c35c99ff15cc49768e",
+                                "uncompressed-sha256": "07a18bd79a55ad2103b58df5d066238521dd704f71c4d48e7edd53ebc05755d4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "0069ee173812d6067759b5e44d2da39d1cbfb113ac7412cc6c221cdddf30aabe",
-                                "uncompressed-sha256": "9efd2cd30d122e1b504a170a3747143819a1b8e784a64034934c53e1d0dbb01e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0e15ba96c6c926371f021e9a1c9cc823659cf892dc0a89c16f5aba00c929db94",
+                                "uncompressed-sha256": "c7e85c688236df27089163d859e33bc47187498b2bf8a13c761c4f58ca38cad8"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "8cebca3dfcf9e883476da367fe1e3371e14b17c9609cc027a9c1a555f23a115a",
-                                "uncompressed-sha256": "42bef2f8f16028961ee963ca353159467bc6861d99edd63ac18b048ba22ff60a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1aca8926f1aa4c252d778b67289ec022879b2d03de64f282a25521c4a5c3025e",
+                                "uncompressed-sha256": "c40f9cdee6a3d597b046cf50d716a25f25b02f249eee86a5133b8ebb4238cbef"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "f92670b4bbe3d29d15287bf239d28ee378bb8d83cc0826e04de6c7dcb79f44f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "915f173637a4a72ebdc1b553bed9a1a87a49d05d01ce24105fb4998367a4c617"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "25960a2ba1179d3b3e89d7c44ba2111a50d2a8fd71cdba25e9bef95b5b4aa5d9",
-                                "uncompressed-sha256": "5abdbee4c31df0af795b5b7fb7975c7b2135b2f321366e62885fff8cd24ece3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "7d978d1fc4a702b472d0d621a66c08ae8296adc14fe4cc25de4eac5bb8a8ab76",
+                                "uncompressed-sha256": "eb6a84210b0445a463e971f3fa8f88f88fe3c267703d2c6cb9aeadf2a2233959"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "a97117e1cab7b66396114b77a31bd10fae28f29c93b5cbf71ab479033626cd33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-iso.x86_64.iso.sig",
+                                "sha256": "f481b47abd80be04e7a457c6e3cc1847c6b66e28cdda023e5469a4d2f5f96aef"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-live-kernel.x86_64.sig",
-                                "sha256": "601d29ee241a50cac84361e03c7f6404b53d4000aae77f7c89709ef9154e8f27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-kernel.x86_64.sig",
+                                "sha256": "05e5f16566f0bea5d21fafcb623afbfde63b668675d90ef2730afe4f93f47a38"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "d13e7bf3728bba229ceda90a452666b5ad9c8c4c0ec48ee8f5a804931ff11a98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "7e9505546c820553a2e510367d1e1ff3bee827aab0bc9bfdceec8b98ab1aefda"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "a17d6da6c37b51dcae2a3869e1410b0090cc7c2640ee300a6751b7ed7a29a4ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "b984da75695bd78350bc3f38a54efd9fdc1501ba4dd9b62ed4d94c3c0ad7f4aa"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "892b80101e9be8dd1123bb67bf83dbb514753786ced309bd4c8d8f1a0d91550b",
-                                "uncompressed-sha256": "a8c585701e63b27f4d22e0013582bc6f9e2ea368776f4fa2e4944dab9ea3e9fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "fe738a563528f3488bc142e6f457c87734efbef513c37a8f58abb9e11aa3b247",
+                                "uncompressed-sha256": "2566e90a7653e7c66cf1c63d61fd8c66ebe54606d58d01a452c336ab7c858ca2"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f839d5018c7c653e1156bc4a694f3288064d3c10c92cc048c96cecbfa26eead8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "3a6def660ff85a0e06a5e6df20573e6cdcc97447325ae893c365ad9e2f5b9060"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "3edafadae26321691e6428e851cb8a0f4d1b5b6aebd0ab613956d8b6cdca651d",
-                                "uncompressed-sha256": "a84e911aa0d57ca4c3d602738a3401c77ce0f480999fdda95bc6a19972b4dece"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "ef36b1c880072d679e0ffe2c21b807ecbb8c9334e7accde072536d86bd0522fc",
+                                "uncompressed-sha256": "faa7665346e12db7973e364d4b950eba0106e7b860632d15f0aaf97ae3363c21"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "05c58d93a9a068a4b4195bfb0fabbb63b1c8e86a7def1115536af3caea024304",
-                                "uncompressed-sha256": "3b7eda95db4d3fdefe0fd9481594f3a988a82ee1f36dac0b22dbf12ea35051d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "907c2ab107562378bd951b5f0161b38052cf991b6daa67b93e65abbf30ee78c8",
+                                "uncompressed-sha256": "01f77da2220a37a7ffc0328f7b2e880479a9f731b99b6a32c29b34d7f52d3d6c"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "6924df26ecda552eb6f5c9a41b585c6a19ee764abf8a5bb33d879e07968341f7",
-                                "uncompressed-sha256": "cfc1c3c4a87ce994dbd81f80b82f34006265757e11045665d86fe8166900511d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "310759633a1a6b107728f7f622d608902ae9653481a1a316cdd101c0240a77c0",
+                                "uncompressed-sha256": "9780c8226bcd6fd64f0df6f071792f49dc7a4b5eaa027edf3dd3bd8a738808bd"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1ad996de992f9e3eba64d09ae5f4fc34935739d2a34f025b299a971902e96ebd",
-                                "uncompressed-sha256": "e799cb77ecb7c8f057f7d50a1717db5d97ec62c3ea504e3978df40284a6ec52e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "8799b3f6c41401b7d8f72a20a2aa62f8050efb18d2d0e8d6a23cb439e29e44c4",
+                                "uncompressed-sha256": "1dc0abe089372f57b6373c5eb8903e8bebc5a9145fe997037b755b1345b7a59a"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "ee28934c6e04b82553a0dffed12000199bf13089359d2ecee17856d451cbbf12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "163c3816067a82d01d1eca87209d54461958ad4ac169679530f50019f48f9bb8"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "e9462e5f964194767613b2b4019b9c5e29ab9d41c72662bce04f65c44fafec36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "563db522571c89096fe01b8dc15d36f2a904c47fc285e629eeabc9c925037ee3"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260523.2.1/x86_64/fedora-coreos-44.20260523.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "14be5e0789efa634291dbb52932ae6dc0f690176a14d2292c6108dadae32d48a",
-                                "uncompressed-sha256": "98d6d5b84a4ff5ab756d5f9651338dfe1a29fde3a3f162c37aac95becf06a655"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ac4e7bd32a811cc3c1ef78828a095789f76242bc54f6c2ab2dc23d0df5ea56e5",
+                                "uncompressed-sha256": "38708b8b7e60edff9c0f19bfdce78f4490b4f84fe43cabc34b1b04e08ad01e2e"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-02d85f8b6d73603d6"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-06d90716cf085ae3c"
                         },
                         "ap-east-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-058440819d3d7b36e"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0f516b669c7a624a1"
                         },
                         "ap-east-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0f911cfb6f2764707"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0b8c6893ac94842d4"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-02f44be9ce56525e8"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0f38e9a4479befc27"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-02231b2c09aab1b7e"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0cab614e0c5e29b72"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0ba8d2f69ff3033c8"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0cba4057c836070cf"
                         },
                         "ap-south-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0b613dcdf3ee5c8c4"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0fc8c8266671971eb"
                         },
                         "ap-south-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0f7fe208b12137019"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-017544d61fdec9e64"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0ad8afca893565139"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-05bbd28dad3219977"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0c7a424791ea1a144"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-07305bc66276a077b"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-02a5f3eb5b5bba95c"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-060b6b9f52dbbe7c8"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0e213a47443a7c860"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-04b7cc3d5cc85f148"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0139ba088034e9bdf"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-01311f276991bdbb1"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-03ebe8ddbb2875687"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-054bc716ca4fdc2c4"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-07969f65309785679"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-00753730afba5e07f"
                         },
                         "ca-central-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-09bb622288d17b2b9"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0c57b5b253e2f90bb"
                         },
                         "ca-west-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-05a8b8ef0f3d91442"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0fdb3abf2bf0f295f"
                         },
                         "eu-central-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0a8d72891cf20686b"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0eeba747eba78ebd7"
                         },
                         "eu-central-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0641b3abd70c63ddf"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0cbea50a54ccbe5e6"
                         },
                         "eu-north-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0e5f2ccb220e5cde3"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-05a403bd7420d115a"
                         },
                         "eu-south-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-069eabe76c6a646dd"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-082d3b04cf35e9760"
                         },
                         "eu-south-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-07bc0195b7f7dd75a"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0a63fa61c458f0204"
                         },
                         "eu-west-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0238c9336b6eb5038"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0e4058d96fb0b1225"
                         },
                         "eu-west-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0020a110a54519fb6"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0490aba91e1b9370a"
                         },
                         "eu-west-3": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0e272136c7fafa979"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0d05c4e4609f7fb3f"
                         },
                         "il-central-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0959355f7c74763d3"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0e02cf1e94389d6f3"
                         },
                         "mx-central-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-00cd5fbbc51067be2"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0366c7074cc167a9f"
                         },
                         "sa-east-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0e47b6057b02467e2"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0f4868763383abe0c"
                         },
                         "us-east-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0b90f38042e587c60"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0acd2cf2407160edd"
                         },
                         "us-east-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-02be95192d7acfb8f"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-079ce62518f9409fa"
                         },
                         "us-west-1": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0a939ae6be0c41817"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-061af1587123ee380"
                         },
                         "us-west-2": {
-                            "release": "44.20260523.2.1",
-                            "image": "ami-0bb75ecd1b006b267"
+                            "release": "44.20260607.2.1",
+                            "image": "ami-0d121311c115b9670"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-44-20260523-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260607-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260523.2.1",
+                    "release": "44.20260607.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b0110cceafa706eb784b4e9940beaf77047f7987d80bb39db4234d69553fccbe"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:95aa6959dd1c7630f3a71bd67789b500dbe2494efc01851f7678091215092e5f"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-05-28T10:34:09Z"
+    "last-modified": "2026-06-10T18:13:13Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260510.1.3",
+      "version": "44.20260523.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260523.1.1",
+      "version": "44.20260607.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1780063200,
+          "start_epoch": 1781121600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-05-28T10:34:08Z"
+    "last-modified": "2026-06-10T18:13:10Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260419.3.1",
+      "version": "44.20260510.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260510.3.1",
+      "version": "44.20260523.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1780063200,
+          "start_epoch": 1781121600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-05-28T10:34:08Z"
+    "last-modified": "2026-06-10T18:13:12Z"
   },
   "releases": [
     {
@@ -173,7 +173,7 @@
       }
     },
     {
-      "version": "44.20260510.2.3",
+      "version": "44.20260523.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -181,11 +181,11 @@
       }
     },
     {
-      "version": "44.20260523.2.1",
+      "version": "44.20260607.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1780063200,
+          "start_epoch": 1781121600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).