### PR TITLE
Roll out stable 44.20260621.3.1, testing 44.20260707.2.1, next 44.20260707.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-06-23T21:53:51Z",
+        "last-modified": "2026-07-08T23:30:24Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "53eca6e3d0cc0acbd8b9c09bbc9a56c4f5d15cbbeb67819d4b96ce45f53dee02",
-                                "uncompressed-sha256": "713b5903c6e00753e16efa54e81870112d2d74912122c3ac0e1d3aa87bd64b92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "b80d6da60d7db3d91913d8eedb98837130a08bcdb5cddb8e3403561f080ceb16",
+                                "uncompressed-sha256": "0d25c566fa4c413d14143c44fff3b39bf3c739e44beeb8c5ddd822d7bd36bee6"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "62059edcffe397f8c838e36d5e1788dc99fced0341b01cf8da9e8fac1f98f02a",
-                                "uncompressed-sha256": "cde0786ddc1e316dbf34ddf1cb70a1f2f3a8b7f154082cae6c7afd1851ad5d94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b60f339d52fff0fb5d5220d02f713a8e89258ee2ac458a29cd4395abda15da2c",
+                                "uncompressed-sha256": "bd563ea15c6788b26ea1793dda7f73a04be2efc8f04b7957de6160aa62afae98"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7b5e55e50b84d196ac3632d798f006c9c206da555c5c9144c2c7e545faf41ea3",
-                                "uncompressed-sha256": "b7a25f3202fc3b4ece9642ac8d938acebc99060f39a4eb86c55d16587f1b3f20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "829d034d1eff27c10c687f436b5a88173c7f106a825f964054222523958b645a",
+                                "uncompressed-sha256": "2d114734eeb43718f35fe30eb36153604304bac3decb681ed7270bd211eed391"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "8404f7c98e95a6ca60bf578f58f2a441e20266780d002488a6eb21cbc0a151dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "92c5ce18177a5f67fd5960e0358a26c2774260df5ceaeea2d527e9416eab1506"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "776840fb4f0ea57e5bbfa764177d64ca5c93c6f696f7a0f03f8769057d5eb231",
-                                "uncompressed-sha256": "353f2c6b81f9e73309a317752a0fd2f8682f0fa68e18ac5c0ee1a6e1eb241d47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "fa027c67248f933838b4e6af5588bcec3117fc3f4fb4aa414ddc0776218832a4",
+                                "uncompressed-sha256": "99993ff2dd0b0c45bf8010059d196b8cf7e095a800ecba638333006f82abf608"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "bc8673e79c8df123e45f9d5663ba0cc955ee571946e8c69f0efb398975ff2dfb",
-                                "uncompressed-sha256": "67e4a13f0e2bf5f0498a38454f5da6a1df45601d7de33ff4c3c1673c93e3b4fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "f8ed307242fb0005482a9610dffa5b8433afbae29e4440445050bfc64f7ff9f5",
+                                "uncompressed-sha256": "ab4a4a97f04cf0da0b80c82b4a0ee3df946bf32cc013abcdec7cddf07df0f90e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "47b02ba2a9d3a2870281c16687e45a121146cc4c4a20564fae37d395f5a31ee4",
-                                "uncompressed-sha256": "9f03951e62d3e3b4ec6da2ac36c8cb2a5c18ecd7fabf0e4646d05746ebc0d552"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "46cb3a4d3c058708bdf45287494a04e52010e25fd40a7853424393b7fb12fcfd",
+                                "uncompressed-sha256": "b4641eca78433100275bd04cca3ce517778eb1f66a6d7f2fb093ab49db1323c8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "2bb08ca7a0d86d957a538dfe3c9eb4c13012f90dd8233cdbd442041b60f6e0ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-iso.aarch64.iso.sig",
+                                "sha256": "d8a7fce04adff9b9bd6a80bd53d51bbecf5a9de155244a246220e2c13a9e9b03"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-kernel.aarch64.sig",
-                                "sha256": "01c4de729aff530638be34686e1d4553b6576151f1e1e3b38d83262f0d05a436"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-kernel.aarch64.sig",
+                                "sha256": "018d71ab8699adce28ff0ce32ea0e1ede76aabe2b2bf51209449b9bb2ce6b525"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "53790735a42d8ba490d59d4fa5f79ae27663ef172d94948e645c69a597f06142"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "2450fcb846671d8afe2911a4d8188d4f0476d864029668e82b09aa3d9e51aa3e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "5c85ecaa8acd622961bf5d96080661eb3a748902313921f9ef4faf8e82114cf0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "98c8b0e0bda8e703667ed14707de60a00a002864e0c768b38cc24919bbbd1a2f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "dea20c89316635df883b6d5d8fb3bf092f8530c537cab54e4b5259aa247869b1",
-                                "uncompressed-sha256": "b06c24158b1d08b85f7aa53b73f4067cfa085522026c6c09185c3fce52b4bb6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "502102284f2f50b01b9b3c11cc36c120e024427a531c051fce86e5c0ac9d680f",
+                                "uncompressed-sha256": "59b84a163f7837e678fcb5a5fc5fd29b5bbd0d00e2fd156b8d5cb80514576033"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "b835ba48162297bc7d8695d2d8efb39a495e4e27b1069e397b65a19df3792498",
-                                "uncompressed-sha256": "d367df16e6b5edd668008e4805e654d3e6f04b8c2c3d49603ac98ec18ea48e85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4c412b49db9f19ec4397a1211e86c7eaed963d5a2a43acd7226ae426a00f1c70",
+                                "uncompressed-sha256": "7aea1f22c59ffb5bb65b18756e23011d034df9cda741678c7dc38499c79a7021"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "c0f959260d94f48456fd8c57da4e3df83b219f14f0061f7b4ccb4086387034ab",
-                                "uncompressed-sha256": "fe966bf1cc49269279fbb6c98305be561347c424680ec3d589fb38252a14d68e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "8eecf7fdfe648b06eeac366907b3f093b1cfaec8bf80c0cbcf48d15f79711670",
+                                "uncompressed-sha256": "2355076f44b73958f2e4994a69157f21f9a6cfa42e35aa8def1b4a973d593394"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/aarch64/fedora-coreos-44.20260621.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "483d91df3304f401aebd6cffde87f7baf1060c95864a8e6203f60f61a0b59b1e",
-                                "uncompressed-sha256": "e7261d52bd09c7f11c2939f732b041e0f7e351cccf4d1aea1ff3296c93775d0d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e680dc10cd8d6579ed11e3e822671415e6ca0fcc2bdf69ef15475aea84ad7d45",
+                                "uncompressed-sha256": "fd795b5dde0d6f8dba74422b715b96ec78938c6f3641de22a777f82ee63b3a27"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-065cc712c0f98c01f"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0f4fa093157e4ff8d"
                         },
                         "ap-east-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-00bda18ddd9d0bd6b"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0427d8488c614ae02"
                         },
                         "ap-east-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-06d85ffdb5694332c"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-025ee0813ca487c02"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-006fbcc12474799fd"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0a5dd4adc465ce957"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-02afb3d0432af8a79"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0f4d2138245f81817"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0875f58bbbad19c21"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-09d96c720659ff6b7"
                         },
                         "ap-south-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0d0ddbb468c76382c"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0033838a41ffec674"
                         },
                         "ap-south-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-01d4b64b8b1cda882"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-09e35d145ba29f407"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0f28b56c8e96fa63b"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-02358f292e0158f9d"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0cf8516387bc652ad"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0d703ca76d1b42c96"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-02fea03dc53f31956"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-07451c44f268929fc"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-008783f660914caa0"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0a1bb28a6fdffbd0a"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-050e18a70df9355f4"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0d34c08d0edf953fc"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-08e53395017efcc64"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-06809cb8c55735455"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-00807a5e10f7eb479"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-07fd7d12ad92dbf30"
                         },
                         "ca-central-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-00bb4fa9200f63f7f"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-031bc3172ef31b0bf"
                         },
                         "ca-west-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0fd1e8ed9300a8588"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-02179a11e3a5bcb08"
                         },
                         "eu-central-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-009f56309cf20c092"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0b47a9c4daa102c4c"
                         },
                         "eu-central-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-06871da669dfd7d8f"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-04602ada4c29d466a"
                         },
                         "eu-north-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-05ca72cbd52f4a233"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0f3a32fdafe28d122"
                         },
                         "eu-south-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-001aea3feab0200b5"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-07cdbdbab6d51fad5"
                         },
                         "eu-south-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0bb5bb94fbee4bb95"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0162d1f066b9017ab"
                         },
                         "eu-west-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-02330ca53e73eaba2"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-09d8cedbaadd5ddca"
                         },
                         "eu-west-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0e83ec0aa8ca51f31"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-01a4585b480e1ac25"
                         },
                         "eu-west-3": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-093e5a0f664015b7b"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-01ba6ba95e4ab02ad"
                         },
                         "il-central-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-06180d8156f2e2284"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-001ffb5fc53330883"
                         },
                         "mx-central-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0ba63dea409c71c18"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0db7bafa20493f212"
                         },
                         "sa-east-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0b1ced8e0425df9f3"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-006fdcdb34b46b973"
                         },
                         "us-east-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0288cefbf5169aaf7"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0b20f95924fcaf43b"
                         },
                         "us-east-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0e9e77c6477555db9"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-06b598bee6c7709c7"
                         },
                         "us-west-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0c2626a516b039e4b"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-01002ea0a8f903824"
                         },
                         "us-west-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0210c45cab3245e49"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0ee747cc7f25bcd00"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260621-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260707-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "08bed7dabe3ae903471edc63d5c5b01d8f09ee4e4fa7bd4ea0c28384de091c8e",
