### PR TITLE
Roll out stable 44.20260607.3.1, testing 44.20260621.2.1, next 44.20260621.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-06-10T18:13:12Z",
+        "last-modified": "2026-06-23T21:53:51Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "097ed87bc761c6ce0e3030665e6e19e5566e2477f34e5892ae1959b2fdf2215c",
-                                "uncompressed-sha256": "211ee638e8323911689601172be375beaad93080e7e5a70fd430097cd796adf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "53eca6e3d0cc0acbd8b9c09bbc9a56c4f5d15cbbeb67819d4b96ce45f53dee02",
+                                "uncompressed-sha256": "713b5903c6e00753e16efa54e81870112d2d74912122c3ac0e1d3aa87bd64b92"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "0721243eed15552627f8e7da21a79e634e58822b01bd05cd87935d25a563c8c7",
-                                "uncompressed-sha256": "11e2348632f658010b7962e1dde06cf0488b1ff7e6f6d3465f56cff1dc18672a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "62059edcffe397f8c838e36d5e1788dc99fced0341b01cf8da9e8fac1f98f02a",
+                                "uncompressed-sha256": "cde0786ddc1e316dbf34ddf1cb70a1f2f3a8b7f154082cae6c7afd1851ad5d94"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "9419a1bfb3c6a9695babd4ea93148065f918fd5d5f3ec0ccaf8c5f68f2f57db9",
-                                "uncompressed-sha256": "fbb2979a18dd57ed11ca248c0a2f3381fa1471d8f834925dff35f1b440667cfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7b5e55e50b84d196ac3632d798f006c9c206da555c5c9144c2c7e545faf41ea3",
+                                "uncompressed-sha256": "b7a25f3202fc3b4ece9642ac8d938acebc99060f39a4eb86c55d16587f1b3f20"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "c977231b72fa25b6c62e999e42321c135cc7716ad3dc8c401127ddb43b2081be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "8404f7c98e95a6ca60bf578f58f2a441e20266780d002488a6eb21cbc0a151dc"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "4d79998fe2755a8d580fd57674543fea113067146aedce4913def2a38a270a98",
-                                "uncompressed-sha256": "9397e514274ead75481d392d9a267ee05197558860234d0c72b70e7ad3dd3404"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "776840fb4f0ea57e5bbfa764177d64ca5c93c6f696f7a0f03f8769057d5eb231",
+                                "uncompressed-sha256": "353f2c6b81f9e73309a317752a0fd2f8682f0fa68e18ac5c0ee1a6e1eb241d47"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "4453d01f53a48c4f472e109705297699d2ef4a9ec2e7690acea47743e0e85f54",
-                                "uncompressed-sha256": "b433ecdd5cd7d3023d0e0c01319dbd35011e32bc58893b545d3cf73e9bf0f73a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "bc8673e79c8df123e45f9d5663ba0cc955ee571946e8c69f0efb398975ff2dfb",
+                                "uncompressed-sha256": "67e4a13f0e2bf5f0498a38454f5da6a1df45601d7de33ff4c3c1673c93e3b4fa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "eceed3a2653a678ba37f56131c406a13d5d07b47a0981996fa701b66b7b3716e",
-                                "uncompressed-sha256": "d40ead4cd4d277e493498b2716f348e3a20a884ec97786bfc9d5912937f3bd7a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "47b02ba2a9d3a2870281c16687e45a121146cc4c4a20564fae37d395f5a31ee4",
+                                "uncompressed-sha256": "9f03951e62d3e3b4ec6da2ac36c8cb2a5c18ecd7fabf0e4646d05746ebc0d552"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "f7ec8debead78de78e56c1c399c2a8e52df3ccece6ea783c56c8562909e1aa08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-iso.aarch64.iso.sig",
+                                "sha256": "2bb08ca7a0d86d957a538dfe3c9eb4c13012f90dd8233cdbd442041b60f6e0ff"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-kernel.aarch64.sig",
-                                "sha256": "8fd6c12d431111bc017a228b3b30f18905e3a156c1a1d882e7daa2c5a288dd15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-kernel.aarch64.sig",
+                                "sha256": "01c4de729aff530638be34686e1d4553b6576151f1e1e3b38d83262f0d05a436"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "b030da0acfddf7e43124ceaa3b11c04eede8920ce03fc46ee93ce6bbf60f8b43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "53790735a42d8ba490d59d4fa5f79ae27663ef172d94948e645c69a597f06142"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "0808009a59ef84a32df344555c987de2fd0a71cc05c2ed45074f365048b23806"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "5c85ecaa8acd622961bf5d96080661eb3a748902313921f9ef4faf8e82114cf0"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "161045da24c20d3e15d30055b96a0ea6e131cbd036c7ef66e9b31cfd84680c35",
-                                "uncompressed-sha256": "f70d250c28170659fcf4fe754905974df04bd7172c3786d173ba9c454026569b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "dea20c89316635df883b6d5d8fb3bf092f8530c537cab54e4b5259aa247869b1",
+                                "uncompressed-sha256": "b06c24158b1d08b85f7aa53b73f4067cfa085522026c6c09185c3fce52b4bb6a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "df85b62581d0c9649647fb711cc0c1922f328e8cc963f3a4feee22ae8002f338",
-                                "uncompressed-sha256": "9d21783d1f4460e031b21c2755a946b4e1d35c98dd26ac53ea60c2494f0c93a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b835ba48162297bc7d8695d2d8efb39a495e4e27b1069e397b65a19df3792498",
+                                "uncompressed-sha256": "d367df16e6b5edd668008e4805e654d3e6f04b8c2c3d49603ac98ec18ea48e85"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "89de46a50518e1285ed60b9345b7ffd3c4c178a2f7d79fd1919401523ee9b4f9",
-                                "uncompressed-sha256": "634513c70060c753cec6d3407c210a4b41522619260c015e152da51e579b3692"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "c0f959260d94f48456fd8c57da4e3df83b219f14f0061f7b4ccb4086387034ab",
+                                "uncompressed-sha256": "fe966bf1cc49269279fbb6c98305be561347c424680ec3d589fb38252a14d68e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/aarch64/fedora-coreos-44.20260607.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e624e79657257c4c68cf4c4d5d249ea9333617978023fa12e4f83a6986641d32",
-                                "uncompressed-sha256": "42020affff1303bb52ba388d7e83bec226caddb974a51420db7bf30e41c81bd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "483d91df3304f401aebd6cffde87f7baf1060c95864a8e6203f60f61a0b59b1e",
+                                "uncompressed-sha256": "e7261d52bd09c7f11c2939f732b041e0f7e351cccf4d1aea1ff3296c93775d0d"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-05f887b29ae0b74a1"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-065cc712c0f98c01f"
                         },
                         "ap-east-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-00cb33f74bc71402d"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-00bda18ddd9d0bd6b"
                         },
                         "ap-east-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0fb95c30bebad244f"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-06d85ffdb5694332c"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0276c54f97f25216c"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-006fbcc12474799fd"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0324a368206e2c758"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-02afb3d0432af8a79"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0a8050d0bfb0549f0"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0875f58bbbad19c21"
                         },
                         "ap-south-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0f6289f8bc1da115d"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0d0ddbb468c76382c"
                         },
                         "ap-south-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-035de6ad66804ba41"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-01d4b64b8b1cda882"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0b54e848778cf6dbc"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0f28b56c8e96fa63b"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-07654b9f2dcf7057d"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0cf8516387bc652ad"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0794c8b1b538e94f1"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-02fea03dc53f31956"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0fb8358018377e747"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-008783f660914caa0"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0826082928e3b75fb"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-050e18a70df9355f4"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0f47bcfc1062f1b54"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-08e53395017efcc64"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0f1b3a99529b00e55"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-00807a5e10f7eb479"
                         },
                         "ca-central-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0dc47040f72f91468"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-00bb4fa9200f63f7f"
                         },
                         "ca-west-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-091971c3c9244d700"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0fd1e8ed9300a8588"
                         },
                         "eu-central-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-012584363906ca43f"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-009f56309cf20c092"
                         },
                         "eu-central-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-00e959acd09ab65d5"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-06871da669dfd7d8f"
                         },
                         "eu-north-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-04da158747a9317fa"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-05ca72cbd52f4a233"
                         },
                         "eu-south-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0277de25702d868c7"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-001aea3feab0200b5"
                         },
                         "eu-south-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0e11cbcb4f7ee2c0e"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0bb5bb94fbee4bb95"
                         },
                         "eu-west-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0c927fa388603f671"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-02330ca53e73eaba2"
                         },
                         "eu-west-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0d702d10bcf7c9164"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0e83ec0aa8ca51f31"
                         },
                         "eu-west-3": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0cf8923cd75ea75e7"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-093e5a0f664015b7b"
                         },
                         "il-central-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0370f087f5ba838e8"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-06180d8156f2e2284"
                         },
                         "mx-central-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-01f26a3371e8f5c2b"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0ba63dea409c71c18"
                         },
                         "sa-east-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-05c3e0076db3c0e31"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0b1ced8e0425df9f3"
                         },
                         "us-east-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0023af1678aceb2f2"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0288cefbf5169aaf7"
                         },
                         "us-east-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-098a0292534d61ba0"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0e9e77c6477555db9"
                         },
                         "us-west-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0a68a59a497e0150d"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0c2626a516b039e4b"
                         },
                         "us-west-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-032da03760dfa109e"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0210c45cab3245e49"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260607-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260621-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "0e1e7850bd28137ea3c8d2fe0600aee3ce83fdb7557bf5e22b60f0f9495b4fe5",
