### PR TITLE
github/workflows/promote-config: Fix potential code injection

### DIFF
--- a/.github/workflows/promote-config.yml
+++ b/.github/workflows/promote-config.yml
@@ -18,10 +18,12 @@ jobs:
       - name: Install dependencies
         run: dnf install -y git jq
       - name: Extract stream name
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           set -euo pipefail
           # XXX: consider using separate labels per stream in the future
-          title="${{ github.event.issue.title }}"
+          title="${ISSUE_TITLE}"
           target_stream=${title%:*}
           # XXX: fold into promote-config.sh
           if [ "${target_stream}" == stable ]; then


### PR DESCRIPTION
From zizmor:

```
error[template-injection]: code injection via template expansion
  --> .github/workflows/promote-config.yml:24:22
   |
21 |         run: |
   |         --- this run block
...
24 |           title="${{ github.event.issue.title }}"
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix
```