-                                "uncompressed-sha256": "1dbdbae7a5f6ee06c59de97398a064283aa8400502c5bea591481af431768618"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "ad9fecc30655af697f34bb0d9726d44cae2bf5d27fb25221db996be44abc1a3c",
+                                "uncompressed-sha256": "a9a724225302cbe41845ec56d038f58c3cebf4ba4fceb959ce510db8020dbbc3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "fd3857a7abd183018997af51d0acbc738e1264d9d2d1237e44264c5b50c62c96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "4a2ecb68bddf6acb432c3c41cbd1b60ceb0db9a2e48373ddc9dc86a19bebe1a8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "d9363d0f3cecc345e63731c6add8b08d55fbbc5d741d4163542e589b6c73d17c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-kernel.ppc64le.sig",
+                                "sha256": "1107a231b463cd249fd2b3be025cd089d23dc3c77efcd34ff7500f37fb4d80a9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "d3f670b226bfff7fd220ab0ac7348c6e7a8db8e4ebf0c1ca18465f062a1a2c7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "28181a014b6db208be5342283dee88eea2530d2c59805186b186dddba1bc72ed"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "f1fbaceb0ef3edb8ede6d0546e9eb21e3a565d097eb90466e24c0083707e7fa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "38f05ac159a25a6c7897a0a1fc0d56d3f1c71c8afbd1dfa459bd46698fbcce1d"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "dbf2af64f65296d4747b54f3f95558056115889b5bbe4c53f91d008c3779da91",
-                                "uncompressed-sha256": "46d7bce0945c50a1f6e4fbc2c9442375e07b4e3a708f0e7384001cb6ea295b87"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "47db46ef146a86024c644d15a28bfe15774af00779ad62e3c5f10b162939d05a",
+                                "uncompressed-sha256": "b6991a3b7eb43f0b877027f60f07d5ac99a0015c42fc6ecc00f02ec3e551b9cb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "994885a236bdc1c476d0689f92396de50d5352a82319d11e6a898abaee2b96be",
-                                "uncompressed-sha256": "eabde9af7eb87c7d07542c0cfff10083511300aeb64077dbf3e9f0d054b6e909"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "a571a3975e7b76837a0f8037e29e49ee57dad9ee883cee4447816e3525801296",
+                                "uncompressed-sha256": "d13a94dbb9ec7339f18ff3331b8e62260d23ac9b779dc1ffd19ff52b65b16199"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "85ae9c5b8abfad5fa4054ebf3b337d6727cedc1b9660255e167acc4a6773c4d1",
-                                "uncompressed-sha256": "342ac91585985bff055af6c996b08043c9ab1a9b8689665d15bb89ea37527393"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "e1a4d9a00cf172cc55e012c2ff23dc443581ab5e591116870f3df333a62fc672",
+                                "uncompressed-sha256": "ed59ff7300d1c4c84b55422460503f8709a5cbd1f348b0f080f93310eb91ad74"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/ppc64le/fedora-coreos-44.20260621.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "ade525d84693245340983a4d75861f6ec6632637d2699961cdcaa709882970db",
-                                "uncompressed-sha256": "1f8ffeb6293137314e59c82058c0e59e2553d98989d8085c1390be81ffa3fee9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "e4cb0838181a84c29933031419a07904d1277583b0196ed06e0ea9b52e2d106a",
+                                "uncompressed-sha256": "84c2909a988a3852c1110182248b4c8c809111dd90a5524da85ef2b28c8127ad"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "49a8f909e1de8152bcbfb53b34b9898b69f8ea890341436aaf4213c1cdf3bcb2",
-                                "uncompressed-sha256": "a2d3c40f63b47492668a33a24d139ead6af67e5fe5ded55b4bb0015f16ccaf5d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "35a1ae0f628fa8a364b1b5bf2ca46fd4195ed0b4f4ba321e86b2f248a64a6138",
+                                "uncompressed-sha256": "682564346c07ef70f610db19f78a3504122542287f34d3592f3ae1a6b0541c4e"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "f33ad9bb0cac3ed8cfbbbf43c05e7c88cfd5820a22d23414be50d72ef57135c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "0a434cea0460bfc3af1154742d2bb80e547f9f4f52d10228854ca677c2f559e6"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "19fb78e894a86ebb2f1b68cd5b84a0947da3d584a987f11789382fc8f7bed328",
-                                "uncompressed-sha256": "11706c3531c58125087866fcc38e22381570dbd2550df9e5092113a303d4eb6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "ff8d24fb468a50fba87998364fd7c0c21d403fbdb2e00e625aac22ffbd10a617",
+                                "uncompressed-sha256": "8634b44592c7f51124e19b26fc662e7a47134a6f03d567d9d4412478ec875fb7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "75c92fc9c3983f7ed0ec6b27f8db98a3a7171174332bf7183fef8cd466a3b24e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-iso.s390x.iso.sig",
+                                "sha256": "c749aaea7b61377e1daddc22d9260268d0a13b9a94745d69ab1459d2641c8235"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-kernel.s390x.sig",
-                                "sha256": "2ba3928a20274a5f95f2dbda6a5479c998a1459798827a1707bf7e8495e98191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-kernel.s390x.sig",
+                                "sha256": "5f8e1c0024859b89938f4e32f46c19b1e0b97535cb6b9ae37d2c8adbedb1f7eb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "6111f9154953db04dd5ef8b4ecd7e9ce76223b851bf8e172c31a3da817094a03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "7079977f8893853ce5a8a8854ce56682e7dac1a7dd68dd2c2afbd10dc07c8357"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "055e5643827d2838dcb402c7f6767285b25e1530cac56b5ed33c6ee5401ef43b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "5868abd7ad6821338402288bd46a28d8bbb8ee92b305fceede7521699cd7d780"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "caffe33cf13b75bf4c01390e2272ce496db0322e5148a7ec2f9646817d536df2",
-                                "uncompressed-sha256": "786024307c75f6d630836a2ef29bff562e609074c9003f086793e5f8377629b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "041cffd729920b03c506a53dcbcbca953fa3ddee9f019f87c0cb2c3d51593675",
+                                "uncompressed-sha256": "4b0029f8a9ae6f4715da6e65206887d29fe13e3b49a502dfc10f10092f3d372a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "5b43edb7aef8f801c8a312424f3bdf54db8d773501a505fbe76b4840e36dd958",
-                                "uncompressed-sha256": "936a77239617ad7e17ede7098f9965d0bb73c92c412ad3e9d1598319b134238b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "82ca161cf8be615ecec80d5f082d53c8bfbd13b31e747193c2ce5035d4761c62",
+                                "uncompressed-sha256": "c5e47904577891877a37fb8b7f262e3bdc96eb82f384ee0889a27d8b5778c59a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/s390x/fedora-coreos-44.20260621.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4c7a8ebfb7ac45897cf38d9ec3c7609fac2116ae37d9cb4d5cd0ddf16476ccb1",
-                                "uncompressed-sha256": "f7acb4890a6c42efa959dcd7e100f4a2c04a16016771ec99f67deaf473b7d570"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "679acd297adb716d6e0cb01da22f4f4abf9a46d7243da2c3e62ee74037bc50be",
+                                "uncompressed-sha256": "bc6ff29fb6eb7d64aa3b2ba68aab87aa7cee7a0502e65ffe5cf65fc10012d2b0"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d48653aec72df199420daeddff8ca415292a4e282a11a65d0d660657e9474349"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:688a21bcba412700c306334c21f71192dfd365a1f4eae2aff5da73ce06e15573"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8b53615fbdd4b7a78fb4a68bf33848eb6b0a2a7d00ab3b714c5248c5879f6733",
-                                "uncompressed-sha256": "301b3ae5372593a7e873ab6a3866003daa1b438c20e8ec11f8a02eebc60f0493"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "ec7b8b89e29d9041aa741a500c065d92c1df1a1a1513cd4b85bfec3eb0fc38ce",
+                                "uncompressed-sha256": "0e14ab9a3f7e18f15ee8cd4a6713b37a790566e47d5370eb04aecc71fde9a1fb"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "9c17dbb9b45e397771b3015d5fc1cd8d85e169f031dd61895af60e31b5ea1d88",
-                                "uncompressed-sha256": "6092acced4b6af0309aebab40aaeaf1f17beebd1fc6b022437d7a5bc45482625"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "f3ceba15fdbb01f96b9aed7008c3013688c25550abfc317e7a79ab0eb011a6cb",
+                                "uncompressed-sha256": "bd9aaf3f5029f3af7fe17abfac922f48d09d964055c203a618feea9567857d42"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "3d602e565b054d5cbc02ce2e12bf3abf52b71b2535fc9b2742a882fb89e0ca8b",
-                                "uncompressed-sha256": "0ea09749852fd471e565ddf529974c564345ea5333e5ec483c8b488fa6130019"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a07216091f7b90aee2eb9ad2c79c2d55148043db6894ce7a8fdb49f3a82ef8aa",
+                                "uncompressed-sha256": "fda3592fa5f810ab131d9ff1c9f8f296f1a07bc1a80c2bd8be5fec1a007bdde8"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9bc6ad85a11a905b2bb57ca8acc6c8cb621bd404539398261451205e8d2df8dd",
-                                "uncompressed-sha256": "a1e6e589bbf4cc4d5f7909cfa162c30d1b32be4fb5550ef5f8322cff0c06066e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3154f4c3bc58be3f012c11d625bea29d70500d2433586b6fa431271d91e16e8d",
+                                "uncompressed-sha256": "ddf4e7b6c0d272d39b7661970272ea1e0ccd7463d1a81eb43bd3858a46324500"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7cbb396fef091c0dcdf301aaff32091b6ccc3d4191a927266ba956933b2ac830",
-                                "uncompressed-sha256": "ab8e651ae1299ca9684463652afab21f9af6b5a00b0bb3aa0453bbe48da63ed5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "92403297dba48b314174a8d56bab1c2ac8c89b7193dd5437114a03bc4df0010a",
+                                "uncompressed-sha256": "b4ed38902aaa97abca97edc6f60c6f7e30076ea83346ae1124ba02575b0f83e5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "66ada8bac6e7cfb1ae458b344d07afa17e382507f4f361660d42e2b4e4d14569",
-                                "uncompressed-sha256": "57ae9975c2d1b305ac20bda77013bce6b1e3fe6c3d36aa3b9156dc41aa5f34c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "e2566cc805d7bd4c43b50ab26529cf9fec59279fe733f4c7590b6674b2818ec7",
+                                "uncompressed-sha256": "3507844ee281444954227e253cc8935598c06a6a7fcecdb6bae24740898465a9"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6d1d79d9e39cfca4cbde32cdaaa811749575bf23e21c0ec938e116033038dab5",
-                                "uncompressed-sha256": "1bbb22a282635e43c164ab2e2015210b00dda54d7a23ffac57f67d87632c6351"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "0bd54ac46fd8fff1dc73c154daa5533c016ba52f8be0cd50357309ac0df28761",
+                                "uncompressed-sha256": "894ef5684069e1b4bc32192cd7b0e25969989e256f1cc4067378ff6f80d6dec4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "8aff16716f1d33714f70bfb12a7335711bc9961046ff9f9ab64e76037c1d61d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f7bd90c8d2918f8af959caa5eda54bdbffcb845b705ba45721ff684a71142db4"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "90a2c9ae0da57118bd94e76eafd19ddb231bbbc7218e5c97f6f86ba549f6bf06",
-                                "uncompressed-sha256": "7f33433a291aeeda20a7f92a5e69b5ac8687bd6ad0fe5a9272d9940ec49d701e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "f00e755ee34063cee7776d79c6146e3563970d36fdb170fd16c661651169db7d",
+                                "uncompressed-sha256": "fd1b4ddecc567b889744f3e22130cc77286d0762bda3d1aab6a8fb2e5043bbfd"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "6785230d3a0a0cc149e32a2f3987a4effd6fd7db8fb6721d33450ff9e926051e",
-                                "uncompressed-sha256": "a75f35d8ee8ba5013f84b7b917bb39fb0c46c8e85396312a5964241f523a4751"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "df16e63079a2882bca74086298becaa3c4c948a94b559bc7106c78953aa81bda",
+                                "uncompressed-sha256": "16a47f908089c0b1c686d4cf112e2e6ea7d4a8773998728f8df71cb5ace1d5b0"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "0c4eb4bb0de451a443ebb061640bb04ca75ef111d6cfedbb7c3e0f6f8738cb34",
-                                "uncompressed-sha256": "e1b8d371a6fa1a1e4d56499ff69175e437e2e5da6b16eceeb75685e702f03545"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "648fe5874b03e3e09ddd2fe98f6b77cbfe9176cc6a52c93a9b760d7affffc75d",
+                                "uncompressed-sha256": "1b04f858556e864ce7f3b0271c572906d849abd14e92f4a7fa04ee76b26c552b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "89c71baf1453ecc58e4f9a47f630d790ffd6f6ffcd7b21962d5e90400b9ac0ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "10dad417ac8935e08c94f9c560121b00e845a36426b912c83332704bc994af98"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2b6e25094914ad3d14e2dfa230e87ab5c3d564504a93f7403ce5c32c7a0b8455",
-                                "uncompressed-sha256": "ed5e13d67682f383c23f13ce14980999a8517a6197b05576b2236f0948efcb2d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "3222eb3f018b6af4ef6b8a72ce21578587a72079526f3180a6b2176380f56f30",
+                                "uncompressed-sha256": "e33a9e9cae0c68e7e9f90fe626c53ce93d89328bc5eae7d90e3fca0ec2929e75"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "b8152e926ad081c147b2161f043937ba8a28ca8a9282730c3be16dfcce26c44a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-iso.x86_64.iso.sig",
+                                "sha256": "71f337fa1715a236df05c5dcd98a38bb21c3de6e2fb7ec1d168c7a4896fc72df"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-kernel.x86_64.sig",
-                                "sha256": "5b26cf74177e2083c1521dcb0c5da667714baee33b71b4aac822c34682edf2af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-kernel.x86_64.sig",
+                                "sha256": "b0389e187ed951727560f517d589f3daa2736dc34dc9aa245b986d72b6f6c3ee"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "54cfa1e76d004c69f2f995bb950e18ca238ef402a7d0255ef5002a417b9a8c0c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "17eddde5d44f0bb438df64449d9bf23c89cc4f70373b6fb11a9690c889dbae84"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "82792870482d67c1ba64ecbf75ccbc269c7ca6b607d77033fe19bf12a165acfc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "2e37949353aeaf47695d5094416cd5ea02f0fe6991754077c6b86ad691e6a941"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "84da52caaa50a95c6c94fa5a636924161a97a208c2b24f1b41695b844c55388b",
-                                "uncompressed-sha256": "aff2f4b9ea3ae41c3646273e4daf009f81c0548c0a386bbf5c3a03d27b01b07a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "3238639aceedd5508d1f52159abf8f6729ec1da1c6e48b815ef1ac6b5570db73",
+                                "uncompressed-sha256": "39124b1741fbc9b373f28b89e51c97b43863e1919bd1d46e386fe7ac81c080e4"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9e8afdda738c38a97d7ff43b4c4168966ccf236e880017e8caa35ab4896e8857"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "aa13c5ea4b0607c5eba6c6a7333d03d2951323e591178947f6b5aaab939966eb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "20df663da31a4941c5d1d01c60eff7299e963466bdcfc186e4be11531bf68b4a",
-                                "uncompressed-sha256": "2f51534156bd1ffce35e574333d320a47a7ac691ecd9c4ab49abed4eeae49a4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "75cbcd8dc7592dbcef6e2242388b536a98dd714ad1778c416255209e13ce1742",
+                                "uncompressed-sha256": "901e8190fd7dde674cd5c1f9828b2abfe8bd444863646612106676b940dcd464"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "18e726c996a00149b714caf8ccbfa1f33dfbf243b246ad04e0f4dc2c67e6f965",
-                                "uncompressed-sha256": "1019c4f140a6c34342aef6631cd0fc9c82fa33e5e5aa9ed29bee36fe5f5fd22a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "98a80d44a97f9bdadd77d53e9112c69770a145db6efd5e7a52710d27f8386061",
+                                "uncompressed-sha256": "7ba1dd803bbc4cdbc097c44f0c83b4d3ba51b205618d031ae5361e03db24554d"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "613bef6c7bec035a930770c0650211ff2c45ab3e20b9ff7ec51efe47425d7a3b",
-                                "uncompressed-sha256": "0e85d1bfad7caf2274ae32816f00003e91e249b092e9eea8acea79dc75843a25"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "e2fec410aa91e5fceecd2d168f0713512ac8c6f97ce20bee830ca32f841735a2",
+                                "uncompressed-sha256": "72d746a079021f7ad7a169b29c8866fd6e360e867ead9b374052528f2e58ae59"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "7a6c8fef8a7d74c55ef5c805e9a9a48bde17d9946f13d218aab850d2a03d3caa",
-                                "uncompressed-sha256": "17337117d3756962d4090d012e1bc4945ee410251e11b713c1000e1d25efd1d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "10fae55d07217f42365f83eadf9f442b8984e19651c983d085400e0c16e39709",
+                                "uncompressed-sha256": "de06e243aa807191ed001efc39da09d199acd19307fe217166b19c4afe739f41"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "29e4870c437ecd34a050242c82b04f4b58a93e68035dc5056c2798fe37e38ddd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "83a75cf1fefe95c10f1e7cd8eb5a120e19dce96c30dae26cf7657bb9100fa26f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "cc8500d51075364eaa98707eb971d6ae53c3c53ed97ae35a154df6cddb6bdef8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "b75f85f9f1f9cd1fdcbc617ab508f1e9e6f933c4a0a100a03a3de2206ccb70ff"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260621.1.1/x86_64/fedora-coreos-44.20260621.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "730b0ea270cd823db259726642dba3112f90932e0b3f52398237353c99c38eaf",
-                                "uncompressed-sha256": "b539c57ad70e937b7b26851543b17d4dc61a9ecb6371355b236190dda0bcdc97"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "05b47aa6ab5b7e35e3b8833175e726a7dd7274798b977b43e098baad3a36f122",
+                                "uncompressed-sha256": "71299fc5fb36c8b3ef9d9d81f62e70f7de40d4eea465ad241eccc883479ff852"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-08e1f462413877074"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0ee4ef3650395ea1a"
                         },
                         "ap-east-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0ce784bfdc06b25ba"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0debece24d548e7e0"
                         },
                         "ap-east-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-061cb086b3db68933"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-086a9732aedc2a564"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-04030b38ff172c52d"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0674e4a9a5b868f40"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0dc3219407b92b9f9"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-09c4e2c9df9fd0def"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0768830915c89b1e8"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0e5786b0275495e12"
                         },
                         "ap-south-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-00fd2f27ed7878451"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0250541218c159bf5"
                         },
                         "ap-south-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0c4d2b8da6ab9376c"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-000364fc53b68559c"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0682482a88e2a4f9c"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-02a4078943acc1161"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0d4a66689d046e613"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0dcb52aca7fa8a781"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-085bcb7f90edcbec5"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-08a1ec7eb006672d6"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-09fe3762db7f95592"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0f03e92ba4da0295d"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-080475cd3b62f06db"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-05f963d8dbcae07f4"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0c4e4ca7d886a7062"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-04a9bc3b1a8b2e7bf"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-07e40286971c7a9a3"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-09f2e9926161b6b70"
                         },
                         "ca-central-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0ef4626e204d4d617"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-02fcd9f941a606f26"
                         },
                         "ca-west-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0bb03bde38380176a"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0094ed9e9bc217d9a"
                         },
                         "eu-central-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-04a6bb99036f1343d"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0082aaaf6b708ca9b"
                         },
                         "eu-central-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0f7e9a30594557e51"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0e3a147cead972c1d"
                         },
                         "eu-north-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-02f1920b9fc2038e1"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0800bc7e0d945afe4"
                         },
                         "eu-south-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-07d84e98cce95fe68"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-04217dfa9884f8f8e"
                         },
                         "eu-south-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-07d6e79afae2776c2"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0ce55f2b973141d2b"
                         },
                         "eu-west-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-06e1a22ed80faa95a"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0b99a6a46f28f3a00"
                         },
                         "eu-west-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0de414785da034289"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0abc9c873036545fd"
                         },
                         "eu-west-3": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0bd6cc69460c64b16"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0e0a76ec41d8a37c6"
                         },
                         "il-central-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0072dc6a98890583e"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-02e7d0a89f8dfa4ff"
                         },
                         "mx-central-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-04d0d1663e7538d81"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0471df65791904fdf"
                         },
                         "sa-east-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-020023a1882f2e7cf"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-06d0185fb5e3b6b0b"
                         },
                         "us-east-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-02ce32162bb8e8330"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-074f8d28e868331ec"
                         },
                         "us-east-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0f6cc7220c9dd1cfd"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0470c5778d24328de"
                         },
                         "us-west-1": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-060d9960ce4573252"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-0367ae0c73abd22b6"
                         },
                         "us-west-2": {
-                            "release": "44.20260621.1.1",
-                            "image": "ami-0a1f6def0bec6382b"
+                            "release": "44.20260707.1.1",
+                            "image": "ami-02dbb9ad09cc80862"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260621-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260707-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260621.1.1",
+                    "release": "44.20260707.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b798773b99fa292588fffb42e10a7dda9cec9a43606afe934d4bd7aca1cd256e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:291d8d38f0059740bd97d84b1da0a8596b599a9c575ff3eaa6d6cf9d284a4376"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-06-23T21:53:48Z",
+        "last-modified": "2026-07-08T23:30:20Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "209cc3a8562b0e80af332cd27a1a0ba168ea9805219f5b9622eea76e5e773996",
-                                "uncompressed-sha256": "47e43643e382e906e3bd7721ed78d69c2753bf3d95d22b956e4062ac6c578e50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "537ca78457a6d392d52b5a1a9aabbf0a54b20af5f27fe7062f96c9598959d802",
+                                "uncompressed-sha256": "114d622a73387699dcbf97b073467a49eccb7e9170a45b263494c17f11cec8dc"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "ffd24f5e6632b497d1b26658dc257b47e370f2834401036555d93edfc69b19b1",
-                                "uncompressed-sha256": "5d5cfe0c4194afd542b0298b14f8ec8ad420b0610c13f3e1f87cb589d687fb40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "65537e328135d26d8ce9d9939f745c33d2de33e3bc36f229919fa177e5a96a71",
+                                "uncompressed-sha256": "bbf5d9a0a4337e6ef0b12e43e7afdb935f0e8dad33ca89c6f3711c85fcd04d48"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "5eacbf4508589518e62b8deba7840906be1dcd587ee340a9ab4150cc1f621e0c",
-                                "uncompressed-sha256": "84dba6f79cfe72ba3f7396ca6a19203e62fbd77e816d4862e73a8ec147099add"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "75b178af110085dcddf510bf4cefa0ca378afb78eeedc8b14f2f911594798c4a",
+                                "uncompressed-sha256": "1cdef6cb820b5a0635fcb32e6b38d9625dca4911ab34e8fd1c30e90b722673a1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "d99d79dae464c92765a7f38fce4add8ee9998cc12bf2f11d141935218e64b893"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "e0c1941c2ddd067e01059d750f3670358316755c61f65c4584bcd428b8bb3a1c"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "ad8a71fa9ef3c48ad8f976a7551ed8fba64037df63bf36d53bbd7ed330b2c8bb",
-                                "uncompressed-sha256": "0705c4441d720eb64e2c0febd06873866220a7f9d67690c6c997f991dd88bfa9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "9c34221cacf363377f5ee27306c3e70b8b578250977bff502653fbb714dbccde",
+                                "uncompressed-sha256": "f0f237e303ae4acffc1d8ef06d1721d21971c2332b3709e0867d165245011e7c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "38069cf62e55c034def9cbded4a74070ed70002fd6e88fbea1f2be182539c4a5",
-                                "uncompressed-sha256": "f8240fb31d5ce4454794602846abe5e8436a715c02d3f2093fef56f63f51f7d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "4c42853462d9f60f3eb81e19304b73e7f6d40b7125b11dddb86d0e834121e77f",
+                                "uncompressed-sha256": "5d5f203ce701388cae09e9d89c1a33f26083dddf305e2008483082d3263ab5ed"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "2de23ddbe36904d074a1ca1ea90e68e08791ac37fc126279ff521dc2054857e9",
-                                "uncompressed-sha256": "d6f39a64d7c8ac2d3d6370dbd7469cd2b2b1e129702e0e4aceafbf61c7d4c6fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "7f702b68ac68c1fce6dd137a4ccc317f219f857659611942f8229be37ced117e",
+                                "uncompressed-sha256": "1d11d892797e29220ac55abb3675a1130bc423a29f0a53c6e120fe7b8d3b8265"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "7c98fecc0832ed4a26f9f0837a566f2b51c316034925d7ad93591b446ea3912d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "cbecb539d5fabc62617fd3dfea041e2a282bb5ea3b126ea10658e0e84c85c60f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-kernel.aarch64.sig",
-                                "sha256": "8fd6c12d431111bc017a228b3b30f18905e3a156c1a1d882e7daa2c5a288dd15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-kernel.aarch64.sig",
+                                "sha256": "01c4de729aff530638be34686e1d4553b6576151f1e1e3b38d83262f0d05a436"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "0b756817f5518674688aca2d92cee297962959cf1f172fbcf5c0bd5101e03174"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "f969913a361fbda40a979e4533c73d88234d6a595d6b2c3f060d831fcbd68497"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "7ab70505828322300dd6081b0f35720c3dadea35c2ef4ba30d6beb9452e3ab77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "dc0bc7df38c5d9443e9052d7e1710b474d3b4f6a7ec81b93e64477f73ec8a418"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "7adfd3ac47eff90a318bd777ff22557852a0c3ef70b86c2cf9280a2ebbbaaaee",
-                                "uncompressed-sha256": "460423d52767efe6b9163234d02ee3872c094edfd6137b81db87eaada8b6027a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "796192e13afbab7aa9bb2ef7a200f0b851b1851d29513cf50c94f5499978d9c5",
+                                "uncompressed-sha256": "1affa158fcd55806f7f68be54ebb4ca662c4384f342bb5af8904d899f8c07a7c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "911919e13ed307d375ff26e6840589d459403c9ea14b120d09ebba57e3820c8a",
-                                "uncompressed-sha256": "46ff5f5e13701760b8edbb0a28b77325e211d664024ac408dab60b6d5604a349"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d62e8a21035123d7d3e5cee3d9e3bbdbb89f1e9dcd20c84932ceb89bf12e6e16",
+                                "uncompressed-sha256": "5ca305894a22db756997d32fe30ad862027b13070016329cc9df7f8151911912"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "222ea9c912554edef4d760573726a3fb5c02cbf5da5c4a5672b9dd91d87f84da",
-                                "uncompressed-sha256": "083ac627cd1b66765ce03c3aa54c2f2d1aee71770e5808d1f6468f7f52b0b539"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "ec936d8ec6558d8e70567645b2ae497503b7e115f28491fb626040ea2dbd411a",
+                                "uncompressed-sha256": "3fb3bcb68e47318a59d78f01f1fc5499a2633b8e39741959bfaf55b139ab4346"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/aarch64/fedora-coreos-44.20260607.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c44f7e7ccba0dbcbb2d1826d35268555d2fa468ca9002c89ca3461caf27a320d",
-                                "uncompressed-sha256": "0c8cc4945fa4dabddf9fbaa8a2f17948d29f3f1c56f0ce7093481c865df1beb5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "84f1eed8e981b00a6058f5eb058a577fb78b53b2d47882bd5a849300b63454b4",
+                                "uncompressed-sha256": "a2421e4accd61e98a0959e07c67674a08d62617732c9d0099c653c1245ecb22a"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-01ca24ca3923a896f"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0173a10cd3c6268c3"
                         },
                         "ap-east-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0368c633d0836d3e3"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0193cfe0ec8ec60ea"
                         },
                         "ap-east-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-06a01e3303dcb44ad"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0c7943ed6f4384278"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-01133269061a7890e"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0fa876721cc44f390"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-012984e10eceef7ee"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-02336e8e8435ceffc"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0f10e5b59d9e311a2"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-08a83a726e43df571"
                         },
                         "ap-south-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0722759cc3aa10004"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0c57c8ab8d076dfd1"
                         },
                         "ap-south-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-04b425ae2f27330c6"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0224883d2b7922ac4"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-053bbcc18c5c293d7"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-049805b714641cf52"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0a0b4b4de655933fa"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0b36b281e8249854d"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-014032de9912f4e1d"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-04cd3b8e2d46986c3"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-033521244080dec99"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-08262eea3f28ae045"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0820ce5a8e9eed054"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-000ca013d1e4719c0"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-093debc32134fc2c5"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0a0e36bd792e20dde"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-019ec65346a182a58"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0c1876d5cb34e1d4e"
                         },
                         "ca-central-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0d8025b23d8341785"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0fa79bfb68d0d6c88"
                         },
                         "ca-west-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0a7fc03185b4df3a2"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-06d6c2728dbde5806"
                         },
                         "eu-central-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-079feff2686c599c2"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-031258abab65fdb68"
                         },
                         "eu-central-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-07a6e2a64a48af63f"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-009ff84a082e3e3db"
                         },
                         "eu-north-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0939a68a4d6e2f0d6"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0baba2e27f514691e"
                         },
                         "eu-south-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0387bf8a9798bb0f8"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0d4403313816dfffa"
                         },
                         "eu-south-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-00440a10b53380f5f"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-07c45188aa458be52"
                         },
                         "eu-west-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0de5b91779733decb"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-07cbba3244ea2c15e"
                         },
                         "eu-west-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0e48312faae427e4e"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0da7336c6c317494b"
                         },
                         "eu-west-3": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0e7508e4075a70fcd"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-013575ccffd4a3ea4"
                         },
                         "il-central-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-06594814cc250708f"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-08a19c4ef75afc51a"
                         },
                         "mx-central-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0b6b6dfda238ab704"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-08b38eaa39a3fa8a4"
                         },
                         "sa-east-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-077aab52b41934d18"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-066592816fac36349"
                         },
                         "us-east-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-02dc38499a3681cec"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0dd07d856bdf5281b"
                         },
                         "us-east-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-078fa5da4dc775918"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0e6f75e185fc1e2d3"
                         },
                         "us-west-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-013abbc78d72ceb02"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-088fca8a20c5a73ed"
                         },
                         "us-west-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-079c5f9728898099f"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-06c41e91776a59a35"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-44-20260607-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260621-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "7be00dce4915fb4722f226a77a47e1acff4a69365ffa0af5f93abbb36f313f07",