-                                "uncompressed-sha256": "8ab72695bb73aca0349fa2a8e451d6b4ac6909cd2226dea944768d7281956e1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "08bed7dabe3ae903471edc63d5c5b01d8f09ee4e4fa7bd4ea0c28384de091c8e",
+                                "uncompressed-sha256": "1dbdbae7a5f6ee06c59de97398a064283aa8400502c5bea591481af431768618"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "2091af7f7f6493a4c577143ea9818c74084b02632f878fe42d2a3648d34124b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "fd3857a7abd183018997af51d0acbc738e1264d9d2d1237e44264c5b50c62c96"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "d336b41fc5a1e6c545212b65efc75ad40a2c5ccc83a247e59783eb0beabb5247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-kernel.ppc64le.sig",
+                                "sha256": "d9363d0f3cecc345e63731c6add8b08d55fbbc5d741d4163542e589b6c73d17c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "43368737949dfd93fb34665c10a3ca2e8c270ea822e99995af9475b2280d50b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "d3f670b226bfff7fd220ab0ac7348c6e7a8db8e4ebf0c1ca18465f062a1a2c7c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "31eeb05eb3db8ac1b526ebd769115c1020e4ef4101c28f01a85466888ad6f033"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f1fbaceb0ef3edb8ede6d0546e9eb21e3a565d097eb90466e24c0083707e7fa9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "3d314c255b537f58c3ba89629f694ddcf761dab5d0d4702e9e8ac1b570a784dd",
-                                "uncompressed-sha256": "43c9622eafd60d9d1a423b6884b0f716db8a751c6d7868ed93a9493664b0163e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "dbf2af64f65296d4747b54f3f95558056115889b5bbe4c53f91d008c3779da91",
+                                "uncompressed-sha256": "46d7bce0945c50a1f6e4fbc2c9442375e07b4e3a708f0e7384001cb6ea295b87"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "6ec69af10da3a759b6cf98bdacac1e88baef02f97e31fcfd6473fed8c92e6246",
-                                "uncompressed-sha256": "d561ec47de91a350b5979ca8fe0c2c694aff1301465b9e8329e4a2bf893d4ef0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "994885a236bdc1c476d0689f92396de50d5352a82319d11e6a898abaee2b96be",
+                                "uncompressed-sha256": "eabde9af7eb87c7d07542c0cfff10083511300aeb64077dbf3e9f0d054b6e909"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "f399b3491697e157cd6b7242b96e65de407c762f0fc659ea6586b5c702e9bf4c",
-                                "uncompressed-sha256": "4362c769dc0e8cfca8b22e850a1cdbd88d7cf598b087beba4b63c2562fb6300f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "85ae9c5b8abfad5fa4054ebf3b337d6727cedc1b9660255e167acc4a6773c4d1",
+                                "uncompressed-sha256": "342ac91585985bff055af6c996b08043c9ab1a9b8689665d15bb89ea37527393"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/ppc64le/fedora-coreos-44.20260607.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "5296e4a9d1c79c1e1d2e0695344cbc0d21660c6e6f7c8450a878d8fac5444967",
-                                "uncompressed-sha256": "bacf7594930392ca05ea13a92d17a6558cd0bb8896f5f1dabf7f9b6d32600e88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "ade525d84693245340983a4d75861f6ec6632637d2699961cdcaa709882970db",
+                                "uncompressed-sha256": "1f8ffeb6293137314e59c82058c0e59e2553d98989d8085c1390be81ffa3fee9"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "9a256d54c09c47ac9353c4920c9063ee329074ba1c9fb9760ca63053d74eb008",
-                                "uncompressed-sha256": "74925808ebd819e24c2846ccecbccfd0cbbae21438d7f31919ecd1223d9d54e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "49a8f909e1de8152bcbfb53b34b9898b69f8ea890341436aaf4213c1cdf3bcb2",
+                                "uncompressed-sha256": "a2d3c40f63b47492668a33a24d139ead6af67e5fe5ded55b4bb0015f16ccaf5d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "42feb5e69b16b0472851b6df138011ee60eff09c1ed9b97ee35dc8aa062f1d79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "f33ad9bb0cac3ed8cfbbbf43c05e7c88cfd5820a22d23414be50d72ef57135c3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "70b955f766804918be02a70565ef71fb12ae086c0d353bbf6d53870a927a9f92",
-                                "uncompressed-sha256": "89675682c13eadfc3456194832f037a53991cfdbf564551430deb1bbf267ec69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "19fb78e894a86ebb2f1b68cd5b84a0947da3d584a987f11789382fc8f7bed328",
+                                "uncompressed-sha256": "11706c3531c58125087866fcc38e22381570dbd2550df9e5092113a303d4eb6b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "9a31e6fa96a284e09b67c09646c04a8393b9ae244b29a830af6bb74333016773"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-iso.s390x.iso.sig",
+                                "sha256": "75c92fc9c3983f7ed0ec6b27f8db98a3a7171174332bf7183fef8cd466a3b24e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-kernel.s390x.sig",
-                                "sha256": "df85eeb1bfcab7a28106ba565d8975616cddcdf175d961848584ee57f9dd723c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-kernel.s390x.sig",
+                                "sha256": "2ba3928a20274a5f95f2dbda6a5479c998a1459798827a1707bf7e8495e98191"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "e84767a45e6943073924ae3f876768ef95322c8e5493c3b5cecf94efe5274ec1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "6111f9154953db04dd5ef8b4ecd7e9ce76223b851bf8e172c31a3da817094a03"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "fa7583e79b1d28e81332dc3c61bdb252aa75f93c0ba1061d2b991e2eed35540d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "055e5643827d2838dcb402c7f6767285b25e1530cac56b5ed33c6ee5401ef43b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "22774bc9712f831594d136967d895a2cb67811c81fe1456bb225b396eb1189c9",
-                                "uncompressed-sha256": "ae9b57f2daa06585861ab8ceb2a8104699aeb95552808f77b9c3b1c3c52c95d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "caffe33cf13b75bf4c01390e2272ce496db0322e5148a7ec2f9646817d536df2",
+                                "uncompressed-sha256": "786024307c75f6d630836a2ef29bff562e609074c9003f086793e5f8377629b4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "968432f68c603b7b4a83896e7082379ab949b492978665332c6ed84d4bb1450c",
-                                "uncompressed-sha256": "184cae56c5a96c8710473f5523305a7b9cb1dcd252268f9d99a4b14732798b4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "5b43edb7aef8f801c8a312424f3bdf54db8d773501a505fbe76b4840e36dd958",
+                                "uncompressed-sha256": "936a77239617ad7e17ede7098f9965d0bb73c92c412ad3e9d1598319b134238b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/s390x/fedora-coreos-44.20260607.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4b8fe94c140bad31baba17c1e041b5fa7ab56a5d62533f3a50c2b5eb978998a6",
-                                "uncompressed-sha256": "f022e137251fb7a6d4f050a9f4e867d39b80321aa8a887357b6148431526b282"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4c7a8ebfb7ac45897cf38d9ec3c7609fac2116ae37d9cb4d5cd0ddf16476ccb1",
+                                "uncompressed-sha256": "f7acb4890a6c42efa959dcd7e100f4a2c04a16016771ec99f67deaf473b7d570"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:0eb4d09463bd0730e16898fb7ac263d5a5daf30b6add0785ec70823120f53f56"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d48653aec72df199420daeddff8ca415292a4e282a11a65d0d660657e9474349"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "10e7db3bea91b38c3c4ae64fd7c83e7bb2aa08a87429fb478cf7b4584af1c639",
-                                "uncompressed-sha256": "9f44b87aa510056c37091c44c1ca7441eb33231b20c6b1f90246eb4605873b35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8b53615fbdd4b7a78fb4a68bf33848eb6b0a2a7d00ab3b714c5248c5879f6733",
+                                "uncompressed-sha256": "301b3ae5372593a7e873ab6a3866003daa1b438c20e8ec11f8a02eebc60f0493"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "6dd00e660d22ab643e8e9dcf983d6f42c598b23ed13f399def0074f2823a7b92",
-                                "uncompressed-sha256": "3701102be798ecb399b6df9aad0f6ae1b5c4d59d9c74cabc95d675aca9918ab4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "9c17dbb9b45e397771b3015d5fc1cd8d85e169f031dd61895af60e31b5ea1d88",
+                                "uncompressed-sha256": "6092acced4b6af0309aebab40aaeaf1f17beebd1fc6b022437d7a5bc45482625"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "69b969c4cb3f16e86f295d239404af609e6f4c95964bc64b6574c6ce0c194500",
-                                "uncompressed-sha256": "554620f8860499d953e97b6a26838c330981b1174e1602db13af5d2109cbbf76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "3d602e565b054d5cbc02ce2e12bf3abf52b71b2535fc9b2742a882fb89e0ca8b",
+                                "uncompressed-sha256": "0ea09749852fd471e565ddf529974c564345ea5333e5ec483c8b488fa6130019"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c91f78adda35a883b957c0bbba552ff12fc9bfba3c2b4ad1d088180d0a739952",
-                                "uncompressed-sha256": "11e1f8886f46e27654f8fede6de43636bcbb6f42a6f70ceb3351fd2e0e788103"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9bc6ad85a11a905b2bb57ca8acc6c8cb621bd404539398261451205e8d2df8dd",
+                                "uncompressed-sha256": "a1e6e589bbf4cc4d5f7909cfa162c30d1b32be4fb5550ef5f8322cff0c06066e"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "924b9c3de5164e9e40feff6c3dbab4f4f61124276cb75fefdd47b237e809799f",
-                                "uncompressed-sha256": "6bdb1a57a39d656f0354ad22f3eed4f8319f9a8ded16eadba4944867d16b430c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7cbb396fef091c0dcdf301aaff32091b6ccc3d4191a927266ba956933b2ac830",
+                                "uncompressed-sha256": "ab8e651ae1299ca9684463652afab21f9af6b5a00b0bb3aa0453bbe48da63ed5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e81b0958e50e3fca1d52691bda87b94e78902939002a4698fc0fd8df78cac58b",
-                                "uncompressed-sha256": "80a8f2845b251d8ad61ea0a2c6640dd9a5fe7f567e9b95507310e622a1d7742a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "66ada8bac6e7cfb1ae458b344d07afa17e382507f4f361660d42e2b4e4d14569",
+                                "uncompressed-sha256": "57ae9975c2d1b305ac20bda77013bce6b1e3fe6c3d36aa3b9156dc41aa5f34c3"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "a57a1693eca1c080d4df6874bb11b8266567220ac7a7100a364c64455bd7143f",
-                                "uncompressed-sha256": "d2e8dbc653c8ef73d9fda6f75ed900df25a6b0a52b27bb93f089b736979d2731"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6d1d79d9e39cfca4cbde32cdaaa811749575bf23e21c0ec938e116033038dab5",
+                                "uncompressed-sha256": "1bbb22a282635e43c164ab2e2015210b00dda54d7a23ffac57f67d87632c6351"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "44914cbd8c49e800d5441a3c966d7e9e100bed9cf745b5802fe3a4b75b415264"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "8aff16716f1d33714f70bfb12a7335711bc9961046ff9f9ab64e76037c1d61d9"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "29b25cc86eef361addb9c73219ed1bcdcf4627e1d659fc7df296fa589eb685b8",
-                                "uncompressed-sha256": "204a8f9ce0f4069fd14d756e4dbad75ef3f5fb92d8a25dc5560a0d025ebf185a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "90a2c9ae0da57118bd94e76eafd19ddb231bbbc7218e5c97f6f86ba549f6bf06",
+                                "uncompressed-sha256": "7f33433a291aeeda20a7f92a5e69b5ac8687bd6ad0fe5a9272d9940ec49d701e"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "646efd56c7db7e0a9deb6c1f50d129f494f04833f602c02160535e9b67c96581",
-                                "uncompressed-sha256": "cd7df0685f34e416be23f33657f24ec234ea2f0c00c2edc913e9ec908689510b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "6785230d3a0a0cc149e32a2f3987a4effd6fd7db8fb6721d33450ff9e926051e",
+                                "uncompressed-sha256": "a75f35d8ee8ba5013f84b7b917bb39fb0c46c8e85396312a5964241f523a4751"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "9ac98959e72b257f012e23676d937a33e36a588f7a3e8b586443fe3b68821798",
-                                "uncompressed-sha256": "d59924d2fc6e3f07206b4137d58c18043ae48a81ec754a248d21eb88dd20717d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "0c4eb4bb0de451a443ebb061640bb04ca75ef111d6cfedbb7c3e0f6f8738cb34",
+                                "uncompressed-sha256": "e1b8d371a6fa1a1e4d56499ff69175e437e2e5da6b16eceeb75685e702f03545"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "5666a0c82440c3bfa7c402467c93d58797687ac58a795a0bd09382bf81c43493"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "89c71baf1453ecc58e4f9a47f630d790ffd6f6ffcd7b21962d5e90400b9ac0ef"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "bd7976c4d6ec87e23eeea6fd7698e79613694d571c92f97988d8dd190baa00f3",
-                                "uncompressed-sha256": "945d94a7aea22107eaa283846b1d79683699949e7ba9e28ffada08400c882a65"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2b6e25094914ad3d14e2dfa230e87ab5c3d564504a93f7403ce5c32c7a0b8455",
+                                "uncompressed-sha256": "ed5e13d67682f383c23f13ce14980999a8517a6197b05576b2236f0948efcb2d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "25a68d1ccb28d019ff7e8f6927dad11f8d8c0324c729e7acfc8d5a55501dbd5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-iso.x86_64.iso.sig",
+                                "sha256": "b8152e926ad081c147b2161f043937ba8a28ca8a9282730c3be16dfcce26c44a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-kernel.x86_64.sig",
-                                "sha256": "05e5f16566f0bea5d21fafcb623afbfde63b668675d90ef2730afe4f93f47a38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-kernel.x86_64.sig",
+                                "sha256": "5b26cf74177e2083c1521dcb0c5da667714baee33b71b4aac822c34682edf2af"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "b5440f25800ba806ae2444296ddcbac7d3dd14b626d4530950a31937cac89eef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "54cfa1e76d004c69f2f995bb950e18ca238ef402a7d0255ef5002a417b9a8c0c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "69c75dad2be87d9743a929bd1c42441b953d6b5f9d320a020c59f0731c0c0a5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "82792870482d67c1ba64ecbf75ccbc269c7ca6b607d77033fe19bf12a165acfc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "59f08e20e2ab4486911e18caba04b933cfea24725e4c6f2c5d73428051538960",
-                                "uncompressed-sha256": "d10dfc85cc047210abd0a363078741a9f9049ca99bf7231d2b80e23741432682"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "84da52caaa50a95c6c94fa5a636924161a97a208c2b24f1b41695b844c55388b",
+                                "uncompressed-sha256": "aff2f4b9ea3ae41c3646273e4daf009f81c0548c0a386bbf5c3a03d27b01b07a"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c28ad712ddb94adefe25e1c6032a5b833c0fd32f76ef12947ec1da973b7e2170"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9e8afdda738c38a97d7ff43b4c4168966ccf236e880017e8caa35ab4896e8857"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "88d21c15b52833aab832ed8bf434b8f46684a685de4d215c19b3c0eac4f83d18",
-                                "uncompressed-sha256": "58df440693e9c2cc24123b1c3422e61d2f0a902b729fb08742bf101bb44a4a2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "20df663da31a4941c5d1d01c60eff7299e963466bdcfc186e4be11531bf68b4a",
+                                "uncompressed-sha256": "2f51534156bd1ffce35e574333d320a47a7ac691ecd9c4ab49abed4eeae49a4e"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "84002a4abb5e65d7d6c076771d83a8823ef5ac449c7b4df6f68e925f27d22005",
-                                "uncompressed-sha256": "94b4640a34f1d572e98a307347d4b06ba0f2bbc61eb52d6047831c285cc2f3b7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "18e726c996a00149b714caf8ccbfa1f33dfbf243b246ad04e0f4dc2c67e6f965",
+                                "uncompressed-sha256": "1019c4f140a6c34342aef6631cd0fc9c82fa33e5e5aa9ed29bee36fe5f5fd22a"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "5b566ce88fd0e1c86847cc0f922965305bf5cecf958428dd591b2c9f0eac0d82",
-                                "uncompressed-sha256": "fe59c9d4ac59b0e635f9e083cdea0997eea11412fc0f25469f4a32664b5856c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "613bef6c7bec035a930770c0650211ff2c45ab3e20b9ff7ec51efe47425d7a3b",
+                                "uncompressed-sha256": "0e85d1bfad7caf2274ae32816f00003e91e249b092e9eea8acea79dc75843a25"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "3f669a0f237da175a367c441d71e5fd414185a8c7660f5ca6e458fb4fc2ef866",
-                                "uncompressed-sha256": "e11602af3d0a215c2a9ce9bd73016d30712b8e7a88b3760dd08a20e96ecc69b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7a6c8fef8a7d74c55ef5c805e9a9a48bde17d9946f13d218aab850d2a03d3caa",
+                                "uncompressed-sha256": "17337117d3756962d4090d012e1bc4945ee410251e11b713c1000e1d25efd1d4"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "fec9e6e1a87638f73c74ff9dbf9c3e4453ecfb5807fc17275708a2830ebb7b48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "29e4870c437ecd34a050242c82b04f4b58a93e68035dc5056c2798fe37e38ddd"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "1fa62c510c81c176b03a165ea38eeb5f6ed743e8b747ef1074f09fb918baa4db"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "cc8500d51075364eaa98707eb971d6ae53c3c53ed97ae35a154df6cddb6bdef8"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260607.1.1/x86_64/fedora-coreos-44.20260607.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "eabaa195aeb9c4aab23664c015b873c153536646e0321eee3bc268978e168f76",
-                                "uncompressed-sha256": "993d1475cad7c437bd39251ddc971d3ddceb1ed846e9d7584a02adec5ec0cd3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "730b0ea270cd823db259726642dba3112f90932e0b3f52398237353c99c38eaf",
+                                "uncompressed-sha256": "b539c57ad70e937b7b26851543b17d4dc61a9ecb6371355b236190dda0bcdc97"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0d15a66f14bdc571b"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-08e1f462413877074"
                         },
                         "ap-east-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0622d1586dd7f7f0c"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0ce784bfdc06b25ba"
                         },
                         "ap-east-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-050774f83e1b64998"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-061cb086b3db68933"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0df6d54dac269c6a3"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-04030b38ff172c52d"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-051924bbf194d4973"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0dc3219407b92b9f9"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0f408333270e1794a"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0768830915c89b1e8"
                         },
                         "ap-south-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-00a1d075a5375aa8f"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-00fd2f27ed7878451"
                         },
                         "ap-south-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0abd57d6247f82edb"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0c4d2b8da6ab9376c"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0daff1618fd0096c4"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0682482a88e2a4f9c"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0d094c2dfad0e47dd"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0d4a66689d046e613"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-086cc3c537b2c3aff"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-085bcb7f90edcbec5"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-031a0e1096bbdeee8"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-09fe3762db7f95592"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0ae52acf8fd254a96"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-080475cd3b62f06db"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0f2b473b17a22b22a"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0c4e4ca7d886a7062"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-03bdc20c67c581a8f"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-07e40286971c7a9a3"
                         },
                         "ca-central-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0474295522258a5ed"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0ef4626e204d4d617"
                         },
                         "ca-west-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0739b17a5aac82b28"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0bb03bde38380176a"
                         },
                         "eu-central-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0713195370423e30f"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-04a6bb99036f1343d"
                         },
                         "eu-central-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-03b23e8f1482c019d"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0f7e9a30594557e51"
                         },
                         "eu-north-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0af1dd97544769f29"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-02f1920b9fc2038e1"
                         },
                         "eu-south-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0ee95142a1b3c3bde"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-07d84e98cce95fe68"
                         },
                         "eu-south-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0096da6fd87aa6ed3"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-07d6e79afae2776c2"
                         },
                         "eu-west-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0252270f3a94e4a44"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-06e1a22ed80faa95a"
                         },
                         "eu-west-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-00fed975a9a012015"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0de414785da034289"
                         },
                         "eu-west-3": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-07d606e599821e31d"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0bd6cc69460c64b16"
                         },
                         "il-central-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-009fefe963011730b"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0072dc6a98890583e"
                         },
                         "mx-central-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-072f66ceb49dbd747"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-04d0d1663e7538d81"
                         },
                         "sa-east-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0328a4f83b417765a"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-020023a1882f2e7cf"
                         },
                         "us-east-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0b8aa540b676d57ad"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-02ce32162bb8e8330"
                         },
                         "us-east-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0a13be469abfc296a"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0f6cc7220c9dd1cfd"
                         },
                         "us-west-1": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0f105cb3eb91d0bc7"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-060d9960ce4573252"
                         },
                         "us-west-2": {
-                            "release": "44.20260607.1.1",
-                            "image": "ami-0b0500b75233f1347"
+                            "release": "44.20260621.1.1",
+                            "image": "ami-0a1f6def0bec6382b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260607-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260621-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260607.1.1",
+                    "release": "44.20260621.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:671263ced9fb8ec4136dca7aeca43130917dafcd1f3f07a081255f55126481c7"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b798773b99fa292588fffb42e10a7dda9cec9a43606afe934d4bd7aca1cd256e"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-06-10T18:13:10Z",
+        "last-modified": "2026-06-23T21:53:48Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "1be595f017149a4eaa9f588e996f284d39bc3fd57e18f549ec3b72ccea35cf62",
-                                "uncompressed-sha256": "917058c6814828696c3f343cea4ffc10ebdc23a5e00ce1a26446ad49153ca51f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "209cc3a8562b0e80af332cd27a1a0ba168ea9805219f5b9622eea76e5e773996",
+                                "uncompressed-sha256": "47e43643e382e906e3bd7721ed78d69c2753bf3d95d22b956e4062ac6c578e50"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "acbfdfb95e2bc8c217183222565693ca4745604b33baaa4cca5e314edef594da",
-                                "uncompressed-sha256": "49bf38f4f04c2cb196f6e8784ec7586b6a0d46a288993e3b72f9d7b31fec6aa1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "ffd24f5e6632b497d1b26658dc257b47e370f2834401036555d93edfc69b19b1",
+                                "uncompressed-sha256": "5d5cfe0c4194afd542b0298b14f8ec8ad420b0610c13f3e1f87cb589d687fb40"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "c71c1d25d61f33af338a7b294b4fe1e9e501fcc7017a60a86252a573b776c5a2",
-                                "uncompressed-sha256": "1dbfc4fae548df52659359ec0312c1c007817d501f83c10d1fa10e7ff293c47d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5eacbf4508589518e62b8deba7840906be1dcd587ee340a9ab4150cc1f621e0c",
+                                "uncompressed-sha256": "84dba6f79cfe72ba3f7396ca6a19203e62fbd77e816d4862e73a8ec147099add"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "1e3eaa11eb8a55d24f5c0d2302d483d51f43a6f014cb1851283b169fcc04cc75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "d99d79dae464c92765a7f38fce4add8ee9998cc12bf2f11d141935218e64b893"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "85029e763cf9e68ca096f86d8bb11440c79e6be69ff89e002da7c2156194af02",
-                                "uncompressed-sha256": "f853d0fe2780c750429122741406b45075b0387c226a442e019c09fef3a91b25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "ad8a71fa9ef3c48ad8f976a7551ed8fba64037df63bf36d53bbd7ed330b2c8bb",
+                                "uncompressed-sha256": "0705c4441d720eb64e2c0febd06873866220a7f9d67690c6c997f991dd88bfa9"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "de1f05ea43bb3dda60b4836ed30a78056b1587e8a639f85dd010941e6c2b745f",
-                                "uncompressed-sha256": "222b0706281cb48a417ecdce5c72e40699268636b6aa15f45b922b6472062bc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "38069cf62e55c034def9cbded4a74070ed70002fd6e88fbea1f2be182539c4a5",
+                                "uncompressed-sha256": "f8240fb31d5ce4454794602846abe5e8436a715c02d3f2093fef56f63f51f7d6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "8824344de6e69d774d38227acb5dd1bac1431687d5b5a2d9226aa15eef59d6f8",
-                                "uncompressed-sha256": "728e553ff3b7057f68b48eb3c4f3719bba1e355728ffb9cb3cf7b2c9528e6333"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "2de23ddbe36904d074a1ca1ea90e68e08791ac37fc126279ff521dc2054857e9",
+                                "uncompressed-sha256": "d6f39a64d7c8ac2d3d6370dbd7469cd2b2b1e129702e0e4aceafbf61c7d4c6fd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "850b01ce4ac8bfa94e2e38b2eabeaa202427b27e6ee62c6d16c66010c86f7584"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "7c98fecc0832ed4a26f9f0837a566f2b51c316034925d7ad93591b446ea3912d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-kernel.aarch64.sig",
-                                "sha256": "d0ebda524533aad795045189ce8d421a30ba687929b537b7cd1b71ebfb129893"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-kernel.aarch64.sig",
+                                "sha256": "8fd6c12d431111bc017a228b3b30f18905e3a156c1a1d882e7daa2c5a288dd15"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "88d9ce43912c1967a330529383556bdbcef32800a36c184a581d0ea6402efff1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "0b756817f5518674688aca2d92cee297962959cf1f172fbcf5c0bd5101e03174"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "09e4f63fdffb76c32946fde8f41b8bbedc54d9a4aca452216b2766b0f1636b53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "7ab70505828322300dd6081b0f35720c3dadea35c2ef4ba30d6beb9452e3ab77"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "d9d5f6d99f005d51504d4c24a4e72cc00de79d6f388f3364a63cabdc482ac421",
-                                "uncompressed-sha256": "9343ccb8451c7a3388551ee0cedf4e20d32f4931532a26d874f64b7ea5c23789"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "7adfd3ac47eff90a318bd777ff22557852a0c3ef70b86c2cf9280a2ebbbaaaee",
+                                "uncompressed-sha256": "460423d52767efe6b9163234d02ee3872c094edfd6137b81db87eaada8b6027a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "0a8bfd00164275be86dbd8ad4d61565e35fd812995cb6ab747f62d605d65d941",
-                                "uncompressed-sha256": "8189032e624e5a12dd4487fb04aaa1c2bb8883db2cd05fec51796efc0ef90554"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "911919e13ed307d375ff26e6840589d459403c9ea14b120d09ebba57e3820c8a",
+                                "uncompressed-sha256": "46ff5f5e13701760b8edbb0a28b77325e211d664024ac408dab60b6d5604a349"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "bf3c0167e1168b729feb480e0c9ed9c601edf3791c99a2de75e803a8346e90d3",
-                                "uncompressed-sha256": "3517058e43732dc27d42a94148ce8f6ca7660588684d460b6a8b8f64fe619ece"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "222ea9c912554edef4d760573726a3fb5c02cbf5da5c4a5672b9dd91d87f84da",
+                                "uncompressed-sha256": "083ac627cd1b66765ce03c3aa54c2f2d1aee71770e5808d1f6468f7f52b0b539"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/aarch64/fedora-coreos-44.20260523.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "8afa8aafd8c53a12cdf9fb31d126abb7f4269fed780cac7f30f088b3afc19c9b",
-                                "uncompressed-sha256": "02db86bd279d4417b51b0c29b3c87db1eab4054629cb6cd8a86746196d95ca27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "c44f7e7ccba0dbcbb2d1826d35268555d2fa468ca9002c89ca3461caf27a320d",
+                                "uncompressed-sha256": "0c8cc4945fa4dabddf9fbaa8a2f17948d29f3f1c56f0ce7093481c865df1beb5"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-077eb48d760e6ee19"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-01ca24ca3923a896f"
                         },
                         "ap-east-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-077b0692025af7c35"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0368c633d0836d3e3"
                         },
                         "ap-east-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-01d0dbf78c1468a3d"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-06a01e3303dcb44ad"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0cd40bf31f8062f70"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-01133269061a7890e"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-09e36e03939a2f556"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-012984e10eceef7ee"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0f358969b5dbf91ae"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0f10e5b59d9e311a2"
                         },
                         "ap-south-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0a2e7009edf08a0be"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0722759cc3aa10004"
                         },
                         "ap-south-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-05006d466c02b80e2"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-04b425ae2f27330c6"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-02baa2be2919cf625"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-053bbcc18c5c293d7"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-04eb94521030888d2"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0a0b4b4de655933fa"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-08c366ae826aaf38b"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-014032de9912f4e1d"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0c0895a8a522a09e7"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-033521244080dec99"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-043a8ef2a7fd39b3a"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0820ce5a8e9eed054"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-03f01ec46c29c57aa"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-093debc32134fc2c5"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0da3c2fc3faa3e5dd"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-019ec65346a182a58"
                         },
                         "ca-central-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-01b41b03e586be5e6"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0d8025b23d8341785"
                         },
                         "ca-west-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-098334f56f6cded7a"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0a7fc03185b4df3a2"
                         },
                         "eu-central-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-015af216ef72d93c3"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-079feff2686c599c2"
                         },
                         "eu-central-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-055653a5e94e05246"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-07a6e2a64a48af63f"
                         },
                         "eu-north-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-04f04dcf0a3832fef"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0939a68a4d6e2f0d6"
                         },
                         "eu-south-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-01b01896f4ee0614e"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0387bf8a9798bb0f8"
                         },
                         "eu-south-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0943d11852557f362"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-00440a10b53380f5f"
                         },
                         "eu-west-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-079d74064d51338d9"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0de5b91779733decb"
                         },
                         "eu-west-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-06affeea02fa5416b"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0e48312faae427e4e"
                         },
                         "eu-west-3": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0fed4ec8b4fda62b4"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0e7508e4075a70fcd"
                         },
                         "il-central-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0579b7c11db134e79"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-06594814cc250708f"
                         },
                         "mx-central-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0877b91220701f029"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0b6b6dfda238ab704"
                         },
                         "sa-east-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-050e4f154995c90c6"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-077aab52b41934d18"
                         },
                         "us-east-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0810e323926a36833"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-02dc38499a3681cec"
                         },
                         "us-east-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-08211606875693329"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-078fa5da4dc775918"
                         },
                         "us-west-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-045f8da9224da48ca"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-013abbc78d72ceb02"
                         },
                         "us-west-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-064762e6c461b4cf5"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-079c5f9728898099f"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-44-20260523-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260607-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c47925eb65718fd93a0dbb1d177f73a3746a57427b2bc0afcf05f31c25ec0c63",