-                                "uncompressed-sha256": "8e922cd491920dab9ba41bd7d506da6a94ef70f848c5d06f615c9f03c71352dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "2d16a5ce2c734ef77fdbdfc1747a590bf5057093096584d22fb42f05a28c9b83",
+                                "uncompressed-sha256": "6b273c41b332792a2b2c5a3084bafb78f325bbc2ec94189be56c04c668ccbf0b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "d1495b5f0ba6e51043062d2507856297a5af1550c8ce0e53b1c4db3a87e5b10b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "69cfff4adc31b48e17f6c8137a399ad352b0df055fe110370d16ccfb969b95f3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "d336b41fc5a1e6c545212b65efc75ad40a2c5ccc83a247e59783eb0beabb5247"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "d9363d0f3cecc345e63731c6add8b08d55fbbc5d741d4163542e589b6c73d17c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "ff3774c407253267df6c42900535db6ba9552c9bc6b8a12402ddc50cdde95909"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "12e50e6731537393430e84f61def6adfaeba108684b19bf764972748cbda60f5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "a29fd938a73a6881e1e537796b629285403d9d67f369c2bbf479cb0cc50def58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "eac92d8f4f7c21427d57b66ed631f2a48b7455b08a7f368e286ad1d4e2e8c826"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "944b87b4b72b180991185b7994bac4bb58aedb7c3f9b8acf189861705b80fb0f",
-                                "uncompressed-sha256": "167cb4a959afa80d2b47fe7a9f637503c63e53cb8135b4739a53c36a58825695"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "b7cb8cd444320fcfaca82141002d30c6e43689735c8823aa745f7273d9d029d0",
+                                "uncompressed-sha256": "5f1561fe2b9dc38496929b9b9e16675c1281a72eead53b6a8c250cf72fabc35c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "3b6dcba0cf0f6b543e7dc5903fe89da515c089ac305e0b0816c22acc2dc0e966",
-                                "uncompressed-sha256": "00bdd66e4f9c709181754cd98bdad39aecbeb285da130acd0946d2608244f080"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "7cdfd123210e6d4af5b63524d160f0139928e8677a279c84e2a93e23af4e915f",
+                                "uncompressed-sha256": "cd0b71312568196196579049285430786a4622b5cc24d3d2ceadcb81e76f4a0b"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "826f9bea884f38e646993be6cb493d713e615194e31c405b526846ff6f813a1e",
-                                "uncompressed-sha256": "d42e096ccde7df5b228bea6c4668c9a2dbc113022f7580cd5ca6e5d5a752a9a4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "b7cac62b4b6b8ff08f46ae9640da2094b302d544ac5511bdd9f52002c0c3bb74",
+                                "uncompressed-sha256": "b4b1e64e7124f7d49b6c24c83702108abeb3e405cca82e02747e4605ae480758"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/ppc64le/fedora-coreos-44.20260607.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "bb70817620985a9b6b8ff8cb518955281c1ef3b7df3e07d0ec306c477db15054",
-                                "uncompressed-sha256": "a0cb64c3af2567464f8455bb5a035c024adc40be0089be25b3b3dd4ed9aadfb0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "26f8cddd12d65e85c3a1a649b60d53ba105ff1783a5c6d448b18946f39a040fe",
+                                "uncompressed-sha256": "0c008962fb5d11dfa6c6e88ba1bec3e5e19e63039932ab44f05a45f06195a974"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "3bcb9f1e5f2ecbdd3dad14d417f70d9bfd0c27a76c85a6950c8f419cde925144",
-                                "uncompressed-sha256": "cd2ba122c5b05a627ec624bd37fe9e85c82071e8f34994c4008805a3aaefe1bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e308afce89bfff3156516a8a06ad821b56e8c0d4fd3d4a87202473527c6fe90e",
+                                "uncompressed-sha256": "47dd8453f8995dad369fd8ed22866193bf00163879bec048e9f6ed26e42604f8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "b27aba3927aa484abfcba0441c3b428cdefa3c5f26db6ab4f17955369580f599"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "fa2e1a976f0383fc8ebaadb016d4a2926fa34726e1e2dcb107197e6899714853"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "4337af97bb0a5b5c2167647718db9d4ec6dc0c69b2dc0b3e7260d987210f56eb",
-                                "uncompressed-sha256": "d8b75dd5fa5c9474f2891fb330be36d7d15541accc479aa0d109fbd7aff9a2f2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "e3c13da320d6b71c8d2aa473f19ff3375edd2bad860f649beeaa48d7830618d7",
+                                "uncompressed-sha256": "6380bb630f8ffaad36ae35db950740bd3f492cf1c134b81ee646af0e413e88cc"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "b2936ddddd8dd39b49036d3d67f2d9a055ebcc9c43ebc26f0cecf7bda46711e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "12af7c1e08f0ff8200ca3fef016ffa573a5b9163a64758164577a357d9ef84f9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-kernel.s390x.sig",
-                                "sha256": "df85eeb1bfcab7a28106ba565d8975616cddcdf175d961848584ee57f9dd723c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-kernel.s390x.sig",
+                                "sha256": "2ba3928a20274a5f95f2dbda6a5479c998a1459798827a1707bf7e8495e98191"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "0c4547b4e2ad5ca53d5b4f945fe4ad09fd4a972ddb34e95f0159790cdbb40b0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "d2b8e2e2707995e71a5c418389aeff1045a7ace16ae7168b6b4640acd8757762"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "177c20e882c07ad942409f12a00585b1f3df4501f20675971c12f1383647f040"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "13acc6f5341211394fb1b5486af75aaf742787e45cc1a6b73e989a38b8027e8f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "06969a537eeee247aa33d0196dff1002c52092fbf3cdd57af60e3ce1abdd582c",
-                                "uncompressed-sha256": "f7712ae5ce6fc0d67b90b23e8fd6bc84edb9655ae8e846e3267f0683596f0339"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "81f01d6146c756ed823569204cc03ca8efe21c3d6cd6a952f8ff532de8689db1",
+                                "uncompressed-sha256": "cf14362ab706048c01c4bb70e50df7b526c1fe3318ad3b60df8a8bbaa46bcef6"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "3cd2c1053a51a8c0dc9486cfcb04ab3262254b876ff44d22b1228d7a719cf117",
-                                "uncompressed-sha256": "896e249acacf58e7716fe73aea5ae06e77fbbbbb408e84d5cbc54a9369c75771"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "acc56742204eef8099834376d124e6ef41bbcf674cb757c27fb730270df5f5e9",
+                                "uncompressed-sha256": "450c9d49764437fa9beb2dd35fad38d4dde8504e2f50faa49f02d803417d4036"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/s390x/fedora-coreos-44.20260607.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "8a58da2cae3981680c6a34d9ba498b1bdd51395f2ad5f78292f8097f68e8d958",
-                                "uncompressed-sha256": "153634d33579702c61c10e3eed21015aee06a745f37961f40eaadca72987a671"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4d32dec86479583715f2c7568a4579dddb76ee58fd6089dd32560880549efdd3",
+                                "uncompressed-sha256": "a5bb5efff3f81b82920ff4aded7eb75fb58165417992bcbc2314b968293afb1e"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:fcb5238ce32f0339027bbcbf8f8c3317a79025adce09796c271bfed65021b8e5"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5270a3593e6c5ceef6920e27455b60bedf667fe6bae93b25529e4310d20b2963"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f3b5417b0c22057229972e50c7c3ba0b8b8674138475b778f02f19de734133c0",
-                                "uncompressed-sha256": "22de0a2d29372220dff7c3c3ea412d303908df8ee9bea99e2d835c18de4cf619"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "4fd36588ddbad5a11f2b88b7c15809c1b0bb3c0bea9b4ab398030ebcb6b27815",
+                                "uncompressed-sha256": "91f5d5e1cab8291e4577a317d55a4c68f8e3e816a30a4b416df3e9c9fcae0b08"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "5750c5aa68425e03f1c24c3d4dba662e105858efdf2ad9a30e4ed4d7aa52e30d",
-                                "uncompressed-sha256": "8977843fdf5c69930a7ce8d9d45f3b56aeb82f1f5a6216aad346ab3ba20e75a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "c8d7d256bd540bcf5fb31881e22e10f0f7b586b1163dc7c8116c0af6fee1da7e",
+                                "uncompressed-sha256": "86d24abda42349e1fe18454c94d446d3fe93ca7691dd2ad340fca08589d9ec39"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "7949c6d1fd19d080ebb1b99e83b1970ca64d18610d6a3621febfbf529b0600f0",
-                                "uncompressed-sha256": "edebe891fc144c721adad5a9e103d2695e767eae31c2799d3cae505cfc3c705f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "35a28f0b1f94063acae9f00ba093d38e7a21694b3216eb18fd68abc1d21f3460",
+                                "uncompressed-sha256": "3871e8a97dbb7ac0e7d465b7ed1206a99b6edec6559550956506e9124e45aacb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9324c70dc4d57fb18c916003ebad3e7af0a1dd53c0d96bf44287cfb7504f75f0",
-                                "uncompressed-sha256": "834203880263b7b10ae79017627b1b523fdc14c3a424842843a0582d27db1451"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "c037f534a2da8ee0c6512352ef22ee015803efdfce0eb2541a1167bfdf74789c",
+                                "uncompressed-sha256": "a9600844241686ec7ec81e561ab5923d7c1afdc5b5d0debe777ca49c777ef8b4"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "41bff415245805b5fbc3cd13f63679da3cb7f7354ae3f87975fc66aa138d6d6c",
-                                "uncompressed-sha256": "df26c1ec18ba4a1ef03b3f9ad3d0115d230d83283bd923ca9fc4df965fa64639"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "a9cab51aed7b530ea89faca82bf7144b424d7ce2f71e867c51e886ef92b1c12d",
+                                "uncompressed-sha256": "87483388ff9a8a1ca60ed459ba7303518e7be9ea4cd43b5f33e153caea6b919f"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "3348a6e8e7ef7ba8664dadf8f5185ecb761616d6081bb46f18048ac4b37889d4",
-                                "uncompressed-sha256": "62136ba5e78f9241303ccc8f3cf0de0eba88eef158adbabe2574704cdcbd2898"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "14be19cfc5a0d65870ab24f0c11f07bffb4d2b778641ed9dfe55296c3957eb21",
+                                "uncompressed-sha256": "d44053a1e746b3faf590578558cfbcfe09562f4d3ddd2144816a566551b738b3"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "e7c160b9f15f36ba6d92b45dd30f4d78c3fcf6e0dd67ceac811c143679f3ec9a",
-                                "uncompressed-sha256": "9a8b4e198466845ac311b997ea23d1b7c05c6c1dfe8b1cecea4bc989333bc697"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "2fdd316aa988f5d084e77b07f6009bd3e0eda819c767833385293e4cee6b038d",
+                                "uncompressed-sha256": "e194c14d184b4b672b93f7dc5f438cf413c26e758a464e5ac50ee65beb2f473c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "082cd19b32fa039cf9a236700a47b3285ad35d872f82c76b641cf9a0cb44d15a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "bcdfa42266a16980671dc02b05bef051430633e9c048f2dc5245c0a91fb53caa"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "f6b6f61772ad946b2174e97d17b31b69713cf1067955cd2a4500538e079bddcb",
-                                "uncompressed-sha256": "c311de240ca6673937867f5914aa4c85c89fbd8e5391f2e160a955a5a67e663c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "9819ac7d3fa97cb8e21f25b2918b4af8b014c6a973b149b100165a6dd2891605",
+                                "uncompressed-sha256": "83056693562b591df5a9cfe5bc92f7564f7da0385149a69e316ee37a12242a90"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "08acabbd10e73f9702c9b915150b248ab81306501a244714aa0af12913399add",
-                                "uncompressed-sha256": "130438507f8a2bf64c84802c42296bbcc8f6d50348ebb0387ef4403ddfbaad8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "57a0f441699398c8318e414736bf185354c24882a6b92a5221c28459d57598a5",
+                                "uncompressed-sha256": "4029e97d88a02770ab85c18842241c119e75e786fe9769d29acadc19f1e3ebcc"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a3f8c63d0bb084da0322271b7f4e8aad7724a351eef9a5b29bfc07d64ae76689",
-                                "uncompressed-sha256": "ce454a308d75c6a1229359e6617d758e7e984cb494581e4a0bbbd7e544704159"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "2fac0b3f8c18d1fb37491bd6d81f1edabdac56c29d3486e4a228c4527a19c41a",
+                                "uncompressed-sha256": "bde9a32ca375a82248b464e2c2f40bbc0bf4093548e49f8196e6516907524090"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "2f7923952bd212676e8f5e30aa1031ad52f941eacea950c78aedda0ea172d821"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "f7d88cdf9e0c30ce5598c956e902018f9d2940f86daa191be87c19f865cbe47a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e4891c2d4143be186fca62d8c5313743c8355650e3f1195c9b41fe16e48593e8",
-                                "uncompressed-sha256": "40ac6b784167e838d849786c3cd01bcc9700523a3f12bb1d10c0c4e10b932c3a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0aa898beb854970d3f923ab791c013afb5c79442002def77e9229bfc3c65ff28",
+                                "uncompressed-sha256": "10b3d557e51ac002eda9c3687e2ef2f39ffa0b00d47f98f4728345de91394604"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "5952237edb8dd54b30a11ff1a5ffef35e027ef449650a0ff427ce08c5f9080da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "ea7cd4e81a5bdd4603865df6bbf0d617c8b69b0aef1ce890746658640f53151a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-kernel.x86_64.sig",
-                                "sha256": "05e5f16566f0bea5d21fafcb623afbfde63b668675d90ef2730afe4f93f47a38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-kernel.x86_64.sig",
+                                "sha256": "5b26cf74177e2083c1521dcb0c5da667714baee33b71b4aac822c34682edf2af"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "2a46f35397047be19e03c3bf84cdab8d394846df15c96fb38954ef797a28c9c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "b88d312dea3b444ba0cb7473ca8402b5273578785e6ed26d473bb6099db88830"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "2e9608ce064c674156748fc8a3e4a43edf0c36b40bb514d0e51ffb128af0e012"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "d955afef0f76b577017549ea64b2a7984a3a306a299aadd9a42c1f90f1e972ea"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "007830b6b7a1bfb4d29bf15de61eccfa6434a1bf3a10510ddf2c073f9cbc6154",
-                                "uncompressed-sha256": "82133c4d85a0d492c77dd50008071b54270e721206ba05171e31c76dfa5f5693"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "f6c8d81c02805cd00804762c1ebfb0092239c86fddec2a2923b4e7079ef13d9e",
+                                "uncompressed-sha256": "ae28aab5bd047b4727c789b14944021ca714dc937ead1cb7cdbd2844b4dbf304"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "9b508701b58fe798d25d16d9741a9538f4923238b4c5eab5e7f055a9f571bb81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "e4a8e2691213bd8990b9515176528aa6d8d02387584652344ad132f6753c61ff"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "4b7cdce0bc2b5138abe49ee9fa581f1f4bb305438a3313f10f312776f5ae7453",
-                                "uncompressed-sha256": "cac8c919d94a24d310e1683bb1764967b2e3e8fd19f68bcff6a941f328bf0f3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "b4b44d52084c8f1dc3c3f47ce0c1452b4c1a8e9e2ca09cc398f72abf3cd3c34c",
+                                "uncompressed-sha256": "b9e619723aadb8c3e4809ef13aa0e7df9122dbe1642976b352aa0bd52b3e009c"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "a11d4472586b118cd0dc993fe8881385a5f061fb5e537fe11f3bbdcf6dac20ef",
-                                "uncompressed-sha256": "0fc3c70c541071f158d557b6590c65ee5cd76e86f2faaa08fdd5057f05820d22"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "959c510eed55f737063c0044c348ecbc8d591d926308fa50c61f14afec01e7f8",
+                                "uncompressed-sha256": "f52c5b3dc0a5b3df3bcd3e172b08457223403abfaa273b931a256d8243c1b9ea"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "30fba74d4bb329d2c49bf6eed4349856d4e50d969e8ae4fa488ae1e6bba723bf",
-                                "uncompressed-sha256": "940cfaec230e743f7d781fb036a117c753d06ffe30ff8cef3b991807aa73b279"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "6083eb3b978b2f5cd79a2bcd4a45ef31cad2af98dc7f438da7009ed338aa9caa",
+                                "uncompressed-sha256": "1da6e4092ed529b143a608f38c637f00249ddf9dc8164568febb09e50a4ef0d3"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6eb083986174ec4b0e588314b9c94947a55a01a8a2d33e2fd865e4ddc6e81e38",
-                                "uncompressed-sha256": "0444acd1b800a1a6b910c1963c0967c2ea03121ec9b200f6acf1ef7fa7c93be3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "fb078ba59ef651d37f0e5b0cbe85b2b89c0aef0df3038b0a2c17388a4854076e",
+                                "uncompressed-sha256": "c35384b4a6f1451fa470cb363b845cc5465edc1ad1f1b2d31a157459318784aa"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "ecd0407802c0b07f7c7b1fe64c68752a9b4baeaa134087fac89e7d40bf23d13f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "13fa2562f71d40a75edb120567ad4f176fb9b238eedbb4b371432a1a48cdf2a9"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "0bf1c6619b2eaba2d720a032faae456008f8b75b22d79f1c3e29abbd2636525c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "8e175c4d6fa03a29e1581961e39edc16a1b37350f55dbaecd5f67498d1e9ab4d"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260607.3.1/x86_64/fedora-coreos-44.20260607.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "df732147e2d0a15857b07f1174336adf5413d1417da1a7052b6f80d7d548776f",
-                                "uncompressed-sha256": "dd68872fda81498a0bc187017c6acc5b23e1b42ab0de29c357597df92818eb28"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a0edbbd6262801d3418d8152cd01e804938f4824172931e2b9f3670f126ebb35",
+                                "uncompressed-sha256": "7e3df33410f73c0fdd7e152c995982544a4f9ba486b744831779af47fcf0d1d1"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-074a64fa736d7c08c"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0562e833d057bb4c7"
                         },
                         "ap-east-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0ce20be8d6f4d7a44"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0937decbffbe69fc0"
                         },
                         "ap-east-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-065cf8196a0ab68c1"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0e20639bc97438587"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0e4875c9a527d6e14"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-08754cd826aeb6f9a"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0d7e468638bf91e4a"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-01b60babbc20f0e53"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-043f2c521a40f84e5"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0631f46254cc5df55"
                         },
                         "ap-south-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0d5171ae62377a069"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0434201a5071b56b1"
                         },
                         "ap-south-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0c54d49cc00a20df8"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-04d918bde0cf3a14a"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0ec0a52aba7d21939"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-096ae0536eeb2f025"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-03a1f07e0cc93feb6"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0f3b5451c7515bd1b"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-006c63c1fc0ff66aa"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0509b03e53d83c749"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0d726b047169b9a2f"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0dc4055475ca4462e"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-049f3504c75fec0e4"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0f049742808b31aeb"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0f77a239ed0d75d32"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0a2bf23dac46903c7"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0967bf44f9e827071"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-09d4657922b253220"
                         },
                         "ca-central-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-018c8c27a8252ea37"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-06b913261a43b4c0f"
                         },
                         "ca-west-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-092e405fb1d510b7b"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-039cf1667109b432d"
                         },
                         "eu-central-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-01b6bd514e1e4285e"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-03899b6eaba55b80e"
                         },
                         "eu-central-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-02bea227f2a864497"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-048915694f5b7cafc"
                         },
                         "eu-north-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0f959d9a72157db28"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0b0ebb540cf5e2ed9"
                         },
                         "eu-south-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-09254d38a23c78ac1"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0ff8e594994d7d1af"
                         },
                         "eu-south-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-088acc5bf0308ac12"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0d3cfa2b8fe873178"
                         },
                         "eu-west-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-09b42f4920c03afa3"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0b88670037270d9e4"
                         },
                         "eu-west-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0f1ecda1ba6296398"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0fc1d2b8ffab91076"
                         },
                         "eu-west-3": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0082f7799011203f2"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0cff7c15996beb629"
                         },
                         "il-central-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-09ae2399bbd89ab19"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0a9bf019802c66c23"
                         },
                         "mx-central-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-027e7df2de8a8fa92"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-09137947bf04ffbe8"
                         },
                         "sa-east-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-05edb1bc1f4a07b88"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-0674e4c3519e6a0cb"
                         },
                         "us-east-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0081f3d938c33c2c6"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-012f6267deae0793b"
                         },
                         "us-east-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-037488c4679c64599"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-09759dc9df3f76e22"
                         },
                         "us-west-1": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0a42d08657740bf59"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-08b63ae8ece218cf6"
                         },
                         "us-west-2": {
-                            "release": "44.20260607.3.1",
-                            "image": "ami-0cd25e81f8d58e1f1"
+                            "release": "44.20260621.3.1",
+                            "image": "ami-066cc91e843e39173"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-44-20260607-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260621-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260607.3.1",
+                    "release": "44.20260621.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a08413b6387176db5705d3e0f894715e3da8b2f64a7d4ff83ac524558491450f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:14aba1b88af7ba1f8a67905511ab5a35211c49279179e2a0b72ae3897b75595d"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-06-23T21:53:50Z",
+        "last-modified": "2026-07-08T23:30:22Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "3fe4f8f9aa0f638ccde268a98d248599d268dc4e6d5bc28797c6982587842fc7",
-                                "uncompressed-sha256": "2303d7376465ae0cfd83121ef43426f9a8db18303c8826eb47d438638edd1b8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "21c403d5709f9dff11891fee5c13d9ccbd89cc84a2c31f29a629edfdc3c38f89",
+                                "uncompressed-sha256": "10cf8d9677e6389f680bb1602628e9c9b1d973f83cb49edd7db9d0fc75352718"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "9f0fce8ac1d3da7d161683f70b8184118bec55d94b329c409240cb2ffbd31d7d",
-                                "uncompressed-sha256": "44430449355ec87461b97bc1b5002f106ebcac590465fcf469da6f945a415ae0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "21cc758a373cedc121241d49544cd9c6ca0461b3625546a6796c79e16cdd2ed3",
+                                "uncompressed-sha256": "6652c947639f50ac98e5d9d6b121c9a2bb86fb698bb62a0750f68a395bbc1092"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "ca7055c9c814e73a4809db0d5f0770780730705096bb944a21d7ec4d5a572776",
-                                "uncompressed-sha256": "f5b76c1de9fc187334ed29c1ac71e37efb83ccb91ea81f2e007c4d654f80e216"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "5f8a5b13cb86ba7c3e87927ae344a5060664c1885990aa3d549be33b3bc94e40",
+                                "uncompressed-sha256": "f6e117d94a534de4b7eb1fd63d5729ed83ca65f0fd866657c5283e5f548e1372"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "1987ccb42c3e7b4770844d7633103c285016d93cb177c65aafd59e7edd005262"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a3b73e80357e731118bfa4972cc937c5de5f37a6b178946999e27df38503c673"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "a2ce577831afc8341136bcfac44911b91c46c0f9551ff262f500ea76b5cd89dd",
-                                "uncompressed-sha256": "9d1051a1f470e4252f29e58e930e3cb27890bc44dd041fe476315dd7cd2135ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "065ff4ebb73de04afc277bd05b7a78bc5942d0727e6e62ed8b1a87b6bcb14455",
+                                "uncompressed-sha256": "ec426ba8089cdcdb2d5dbbb670b0741ae9e46d8a9f65f379bc6893812817d897"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "132a115b05d9b3ced65503106b4661914804c734b62d08dabd349db87621f380",
-                                "uncompressed-sha256": "dda4ec80f53cee415349bc84bd76bc6a0442496a0a168f75febc1328e316582f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "e962710cbf7bb15e10dbca3b6062c40787723d0a70a54fd7ff88127471186061",
+                                "uncompressed-sha256": "5babd5144654115a2afa0858638f0ed509baca29f5fdbf1bba274b1a27c99d94"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "f3f3d4fa3ef828543ee2eea5576ed41c6d7c2b5595b3b645f8a615412026a17d",
-                                "uncompressed-sha256": "6c4a4cfdd12c478bb4f825ff4fcbbfd0bfe04efda51b68d6b2842e8638768d21"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "1bd805ef57abd8bff5c33e51f284c9a52233083ffd7b17c7b7753cef5edb73f3",
+                                "uncompressed-sha256": "7fc110f7966bf4e6722edcf5d701127e62a75fc0a33818ce974c717b8b849015"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "4e3a988d1655c2e6b254caf4514187dcd70091149a252ff9b6b9bbd121c08c47"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-iso.aarch64.iso.sig",
+                                "sha256": "c8bb38615e64d8058d713b6023cb0c79410fd06840159ea50cc3d2e0b13e1cb1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-kernel.aarch64.sig",
-                                "sha256": "01c4de729aff530638be34686e1d4553b6576151f1e1e3b38d83262f0d05a436"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-kernel.aarch64.sig",
+                                "sha256": "018d71ab8699adce28ff0ce32ea0e1ede76aabe2b2bf51209449b9bb2ce6b525"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "e71585f76994308a0f288c175cd8bed5924d98b8dcc08eb89754e993ee60596f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "daf0502020084735fb874613bd0402b6c3e10849981fc36d2c4e1a82dfbb8876"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "2ba2f1d3f167501432cd2700f8803bac613c33f61786dd0e2c8ebd2333984ede"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "718db7d928352b5eb097d4a3bc61a575e07499d16adef80391447eef0a6fe2f5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "2881e7cd37b8d18f21f656b257f32602ca5f8af20d4d8813fba5b098d23adef9",
-                                "uncompressed-sha256": "eeeeb549f48104bb8dff4ba51e9b086e24b569738f0c2ab90af9f42f1bc2cd96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "0379925d398ec790dabb365d8c8205fbd47b33f9e3953a779529d1e74b5a38b1",
+                                "uncompressed-sha256": "5b681edd1f01ca3f179261adb920482cb0f25aa9973662114f22c75c7324ef8b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "89418aa63fbfea75098459f6c92207a99504ef9d815344c5efff655283d06821",
-                                "uncompressed-sha256": "a80844fe04d2178f643308ec45353dac5bc5cb7178279ef148504381d598169a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "99b313d1effea4320b30d417c857cc177518ef198f2c1e089c47815ac623a2fc",
+                                "uncompressed-sha256": "8e103fbf5f8b0e6892ad04698fb3f6190e33aa03d9881bc88f5185b5a8cefa4b"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "2caee3692bcbbbe0cb9d0472bc644162dbf974d96f59a71808995f535f13034f",
-                                "uncompressed-sha256": "f6ea86a30549fb4341a38c6f34d71c16b74159ec8a36088ad6d7a3308c800913"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "1eaea222a1c4e3911147f8b571c8e47cdd36c2135e8e3aabd036bfd209d9445a",
+                                "uncompressed-sha256": "e92524256009df43ab457f1ecb3b58f50d62566577803af35be1ab7330674911"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/aarch64/fedora-coreos-44.20260621.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "58db7d9a92b3489e4fae03911ed0d082beae0f69695e510e343788cc116a765a",
-                                "uncompressed-sha256": "daeed914b8bdc223b67b5444d5f3ca12e8371f3c1a8cb3393bbedf42e78eaf26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "effc0f86fa558babed35cbeaae66c084d13909bfdb3b48dc99227cd33f637ac6",
+                                "uncompressed-sha256": "d8fbef331a1cbae79ecd15f9f8cc8893eac13bb0fad0453a769e4d92e654ef9a"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-082ec0c3c4dc7c62b"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0872a8c621c951e79"
                         },
                         "ap-east-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0fad9d5b59f759ebe"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-025df0470327bb5ca"
                         },
                         "ap-east-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0a9f4c34a39f62e75"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-09b52c258fb4978e1"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0c3f01f4de384d282"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-09308bc703efda923"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0d685118b9ae3b0b1"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0d88bb2bfa41571d9"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-098e285e5aa64ca10"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-03ce33ad10fa9273a"
                         },
                         "ap-south-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0c095ebb79f6135a9"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-01bb383ed2406766a"
                         },
                         "ap-south-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-096b572e428b3e96c"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0c974941640653287"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-016b6e8fc59bf1b85"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0eb1595356d557c22"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-07683031c0b65a6cc"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0d0ece28ab21248eb"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0bee3fd0ce12e3bbf"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0e4dadc182b1049e7"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-07501fd7378dcd44e"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0047db5a7876826d3"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0eb8e51ce71f5be93"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0571ce4e3589f32cc"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-096dee7926668751c"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-032d53d0ef1d5c8c3"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0d7edc0fb85ddd736"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0b3c76959797e43e5"
                         },
                         "ca-central-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0913553381ddce400"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0a5bf74294be1443c"
                         },
                         "ca-west-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-052742884bde487cb"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0b9c081b9ecd204fc"
                         },
                         "eu-central-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0384f9bd3669a7bf9"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-042c6dd5f7930abea"
                         },
                         "eu-central-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-021f6a6fd1f242d6d"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0968a3989fe5848cf"
                         },
                         "eu-north-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-07ddb2d28141af2db"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0195d25dd2bbe2c93"
                         },
                         "eu-south-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-079885d7bdeb7d980"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-070bbfcd06686bed7"
                         },
                         "eu-south-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-06d885a880f27540e"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0af180d51e5583809"
                         },
                         "eu-west-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-01f4625b71edcd4f2"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-05b4ed119bff27494"
                         },
                         "eu-west-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-098177eb519165e4a"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-02b12411d1f4d8fc3"
                         },
                         "eu-west-3": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-013aee6a1eee7b6bb"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0aec68ea827dc86a4"
                         },
                         "il-central-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-056bd7f594ad89a27"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-07df9fdc5505552f1"
                         },
                         "mx-central-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-00aafc535665fc4a9"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0848df64190896358"
                         },
                         "sa-east-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0af29468a0023b955"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-051b8def0db966455"
                         },
                         "us-east-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-036eebc1573c94bb1"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-077c65d20ce22a90c"
                         },
                         "us-east-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0b170adf27dc3e5d4"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-08986543800af8886"
                         },
                         "us-west-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0083081710867e4dd"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0f0f293895d5f378c"
                         },
                         "us-west-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0c08af607b829a21a"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0a929e48f81f2475d"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-44-20260621-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260707-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a922605199b0276248519c4f7778f4e8aba4f5aa0ab57319036cfc0f0f714c0f",
-                                "uncompressed-sha256": "7efd31af80e50ea99c3bb1fccbeacc04a1ab36d48654c4596c1668673d6abae7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "a42da865d54bf81d1a5402cf30f200d5fcedd87e4829514546cbc138c3260902",
+                                "uncompressed-sha256": "391df3081e5b0b7a72762125e33e03aba5a6684f89511f68a3cb5dbbc171d9b4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "fd202152fc3289167e9cc0f88a1055ae06196b9e3218675907ff134e872f19fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "ca2498a1f22ad207dc0695025af9d291d686dc5ea240e02fa988e70c1f9c857f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "d9363d0f3cecc345e63731c6add8b08d55fbbc5d741d4163542e589b6c73d17c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-kernel.ppc64le.sig",
+                                "sha256": "1107a231b463cd249fd2b3be025cd089d23dc3c77efcd34ff7500f37fb4d80a9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "1e43f21dba1758ae7ccefb256f84aa7107a95c5d5ae55d65abf03cce16f9500e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "41d160fd3e09e1bf27777c631b8b93e3ab104c4da3514e45eae72c684f3cc03c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "a65b6467796cf5a2eb39d234bd77815defae36fb203d3c3a85ac8b7967068df3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "d69cdfa226181d59e2060247b265fbd68ea05eb78a4368bb5ab907d1b4224cea"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "6bc7bd4223d5c2f0b156b37b82320377f19cfdc685bdd6f8c3baea84f7d0b831",
-                                "uncompressed-sha256": "613bbbb4b8645b53274138307bbbe73b5bc233facc30b206f971e8f9b44d7a16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "71239e7c7effca022635b4a767fab7a44ce102bca3aef4f94873cefae7c3564f",
+                                "uncompressed-sha256": "eb2e3033e8a3d3d839c4b00deee4446d1c97b65c40e6381eb777f2ddd73a8f1b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "23c31fbcef8023df75088c56533655560790c2eb5f9f528a390ad5655966a74d",
-                                "uncompressed-sha256": "7590e9712be47754c9dc6caa0df12fc4b388e6704488ac57ee82a517c2c57615"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e7ab6b3567f0b366d0c23a4c684fc2de44103cf394db86f1e8699279297aeddd",
+                                "uncompressed-sha256": "f309007d2f0f77a0b71daa634af842e0c6ad1397d6f68fb82b7601fcb6132940"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "10fa22d4eb33524c0d5b35fe9e77c845eed91db4f35a7b8cb3119652ecd065fe",
-                                "uncompressed-sha256": "80549cc7645a5f87d45cc98cf46631f04a84f626a1f57b453ecf90a558de5410"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "774cb147450696bac81720e50c5b43715358a2847b5a3f4026b81fe891cb102d",
+                                "uncompressed-sha256": "a8dc3d2f80c13e08bf092064226eb57075e67ed5dba57bf6ee428ad438b76d60"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/ppc64le/fedora-coreos-44.20260621.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "257649291b70967138a7b5cfbef28f1bde5dc2ef7c24a18246245b98ddd2dfa4",
-                                "uncompressed-sha256": "0f16944c83dee7f31eabdcff3475e5074066da8fd19c7bb5880bfdd6c2dfa401"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "289f4966df5f8367a74d8b622f550741ce9177d981f68507c41bdb9634ce0bca",
+                                "uncompressed-sha256": "dd9383ffa191b6c8df451e57ff6df4d910935d8ba6fd4694855c0fa3beea9b5f"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "591aa910a1f7c4ecb9e3d102c8cf16e041d0b1ada6dc2573d0c46f33e99bc95a",
-                                "uncompressed-sha256": "e7e8d64097072650bab3fe09671e219180c2afa8565b5fdc2bbf943a2a047390"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "684227300ba2fef6153332498556ce2f71629208d9a65639284354a9ef21b7a3",
+                                "uncompressed-sha256": "40b3b056b112b313ae25a29b01e8e10b5b48d75032e0f9a94ef776245a0e274d"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "65987946aab181f28c0cb42e65ccbc6c8f0015d1e1293b39d8919eb924903abb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "727576ea41c016932e8aff46a6deb3c799ce81ef62b66342b5f4be929c4347ce"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1069fc13bb29c6f88731140c673402eda3792aee27c564aa2580adfad6d69fd3",
-                                "uncompressed-sha256": "d32a8551efb458e18886c0c1eb9cd906c2e2a8af27bf24bf479d5c2fa00d097e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "55cd12b4df26b721f93f985a76a3f39d4517abb4ca6734f5ff10dcd14a586bc1",
+                                "uncompressed-sha256": "7fed23df8236e6202befa7acf0b644a72a914df93d19539546eb4ba7dd16c62a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "156640c2d6fe17b6d213d697019cb2cad72f2dbfd914257db612b7bdc4701ad5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-iso.s390x.iso.sig",
+                                "sha256": "b023bb0a8720c83b64c2a68a3c0c5df45b80a252311a9e80e82b9e80a693c533"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-kernel.s390x.sig",
-                                "sha256": "2ba3928a20274a5f95f2dbda6a5479c998a1459798827a1707bf7e8495e98191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-kernel.s390x.sig",
+                                "sha256": "5f8e1c0024859b89938f4e32f46c19b1e0b97535cb6b9ae37d2c8adbedb1f7eb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "6692f00a2a6755a5c23caa7ab73ea9cbe081d491d82117b0342ca140a909686c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "17be36672d11716787fd946a193fbc6ddba60129ffc69f86eb07865022f45ee1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "1c52c67d89aee9a4d0d9fc7deca78085341404f4c5dd827b53740842d11a51b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "7c7faf29f29d2d02de9c9b3a960bc7e1616583c08d1120fdae40669e3e74ccc9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "7a50054456f6463314a637a795f13633162bcd779d45a6f4af8152317a697723",
-                                "uncompressed-sha256": "729d29903f396bd6a6581d352f524deec39298d635d7241c54c7b54e5302d92f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "a15dc760bfc73b485393e75a1b1212d21b340c381f87bacb266318806ab8bb47",
+                                "uncompressed-sha256": "39d43a4ce0f8c5c5366ce69ce613128a012655acc4b46b380109987cce86bec8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "0d2794b15ff2bb5946bc0ed95faf33878ff2d24f7607867d4e5e6c9a3262bbb0",
-                                "uncompressed-sha256": "f5ed290cf9c5fac42dcbd17980d5fd9d2f192b2a2d9df51c852079891744b948"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "c5eb16c8947960acb796c82ed81715ab5b638c77c56c88bb81a5576127dfc0be",
+                                "uncompressed-sha256": "551e4e462a8d18e58e91940b87b5e447ac841286231d5a342002f99885bd8f01"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/s390x/fedora-coreos-44.20260621.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "ebe5307f05f3fd34d27ec665f8128ec8357ba05d66261cb6cf3f78ba75381f9f",
-                                "uncompressed-sha256": "6ac8f2c45dffe8adbbc8535ce00a7a8e4dbb0c7a5d3a52e4f190299d8db9bdef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "277c6aa666b46353bc6c437ca47a4844ab4dffa0bf192a9ac070309570bbe771",
+                                "uncompressed-sha256": "fa35a236ac92217953651090a0cbdbd5a7811a221d41713c97eb122115ba5b16"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e8dec28db42e54b92b60679aaa2bd4b55262572052eeb628d98fcb96cca7f23a"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:954e0be2cd65d13584020d2132161ea3af2d46c4f8cfccb8aaa60b5bf6c5e62c"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "1f2fa672965488776886ff522c3fa81b701552a009f5cd9ac2cc849e4fb323d9",
-                                "uncompressed-sha256": "cd5e4297cc29d7a350af7ef6c6fe8e31af6d0f590eb2fe03b0bac425cda1446a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "cd85ce1fc8d52787c84343315e9ed499f4e550f886de58032583348f246f7115",
+                                "uncompressed-sha256": "72841fd4de83b30cbf9101ceb08f347c48b2f2fe1fac363b48b634530b3c031c"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "bcd472cc19a9c55f5ed1383a46ff3e62187a667b82918954f2f3a270f8b78662",
-                                "uncompressed-sha256": "ea62280d9fe001209e3af1cd1365ade5a7679d682eca1d14d71e694b39839f5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "a2985d0c3b70a2da20c51e3a92f8231719b89e76722cfbb6bcd4990661310805",
+                                "uncompressed-sha256": "6a757de16b5d06cef23bc2415fde7ec17295f9df8d87366d775de758b4bd86c9"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "d741751f7dbf2d46452e4e2b21270aeb693c0e8892314bd1502c069947514837",
-                                "uncompressed-sha256": "e6dd85924f7659e71e0835764efbf12e59c8be8e4aa128604102a6505a820cf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "2659f474facecc5d2a3a030b5d01b2b142dee40393c8e2a439dc4b072c947fa2",
+                                "uncompressed-sha256": "c207c2afbe1206bd2cfeededa717c8d8d08d0ff8a4ca50bcd670c86f4088178f"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "500b93c3a8abc78190de7afd35e0e1e36ff372483621a22c9dca3f80cb6b3937",
-                                "uncompressed-sha256": "25896f088abca53897c67d8b77e1b51ba77d4ba147ad64a50a5099e6444686a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "db0baad0385e95ae06c9e4e38e5d1cbd134ff02f5f2a6345d6bb1f71741844ae",
+                                "uncompressed-sha256": "20eb23dcea3642a94d5def7c9810019374418bb02b93eaed3f8f8bdb80424a08"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7665c309032d999f119dba306933f434be15faf0c7f0e857794f5e27bf127e25",
-                                "uncompressed-sha256": "d4cce29cb28f8b167887870244725e77f2ca4fbadbcdc3a8343b29496f248f78"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8db4c568eb11bc81ee033b03138058141f7fe2259dce11c0ec05291a25d8cfa9",
+                                "uncompressed-sha256": "284f8b47dcf081506453ca61b19dac17f9f6a9dfdecd0cbf63eda802aa463634"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "164d77106bd4afbac514e7e0ee03ca2aeb9fe136f531afd023ee52b601f5d8b7",
-                                "uncompressed-sha256": "5a9cd116e4ff6162e629c7b72798a7a8069b29a8d685a89703eb818a2dcb4257"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "7879b6d8c42a74e968101bf205f339c48bd3ab56d4e5f9feb2f44f42c84c6a7b",
+                                "uncompressed-sha256": "37d4b72540d905aca2eb10362112585bf94e8c0af2183ec79a934265c91c55c4"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "8888e2f2505f5d9980959381493bb25967fe7e61f3d1e005c78a0d0158864714",
-                                "uncompressed-sha256": "0de01e3a3b5e375f0d03c495503ef05a8b3b477e0dd9f0c8397868b19aad9855"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6333f5b61467b3f533012b231330ba2e66cc761adc8cde6cde610cc138ebe56c",
+                                "uncompressed-sha256": "de72a9a1e40fe9b75b3b07ee72681ed6e0636e9b1af1667391e85f6bb45513bb"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "54042ef069a85bc610c5ab5396b35f703403796c8f0609b8705611fc77bf696b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9f50476e6a65d4055a83e99bcb258014775f2ccff3948902917c584c2d2461ef"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "7ca38c6ca24b53276304ed20c598696a6fc36125724490c6bb208b0688ffeec6",
-                                "uncompressed-sha256": "f62b5697dc78234bee8f5d7b83c642bbf20aa72aea0f53df343b63e78c68e5d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "5922e435730f1760322957037af2b35c4f659826c7a1a964d4e9d4ba4c1cce60",
+                                "uncompressed-sha256": "7ebb2a0e37ab872125ab8e4ace2e7ec065ad1b0a29cccd76224d1b76d316a7ab"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "6bcab7d80bef5b986656afb037d793131fd6a46a4c30e4274b320ca3f9ec2906",
-                                "uncompressed-sha256": "f034ec47d75b724e84a0a89ce1fcb3dc5236927e16345615bb5d508202254c4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e2505bc0effb408554bc01294c33ca301d54646e8411a37600721ca487e3f56e",
+                                "uncompressed-sha256": "8adaa9083db4d2f9f41b301c619676e6c1d2efb0a8e5121cf68fe00d33c082ea"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "6a81ee952e32aaee2753d52feb048acb2545ed65687bc096335d0262db07664a",
-                                "uncompressed-sha256": "101c2e2a84ccbbe5bb73caf028addaa50fc3ed47ea44a81ff780a0395b81c4ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c2d4e61b59ecba754e393fd3c5c91d58259aa05416a31895ebebd6ddfbbc74be",
+                                "uncompressed-sha256": "9fb5242a9931180bc0a0fe76a1ab854372dad6de18601b01ccd062871db72df0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "72c009d72a690ad657af098179ab80bbca2fed59660001546e75acea1d74e15f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "73916ff2bfd8dbde7e91eedad7752bd8092b4a5e76c6da0e69baa38f4ee4ee33"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9927277f6a3c7127c103560863a99a74fc184b413cfda8f0c72ed0e2c0552e75",
-                                "uncompressed-sha256": "1efb2c0733c2dd6bcaf82050d800971b1bc38f4c53519877ae1ec03fa9b1e815"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "ef7ceef6332d083f78df9c972958a62da9a0d0b295d322b6e0068fb9fec0f79a",
+                                "uncompressed-sha256": "c99522f219de12b8f23fdba4dead51b04d48e8bd1510568ecc935736e18952ef"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "38aea7ce5c37ac5a60640ceb6aa81da8b1120efec24a572be2a7bf481ad5f196"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-iso.x86_64.iso.sig",
+                                "sha256": "a2d8f9124008274e2c9ad2ca0d305cba8a3017993e0ca70745cf86f1cbb80e80"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-kernel.x86_64.sig",
-                                "sha256": "5b26cf74177e2083c1521dcb0c5da667714baee33b71b4aac822c34682edf2af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-kernel.x86_64.sig",
+                                "sha256": "b0389e187ed951727560f517d589f3daa2736dc34dc9aa245b986d72b6f6c3ee"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "ca44a0ed28ccb4b950b844a730e938d964b779efa4842b4a158b9d89a0fed7d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "5770ef0a2eef37a7e8f578e0a1de9f7c4577fa1b3a40d2b475f438857bd56536"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "d53646d0e9e5a0149ce0497484d2754e950ccace6cc76b4370c5068115b61d30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "f87b47e6d6340f802b1af42de714d578b1059abb47457ac2de5eabf73025f44a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "54a239a560d0cb2991fa6038a77c2b3744c67b5f35c031e5a1ab4bf39be99dee",
-                                "uncompressed-sha256": "7404cf492643ee8f9adf0935e5375d1a1e90755fae20eadf7871dda3d1662a05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "957e7e3c3f89c96c0db70e244efde82afef3761494df2a4ab60282f4df82b94e",
+                                "uncompressed-sha256": "26ea06dbe4ad7450647ce451530689619f221f8f91baf11f2913ef8c0c1469d6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "6b24a15607207ae383b2916ba7a5b3d371fb6bb11279b428128a56d83d35c0dd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4936571e6191ab7a9400a8b0ca4eae94dd3bafbfc5c1d6c7a7b77377ced0a492"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "52a6f4d8eb3c89a6aa83a0072d40ae2bd69d46f968821e172fc752836b9be7a6",
-                                "uncompressed-sha256": "cca1405016a982b485089ffeb49661c3ba639df979517a4ebc4cdf38f33a3e62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "30fbb28c35fc1ee676714c2b0f40ebb04ba0872ccaf82c481f83e6d8ae95d9fd",
+                                "uncompressed-sha256": "91445add87a7aa021cd1c11968072d127eac80986ec0c53db715651ee15b2c2b"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7e5097eaf81b5fe734520f4186e9473984f60e515dbee5f1c62b21eb0dca534c",
-                                "uncompressed-sha256": "b18e8c49263ac952c79ba7430fd3eaf37e1a77179b9a8e076871807a9fc317e0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "d27b5c7f8661f1666e18bd3346d68fffb2dfbe416ae3f2535599476d69cfaea2",
+                                "uncompressed-sha256": "db70c72118ed7dff37a4d3c1f1b2d698be50250f023c548cf9cb342e66056f39"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "d6ca06af18139dfc5d08b4b240f04ad180f38f43cee17c51437f968fe237a1a0",
-                                "uncompressed-sha256": "9149518898cfbd27f442ea3c909b04cf6ff0a4ab14f02a80aa81615c27261701"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "9c3418e3555a4ea401ceec858c28a00fcd190ca5aa16007f2daf1c5829735c37",
+                                "uncompressed-sha256": "6e4c3413c4e3fa29ee13e8dcc074d5a564d13ab90e2d1767126abb151cbb4100"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ec834e7b67dafe37279080efcf4b71a96fcbfa31770323a56d7340f1a627aeef",
-                                "uncompressed-sha256": "5549951b895ab6663dbbe4406e6ae2e9d09b23ce5987b824b18e814b0014f545"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "ffa1e63a613abc50652b4343f9c7ce90f4bac193ead2c87cba6988c2733ef300",
+                                "uncompressed-sha256": "3a2c0a9be52f4211310e7d7b8821dde23ea5b52422267386175a335d25073266"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "390999a60a4637f8ab9246eaa1d0e78dbf03be1d52275dca7065cfba2f88ea77"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "286f9070797cf462f36ad9770907b5fc22fa90be6709fedfd297a101881c8eb7"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "197d38f6c29732def1eb4316717e43060b9f7479d35a0ed2608f366dad4968f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "0c9d59fb583f23f36c6395d98cbfdaed95d91c72c48eca9b2d1b8d4320118318"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260621.2.1/x86_64/fedora-coreos-44.20260621.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4b7487acd6bdb73fe4b6f44576c5c303c69940323c0d50c546ace87f4b75b01e",
-                                "uncompressed-sha256": "3b2ef60f980ef07f8509d51590ee636c0b4c0fb43fb87aa8e82dc871f947bfc1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "5a2328ed818faed029863df54f53df47b9e88d6b12fd02637bde202bfccaaf1a",
+                                "uncompressed-sha256": "8e298d2404f34709e3c2e01329a165ca47017594d29c07bab6778df9097cce06"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-00bfa56cf04b15cb2"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0987415a98256f389"
                         },
                         "ap-east-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0e7c44f8e17646c72"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0189c8eb2d694ee77"
                         },
                         "ap-east-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0eea13bb586895a16"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0e88b5cfd8d6a5f64"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0a0c1ef4866f692e0"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-000403330f8b083db"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0ca1feb620f38b64d"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-08ccaf207fb758727"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0addda037b9f581a7"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0f8c2e7b837367346"
                         },
                         "ap-south-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0d6f7c2f905be0fcd"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0f93606b0a7c27a70"
                         },
                         "ap-south-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0b3e2b271cf4c5906"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0e8d33b5b38cafb19"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-06f24c5d1f0f63ff5"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-033953b44a8546b5a"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-08f64b863f40bdd91"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-080d8b565c09ad9e0"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0468cab509ff1d070"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0c542034f225aa3da"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0fd245a5408df7f4e"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0c051419ddcd24032"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0800e6b009ddcd116"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0f3ba6f782e39df8f"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-06667aadf7b56a5c5"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0d5093a291c6a2e44"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0e79c6912872101b9"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-09b22f198458830df"
                         },
                         "ca-central-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-085990b2c5b0fb858"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-00ae626780863035d"
                         },
                         "ca-west-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-03aeef2ec668ee644"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0f64a3137395bec19"
                         },
                         "eu-central-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0da5b95b43b48bc11"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-02e1408a82fa721ec"
                         },
                         "eu-central-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0e7d61e4f454ddfc1"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0eac822eca2694105"
                         },
                         "eu-north-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-07cf7cf2f2d279b84"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-09c46f2d28074fc63"
                         },
                         "eu-south-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-04c1555339c65da96"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-06800313ccae14eb5"
                         },
                         "eu-south-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-062849954cc4708a2"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-08ee62138a48b3eee"
                         },
                         "eu-west-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-01a339c1c33dc4407"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0abf6980b5cb10672"
                         },
                         "eu-west-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0d35c50a955d48fa5"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-05787ec0ece275cf0"
                         },
                         "eu-west-3": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-02fe3573d83ee55c0"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0cfdc6567cc493437"
                         },
                         "il-central-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0b3fa10de6f72efad"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-022b5a478a411e251"
                         },
                         "mx-central-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0379fee172e186ac4"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0cbfc41f6bf949044"
                         },
                         "sa-east-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-03f4a487d7fca7119"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0e1c70c553de7ed60"
                         },
                         "us-east-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-058319937d5719f76"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0041e2345af8348e9"
                         },
                         "us-east-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-05be70a8e71bfffa2"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-04f77aeb29c1b4969"
                         },
                         "us-west-1": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0c967663bbb266f7d"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0f0bc8140ac72e824"
                         },
                         "us-west-2": {
-                            "release": "44.20260621.2.1",
-                            "image": "ami-0086759a5954aa41a"
+                            "release": "44.20260707.2.1",
+                            "image": "ami-0fe6b2f28eec91553"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-44-20260621-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260707-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260621.2.1",
+                    "release": "44.20260707.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d61689e48700386467d6aa17212f46910fcc351354fcfb496d904dbfc41a3288"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3bf607b9470d1947c8ff3b0f268c015dc446493a6899bcedc9969d131c02f4d0"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-06-23T21:53:51Z"
+    "last-modified": "2026-07-08T23:30:24Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260607.1.1",
+      "version": "44.20260621.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260621.1.1",
+      "version": "44.20260707.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1782309600,
+          "start_epoch": 1783605600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-06-23T21:53:49Z"
+    "last-modified": "2026-07-08T23:30:21Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260523.3.1",
+      "version": "44.20260607.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260607.3.1",
+      "version": "44.20260621.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1782309600,
+          "start_epoch": 1783605600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-06-23T21:53:50Z"
+    "last-modified": "2026-07-08T23:30:23Z"
   },
   "releases": [
     {
@@ -173,7 +173,7 @@
       }
     },
     {
-      "version": "44.20260607.2.1",
+      "version": "44.20260621.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -181,11 +181,11 @@
       }
     },
     {
-      "version": "44.20260621.2.1",
+      "version": "44.20260707.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1782309600,
+          "start_epoch": 1783605600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @yasminvalim via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).