-                                "uncompressed-sha256": "1dd3602635bbfbcd47e7c274afd332b35060423dca4c36ad982028ffc4bce128"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "7be00dce4915fb4722f226a77a47e1acff4a69365ffa0af5f93abbb36f313f07",
+                                "uncompressed-sha256": "8e922cd491920dab9ba41bd7d506da6a94ef70f848c5d06f615c9f03c71352dd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "6ffa3d83ef6cb140a60c36797150b373a1449bedef4eda6a2600762585c62b00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "d1495b5f0ba6e51043062d2507856297a5af1550c8ce0e53b1c4db3a87e5b10b"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "c8a5f3231b5204a152711d3f583ca104a8522741ccd05f5d4e88392e745dfa1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "d336b41fc5a1e6c545212b65efc75ad40a2c5ccc83a247e59783eb0beabb5247"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "0ad559054c3ec63e838dfa34150b23730e108f8ae419a338df8aebae8b9e176a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "ff3774c407253267df6c42900535db6ba9552c9bc6b8a12402ddc50cdde95909"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "e8c992e1b7f830e1a1b9ee5b450a4f30a918125269e53f9d2e09592e56ff0f5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a29fd938a73a6881e1e537796b629285403d9d67f369c2bbf479cb0cc50def58"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6976a5ef920c7e3a5b62dfc888c70d572af6284cb18a95d387b7b3396f46199b",
-                                "uncompressed-sha256": "c66cae39f41ed14d9f2f921c24ba3dea228fab385beab9304a482c2dedf8143e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "944b87b4b72b180991185b7994bac4bb58aedb7c3f9b8acf189861705b80fb0f",
+                                "uncompressed-sha256": "167cb4a959afa80d2b47fe7a9f637503c63e53cb8135b4739a53c36a58825695"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "019771f1a06634c08a788d5b39fa722cbec49111abf21afccb505f837a5769ca",
-                                "uncompressed-sha256": "444ecfe01044e940febab7e56367424e6171c47752f8d5b39b64c8ebe2857e32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "3b6dcba0cf0f6b543e7dc5903fe89da515c089ac305e0b0816c22acc2dc0e966",
+                                "uncompressed-sha256": "00bdd66e4f9c709181754cd98bdad39aecbeb285da130acd0946d2608244f080"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "5af99103efd6c1a4db4518e7840f5d526a76fa6ba9377e6e628568b0a559e1a9",
-                                "uncompressed-sha256": "f3d018dd25d663e6798258ecb1166d8a8236f3105908069792349c92bbc5df49"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "826f9bea884f38e646993be6cb493d713e615194e31c405b526846ff6f813a1e",
+                                "uncompressed-sha256": "d42e096ccde7df5b228bea6c4668c9a2dbc113022f7580cd5ca6e5d5a752a9a4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/ppc64le/fedora-coreos-44.20260523.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "af50734dca3579ee07e6029afcedc843405527657036d0b98932ed2d60d6f050",
-                                "uncompressed-sha256": "e73e33de9260033f1a4fc6dec8f593eeb2d761f72c4b00b7ad6dab8208944f07"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "bb70817620985a9b6b8ff8cb518955281c1ef3b7df3e07d0ec306c477db15054",
+                                "uncompressed-sha256": "a0cb64c3af2567464f8455bb5a035c024adc40be0089be25b3b3dd4ed9aadfb0"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "93d0c0acb8e0dff162875e4e0f37e6e286b44ed610daaf2de171320132b959bd",
-                                "uncompressed-sha256": "325db3b7402977591ccf1adc32abf50d7b1658197cfccba8ac00fce009322594"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "3bcb9f1e5f2ecbdd3dad14d417f70d9bfd0c27a76c85a6950c8f419cde925144",
+                                "uncompressed-sha256": "cd2ba122c5b05a627ec624bd37fe9e85c82071e8f34994c4008805a3aaefe1bb"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "1ee79810123bed11db8df34b468f2f0dc2db1cc3efc7db6fc74b6e553beef029"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "b27aba3927aa484abfcba0441c3b428cdefa3c5f26db6ab4f17955369580f599"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "012874e795503a2a01331e7ff02ab302c8eef7955ad72d9aaaa147eabcce1ae8",
-                                "uncompressed-sha256": "79b81412a0706f6b57c361eb88f3cbc974d9ddd5a99b48fcaf39818c516b149c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4337af97bb0a5b5c2167647718db9d4ec6dc0c69b2dc0b3e7260d987210f56eb",
+                                "uncompressed-sha256": "d8b75dd5fa5c9474f2891fb330be36d7d15541accc479aa0d109fbd7aff9a2f2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "bb30e6063e91e65ebdc8f6a82c83f1163ae89fcd6e97d0ecafd63ec3a0a0f860"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "b2936ddddd8dd39b49036d3d67f2d9a055ebcc9c43ebc26f0cecf7bda46711e0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-kernel.s390x.sig",
-                                "sha256": "f79763d82d6246fa460c3c80146f1b5a469c09babd62108f54389439ee63ff86"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-kernel.s390x.sig",
+                                "sha256": "df85eeb1bfcab7a28106ba565d8975616cddcdf175d961848584ee57f9dd723c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "43ddf858053b0b30483bb940cd1e21987d00e3a1df5dce24d33a83284e7bdf6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "0c4547b4e2ad5ca53d5b4f945fe4ad09fd4a972ddb34e95f0159790cdbb40b0b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "3f04b781357948ee430674bab8bc88d410803ae7d31a62c39e9ed511e2de2eb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "177c20e882c07ad942409f12a00585b1f3df4501f20675971c12f1383647f040"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "04be998bca47aede47857ce45e1da4558ed3248ef180ec0ffc834d824f98edf7",
-                                "uncompressed-sha256": "4ca135aede8ff89daa7b349eb30e8dd9dc7dd7d4e890093a9be0372ea215b8b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "06969a537eeee247aa33d0196dff1002c52092fbf3cdd57af60e3ce1abdd582c",
+                                "uncompressed-sha256": "f7712ae5ce6fc0d67b90b23e8fd6bc84edb9655ae8e846e3267f0683596f0339"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "736e8ce9b8841ba82c17a5c69a28b46df587056bb2f16e6739a28ac670dd7da6",
-                                "uncompressed-sha256": "742d608b6552ff14755596e1d2e059600854e087fe245e66a71755ffb46149cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "3cd2c1053a51a8c0dc9486cfcb04ab3262254b876ff44d22b1228d7a719cf117",
+                                "uncompressed-sha256": "896e249acacf58e7716fe73aea5ae06e77fbbbbb408e84d5cbc54a9369c75771"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/s390x/fedora-coreos-44.20260523.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "a4e6fd7179a787b36f7f80382fc1fa602f07ead1e0b04fd9dba3eb62cd2ec5f4",
-                                "uncompressed-sha256": "5f5b58c8a1b111cd015ab8c5e344e527c80112352fb746133e7bf41d4fb598cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "8a58da2cae3981680c6a34d9ba498b1bdd51395f2ad5f78292f8097f68e8d958",
+                                "uncompressed-sha256": "153634d33579702c61c10e3eed21015aee06a745f37961f40eaadca72987a671"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:04241601f06967df871bcfdd363321cc2489aec468f0d1acc213b2c8e796f9f0"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:fcb5238ce32f0339027bbcbf8f8c3317a79025adce09796c271bfed65021b8e5"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "a7ef1cabe9d8fe1ea3b53d25c397dc0e1e6d6827894278c7b3e289c1789eae71",
-                                "uncompressed-sha256": "2e35348855371487db841fcf4525f17f6eadd0b63724c9ea87cfe022e415035b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f3b5417b0c22057229972e50c7c3ba0b8b8674138475b778f02f19de734133c0",
+                                "uncompressed-sha256": "22de0a2d29372220dff7c3c3ea412d303908df8ee9bea99e2d835c18de4cf619"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "522faf91243dbd2d34d4d95f84eab1058c04ac6f2e2cd63ff99793d12ba9f7eb",
-                                "uncompressed-sha256": "e1f4f726b4e2738368a96f7c65ed4ac0c2fba6594cdf84c4fac6a3ddb4d2a75f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "5750c5aa68425e03f1c24c3d4dba662e105858efdf2ad9a30e4ed4d7aa52e30d",
+                                "uncompressed-sha256": "8977843fdf5c69930a7ce8d9d45f3b56aeb82f1f5a6216aad346ab3ba20e75a9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ed1108284febe762eb0f8e0d4089bc8196026b2684f16aaa31100bfde32512a9",
-                                "uncompressed-sha256": "c22a602ebaef7a7e87ad2dd3dca11d977c01d1867830d3ca395bbcc659d40c75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "7949c6d1fd19d080ebb1b99e83b1970ca64d18610d6a3621febfbf529b0600f0",
+                                "uncompressed-sha256": "edebe891fc144c721adad5a9e103d2695e767eae31c2799d3cae505cfc3c705f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "09f6663c645e43d97b97ef50547f804bb35443d8e74a9c8bb4969a0a02168520",
-                                "uncompressed-sha256": "4f849036b7bb393bf6420f97fd34601e211f3f510bd7bd14ae7d18aee61787f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9324c70dc4d57fb18c916003ebad3e7af0a1dd53c0d96bf44287cfb7504f75f0",
+                                "uncompressed-sha256": "834203880263b7b10ae79017627b1b523fdc14c3a424842843a0582d27db1451"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "1526d567ab02f4a9b628460f5b6ae18cd3e28a66f7e2754ac8bd3aca74758a50",
-                                "uncompressed-sha256": "6adcba78db7c22b9e5637ccb59af61e6270bc99668422106c8bf08e593eb00e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "41bff415245805b5fbc3cd13f63679da3cb7f7354ae3f87975fc66aa138d6d6c",
+                                "uncompressed-sha256": "df26c1ec18ba4a1ef03b3f9ad3d0115d230d83283bd923ca9fc4df965fa64639"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "db0513b6485af91cc1d834c3b826defc2a00050af33d984ea141befe06def4ab",
-                                "uncompressed-sha256": "5f9d38b4a4d9bdc3d3d8ae4a819738a744af23a08e741c5bc781f7d9481e95de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "3348a6e8e7ef7ba8664dadf8f5185ecb761616d6081bb46f18048ac4b37889d4",
+                                "uncompressed-sha256": "62136ba5e78f9241303ccc8f3cf0de0eba88eef158adbabe2574704cdcbd2898"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "29ca0feb192e8003d34b3948ff3f451707f2c10fbeeebafa836d9625e6cb8ad8",
-                                "uncompressed-sha256": "5f715563a1f7fb61db0254631f50196edc33e926def752d228cb76b012d44eef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "e7c160b9f15f36ba6d92b45dd30f4d78c3fcf6e0dd67ceac811c143679f3ec9a",
+                                "uncompressed-sha256": "9a8b4e198466845ac311b997ea23d1b7c05c6c1dfe8b1cecea4bc989333bc697"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "805e1a6ba66b2fd5b04ed8fef293c395bb26e85e6cdd13dead94567dbb757035"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "082cd19b32fa039cf9a236700a47b3285ad35d872f82c76b641cf9a0cb44d15a"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "2c664c6a3826704dde713948850258b8ea93c83469f5c23cd21f7cc79b7fda30",
-                                "uncompressed-sha256": "8a87b13425df2e094266575b57471a2501d8ae5c4e6d4ea070fe502d3dfbe4f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "f6b6f61772ad946b2174e97d17b31b69713cf1067955cd2a4500538e079bddcb",
+                                "uncompressed-sha256": "c311de240ca6673937867f5914aa4c85c89fbd8e5391f2e160a955a5a67e663c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "62eb4c0b8f79c3e3750a3f438357a3d2489e91f71705c2205d3b25a0a5dfcfea",
-                                "uncompressed-sha256": "85f661a73b13cbbab136c7760470f36ef28a9c22f6ab2782c6fc435815f5840d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "08acabbd10e73f9702c9b915150b248ab81306501a244714aa0af12913399add",
+                                "uncompressed-sha256": "130438507f8a2bf64c84802c42296bbcc8f6d50348ebb0387ef4403ddfbaad8a"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "070d445d188260420342616a11585b731a9fef9217d8f5b15d05571cb85baa8e",
-                                "uncompressed-sha256": "d359d2aa530d80a7a7916c00f147244f76ceba0560658d0578f20bcc2ec64ea7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a3f8c63d0bb084da0322271b7f4e8aad7724a351eef9a5b29bfc07d64ae76689",
+                                "uncompressed-sha256": "ce454a308d75c6a1229359e6617d758e7e984cb494581e4a0bbbd7e544704159"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a73f8bd3a0b69a30653735d5e21954eb446bb07581a0549fb8d3094bea66f007"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "2f7923952bd212676e8f5e30aa1031ad52f941eacea950c78aedda0ea172d821"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "d2b12e1bace6af53fd18e2264540c15290d2a5f451d365030c013ac06f343279",
-                                "uncompressed-sha256": "4dbd878df702406f184bbb63fdd5378b2236edd25b47767a4f8dfa6bf7723918"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "e4891c2d4143be186fca62d8c5313743c8355650e3f1195c9b41fe16e48593e8",
+                                "uncompressed-sha256": "40ac6b784167e838d849786c3cd01bcc9700523a3f12bb1d10c0c4e10b932c3a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "1b231a04c6ade01eec35d48ec78b337be6b2552969a2ec3460a3599cfc18f6e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "5952237edb8dd54b30a11ff1a5ffef35e027ef449650a0ff427ce08c5f9080da"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-kernel.x86_64.sig",
-                                "sha256": "601d29ee241a50cac84361e03c7f6404b53d4000aae77f7c89709ef9154e8f27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-kernel.x86_64.sig",
+                                "sha256": "05e5f16566f0bea5d21fafcb623afbfde63b668675d90ef2730afe4f93f47a38"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "3229adf819a8d0ab734902baeec799c500b9c91baf6a82c6089c72bdd63d5d33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "2a46f35397047be19e03c3bf84cdab8d394846df15c96fb38954ef797a28c9c4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "81851dacc308412bea80e116b2fff6d00d7e4b0202cf44477bcd4e1e3d6c6211"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "2e9608ce064c674156748fc8a3e4a43edf0c36b40bb514d0e51ffb128af0e012"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "7515275337e781f29f614bc463961c0d515cd3e514bdf0920e81da85a44e8c07",
-                                "uncompressed-sha256": "886cf49512c2f381cf99ace417b8f25e182de4dd317bf03c2de1c66aeaa97b0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "007830b6b7a1bfb4d29bf15de61eccfa6434a1bf3a10510ddf2c073f9cbc6154",
+                                "uncompressed-sha256": "82133c4d85a0d492c77dd50008071b54270e721206ba05171e31c76dfa5f5693"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ecfb1ca061c2168e6d7641e7b1489b6860201c9b1fcb8a1e56507ae1988e40bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "9b508701b58fe798d25d16d9741a9538f4923238b4c5eab5e7f055a9f571bb81"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "082e2bb48914922b96e76d963b24c715343ffc27c5cf586dca147a92c765bb95",
-                                "uncompressed-sha256": "990f66bfaa842782c8f85d65ffd782197673a32a0fee13a231613b7600a2396e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "4b7cdce0bc2b5138abe49ee9fa581f1f4bb305438a3313f10f312776f5ae7453",
+                                "uncompressed-sha256": "cac8c919d94a24d310e1683bb1764967b2e3e8fd19f68bcff6a941f328bf0f3c"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a3d861e2643fd29cb8286ac6670277fa2fc0c4aa95bd8e3f61401929af84c86c",
-                                "uncompressed-sha256": "e25e4640ec1ea3eb49a341fde4c4eb863390566b32fad3d6dd645bcbbafb3fd6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "a11d4472586b118cd0dc993fe8881385a5f061fb5e537fe11f3bbdcf6dac20ef",
+                                "uncompressed-sha256": "0fc3c70c541071f158d557b6590c65ee5cd76e86f2faaa08fdd5057f05820d22"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "683aa7fee0dd35659fe5509b7e0b1a46aa3aa1aae14a566dc356226372c21bc7",
-                                "uncompressed-sha256": "b2d3644dbed6772a0c21002b101ea5da5108448619ccf11b8c0e2e3994ac3bf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "30fba74d4bb329d2c49bf6eed4349856d4e50d969e8ae4fa488ae1e6bba723bf",
+                                "uncompressed-sha256": "940cfaec230e743f7d781fb036a117c753d06ffe30ff8cef3b991807aa73b279"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "b62d2628784723c342be8761e6d02900413f94670e7d41cf498d4c35c8befeb7",
-                                "uncompressed-sha256": "39c88898cabe7f5c9dbad15eba0833b89b5474df4efcb47be0f856c1a409c8c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "6eb083986174ec4b0e588314b9c94947a55a01a8a2d33e2fd865e4ddc6e81e38",
+                                "uncompressed-sha256": "0444acd1b800a1a6b910c1963c0967c2ea03121ec9b200f6acf1ef7fa7c93be3"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "711ccce82f400bd28c5ab94397446b6616c6de2e31f37edb2ebf90b1db464d60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "ecd0407802c0b07f7c7b1fe64c68752a9b4baeaa134087fac89e7d40bf23d13f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "790e7643142249ea5b4fda19cbdf026eed858aae398ae7186eec27c492620653"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "0bf1c6619b2eaba2d720a032faae456008f8b75b22d79f1c3e29abbd2636525c"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260523.3.1/x86_64/fedora-coreos-44.20260523.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "503399255ae9b0b3561c535470491aa3aea7fcd0588fb320ead0a8b4dbab16cd",
-                                "uncompressed-sha256": "64871b91c5056df647bbec63c43dbd1bc7e33e0eb8a33983b75547ce404ec806"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "df732147e2d0a15857b07f1174336adf5413d1417da1a7052b6f80d7d548776f",
+                                "uncompressed-sha256": "dd68872fda81498a0bc187017c6acc5b23e1b42ab0de29c357597df92818eb28"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-09b309c3dd9dd9a02"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-074a64fa736d7c08c"
                         },
                         "ap-east-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-01aac37ef2f86bb22"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0ce20be8d6f4d7a44"
                         },
                         "ap-east-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0bb7a0fbe4b0f6bb8"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-065cf8196a0ab68c1"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0f86b6227542f0284"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0e4875c9a527d6e14"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-02c299de047076913"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0d7e468638bf91e4a"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0558e0b09c646b466"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-043f2c521a40f84e5"
                         },
                         "ap-south-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-04e8b77be2430ac59"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0d5171ae62377a069"
                         },
                         "ap-south-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0e16809846bf89c42"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0c54d49cc00a20df8"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-004f9a514405a94df"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0ec0a52aba7d21939"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0c0283fef53ea38e0"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-03a1f07e0cc93feb6"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0ec0549d62df1f920"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-006c63c1fc0ff66aa"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0fc83de0d19b5d8d7"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0d726b047169b9a2f"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-08aa09a9ed7b8b286"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-049f3504c75fec0e4"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0d48287491c2d78fd"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0f77a239ed0d75d32"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0553e75cd4a0ef5b8"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0967bf44f9e827071"
                         },
                         "ca-central-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0cda90c90dd2f2525"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-018c8c27a8252ea37"
                         },
                         "ca-west-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0ad98358e2aa905db"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-092e405fb1d510b7b"
                         },
                         "eu-central-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-02fd4b588390c1b5f"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-01b6bd514e1e4285e"
                         },
                         "eu-central-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0c4b1fd8eccfaa37c"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-02bea227f2a864497"
                         },
                         "eu-north-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-00428175365466f50"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0f959d9a72157db28"
                         },
                         "eu-south-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-090ed417d3ec00e58"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-09254d38a23c78ac1"
                         },
                         "eu-south-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-01851193866a3e61a"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-088acc5bf0308ac12"
                         },
                         "eu-west-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-083427e92d287e833"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-09b42f4920c03afa3"
                         },
                         "eu-west-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0b7b91381cead50a8"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0f1ecda1ba6296398"
                         },
                         "eu-west-3": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0f19b835054ef1e31"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0082f7799011203f2"
                         },
                         "il-central-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0d2a5ca2c845558fc"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-09ae2399bbd89ab19"
                         },
                         "mx-central-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-01bab265f1134b136"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-027e7df2de8a8fa92"
                         },
                         "sa-east-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-090e24bd2823bdb82"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-05edb1bc1f4a07b88"
                         },
                         "us-east-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0f1333d7c6ecd788d"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0081f3d938c33c2c6"
                         },
                         "us-east-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0fd76d4060c7a268c"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-037488c4679c64599"
                         },
                         "us-west-1": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-0c7a75bed141eb382"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0a42d08657740bf59"
                         },
                         "us-west-2": {
-                            "release": "44.20260523.3.1",
-                            "image": "ami-094727d01fd475c35"
+                            "release": "44.20260607.3.1",
+                            "image": "ami-0cd25e81f8d58e1f1"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-44-20260523-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260607-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260523.3.1",
+                    "release": "44.20260607.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4744fb2b365b83b2935c79490374ebf89117a3e8eb09dd262c43384525417d75"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a08413b6387176db5705d3e0f894715e3da8b2f64a7d4ff83ac524558491450f"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-06-10T18:13:11Z",
+        "last-modified": "2026-06-23T21:53:50Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ce42a398e5f4ff9286cafbbb970ae3055bb0226ceec3380e55338c1f0d8db704",
-                                "uncompressed-sha256": "5c7484ec1d4845c627239e32599090ca3b5db6914d18730e2d1085c71a93c7f4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "3fe4f8f9aa0f638ccde268a98d248599d268dc4e6d5bc28797c6982587842fc7",
+                                "uncompressed-sha256": "2303d7376465ae0cfd83121ef43426f9a8db18303c8826eb47d438638edd1b8c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "066b6af1c572437e249b00880507d8402005821a34a2221c164ed549cac283e7",
-                                "uncompressed-sha256": "dc54bfe723e382d83ad9e999d4638d3a8ac03e8e5f57587bfca67621441dbbc0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "9f0fce8ac1d3da7d161683f70b8184118bec55d94b329c409240cb2ffbd31d7d",
+                                "uncompressed-sha256": "44430449355ec87461b97bc1b5002f106ebcac590465fcf469da6f945a415ae0"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "dc7b19e2668ce8e5fe1c5524f0498e005e681fe7659c29f6eeab6a9f7e6a82f4",
-                                "uncompressed-sha256": "a4e8a9fbd9c9b9501ddee795e4c58ad07d569692dd55b8cb8a71855f4119a6d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "ca7055c9c814e73a4809db0d5f0770780730705096bb944a21d7ec4d5a572776",
+                                "uncompressed-sha256": "f5b76c1de9fc187334ed29c1ac71e37efb83ccb91ea81f2e007c4d654f80e216"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "205e30c342cc4356a37489b1935f23648957de77f00a0718f2f1abeb5ad117b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "1987ccb42c3e7b4770844d7633103c285016d93cb177c65aafd59e7edd005262"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "ae429c5d36a750f5af6fc04d56f3bddb0df696b60eadd0badb80102ef1b81f04",
-                                "uncompressed-sha256": "a4643d1ab98a2a06120bec54127a8040ed260c4ae8ffe41c1917f35d0422741e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "a2ce577831afc8341136bcfac44911b91c46c0f9551ff262f500ea76b5cd89dd",
+                                "uncompressed-sha256": "9d1051a1f470e4252f29e58e930e3cb27890bc44dd041fe476315dd7cd2135ac"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "24a2af618d43710a88d7d479573412499bfc472b40f48894d563c0b1c83e9f4a",
-                                "uncompressed-sha256": "5b16f1f491192671b2bcec180cda96bb200dd8fd99a9fbaf9ed2da18c67119ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "132a115b05d9b3ced65503106b4661914804c734b62d08dabd349db87621f380",
+                                "uncompressed-sha256": "dda4ec80f53cee415349bc84bd76bc6a0442496a0a168f75febc1328e316582f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a73daef49726747d2d42db5f49cc34cc203f6f225f73af6ed84686beb73c0a7e",
-                                "uncompressed-sha256": "ad3bef720f1735b12fcd90e2c0a815927668fba03a2c4de05d79c4b4d2c334c1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "f3f3d4fa3ef828543ee2eea5576ed41c6d7c2b5595b3b645f8a615412026a17d",
+                                "uncompressed-sha256": "6c4a4cfdd12c478bb4f825ff4fcbbfd0bfe04efda51b68d6b2842e8638768d21"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "9d8516e4be6da960f127055c44d6f9b6153b682bc4a31e1e2dbe6497c5f3cc3b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-iso.aarch64.iso.sig",
+                                "sha256": "4e3a988d1655c2e6b254caf4514187dcd70091149a252ff9b6b9bbd121c08c47"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-kernel.aarch64.sig",
-                                "sha256": "8fd6c12d431111bc017a228b3b30f18905e3a156c1a1d882e7daa2c5a288dd15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-kernel.aarch64.sig",
+                                "sha256": "01c4de729aff530638be34686e1d4553b6576151f1e1e3b38d83262f0d05a436"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "c8d9d99cfcfd94826ee213a7d60199418c7e5cb8c2f9cc5a183feac30219b50a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "e71585f76994308a0f288c175cd8bed5924d98b8dcc08eb89754e993ee60596f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "3bc1cf02ccc01d20d450a87a919a630e59618f1b5a84df382db53e541cf069ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "2ba2f1d3f167501432cd2700f8803bac613c33f61786dd0e2c8ebd2333984ede"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "f86c43ed01d6e27631e6c2bea8be057f7c2bab0915dab0afabf6a535eb2559cb",
-                                "uncompressed-sha256": "6fb84671d271ed172938442cf5083183229c5e5f076508e5f9c567cbc2fdf0f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "2881e7cd37b8d18f21f656b257f32602ca5f8af20d4d8813fba5b098d23adef9",
+                                "uncompressed-sha256": "eeeeb549f48104bb8dff4ba51e9b086e24b569738f0c2ab90af9f42f1bc2cd96"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "e81ef254c415600d4eb89bfdceb992e394136bc9af48c6b458622d2cbc93ca75",
-                                "uncompressed-sha256": "5f594a9620bfb3f0ffc25643a14a948accfc87eb6f6dfa3ff0d11283f7941152"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "89418aa63fbfea75098459f6c92207a99504ef9d815344c5efff655283d06821",
+                                "uncompressed-sha256": "a80844fe04d2178f643308ec45353dac5bc5cb7178279ef148504381d598169a"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "34d256313b2f9efdb6160dc30c3d8646275b4cab60d4b292618b99debed2a058",
-                                "uncompressed-sha256": "6d1aa3d7d0173481ca387ed0bec96f6fa6efc6bfb70fc722c3d5ff52cd4171ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "2caee3692bcbbbe0cb9d0472bc644162dbf974d96f59a71808995f535f13034f",
+                                "uncompressed-sha256": "f6ea86a30549fb4341a38c6f34d71c16b74159ec8a36088ad6d7a3308c800913"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/aarch64/fedora-coreos-44.20260607.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c30610766481294971832aed805a43a7110868886770802a6b8765133f48dbde",
-                                "uncompressed-sha256": "121a5addf6e1e74fcc3944c372144306becc49f5a68839094c5008a76be99b36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "58db7d9a92b3489e4fae03911ed0d082beae0f69695e510e343788cc116a765a",
+                                "uncompressed-sha256": "daeed914b8bdc223b67b5444d5f3ca12e8371f3c1a8cb3393bbedf42e78eaf26"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0c98ee04ef7cf92d7"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-082ec0c3c4dc7c62b"
                         },
                         "ap-east-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0c7bd8ee17412665f"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0fad9d5b59f759ebe"
                         },
                         "ap-east-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-067412b0619ba528c"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0a9f4c34a39f62e75"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-06362379d742a90d0"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0c3f01f4de384d282"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0b42e2a50472e35ea"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0d685118b9ae3b0b1"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-068db90a0cfe48a11"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-098e285e5aa64ca10"
                         },
                         "ap-south-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-047e99040c8ab9277"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0c095ebb79f6135a9"
                         },
                         "ap-south-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0316b2c54af66d6dd"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-096b572e428b3e96c"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0f6db4bc48baad329"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-016b6e8fc59bf1b85"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0b586b07a2eb2b9b3"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-07683031c0b65a6cc"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0324172df393216f2"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0bee3fd0ce12e3bbf"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-00ebad98700185035"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-07501fd7378dcd44e"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0d0874ff7860f5346"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0eb8e51ce71f5be93"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0010373f9409be5d3"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-096dee7926668751c"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0adcd451700f6e462"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0d7edc0fb85ddd736"
                         },
                         "ca-central-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0054c065fe458748f"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0913553381ddce400"
                         },
                         "ca-west-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0729b44e905f0977b"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-052742884bde487cb"
                         },
                         "eu-central-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-06b738d2982a3a0c9"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0384f9bd3669a7bf9"
                         },
                         "eu-central-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0ea24b21a3a3c3c4f"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-021f6a6fd1f242d6d"
                         },
                         "eu-north-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0c180248c90e15ae8"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-07ddb2d28141af2db"
                         },
                         "eu-south-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0536fa3e8694542f7"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-079885d7bdeb7d980"
                         },
                         "eu-south-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-02c11639134f7b5c1"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-06d885a880f27540e"
                         },
                         "eu-west-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-02737d42fea716c0a"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-01f4625b71edcd4f2"
                         },
                         "eu-west-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0d21d09664d1e2067"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-098177eb519165e4a"
                         },
                         "eu-west-3": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-052c1fbfdc2fa7b07"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-013aee6a1eee7b6bb"
                         },
                         "il-central-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-08962c617b1f926dc"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-056bd7f594ad89a27"
                         },
                         "mx-central-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0fcd522aaa066d3b9"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-00aafc535665fc4a9"
                         },
                         "sa-east-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-04c424fde93ee27cc"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0af29468a0023b955"
                         },
                         "us-east-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-03bc637634f90c536"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-036eebc1573c94bb1"
                         },
                         "us-east-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-01cc372e84ee7681d"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0b170adf27dc3e5d4"
                         },
                         "us-west-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0e987e72d75d95440"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0083081710867e4dd"
                         },
                         "us-west-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0e181e7acade58482"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0c08af607b829a21a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-44-20260607-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260621-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "f75b83ee510ffe9d427865933177091ed0353c0f825644e3a321618c27975153",
-                                "uncompressed-sha256": "bef0498519913a4c41c4d88b2a9e125700b77b1dee7163a3712c0cc97249afa7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "a922605199b0276248519c4f7778f4e8aba4f5aa0ab57319036cfc0f0f714c0f",
+                                "uncompressed-sha256": "7efd31af80e50ea99c3bb1fccbeacc04a1ab36d48654c4596c1668673d6abae7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "49f2c3e6374f5ba5a4bbeaa163c1567c3139aad7fc0436670d0ada8f45aa36f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "fd202152fc3289167e9cc0f88a1055ae06196b9e3218675907ff134e872f19fd"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "d336b41fc5a1e6c545212b65efc75ad40a2c5ccc83a247e59783eb0beabb5247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-kernel.ppc64le.sig",
+                                "sha256": "d9363d0f3cecc345e63731c6add8b08d55fbbc5d741d4163542e589b6c73d17c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "a260e316949eaeac4d0eccd4847aff264ca6124d292daa0f29670f15e6492d93"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "1e43f21dba1758ae7ccefb256f84aa7107a95c5d5ae55d65abf03cce16f9500e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "0bba1bd7f470938158920e496e5fcbd9f272e14c245f3283b75db1154ec519ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "a65b6467796cf5a2eb39d234bd77815defae36fb203d3c3a85ac8b7967068df3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "0250dd321bd5a4cbbc26585325863536fc05af371e857ac0567cce6d277da33f",
-                                "uncompressed-sha256": "ff4f3950a92b049ed1323e496eff9dd8671a824ecc5abe9594e500cd75247c5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "6bc7bd4223d5c2f0b156b37b82320377f19cfdc685bdd6f8c3baea84f7d0b831",
+                                "uncompressed-sha256": "613bbbb4b8645b53274138307bbbe73b5bc233facc30b206f971e8f9b44d7a16"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "ae8dc60e1183a3d10855ab3bd6c67bb030c8fe2ebf61598d04ce953200b8f9fa",
-                                "uncompressed-sha256": "7611983006c2cd8694fb9a92d1d276bb775434ec7e94484be04618683aeaa819"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "23c31fbcef8023df75088c56533655560790c2eb5f9f528a390ad5655966a74d",
+                                "uncompressed-sha256": "7590e9712be47754c9dc6caa0df12fc4b388e6704488ac57ee82a517c2c57615"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b1e1cbee6b3eb4f8f7c59084db716ff0992dc95e8f1ef10a1410e8601025e2d0",
-                                "uncompressed-sha256": "950c07dbe1ee5fc2092a3341c533fa826d65b3a33089903541d7ff7236d4f784"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "10fa22d4eb33524c0d5b35fe9e77c845eed91db4f35a7b8cb3119652ecd065fe",
+                                "uncompressed-sha256": "80549cc7645a5f87d45cc98cf46631f04a84f626a1f57b453ecf90a558de5410"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/ppc64le/fedora-coreos-44.20260607.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "b7ee504974d7dae22341059e60331dde4f749c6fc50d3ba95b1a50f57cd99566",
-                                "uncompressed-sha256": "f4737107b1999b108a47531fc4de4220b0275cf396b877875e04a65c7f65b00c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "257649291b70967138a7b5cfbef28f1bde5dc2ef7c24a18246245b98ddd2dfa4",
+                                "uncompressed-sha256": "0f16944c83dee7f31eabdcff3475e5074066da8fd19c7bb5880bfdd6c2dfa401"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "841f251f9a0dc54510d24ab1f359a8e4c862286526c892d5018dc7ba36f4d7c7",
-                                "uncompressed-sha256": "e52e73c92bf31e96a1f6cb15cd328119c4219b13953efdba7e49c13c4ebc23cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "591aa910a1f7c4ecb9e3d102c8cf16e041d0b1ada6dc2573d0c46f33e99bc95a",
+                                "uncompressed-sha256": "e7e8d64097072650bab3fe09671e219180c2afa8565b5fdc2bbf943a2a047390"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "e0ccf28c74e3de697e9ed4b4df0cb714683fde462560084c864756a5c48a3f2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "65987946aab181f28c0cb42e65ccbc6c8f0015d1e1293b39d8919eb924903abb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "9eb385317687bb8a4a9f7c93d67dbda90917396e8b1c9f922a344d55cc4f395f",
-                                "uncompressed-sha256": "cf1dc0cbea147708043657b394f71bd2998f5a40f0ba681cabe24b6bde27f1dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "1069fc13bb29c6f88731140c673402eda3792aee27c564aa2580adfad6d69fd3",
+                                "uncompressed-sha256": "d32a8551efb458e18886c0c1eb9cd906c2e2a8af27bf24bf479d5c2fa00d097e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "de37151d934d218960cbfab5ed0b609006cffbf733695fc5a688c12777240d25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-iso.s390x.iso.sig",
+                                "sha256": "156640c2d6fe17b6d213d697019cb2cad72f2dbfd914257db612b7bdc4701ad5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-kernel.s390x.sig",
-                                "sha256": "df85eeb1bfcab7a28106ba565d8975616cddcdf175d961848584ee57f9dd723c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-kernel.s390x.sig",
+                                "sha256": "2ba3928a20274a5f95f2dbda6a5479c998a1459798827a1707bf7e8495e98191"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "b6ccc7d4ebe7756724616e5620b61394f55d7cd12c51957baba98bfbc393d7ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "6692f00a2a6755a5c23caa7ab73ea9cbe081d491d82117b0342ca140a909686c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "acf6fcce805ea884c762feb7238d97c032077511c8806db10cae39b0a290267d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "1c52c67d89aee9a4d0d9fc7deca78085341404f4c5dd827b53740842d11a51b5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "9678b076b7e3b2f973e5f13bf1b3b3a0fa9bc9cf8377551d621295103fdd698f",
-                                "uncompressed-sha256": "56fbc91fee0961dbe7f35845e2853904c36dd6abd5016a8e2cadbfed344582cd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "7a50054456f6463314a637a795f13633162bcd779d45a6f4af8152317a697723",
+                                "uncompressed-sha256": "729d29903f396bd6a6581d352f524deec39298d635d7241c54c7b54e5302d92f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "65446f6707011da9da9dfed22ad38c573a244d5ce24db8cccfc9732fe4fdee69",
-                                "uncompressed-sha256": "5b3efda37b351b6064ce20ffae2856c1b2af40e6a4ab160d982867b1b01e4f33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "0d2794b15ff2bb5946bc0ed95faf33878ff2d24f7607867d4e5e6c9a3262bbb0",
+                                "uncompressed-sha256": "f5ed290cf9c5fac42dcbd17980d5fd9d2f192b2a2d9df51c852079891744b948"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/s390x/fedora-coreos-44.20260607.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "297b470530b5e16322b7d99e35b2babeca9af31ded2feac0f3e341350ac7aa84",
-                                "uncompressed-sha256": "0feca3fa5af499f5b972acbec7f6319f6bfc77008ab06d0c9c4d249163446b1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ebe5307f05f3fd34d27ec665f8128ec8357ba05d66261cb6cf3f78ba75381f9f",
+                                "uncompressed-sha256": "6ac8f2c45dffe8adbbc8535ce00a7a8e4dbb0c7a5d3a52e4f190299d8db9bdef"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:2277ac19b218e1d696739cc255e7479cd6968407b78e4ab248364d729672b837"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e8dec28db42e54b92b60679aaa2bd4b55262572052eeb628d98fcb96cca7f23a"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "5cda373aba353379912a071ac8618c4ade0a51d650b809a85bc02f6af5e26f34",
-                                "uncompressed-sha256": "8b7f57ca9650fccc3e11e1238e9941ddb974a253d599e44640fd0dd91c1959dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1f2fa672965488776886ff522c3fa81b701552a009f5cd9ac2cc849e4fb323d9",
+                                "uncompressed-sha256": "cd5e4297cc29d7a350af7ef6c6fe8e31af6d0f590eb2fe03b0bac425cda1446a"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "af3a338d44bb6f8840276e65b4300fb690ed03f07a1ed543ce112e10c7b86cc2",
-                                "uncompressed-sha256": "1411bb78c5a1ea0c03ca04167b169bcfbfb414bfc62f989dfd5c64527f61908a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "bcd472cc19a9c55f5ed1383a46ff3e62187a667b82918954f2f3a270f8b78662",
+                                "uncompressed-sha256": "ea62280d9fe001209e3af1cd1365ade5a7679d682eca1d14d71e694b39839f5c"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1d380c971ce27361cce9e12af27a723e6a1f401503cdc5dd3dc62c91644c5bd4",
-                                "uncompressed-sha256": "15da98cef337e3bb7260ecc6f0e576bc9f824f460176eec104c19476a47053de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d741751f7dbf2d46452e4e2b21270aeb693c0e8892314bd1502c069947514837",
+                                "uncompressed-sha256": "e6dd85924f7659e71e0835764efbf12e59c8be8e4aa128604102a6505a820cf9"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9459ca60c0e7bdea43df6209631fcc3c3f03fecd151bf729c2682b03e4b364aa",
-                                "uncompressed-sha256": "6aa99eb11510920745f92e517a0354e027b5be5e10f55341648743ee40d4d737"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "500b93c3a8abc78190de7afd35e0e1e36ff372483621a22c9dca3f80cb6b3937",
+                                "uncompressed-sha256": "25896f088abca53897c67d8b77e1b51ba77d4ba147ad64a50a5099e6444686a7"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "423266ccedaefe3ae52ad1536686a634f356038a6fd821abe660fe6a51232de6",
-                                "uncompressed-sha256": "bc31bddc1f9d9f6061ef520504c8eb64a0e8449100a15941de222b75375c7bea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7665c309032d999f119dba306933f434be15faf0c7f0e857794f5e27bf127e25",
+                                "uncompressed-sha256": "d4cce29cb28f8b167887870244725e77f2ca4fbadbcdc3a8343b29496f248f78"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "8fbeb03d205f8a1b4cd0a943b5b9d798f9e287a2b889ac289ccaaa731c018107",
-                                "uncompressed-sha256": "89073aced75ea18a8e80f2d590c8a6b971de2f9ee45e93fae042de6585ff0e75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "164d77106bd4afbac514e7e0ee03ca2aeb9fe136f531afd023ee52b601f5d8b7",
+                                "uncompressed-sha256": "5a9cd116e4ff6162e629c7b72798a7a8069b29a8d685a89703eb818a2dcb4257"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "7223d266fe9f7c0f9e437d3e70413ffa0aef031c486817f2ae93d47e9ff0f781",
-                                "uncompressed-sha256": "115848b0c69d713536883dc874e88c10cbfedb505a5eb6e16b73816c8420f9e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8888e2f2505f5d9980959381493bb25967fe7e61f3d1e005c78a0d0158864714",
+                                "uncompressed-sha256": "0de01e3a3b5e375f0d03c495503ef05a8b3b477e0dd9f0c8397868b19aad9855"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1a0f40557fba6649404196828c279371a64f2e4f79bb5f0665afd4bae73ef817"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "54042ef069a85bc610c5ab5396b35f703403796c8f0609b8705611fc77bf696b"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "eb6d3999e887a0a6a7e602c0dc6570cb214ae32144e935c35c99ff15cc49768e",
-                                "uncompressed-sha256": "07a18bd79a55ad2103b58df5d066238521dd704f71c4d48e7edd53ebc05755d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "7ca38c6ca24b53276304ed20c598696a6fc36125724490c6bb208b0688ffeec6",
+                                "uncompressed-sha256": "f62b5697dc78234bee8f5d7b83c642bbf20aa72aea0f53df343b63e78c68e5d6"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "0e15ba96c6c926371f021e9a1c9cc823659cf892dc0a89c16f5aba00c929db94",
-                                "uncompressed-sha256": "c7e85c688236df27089163d859e33bc47187498b2bf8a13c761c4f58ca38cad8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "6bcab7d80bef5b986656afb037d793131fd6a46a4c30e4274b320ca3f9ec2906",
+                                "uncompressed-sha256": "f034ec47d75b724e84a0a89ce1fcb3dc5236927e16345615bb5d508202254c4b"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1aca8926f1aa4c252d778b67289ec022879b2d03de64f282a25521c4a5c3025e",
-                                "uncompressed-sha256": "c40f9cdee6a3d597b046cf50d716a25f25b02f249eee86a5133b8ebb4238cbef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6a81ee952e32aaee2753d52feb048acb2545ed65687bc096335d0262db07664a",
+                                "uncompressed-sha256": "101c2e2a84ccbbe5bb73caf028addaa50fc3ed47ea44a81ff780a0395b81c4ad"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "915f173637a4a72ebdc1b553bed9a1a87a49d05d01ce24105fb4998367a4c617"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "72c009d72a690ad657af098179ab80bbca2fed59660001546e75acea1d74e15f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "7d978d1fc4a702b472d0d621a66c08ae8296adc14fe4cc25de4eac5bb8a8ab76",
-                                "uncompressed-sha256": "eb6a84210b0445a463e971f3fa8f88f88fe3c267703d2c6cb9aeadf2a2233959"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9927277f6a3c7127c103560863a99a74fc184b413cfda8f0c72ed0e2c0552e75",
+                                "uncompressed-sha256": "1efb2c0733c2dd6bcaf82050d800971b1bc38f4c53519877ae1ec03fa9b1e815"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "f481b47abd80be04e7a457c6e3cc1847c6b66e28cdda023e5469a4d2f5f96aef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-iso.x86_64.iso.sig",
+                                "sha256": "38aea7ce5c37ac5a60640ceb6aa81da8b1120efec24a572be2a7bf481ad5f196"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-kernel.x86_64.sig",
-                                "sha256": "05e5f16566f0bea5d21fafcb623afbfde63b668675d90ef2730afe4f93f47a38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-kernel.x86_64.sig",
+                                "sha256": "5b26cf74177e2083c1521dcb0c5da667714baee33b71b4aac822c34682edf2af"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "7e9505546c820553a2e510367d1e1ff3bee827aab0bc9bfdceec8b98ab1aefda"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "ca44a0ed28ccb4b950b844a730e938d964b779efa4842b4a158b9d89a0fed7d7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "b984da75695bd78350bc3f38a54efd9fdc1501ba4dd9b62ed4d94c3c0ad7f4aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "d53646d0e9e5a0149ce0497484d2754e950ccace6cc76b4370c5068115b61d30"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "fe738a563528f3488bc142e6f457c87734efbef513c37a8f58abb9e11aa3b247",
-                                "uncompressed-sha256": "2566e90a7653e7c66cf1c63d61fd8c66ebe54606d58d01a452c336ab7c858ca2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "54a239a560d0cb2991fa6038a77c2b3744c67b5f35c031e5a1ab4bf39be99dee",
+                                "uncompressed-sha256": "7404cf492643ee8f9adf0935e5375d1a1e90755fae20eadf7871dda3d1662a05"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "3a6def660ff85a0e06a5e6df20573e6cdcc97447325ae893c365ad9e2f5b9060"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "6b24a15607207ae383b2916ba7a5b3d371fb6bb11279b428128a56d83d35c0dd"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "ef36b1c880072d679e0ffe2c21b807ecbb8c9334e7accde072536d86bd0522fc",
-                                "uncompressed-sha256": "faa7665346e12db7973e364d4b950eba0106e7b860632d15f0aaf97ae3363c21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "52a6f4d8eb3c89a6aa83a0072d40ae2bd69d46f968821e172fc752836b9be7a6",
+                                "uncompressed-sha256": "cca1405016a982b485089ffeb49661c3ba639df979517a4ebc4cdf38f33a3e62"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "907c2ab107562378bd951b5f0161b38052cf991b6daa67b93e65abbf30ee78c8",
-                                "uncompressed-sha256": "01f77da2220a37a7ffc0328f7b2e880479a9f731b99b6a32c29b34d7f52d3d6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "7e5097eaf81b5fe734520f4186e9473984f60e515dbee5f1c62b21eb0dca534c",
+                                "uncompressed-sha256": "b18e8c49263ac952c79ba7430fd3eaf37e1a77179b9a8e076871807a9fc317e0"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "310759633a1a6b107728f7f622d608902ae9653481a1a316cdd101c0240a77c0",
-                                "uncompressed-sha256": "9780c8226bcd6fd64f0df6f071792f49dc7a4b5eaa027edf3dd3bd8a738808bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "d6ca06af18139dfc5d08b4b240f04ad180f38f43cee17c51437f968fe237a1a0",
+                                "uncompressed-sha256": "9149518898cfbd27f442ea3c909b04cf6ff0a4ab14f02a80aa81615c27261701"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "8799b3f6c41401b7d8f72a20a2aa62f8050efb18d2d0e8d6a23cb439e29e44c4",
-                                "uncompressed-sha256": "1dc0abe089372f57b6373c5eb8903e8bebc5a9145fe997037b755b1345b7a59a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "ec834e7b67dafe37279080efcf4b71a96fcbfa31770323a56d7340f1a627aeef",
+                                "uncompressed-sha256": "5549951b895ab6663dbbe4406e6ae2e9d09b23ce5987b824b18e814b0014f545"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "163c3816067a82d01d1eca87209d54461958ad4ac169679530f50019f48f9bb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "390999a60a4637f8ab9246eaa1d0e78dbf03be1d52275dca7065cfba2f88ea77"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "563db522571c89096fe01b8dc15d36f2a904c47fc285e629eeabc9c925037ee3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "197d38f6c29732def1eb4316717e43060b9f7479d35a0ed2608f366dad4968f1"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260607.2.1/x86_64/fedora-coreos-44.20260607.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "ac4e7bd32a811cc3c1ef78828a095789f76242bc54f6c2ab2dc23d0df5ea56e5",
-                                "uncompressed-sha256": "38708b8b7e60edff9c0f19bfdce78f4490b4f84fe43cabc34b1b04e08ad01e2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "4b7487acd6bdb73fe4b6f44576c5c303c69940323c0d50c546ace87f4b75b01e",
+                                "uncompressed-sha256": "3b2ef60f980ef07f8509d51590ee636c0b4c0fb43fb87aa8e82dc871f947bfc1"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-06d90716cf085ae3c"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-00bfa56cf04b15cb2"
                         },
                         "ap-east-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0f516b669c7a624a1"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0e7c44f8e17646c72"
                         },
                         "ap-east-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0b8c6893ac94842d4"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0eea13bb586895a16"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0f38e9a4479befc27"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0a0c1ef4866f692e0"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0cab614e0c5e29b72"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0ca1feb620f38b64d"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0cba4057c836070cf"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0addda037b9f581a7"
                         },
                         "ap-south-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0fc8c8266671971eb"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0d6f7c2f905be0fcd"
                         },
                         "ap-south-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-017544d61fdec9e64"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0b3e2b271cf4c5906"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-05bbd28dad3219977"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-06f24c5d1f0f63ff5"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-07305bc66276a077b"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-08f64b863f40bdd91"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-060b6b9f52dbbe7c8"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0468cab509ff1d070"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-04b7cc3d5cc85f148"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0fd245a5408df7f4e"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-01311f276991bdbb1"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0800e6b009ddcd116"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-054bc716ca4fdc2c4"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-06667aadf7b56a5c5"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-00753730afba5e07f"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0e79c6912872101b9"
                         },
                         "ca-central-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0c57b5b253e2f90bb"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-085990b2c5b0fb858"
                         },
                         "ca-west-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0fdb3abf2bf0f295f"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-03aeef2ec668ee644"
                         },
                         "eu-central-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0eeba747eba78ebd7"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0da5b95b43b48bc11"
                         },
                         "eu-central-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0cbea50a54ccbe5e6"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0e7d61e4f454ddfc1"
                         },
                         "eu-north-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-05a403bd7420d115a"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-07cf7cf2f2d279b84"
                         },
                         "eu-south-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-082d3b04cf35e9760"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-04c1555339c65da96"
                         },
                         "eu-south-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0a63fa61c458f0204"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-062849954cc4708a2"
                         },
                         "eu-west-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0e4058d96fb0b1225"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-01a339c1c33dc4407"
                         },
                         "eu-west-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0490aba91e1b9370a"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0d35c50a955d48fa5"
                         },
                         "eu-west-3": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0d05c4e4609f7fb3f"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-02fe3573d83ee55c0"
                         },
                         "il-central-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0e02cf1e94389d6f3"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0b3fa10de6f72efad"
                         },
                         "mx-central-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0366c7074cc167a9f"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0379fee172e186ac4"
                         },
                         "sa-east-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0f4868763383abe0c"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-03f4a487d7fca7119"
                         },
                         "us-east-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0acd2cf2407160edd"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-058319937d5719f76"
                         },
                         "us-east-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-079ce62518f9409fa"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-05be70a8e71bfffa2"
                         },
                         "us-west-1": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-061af1587123ee380"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0c967663bbb266f7d"
                         },
                         "us-west-2": {
-                            "release": "44.20260607.2.1",
-                            "image": "ami-0d121311c115b9670"
+                            "release": "44.20260621.2.1",
+                            "image": "ami-0086759a5954aa41a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-44-20260607-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260621-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260607.2.1",
+                    "release": "44.20260621.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:95aa6959dd1c7630f3a71bd67789b500dbe2494efc01851f7678091215092e5f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d61689e48700386467d6aa17212f46910fcc351354fcfb496d904dbfc41a3288"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-06-10T18:13:13Z"
+    "last-modified": "2026-06-23T21:53:51Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260523.1.1",
+      "version": "44.20260607.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260607.1.1",
+      "version": "44.20260621.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1781121600,
+          "start_epoch": 1782309600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-06-10T18:13:10Z"
+    "last-modified": "2026-06-23T21:53:49Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260510.3.1",
+      "version": "44.20260523.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260523.3.1",
+      "version": "44.20260607.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1781121600,
+          "start_epoch": 1782309600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-06-10T18:13:12Z"
+    "last-modified": "2026-06-23T21:53:50Z"
   },
   "releases": [
     {
@@ -173,7 +173,7 @@
       }
     },
     {
-      "version": "44.20260523.2.1",
+      "version": "44.20260607.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -181,11 +181,11 @@
       }
     },
     {
-      "version": "44.20260607.2.1",
+      "version": "44.20260621.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1781121600,
+          "start_epoch": 1782309600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).