### PR TITLE
Roll out stable 44.20260707.3.1, testing 44.20260720.2.1, next 44.20260720.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-07-08T23:30:24Z",
+        "last-modified": "2026-07-21T14:07:14Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "b80d6da60d7db3d91913d8eedb98837130a08bcdb5cddb8e3403561f080ceb16",
-                                "uncompressed-sha256": "0d25c566fa4c413d14143c44fff3b39bf3c739e44beeb8c5ddd822d7bd36bee6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "67c4a382ce770df1cf8fb82090a4d37f0ea1fe8c2db656d02410488464096804",
+                                "uncompressed-sha256": "b3e9100054c591e17ca4a5c6116e8a9e2ecd227e5916a19d966d29cb3fb4bf76"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b60f339d52fff0fb5d5220d02f713a8e89258ee2ac458a29cd4395abda15da2c",
-                                "uncompressed-sha256": "bd563ea15c6788b26ea1793dda7f73a04be2efc8f04b7957de6160aa62afae98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "d9b87121c0a2d1e801c18114200c44cc31359a09cf58d3c12728ab7062b7be31",
+                                "uncompressed-sha256": "2caa524b290fe082b47d4327683284b87bebe8940aba15d8ab702a984814a037"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "829d034d1eff27c10c687f436b5a88173c7f106a825f964054222523958b645a",
-                                "uncompressed-sha256": "2d114734eeb43718f35fe30eb36153604304bac3decb681ed7270bd211eed391"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "bacfd08b6f22c639899785e649a4045d4a58768d587b92afb27d2b49f1705b6f",
+                                "uncompressed-sha256": "915f736707849abe7bf9ef2dd0294e4c2f730a5cc16798eff0b25edc7af26336"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "92c5ce18177a5f67fd5960e0358a26c2774260df5ceaeea2d527e9416eab1506"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a609cf0fa619d37ba6fb9e8b91a2b3ad9966d0ca00f53204fd79da0f0b10ef84"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "fa027c67248f933838b4e6af5588bcec3117fc3f4fb4aa414ddc0776218832a4",
-                                "uncompressed-sha256": "99993ff2dd0b0c45bf8010059d196b8cf7e095a800ecba638333006f82abf608"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "1f45b3576807ab1a78905b1cad47cda58a66214cb06cc4e94cb7654d97ccaf7d",
+                                "uncompressed-sha256": "a9c34c3020ccf8a9d587cc8ae48f1cd0627a3cb2e8a033eff6611716ac640839"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "f8ed307242fb0005482a9610dffa5b8433afbae29e4440445050bfc64f7ff9f5",
-                                "uncompressed-sha256": "ab4a4a97f04cf0da0b80c82b4a0ee3df946bf32cc013abcdec7cddf07df0f90e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "5143db42dcfd1b7800723d8adb74ff76d2335d3f2409d76fc98e4141b9de2635",
+                                "uncompressed-sha256": "3956275782499361a9919be99a013fe154f6248f3149fe77442808b6f49a60fd"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "46cb3a4d3c058708bdf45287494a04e52010e25fd40a7853424393b7fb12fcfd",
-                                "uncompressed-sha256": "b4641eca78433100275bd04cca3ce517778eb1f66a6d7f2fb093ab49db1323c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "ea8fc5fbeb6e72c3cc766a0d981be1e7f80b6ce7ba611bd1aa635c3f1f26cdcb",
+                                "uncompressed-sha256": "396796cfe400b2795ca3cd165a1885bc0a6dd4aa131a369b5c8856bdb17d176e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "d8a7fce04adff9b9bd6a80bd53d51bbecf5a9de155244a246220e2c13a9e9b03"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-iso.aarch64.iso.sig",
+                                "sha256": "475b1a082a935f27d9498f8005a4c53fcec8d338279ea7d8985a54bcf1d3d782"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-kernel.aarch64.sig",
-                                "sha256": "018d71ab8699adce28ff0ce32ea0e1ede76aabe2b2bf51209449b9bb2ce6b525"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-kernel.aarch64.sig",
+                                "sha256": "65e828721142335cd235ab34ff8bbe2ead12191f99c3161f69a1a53c72579b2e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "2450fcb846671d8afe2911a4d8188d4f0476d864029668e82b09aa3d9e51aa3e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "f30eb7b5bd8c15855e692f635bb9477b2dd50871d33fa0da10f4a944a82afb09"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "98c8b0e0bda8e703667ed14707de60a00a002864e0c768b38cc24919bbbd1a2f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "b42cbd17b4fe11324293443b48119146ec6b8903b1f63203f21bc213db5b7b90"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "502102284f2f50b01b9b3c11cc36c120e024427a531c051fce86e5c0ac9d680f",
-                                "uncompressed-sha256": "59b84a163f7837e678fcb5a5fc5fd29b5bbd0d00e2fd156b8d5cb80514576033"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "cd262800d821aaa7d4dd24a900b7b4973c5921b317596af6be34bde97bfb8fea",
+                                "uncompressed-sha256": "3623d934eb4f8564dfd9771a9c5579050b307d45147d75e2ed4f14eafee233cf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4c412b49db9f19ec4397a1211e86c7eaed963d5a2a43acd7226ae426a00f1c70",
-                                "uncompressed-sha256": "7aea1f22c59ffb5bb65b18756e23011d034df9cda741678c7dc38499c79a7021"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "781fbdb00ea0fe20da0f7c5410ddf76d909e8ea8241827489765adffdea65fb7",
+                                "uncompressed-sha256": "6762d0f2afff6a2921aafa44cd48a76c27a0c5df0926ce9edc1d1249a3162f5a"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "8eecf7fdfe648b06eeac366907b3f093b1cfaec8bf80c0cbcf48d15f79711670",
-                                "uncompressed-sha256": "2355076f44b73958f2e4994a69157f21f9a6cfa42e35aa8def1b4a973d593394"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "2982f1efd206982146b8329007e2de0817924b6bb19ec37bdd7a022f1cfdae4f",
+                                "uncompressed-sha256": "f3a3feb52e456e6c77312d9899f1ed3992d3bc9b51dcecd38734447d3233df91"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/aarch64/fedora-coreos-44.20260707.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e680dc10cd8d6579ed11e3e822671415e6ca0fcc2bdf69ef15475aea84ad7d45",
-                                "uncompressed-sha256": "fd795b5dde0d6f8dba74422b715b96ec78938c6f3641de22a777f82ee63b3a27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "81046efe1680e1a99b302c7007256388def250d69f672551820fcccfc154fe64",
+                                "uncompressed-sha256": "d43390267dbbd2236aa75eb54e5d90127ecdb9e3a751b7e07e261f54df5ee991"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0f4fa093157e4ff8d"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0436d4d459c22ddc6"
                         },
                         "ap-east-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0427d8488c614ae02"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-009cdf98a036c90d2"
                         },
                         "ap-east-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-025ee0813ca487c02"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0f21fb3e5b488169c"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0a5dd4adc465ce957"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-087f775baa101060d"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0f4d2138245f81817"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0df9aaa583e269c3b"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-09d96c720659ff6b7"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-043d4274effa21cad"
                         },
                         "ap-south-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0033838a41ffec674"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0251d9f4d15bf8d2e"
                         },
                         "ap-south-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-09e35d145ba29f407"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0a5eb5527ca656335"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-02358f292e0158f9d"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-04a0b8bfb39c85010"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0d703ca76d1b42c96"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-09bf1e8f60bc0714a"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-07451c44f268929fc"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0fb84544470bb99ed"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0a1bb28a6fdffbd0a"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-06104758d06a47be1"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0d34c08d0edf953fc"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0e7d66a2b72adfc7b"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-06809cb8c55735455"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-073dd1e0eb65b2944"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-07fd7d12ad92dbf30"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0fc8472d8690edf71"
                         },
                         "ca-central-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-031bc3172ef31b0bf"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0eddf67a9f3b45b2b"
                         },
                         "ca-west-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-02179a11e3a5bcb08"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0d2e3517a96c55cae"
                         },
                         "eu-central-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0b47a9c4daa102c4c"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0e4407a5849fe9a36"
                         },
                         "eu-central-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-04602ada4c29d466a"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0380fad0c6f802c68"
                         },
                         "eu-north-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0f3a32fdafe28d122"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-01d8810653e5dd217"
                         },
                         "eu-south-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-07cdbdbab6d51fad5"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0c5aa065d8df16df3"
                         },
                         "eu-south-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0162d1f066b9017ab"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-020a8ba8a0d940db7"
                         },
                         "eu-west-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-09d8cedbaadd5ddca"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0506b14871bf45a67"
                         },
                         "eu-west-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-01a4585b480e1ac25"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0af30889223dd50bd"
                         },
                         "eu-west-3": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-01ba6ba95e4ab02ad"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0ceaecd3296d1b058"
                         },
                         "il-central-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-001ffb5fc53330883"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0c6cab2a745eed66c"
                         },
                         "mx-central-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0db7bafa20493f212"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-084caf8fde30aa938"
                         },
                         "sa-east-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-006fdcdb34b46b973"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-06b99c3c683d525f7"
                         },
                         "us-east-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0b20f95924fcaf43b"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0e46714f061aba47b"
                         },
                         "us-east-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-06b598bee6c7709c7"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-090f8625cee349ac1"
                         },
                         "us-west-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-01002ea0a8f903824"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-059d6b23d070fb73a"
                         },
                         "us-west-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0ee747cc7f25bcd00"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-01593f1917f45e483"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260707-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260720-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "ad9fecc30655af697f34bb0d9726d44cae2bf5d27fb25221db996be44abc1a3c",
-                                "uncompressed-sha256": "a9a724225302cbe41845ec56d038f58c3cebf4ba4fceb959ce510db8020dbbc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "465aef91d8a6396a00b36e262811a12f1fe0a27f41df25215b10a0fb987af5ae",
+                                "uncompressed-sha256": "a4ad29d23b919cb78e69dfdf276850645377951dee733dddde01d2a2d8a7b390"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "4a2ecb68bddf6acb432c3c41cbd1b60ceb0db9a2e48373ddc9dc86a19bebe1a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "eaca3ae4354315a7c8f6264f7a94da88fae8af8b843f5fb8b7ed846b1cffbb3c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "1107a231b463cd249fd2b3be025cd089d23dc3c77efcd34ff7500f37fb4d80a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-kernel.ppc64le.sig",
+                                "sha256": "4bf2a7173bd32993e9097c68c8c0036a1dd2b3028ba7c93c74367c1e15743196"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "28181a014b6db208be5342283dee88eea2530d2c59805186b186dddba1bc72ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "5954b14b1aa5e6b5d98f847e9c88c51b22ac9182e668cdf33e3b9c37f03bbe1f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "38f05ac159a25a6c7897a0a1fc0d56d3f1c71c8afbd1dfa459bd46698fbcce1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "caae1ce5248afd37948c55e4196d5c3ccf7c79d96824c147334b738225868fce"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "47db46ef146a86024c644d15a28bfe15774af00779ad62e3c5f10b162939d05a",
-                                "uncompressed-sha256": "b6991a3b7eb43f0b877027f60f07d5ac99a0015c42fc6ecc00f02ec3e551b9cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "1f21d40dd4b5cf7226b616d0a064ad0b8f1d8790b4e729141d78098c86736d65",
+                                "uncompressed-sha256": "eb1dc363ddc5907ad362d9155d5edf5844036df87e209fd68061265a75d4440e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "a571a3975e7b76837a0f8037e29e49ee57dad9ee883cee4447816e3525801296",
-                                "uncompressed-sha256": "d13a94dbb9ec7339f18ff3331b8e62260d23ac9b779dc1ffd19ff52b65b16199"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "4e97d86c3e15cbdea907038ed0f05a04c91d20ef1f1bba2f5b44f8c8ee33ab7f",
+                                "uncompressed-sha256": "70d74a59d8ebdb3cade1d74a74ee177e4d225e86777d77e9b28762229b2a4c96"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "e1a4d9a00cf172cc55e012c2ff23dc443581ab5e591116870f3df333a62fc672",
-                                "uncompressed-sha256": "ed59ff7300d1c4c84b55422460503f8709a5cbd1f348b0f080f93310eb91ad74"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "d1bfa3115718ef010c19a94ad0a389dde235c26ae8f87f6e50aa8cce51f8f335",
+                                "uncompressed-sha256": "1a3523a6be2dbb5ce8056e3ecc05d3f2707311b5f505e24b91b0b2ebffcf05cc"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/ppc64le/fedora-coreos-44.20260707.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "e4cb0838181a84c29933031419a07904d1277583b0196ed06e0ea9b52e2d106a",
-                                "uncompressed-sha256": "84c2909a988a3852c1110182248b4c8c809111dd90a5524da85ef2b28c8127ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "db94e44ed651e3cde9efe03051592e0fd1acca1e758f11b81b14ee7321e0e455",
+                                "uncompressed-sha256": "6321fc521a8f324597c797a38ed24044cf2e074f4f8a44879fda7604114ce0f8"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "35a1ae0f628fa8a364b1b5bf2ca46fd4195ed0b4f4ba321e86b2f248a64a6138",
-                                "uncompressed-sha256": "682564346c07ef70f610db19f78a3504122542287f34d3592f3ae1a6b0541c4e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b445104978033b39fc3621c4335d8d007023c8276a8361445dabbf92d88066c4",
+                                "uncompressed-sha256": "b2324b20356d130b26dff2910dca1fe2b386b0d13b1c520bc1c2e588d9813b38"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "0a434cea0460bfc3af1154742d2bb80e547f9f4f52d10228854ca677c2f559e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "a66268bad1a85abeec08b5a973f1e7080a8e0a6cc350b264a0fc8c24e3425a8c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "ff8d24fb468a50fba87998364fd7c0c21d403fbdb2e00e625aac22ffbd10a617",
-                                "uncompressed-sha256": "8634b44592c7f51124e19b26fc662e7a47134a6f03d567d9d4412478ec875fb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "857b0eb1eae896134517cc154b22581250a3af30bb2715bf34a2bd397b896fb0",
+                                "uncompressed-sha256": "13d702ab310b2e65b0bf97b67a467c55be80c660cd34e02831a0afa689d30053"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "c749aaea7b61377e1daddc22d9260268d0a13b9a94745d69ab1459d2641c8235"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-iso.s390x.iso.sig",
+                                "sha256": "9656b62e8831999035b9547e5eab01ca2b96e2177fe20269aa8e508c01be99a0"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-kernel.s390x.sig",
-                                "sha256": "5f8e1c0024859b89938f4e32f46c19b1e0b97535cb6b9ae37d2c8adbedb1f7eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-kernel.s390x.sig",
+                                "sha256": "7fda5d822d42d3e692daaa4964e1c1cd38c605c0c2e5da6678f51b7a0697bc26"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "7079977f8893853ce5a8a8854ce56682e7dac1a7dd68dd2c2afbd10dc07c8357"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "26c15c4298333ab9e0988299c06747194dbc3c46539955922694dc51a9f209f1"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "5868abd7ad6821338402288bd46a28d8bbb8ee92b305fceede7521699cd7d780"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "a1055cb91e535a8c515c2fee6c91cadb3420b82578c06308d4fe6240ad234437"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "041cffd729920b03c506a53dcbcbca953fa3ddee9f019f87c0cb2c3d51593675",
-                                "uncompressed-sha256": "4b0029f8a9ae6f4715da6e65206887d29fe13e3b49a502dfc10f10092f3d372a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "6262106199fd2545c12768d66b81f75f37df7e189c640a6e0a68d9f6b28bdf76",
+                                "uncompressed-sha256": "0d0a36a16effe5d4c66146136905e723a6d41b0d251e7a38d77e2b8c4a21cd5e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "82ca161cf8be615ecec80d5f082d53c8bfbd13b31e747193c2ce5035d4761c62",
-                                "uncompressed-sha256": "c5e47904577891877a37fb8b7f262e3bdc96eb82f384ee0889a27d8b5778c59a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "9ef56eb11ad5ab535c369bc726c2b6e3ffa42aa4202de361ff157d1a8c4f5a35",
+                                "uncompressed-sha256": "4a5aa8473a2d0fbbf24d2c62813fcff2941d532c2bc9b32f575d637af2e0c67f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/s390x/fedora-coreos-44.20260707.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "679acd297adb716d6e0cb01da22f4f4abf9a46d7243da2c3e62ee74037bc50be",
-                                "uncompressed-sha256": "bc6ff29fb6eb7d64aa3b2ba68aab87aa7cee7a0502e65ffe5cf65fc10012d2b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6d03409e10e3be21c5da13992159d94b14eeb44104e6031fac5f458c8b78c9e7",
+                                "uncompressed-sha256": "56f5807f8e14bb1d7a1149e57e3ea653f873c480a460adedaac4e8c5c9bee7e3"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:688a21bcba412700c306334c21f71192dfd365a1f4eae2aff5da73ce06e15573"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9c90df7c98583b0700b24bb86d2bc393d021fe80cdb0ed1e66cf3e24735bcf0f"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "ec7b8b89e29d9041aa741a500c065d92c1df1a1a1513cd4b85bfec3eb0fc38ce",
-                                "uncompressed-sha256": "0e14ab9a3f7e18f15ee8cd4a6713b37a790566e47d5370eb04aecc71fde9a1fb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "f2ff749250da3dfdad7c4defac0d373d626a358a3ba531440cf862c1151ad47d",
+                                "uncompressed-sha256": "b7db1a5bf42cbcc54893f0423b01698d43160f94e0da7c45a7a8d0e8bd9c59de"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "f3ceba15fdbb01f96b9aed7008c3013688c25550abfc317e7a79ab0eb011a6cb",
-                                "uncompressed-sha256": "bd9aaf3f5029f3af7fe17abfac922f48d09d964055c203a618feea9567857d42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "b2b589c287233c1013990f6f1d59eb0c15b815627a5529bf673819553eabc211",
+                                "uncompressed-sha256": "621bc61488805ab743037cfed10726b010cc1521317a345942fe2048eae78512"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a07216091f7b90aee2eb9ad2c79c2d55148043db6894ce7a8fdb49f3a82ef8aa",
-                                "uncompressed-sha256": "fda3592fa5f810ab131d9ff1c9f8f296f1a07bc1a80c2bd8be5fec1a007bdde8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "9527493e032f5a35282d4583cfd054db37a5e587b9d0e527c096b63f2866dcca",
+                                "uncompressed-sha256": "56e31ce3719d2231c02f8fb181c11da3df39182f5a1b3a57ecd2e971231740cb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3154f4c3bc58be3f012c11d625bea29d70500d2433586b6fa431271d91e16e8d",
-                                "uncompressed-sha256": "ddf4e7b6c0d272d39b7661970272ea1e0ccd7463d1a81eb43bd3858a46324500"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "9f99572d46e313307d0b748f50910a0d5c93890a50c510b8bd848138b57192a8",
+                                "uncompressed-sha256": "b4844339114cc0f923be824f7f18fdf87d7de046f75017c0f70c7388abc8d4b9"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "92403297dba48b314174a8d56bab1c2ac8c89b7193dd5437114a03bc4df0010a",
-                                "uncompressed-sha256": "b4ed38902aaa97abca97edc6f60c6f7e30076ea83346ae1124ba02575b0f83e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "48c8fe89c25462801146876c905a023b3d5b9ef1939f40de39b4ebd282585ac4",
+                                "uncompressed-sha256": "dee6a1923ecf65b9277e1cdb4b803cbfa3a71ee1f7f2bcb861e0b46705141260"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "e2566cc805d7bd4c43b50ab26529cf9fec59279fe733f4c7590b6674b2818ec7",
-                                "uncompressed-sha256": "3507844ee281444954227e253cc8935598c06a6a7fcecdb6bae24740898465a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "0232c40fd59248f860137b7f4eef08b72f4afe2f5aaa1875e98ccd233413f533",
+                                "uncompressed-sha256": "28f6cb7326b571173bda2653f21fc37d43e4b7dc1087681b2598c542c91f48e8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "0bd54ac46fd8fff1dc73c154daa5533c016ba52f8be0cd50357309ac0df28761",
-                                "uncompressed-sha256": "894ef5684069e1b4bc32192cd7b0e25969989e256f1cc4067378ff6f80d6dec4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ae55faeb35b929b88384ca36efa1b6f31049c76512090f072febb751b86e25ff",
+                                "uncompressed-sha256": "1518cc1effc38538b8baad1b546546e9efc50e21932e4a07057be254db046ac4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f7bd90c8d2918f8af959caa5eda54bdbffcb845b705ba45721ff684a71142db4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "ad41c946d3fd7c65191005d46740d689d55e7cb8758ab23a04e1001c92244ae1"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "f00e755ee34063cee7776d79c6146e3563970d36fdb170fd16c661651169db7d",
-                                "uncompressed-sha256": "fd1b4ddecc567b889744f3e22130cc77286d0762bda3d1aab6a8fb2e5043bbfd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "590e64eee54f34cdc9370116a06216799de2778c6ffabf65eb8b9bbba9029f92",
+                                "uncompressed-sha256": "a546f99816571b51f30e09f0da9b5d2ce2ea6d444ec343248b9a0b51ec3453ef"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "df16e63079a2882bca74086298becaa3c4c948a94b559bc7106c78953aa81bda",
-                                "uncompressed-sha256": "16a47f908089c0b1c686d4cf112e2e6ea7d4a8773998728f8df71cb5ace1d5b0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "ba0876a8f27292db60a981a733d6f0d3d7511574a49fac372edfa6c49a06959b",
+                                "uncompressed-sha256": "8df9a8d53c8ab8a126eb17980ffe1b6fac6b74068b91972136c6934eed5d4dcd"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "648fe5874b03e3e09ddd2fe98f6b77cbfe9176cc6a52c93a9b760d7affffc75d",
-                                "uncompressed-sha256": "1b04f858556e864ce7f3b0271c572906d849abd14e92f4a7fa04ee76b26c552b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "335499d99550eb024f15a1f063f2d5af72b4489e92883679324584142c43a75b",
+                                "uncompressed-sha256": "008a9a91e0aa69e2924feec212f022d842a6f0a69c51356cc86d810bd1c0f7d3"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "10dad417ac8935e08c94f9c560121b00e845a36426b912c83332704bc994af98"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "0cfccc7af4b3a416989677dccdfd69d76d35f413364f469aab736b32679413a9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "3222eb3f018b6af4ef6b8a72ce21578587a72079526f3180a6b2176380f56f30",
-                                "uncompressed-sha256": "e33a9e9cae0c68e7e9f90fe626c53ce93d89328bc5eae7d90e3fca0ec2929e75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "2b5f7421f14c8e688bd52d3e991a07faf1a6880c4c1810f95ba853e0d803a90a",
+                                "uncompressed-sha256": "f95de61535629ca7d2e9507a5cd2c9e101e53322b0c889e26186a104a1cad15c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "71f337fa1715a236df05c5dcd98a38bb21c3de6e2fb7ec1d168c7a4896fc72df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-iso.x86_64.iso.sig",
+                                "sha256": "83a4b249f5e7c06305bf20514ade133f556b2e3df456a6e666889045c78afe38"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-kernel.x86_64.sig",
-                                "sha256": "b0389e187ed951727560f517d589f3daa2736dc34dc9aa245b986d72b6f6c3ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-kernel.x86_64.sig",
+                                "sha256": "6cdf5024ca807335491c33a271ca7dba28278879ab93db8bd1da99eab2d48acd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "17eddde5d44f0bb438df64449d9bf23c89cc4f70373b6fb11a9690c889dbae84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "d141b0019c6a8f261f12f21d7cc2f0f695e0573e2605a73e17a4935d10b27082"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "2e37949353aeaf47695d5094416cd5ea02f0fe6991754077c6b86ad691e6a941"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "fdf978fb03cf7cabfe9f6afd7867a60931ef4f00f8e7b8ef179c330af9cb2cf7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "3238639aceedd5508d1f52159abf8f6729ec1da1c6e48b815ef1ac6b5570db73",
-                                "uncompressed-sha256": "39124b1741fbc9b373f28b89e51c97b43863e1919bd1d46e386fe7ac81c080e4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "54c8610a95b3742c902e4a915f8f90cc6d187d7311598b7630aa6a6128f9c211",
+                                "uncompressed-sha256": "d7571b218e09dd2622da60a4ba5b218dacea7cb9453c153e8d79ebd979be2048"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "aa13c5ea4b0607c5eba6c6a7333d03d2951323e591178947f6b5aaab939966eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f6bc651019e635ef58b942a4f157db44724c517c8fa7567b189fcce35c32a048"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "75cbcd8dc7592dbcef6e2242388b536a98dd714ad1778c416255209e13ce1742",
-                                "uncompressed-sha256": "901e8190fd7dde674cd5c1f9828b2abfe8bd444863646612106676b940dcd464"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "df53593f4b4417fc3f7e86bca069811dbf440733e4cb49179b9fa77a1029d8d6",
+                                "uncompressed-sha256": "08bbcf1f584682910846c76dda687286454823c35bf462ef0354c0897d089def"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "98a80d44a97f9bdadd77d53e9112c69770a145db6efd5e7a52710d27f8386061",
-                                "uncompressed-sha256": "7ba1dd803bbc4cdbc097c44f0c83b4d3ba51b205618d031ae5361e03db24554d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "527c5cbfcf536e359a182c28250d49e071ebb9fed58e6d8cecd7244c008185ec",
+                                "uncompressed-sha256": "338d67c1e41c8107df248d6befcd958396621f17b04ffa0a3d3e51e7629513a7"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "e2fec410aa91e5fceecd2d168f0713512ac8c6f97ce20bee830ca32f841735a2",
-                                "uncompressed-sha256": "72d746a079021f7ad7a169b29c8866fd6e360e867ead9b374052528f2e58ae59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "97d1c52bd9b23bbc22bbfc1025b080d333a7ba3506cc4bd9522161eefa2e0265",
+                                "uncompressed-sha256": "19bf91c2f1c05b0d87b8e52260b1a035a586a6d4585e9662909c4d68bc19045e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "10fae55d07217f42365f83eadf9f442b8984e19651c983d085400e0c16e39709",
-                                "uncompressed-sha256": "de06e243aa807191ed001efc39da09d199acd19307fe217166b19c4afe739f41"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d05460e9149a78468d3146eab5dc13d066800a8bd6d51b08383a3a7c38e87fec",
+                                "uncompressed-sha256": "140647344146134f18e2de1ad706fcdec2d55c107273533c429bf0f5178c0076"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "83a75cf1fefe95c10f1e7cd8eb5a120e19dce96c30dae26cf7657bb9100fa26f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "2e5193ee58d261c704d018a44db5394792b42e1237ffcb7f34eb885b95301ed2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "b75f85f9f1f9cd1fdcbc617ab508f1e9e6f933c4a0a100a03a3de2206ccb70ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "bdf095efad4d4b549dc7a70e174df45a62d40d5f6b17ef9c25797e62f5f4e0ba"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260707.1.1/x86_64/fedora-coreos-44.20260707.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "05b47aa6ab5b7e35e3b8833175e726a7dd7274798b977b43e098baad3a36f122",
-                                "uncompressed-sha256": "71299fc5fb36c8b3ef9d9d81f62e70f7de40d4eea465ad241eccc883479ff852"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b330ae60b83705c571f8afc1755e5f67204434f4b6cfd3945f6ea2610d6bfa42",
+                                "uncompressed-sha256": "4cce6984be662d0cca86d3060dafdc3bcdf2b1a0f6a191478da192690dd3f047"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0ee4ef3650395ea1a"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-08b2471327fe245ce"
                         },
                         "ap-east-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0debece24d548e7e0"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-04eeb015d899b4a40"
                         },
                         "ap-east-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-086a9732aedc2a564"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-01a7b0cfcce7974dc"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0674e4a9a5b868f40"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0deb2f3bce052bbd4"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-09c4e2c9df9fd0def"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-012cb7d2ddc731b83"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0e5786b0275495e12"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-08b35e129f0695e2b"
                         },
                         "ap-south-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0250541218c159bf5"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-060b802460f6d83b7"
                         },
                         "ap-south-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-000364fc53b68559c"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-08a397335f753e431"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-02a4078943acc1161"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0fc5b61c681a6897d"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0dcb52aca7fa8a781"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0cf2f264c37662178"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-08a1ec7eb006672d6"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-08c9fd1323df88185"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0f03e92ba4da0295d"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0d09004b5f6430dfb"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-05f963d8dbcae07f4"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-002dd8e15c69c8454"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-04a9bc3b1a8b2e7bf"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-081e8edd078e91c2e"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-09f2e9926161b6b70"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0bcf306bbe28600e9"
                         },
                         "ca-central-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-02fcd9f941a606f26"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-039c8557c5f77a5ff"
                         },
                         "ca-west-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0094ed9e9bc217d9a"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-07e1aa8266a333b77"
                         },
                         "eu-central-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0082aaaf6b708ca9b"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-08e508e7d0323be8a"
                         },
                         "eu-central-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0e3a147cead972c1d"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0896b69d459c18a99"
                         },
                         "eu-north-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0800bc7e0d945afe4"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0d2d6254330140f99"
                         },
                         "eu-south-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-04217dfa9884f8f8e"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-06a0dc9b6d442cc1c"
                         },
                         "eu-south-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0ce55f2b973141d2b"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-01cde830d3624c75f"
                         },
                         "eu-west-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0b99a6a46f28f3a00"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-05713fec8aefc6e6d"
                         },
                         "eu-west-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0abc9c873036545fd"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-00d4fbcc29202067b"
                         },
                         "eu-west-3": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0e0a76ec41d8a37c6"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-09870b8d6d62ef944"
                         },
                         "il-central-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-02e7d0a89f8dfa4ff"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-041af70e5d30cdf1c"
                         },
                         "mx-central-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0471df65791904fdf"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0bfd33a4f80220854"
                         },
                         "sa-east-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-06d0185fb5e3b6b0b"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0a07271eeae693fad"
                         },
                         "us-east-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-074f8d28e868331ec"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-08eb3e0144b3377d7"
                         },
                         "us-east-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0470c5778d24328de"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-04852095ceef071c1"
                         },
                         "us-west-1": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-0367ae0c73abd22b6"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-06af0884cc16e17a2"
                         },
                         "us-west-2": {
-                            "release": "44.20260707.1.1",
-                            "image": "ami-02dbb9ad09cc80862"
+                            "release": "44.20260720.1.1",
+                            "image": "ami-0fee0624877cbdca0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260707-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260720-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260707.1.1",
+                    "release": "44.20260720.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:291d8d38f0059740bd97d84b1da0a8596b599a9c575ff3eaa6d6cf9d284a4376"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4f03086c2da1f23e3b98af6cc423125ec5a65e2cb1c62e4fa1ffbe2567dcae98"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-07-08T23:30:20Z",
+        "last-modified": "2026-07-21T14:07:12Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "537ca78457a6d392d52b5a1a9aabbf0a54b20af5f27fe7062f96c9598959d802",
-                                "uncompressed-sha256": "114d622a73387699dcbf97b073467a49eccb7e9170a45b263494c17f11cec8dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "6393ddcc0cd405d6a102e64d0dfeb1019854b4f4476de10d1f20cfc573f910a8",
+                                "uncompressed-sha256": "445d97cbda5ebd956ef649fbabab9a4732c91382ecc017ef01fbfe7b1483c001"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "65537e328135d26d8ce9d9939f745c33d2de33e3bc36f229919fa177e5a96a71",
-                                "uncompressed-sha256": "bbf5d9a0a4337e6ef0b12e43e7afdb935f0e8dad33ca89c6f3711c85fcd04d48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3db50ac081a1f1fbd197d34b8685b16c69b691855e8eaefba4f057bb7822987c",
+                                "uncompressed-sha256": "4dd0c7dbe41e6d80c14483ccf6de783ddecb4182d32966909d392979275a4f84"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "75b178af110085dcddf510bf4cefa0ca378afb78eeedc8b14f2f911594798c4a",
-                                "uncompressed-sha256": "1cdef6cb820b5a0635fcb32e6b38d9625dca4911ab34e8fd1c30e90b722673a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0c12652ccf47290866c4fd1604bd3c0a9de1881eda94922ea172683673532356",
+                                "uncompressed-sha256": "d52d23791bd811712495bb406b60b976a2023ebb63ada17a66f68f8e3710ea81"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "e0c1941c2ddd067e01059d750f3670358316755c61f65c4584bcd428b8bb3a1c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "6f9eec3050c4609c2d1fd2a9a2202ab9f523e431bac7610a4bda83c53757069c"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "9c34221cacf363377f5ee27306c3e70b8b578250977bff502653fbb714dbccde",
-                                "uncompressed-sha256": "f0f237e303ae4acffc1d8ef06d1721d21971c2332b3709e0867d165245011e7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "ada1a5e1cee9ea41e14905a60b33cb7bc3f04fae008c5770b68541b0f1c5c06e",
+                                "uncompressed-sha256": "201698980ff57947feba4e42e0c42516a26616d763c42ee9977c48266e5fd144"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "4c42853462d9f60f3eb81e19304b73e7f6d40b7125b11dddb86d0e834121e77f",
-                                "uncompressed-sha256": "5d5f203ce701388cae09e9d89c1a33f26083dddf305e2008483082d3263ab5ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "1fdfb7b275dcfa772cf00d75c9626e675fd8c495683125f42a3c0b43f819a0eb",
+                                "uncompressed-sha256": "4d0599b687999c6ea45aed8c7a8e1162bf91364a0a5a989a745bcac70e329831"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "7f702b68ac68c1fce6dd137a4ccc317f219f857659611942f8229be37ced117e",
-                                "uncompressed-sha256": "1d11d892797e29220ac55abb3675a1130bc423a29f0a53c6e120fe7b8d3b8265"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "042917ee574c92bb76522d396880e3fcccf9c2c5fa61776a6bfb701b63de0fae",
+                                "uncompressed-sha256": "bdfb418eece364c9b7edd493794dcecac3d2f457d34720d85a4e3ba5096059bf"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "cbecb539d5fabc62617fd3dfea041e2a282bb5ea3b126ea10658e0e84c85c60f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "1fce8a43bddccd7f156966bf9bdb7dd0c487c56acfc593e7c22d8d1eb382d80d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-kernel.aarch64.sig",
-                                "sha256": "01c4de729aff530638be34686e1d4553b6576151f1e1e3b38d83262f0d05a436"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-kernel.aarch64.sig",
+                                "sha256": "018d71ab8699adce28ff0ce32ea0e1ede76aabe2b2bf51209449b9bb2ce6b525"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "f969913a361fbda40a979e4533c73d88234d6a595d6b2c3f060d831fcbd68497"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "d818157fc6beab93c057311c52bab5d166a1ef278f667d6c598a428c6948c5f5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "dc0bc7df38c5d9443e9052d7e1710b474d3b4f6a7ec81b93e64477f73ec8a418"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "84328a38572832363d9fb6a85e122fa93967addbb42ee8a6e20b412db0d42e27"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "796192e13afbab7aa9bb2ef7a200f0b851b1851d29513cf50c94f5499978d9c5",
-                                "uncompressed-sha256": "1affa158fcd55806f7f68be54ebb4ca662c4384f342bb5af8904d899f8c07a7c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "39d25b4aee2706659fe808dd555b8a1a47862dd19177e35ea57684c866f6458b",
+                                "uncompressed-sha256": "8c182066866442a20b50541f0abb6e7680bd28399a2a9e1d050a53b034f4ea16"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d62e8a21035123d7d3e5cee3d9e3bbdbb89f1e9dcd20c84932ceb89bf12e6e16",
-                                "uncompressed-sha256": "5ca305894a22db756997d32fe30ad862027b13070016329cc9df7f8151911912"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b0e3985f99c5f2ae66be473098c3359ed2b8bb8bbf772a800797e32c9f3f42a3",
+                                "uncompressed-sha256": "061200f5df6571874dbec6eff03e7f4b6a7e5c101ae2bb54574275a000ddafef"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "ec936d8ec6558d8e70567645b2ae497503b7e115f28491fb626040ea2dbd411a",
-                                "uncompressed-sha256": "3fb3bcb68e47318a59d78f01f1fc5499a2633b8e39741959bfaf55b139ab4346"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "3cb9f05528b6ec5597546e4489e1c9ab0f182faa80afedceff1badb81d4c9d95",
+                                "uncompressed-sha256": "5389e3e5a5ade479de552ea511d0b41a65ff915e74106a1288b0a7be7d90d6b1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/aarch64/fedora-coreos-44.20260621.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "84f1eed8e981b00a6058f5eb058a577fb78b53b2d47882bd5a849300b63454b4",
-                                "uncompressed-sha256": "a2421e4accd61e98a0959e07c67674a08d62617732c9d0099c653c1245ecb22a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "2877b34cc4572f2e3f3027ad056f7bd89f5069a540f3a6a8785108f695297883",
+                                "uncompressed-sha256": "f3a409bae113474cc331afab05ac3a964c44315cd5c5eb44bcf43d54cca2c38b"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0173a10cd3c6268c3"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0fde07d888b413c1c"
                         },
                         "ap-east-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0193cfe0ec8ec60ea"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-01246416cf8db29a7"
                         },
                         "ap-east-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0c7943ed6f4384278"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0d559becdf4a78037"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0fa876721cc44f390"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-002ee8ed329321f3e"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-02336e8e8435ceffc"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0264c7a43f7c9e04b"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-08a83a726e43df571"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0f404de3237874e41"
                         },
                         "ap-south-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0c57c8ab8d076dfd1"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-03aa8ae4b84614112"
                         },
                         "ap-south-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0224883d2b7922ac4"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0868173187c19b681"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-049805b714641cf52"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0263a9a531a609e1e"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0b36b281e8249854d"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-05a5934040c684d21"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-04cd3b8e2d46986c3"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0533f29cf6f542f98"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-08262eea3f28ae045"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-06adc08e2c0479221"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-000ca013d1e4719c0"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0315f40e47f0dcda8"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0a0e36bd792e20dde"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0dec01d70b041b51a"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0c1876d5cb34e1d4e"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-074196bf6083846d4"
                         },
                         "ca-central-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0fa79bfb68d0d6c88"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-05d2b0b0438a14bf3"
                         },
                         "ca-west-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-06d6c2728dbde5806"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-03d30bdf449705922"
                         },
                         "eu-central-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-031258abab65fdb68"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0704ad2ac2e153204"
                         },
                         "eu-central-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-009ff84a082e3e3db"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0017c69671d3b80a8"
                         },
                         "eu-north-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0baba2e27f514691e"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0a6fa782d0d3ae94b"
                         },
                         "eu-south-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0d4403313816dfffa"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0c09dc1c77627dcda"
                         },
                         "eu-south-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-07c45188aa458be52"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-05938abac22645ca5"
                         },
                         "eu-west-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-07cbba3244ea2c15e"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-08af5d9fc5c1edb78"
                         },
                         "eu-west-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0da7336c6c317494b"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0c77fa25d3c56a318"
                         },
                         "eu-west-3": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-013575ccffd4a3ea4"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-072e2c0e12885fffa"
                         },
                         "il-central-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-08a19c4ef75afc51a"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-03293ea8ba6f37049"
                         },
                         "mx-central-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-08b38eaa39a3fa8a4"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-082cf0f19e441ca5a"
                         },
                         "sa-east-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-066592816fac36349"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-047816ea5561263e0"
                         },
                         "us-east-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0dd07d856bdf5281b"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0e1bd1e95449d195e"
                         },
                         "us-east-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0e6f75e185fc1e2d3"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0e0670a41ecf49301"
                         },
                         "us-west-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-088fca8a20c5a73ed"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0ebb59172dad5cf0a"
                         },
                         "us-west-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-06c41e91776a59a35"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-057c08ebc21839db8"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-44-20260621-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260707-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "2d16a5ce2c734ef77fdbdfc1747a590bf5057093096584d22fb42f05a28c9b83",
-                                "uncompressed-sha256": "6b273c41b332792a2b2c5a3084bafb78f325bbc2ec94189be56c04c668ccbf0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "676de369425c90983a5bb08ee964fa73aeef28660b14b97b953fc95e6ad514ae",
+                                "uncompressed-sha256": "2723dee9f2715119e5a4d6a1d3f37a816032d21cbd1a61e57124b7464e32d511"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "69cfff4adc31b48e17f6c8137a399ad352b0df055fe110370d16ccfb969b95f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "2fd09d42b18c55362a7f1a387db64e97426a9eac1203775ec79067f38a82a53a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "d9363d0f3cecc345e63731c6add8b08d55fbbc5d741d4163542e589b6c73d17c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "1107a231b463cd249fd2b3be025cd089d23dc3c77efcd34ff7500f37fb4d80a9"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "12e50e6731537393430e84f61def6adfaeba108684b19bf764972748cbda60f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e02b7407ff59695ef64851eea58ae2d45089aa7a2fdf8683258d379de85b1de4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "eac92d8f4f7c21427d57b66ed631f2a48b7455b08a7f368e286ad1d4e2e8c826"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "23ab01ddad60bda90b88cd1658a6c6cd50b82d3255729618e7bd6357c83f15e6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "b7cb8cd444320fcfaca82141002d30c6e43689735c8823aa745f7273d9d029d0",
-                                "uncompressed-sha256": "5f1561fe2b9dc38496929b9b9e16675c1281a72eead53b6a8c250cf72fabc35c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "19afb7eab0c6463b20ee1bc27b1809d1cd208345ab00f099e9988090c0e69a4d",
+                                "uncompressed-sha256": "19eef77c6437109d4bbaea1a9df79ff65060e5656f03426ba6a8dc71fd75d262"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "7cdfd123210e6d4af5b63524d160f0139928e8677a279c84e2a93e23af4e915f",
-                                "uncompressed-sha256": "cd0b71312568196196579049285430786a4622b5cc24d3d2ceadcb81e76f4a0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "cfa850e9573f2694842a8188e8d88c805d94ed54f75a380bc509a122a4591e5d",
+                                "uncompressed-sha256": "4d625da043f93a9cf8a989a69f750d1f972e38510338bcca6d73862733677799"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b7cac62b4b6b8ff08f46ae9640da2094b302d544ac5511bdd9f52002c0c3bb74",
-                                "uncompressed-sha256": "b4b1e64e7124f7d49b6c24c83702108abeb3e405cca82e02747e4605ae480758"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "ab55461410930987ea34d1d7f78bcbd82e18e456f5cd4924ef11bc1ec9f66ab9",
+                                "uncompressed-sha256": "579acccbca1e0a8feabfb6b945012ccd124c8bb91b3965c4d96ff297d1d1576f"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/ppc64le/fedora-coreos-44.20260621.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "26f8cddd12d65e85c3a1a649b60d53ba105ff1783a5c6d448b18946f39a040fe",
-                                "uncompressed-sha256": "0c008962fb5d11dfa6c6e88ba1bec3e5e19e63039932ab44f05a45f06195a974"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "23a7881b6b747cdf5f56c45759922f3822b591f89fecc71909cbde47a1e9d010",
+                                "uncompressed-sha256": "cd3540ec501d490730e94c8a24a3aefea4cf27fcde70aad19e677152849057b6"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "e308afce89bfff3156516a8a06ad821b56e8c0d4fd3d4a87202473527c6fe90e",
-                                "uncompressed-sha256": "47dd8453f8995dad369fd8ed22866193bf00163879bec048e9f6ed26e42604f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "ad2952fcf78dc5313388a8b66e4a94bbef5a4d2899b1e97a96f4573a049a27ff",
+                                "uncompressed-sha256": "f4d85db220fab9683d6d9b3d5217916b5b3720dfe3d48b905c493aff8927021f"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "fa2e1a976f0383fc8ebaadb016d4a2926fa34726e1e2dcb107197e6899714853"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "64170a682180e91efc15509b45792995b1b00c9b93bb5cde9e4865b9444ae075"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "e3c13da320d6b71c8d2aa473f19ff3375edd2bad860f649beeaa48d7830618d7",
-                                "uncompressed-sha256": "6380bb630f8ffaad36ae35db950740bd3f492cf1c134b81ee646af0e413e88cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "3d93385a800659c3bdc49017cc34d4a472f66d60e295b5b6b58d35df1d94f633",
+                                "uncompressed-sha256": "a1f2e4d38ce78b5b11f725e5139d3072779a0f12a2aefe9c5a372d1535ea8b5a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "12af7c1e08f0ff8200ca3fef016ffa573a5b9163a64758164577a357d9ef84f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "37ddc9449af05f0bb105e8d10cda615a3146eb6f9e84ecea56459dc10046a489"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-kernel.s390x.sig",
-                                "sha256": "2ba3928a20274a5f95f2dbda6a5479c998a1459798827a1707bf7e8495e98191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-kernel.s390x.sig",
+                                "sha256": "5f8e1c0024859b89938f4e32f46c19b1e0b97535cb6b9ae37d2c8adbedb1f7eb"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "d2b8e2e2707995e71a5c418389aeff1045a7ace16ae7168b6b4640acd8757762"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "de1dfbe5162bf6ec4d8de071fb6b77f18e904e0da2b6aa212af373bd1410e701"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "13acc6f5341211394fb1b5486af75aaf742787e45cc1a6b73e989a38b8027e8f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "8e680c9d4f6123004ba57e243dd5cc910761492b7699ff33ac19d4fd9121cc66"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "81f01d6146c756ed823569204cc03ca8efe21c3d6cd6a952f8ff532de8689db1",
-                                "uncompressed-sha256": "cf14362ab706048c01c4bb70e50df7b526c1fe3318ad3b60df8a8bbaa46bcef6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "46744727f8fa82076fc56c77d43446a12e6f65449b19f673285d3519e22a2f7e",
+                                "uncompressed-sha256": "b7795c504bec09e3e166f32ff2ed2535c5faadd29d6b3486444187fce5be2218"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "acc56742204eef8099834376d124e6ef41bbcf674cb757c27fb730270df5f5e9",
-                                "uncompressed-sha256": "450c9d49764437fa9beb2dd35fad38d4dde8504e2f50faa49f02d803417d4036"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ceaf2ecacac573d80859caf3efbc82c476ac168fd4b3b1d53ab3b3fcc71d1821",
+                                "uncompressed-sha256": "0d5868a02bbe681e41bfaf84c5927f8add444b229039f29dd27c3f1383d41cd7"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/s390x/fedora-coreos-44.20260621.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4d32dec86479583715f2c7568a4579dddb76ee58fd6089dd32560880549efdd3",
-                                "uncompressed-sha256": "a5bb5efff3f81b82920ff4aded7eb75fb58165417992bcbc2314b968293afb1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "206011aaaebca2d89bc3ec3e1eb812880e7b98f0e1c2b695856a18564581969f",
+                                "uncompressed-sha256": "fc2ac4cf733e8fc90ad0c60790e2d65a365ea5a9a5108de227186b7afc6b1dc8"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5270a3593e6c5ceef6920e27455b60bedf667fe6bae93b25529e4310d20b2963"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5d5f3dfa1c18e165d4d6d713e1b72be9d4bd26068b657933fdfcf7255f9694f2"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "4fd36588ddbad5a11f2b88b7c15809c1b0bb3c0bea9b4ab398030ebcb6b27815",
-                                "uncompressed-sha256": "91f5d5e1cab8291e4577a317d55a4c68f8e3e816a30a4b416df3e9c9fcae0b08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "fa1823c6fa6c60d97493661f11b39c500ef5a73ba78d9b97afeda02fef46012e",
+                                "uncompressed-sha256": "87a601751b93d74d73fb0546670da6fe6e063bb5adee271a00a3099dbfaf47d2"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "c8d7d256bd540bcf5fb31881e22e10f0f7b586b1163dc7c8116c0af6fee1da7e",
-                                "uncompressed-sha256": "86d24abda42349e1fe18454c94d446d3fe93ca7691dd2ad340fca08589d9ec39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "dcc88b8546c7a5284e4dbef059988b49c9d6cb1058b72eddfa802f983dffef67",
+                                "uncompressed-sha256": "e26680193382b1f4b02cb4ceae053c4a6f626163b12833edec5d2706c39a09da"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "35a28f0b1f94063acae9f00ba093d38e7a21694b3216eb18fd68abc1d21f3460",
-                                "uncompressed-sha256": "3871e8a97dbb7ac0e7d465b7ed1206a99b6edec6559550956506e9124e45aacb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "08779000c294554dd22d3435250c8e77211954b0baef66d6ea22a104cbcec869",
+                                "uncompressed-sha256": "c88116cfe4006d70415cbe33e2006d728cef6ed9576e534e1fc2b6ebf5870335"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "c037f534a2da8ee0c6512352ef22ee015803efdfce0eb2541a1167bfdf74789c",
-                                "uncompressed-sha256": "a9600844241686ec7ec81e561ab5923d7c1afdc5b5d0debe777ca49c777ef8b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "49e62c45ad948c72fc49a83a806f380156f8fbd5e69fc23f7d046bcaa7d62a30",
+                                "uncompressed-sha256": "d85eca0bc994761b65bc7c0a8a00a6f2a62508e2c6a99be2de1446923a36e095"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "a9cab51aed7b530ea89faca82bf7144b424d7ce2f71e867c51e886ef92b1c12d",
-                                "uncompressed-sha256": "87483388ff9a8a1ca60ed459ba7303518e7be9ea4cd43b5f33e153caea6b919f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "7f3b4ca636cd741c059b87a53e15e3ebb8651a2acade47cf9b526c226285a33d",
+                                "uncompressed-sha256": "452a7dd216a706d5b3bae87d74ddbf651d7ef5ad7990bab8e13093af5af2b74c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "14be19cfc5a0d65870ab24f0c11f07bffb4d2b778641ed9dfe55296c3957eb21",
-                                "uncompressed-sha256": "d44053a1e746b3faf590578558cfbcfe09562f4d3ddd2144816a566551b738b3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "4fede95a887a6b67428883a1c503c074e1f83f33bf5dc51a7ed197f71bf6349b",
+                                "uncompressed-sha256": "411c45d6bdc33cf6a2986f04cfa11804e8fc4103ba8d3efcc96445fc36dcc6dc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "2fdd316aa988f5d084e77b07f6009bd3e0eda819c767833385293e4cee6b038d",
-                                "uncompressed-sha256": "e194c14d184b4b672b93f7dc5f438cf413c26e758a464e5ac50ee65beb2f473c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "f90322b81424bbc72d080d89f44a50e276d56c8301ff96ae972459adf60d2f05",
+                                "uncompressed-sha256": "37c95239e74e8fff747f6a71f80e163beaec12dcbb956f4397db42c306269158"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "bcdfa42266a16980671dc02b05bef051430633e9c048f2dc5245c0a91fb53caa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "574367a4cc3c4cf1f7230a518e0501716675fe3afb6b7baedeb6bf00dfb92661"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "9819ac7d3fa97cb8e21f25b2918b4af8b014c6a973b149b100165a6dd2891605",
-                                "uncompressed-sha256": "83056693562b591df5a9cfe5bc92f7564f7da0385149a69e316ee37a12242a90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "ef31a55cba200149295ec9720d9b424a3c0310c0753ee6dbd7126bf30e65011e",
+                                "uncompressed-sha256": "c62d0b4a0833ee10691a32c1a488b0309d58a1224320014e21258065434f618d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "57a0f441699398c8318e414736bf185354c24882a6b92a5221c28459d57598a5",
-                                "uncompressed-sha256": "4029e97d88a02770ab85c18842241c119e75e786fe9769d29acadc19f1e3ebcc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "6235b86e4181b9d61d1100ae81dab07a494aad78ab610bbde5d4200a06fd9c75",
+                                "uncompressed-sha256": "3dc7a358f97fa7574a3f1086d56cc053cd479ff36538acf233ad499a5d48ec8c"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "2fac0b3f8c18d1fb37491bd6d81f1edabdac56c29d3486e4a228c4527a19c41a",
-                                "uncompressed-sha256": "bde9a32ca375a82248b464e2c2f40bbc0bf4093548e49f8196e6516907524090"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "6aaba39f5e7e6c50b23c6bae3492e10d3e1a2b78f9165355b9a5447884797354",
+                                "uncompressed-sha256": "856784bcf6dd384112083a4e3a6c4c7a4600ee1dc20087a3b54718568db6dff3"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "f7d88cdf9e0c30ce5598c956e902018f9d2940f86daa191be87c19f865cbe47a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "5dca2fbcb7a9c049b46ed05d8d4ef1ebe18c49923e8a7019dcc4fdb50d0c95d9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0aa898beb854970d3f923ab791c013afb5c79442002def77e9229bfc3c65ff28",
-                                "uncompressed-sha256": "10b3d557e51ac002eda9c3687e2ef2f39ffa0b00d47f98f4728345de91394604"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0c5329e689dd11eb8df4e256b03bbc6b7cef282aa487c6aae53455ddd0875768",
+                                "uncompressed-sha256": "ef46b6ab5ac8be259379a93ea399ecdd9f01b44690539551612af7bfd34e5669"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "ea7cd4e81a5bdd4603865df6bbf0d617c8b69b0aef1ce890746658640f53151a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "8ffd0d0fc218eae95c578ec12839fe598d60f96de85fab63d424ad021ed1a62f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-kernel.x86_64.sig",
-                                "sha256": "5b26cf74177e2083c1521dcb0c5da667714baee33b71b4aac822c34682edf2af"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-kernel.x86_64.sig",
+                                "sha256": "b0389e187ed951727560f517d589f3daa2736dc34dc9aa245b986d72b6f6c3ee"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "b88d312dea3b444ba0cb7473ca8402b5273578785e6ed26d473bb6099db88830"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "360c3b6b4cc8a58807fca8ac6947c8ec578e482af52d2311ae99ef02fe9d8dc5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "d955afef0f76b577017549ea64b2a7984a3a306a299aadd9a42c1f90f1e972ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "b500e557397bc76c87b83e17cb0f149a1386ca4e1fd79e61c6e10fe8361c5b44"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "f6c8d81c02805cd00804762c1ebfb0092239c86fddec2a2923b4e7079ef13d9e",
-                                "uncompressed-sha256": "ae28aab5bd047b4727c789b14944021ca714dc937ead1cb7cdbd2844b4dbf304"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "ca1ef085991998a7d33d3d64b55323eea7a1b563ff1b36c363dbb415eeb4b47f",
+                                "uncompressed-sha256": "d4d3e7aac832adf868b91640d46a7404e619d93167a443102b2d35e9e5820981"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e4a8e2691213bd8990b9515176528aa6d8d02387584652344ad132f6753c61ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f9dae7e0f2feea104342d703d842b3bf34cb074055a97a9737286c786e06cfee"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "b4b44d52084c8f1dc3c3f47ce0c1452b4c1a8e9e2ca09cc398f72abf3cd3c34c",
-                                "uncompressed-sha256": "b9e619723aadb8c3e4809ef13aa0e7df9122dbe1642976b352aa0bd52b3e009c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "7e6dd402f2aeae95b163043ee769568cf93f62450da0c5c12effe2f674da16b7",
+                                "uncompressed-sha256": "93afccb4e03bd040448577080feef63fb0e2b251c438684f736c90987f0f80ba"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "959c510eed55f737063c0044c348ecbc8d591d926308fa50c61f14afec01e7f8",
-                                "uncompressed-sha256": "f52c5b3dc0a5b3df3bcd3e172b08457223403abfaa273b931a256d8243c1b9ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3b54ee10790c3d572246654f39e76397d31a63660017bb2c64e2e89586eb93cd",
+                                "uncompressed-sha256": "5f183336d1d0a3f0746e22d1f2869700064568b3ee52ee6ab5a1eb25274780c2"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "6083eb3b978b2f5cd79a2bcd4a45ef31cad2af98dc7f438da7009ed338aa9caa",
-                                "uncompressed-sha256": "1da6e4092ed529b143a608f38c637f00249ddf9dc8164568febb09e50a4ef0d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "af91c10531a5205536b2f38f26629842b8c30c003be36a988545ad4cbd8f4f35",
+                                "uncompressed-sha256": "67275702c0e7900a118a22af15cd6c6a0cf035e1fdd5de8864485c676526315b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "fb078ba59ef651d37f0e5b0cbe85b2b89c0aef0df3038b0a2c17388a4854076e",
-                                "uncompressed-sha256": "c35384b4a6f1451fa470cb363b845cc5465edc1ad1f1b2d31a157459318784aa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "35eb8e1f601b2b65545402df54b2dbb2a48e75f1d4483de5dc575d020ddefa1e",
+                                "uncompressed-sha256": "231a74024e12e5a9b2e7fa64ec948d51986b70f3735cdf68fadcaba095ceb18d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "13fa2562f71d40a75edb120567ad4f176fb9b238eedbb4b371432a1a48cdf2a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "938abaa0673e7eca3e62113d0e7d1ae7f6e0615d24a6fda3b1e62f4db370c9e5"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "8e175c4d6fa03a29e1581961e39edc16a1b37350f55dbaecd5f67498d1e9ab4d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "73d93726c24fd431b32eaaf34445538d6b58744336d82ff63f9664e3d62c8358"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260621.3.1/x86_64/fedora-coreos-44.20260621.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "a0edbbd6262801d3418d8152cd01e804938f4824172931e2b9f3670f126ebb35",
-                                "uncompressed-sha256": "7e3df33410f73c0fdd7e152c995982544a4f9ba486b744831779af47fcf0d1d1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "14dc48ef8719d902f299c352a199660bbfb0b9dea933d6829d9dc74603f61b00",
+                                "uncompressed-sha256": "49079f5516c333b7be1a8b9e7d89f856f0163039d5afcc8238e646526e59ab00"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0562e833d057bb4c7"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0af87d15e2e9295cd"
                         },
                         "ap-east-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0937decbffbe69fc0"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-05e6a16031f837c7f"
                         },
                         "ap-east-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0e20639bc97438587"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-01f7ee20f956a3323"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-08754cd826aeb6f9a"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-05c2c9430b973c8a2"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-01b60babbc20f0e53"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-00698ee33b2c9501c"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0631f46254cc5df55"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-083f0fac5bb751f93"
                         },
                         "ap-south-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0434201a5071b56b1"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0dfe066ee27fd30c7"
                         },
                         "ap-south-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-04d918bde0cf3a14a"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-085ef7dcb4ce83765"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-096ae0536eeb2f025"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-03bf2b6d9bc200d11"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0f3b5451c7515bd1b"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-083da109e350a8db5"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0509b03e53d83c749"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-05cc86dcd55f8340b"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0dc4055475ca4462e"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-008ab34084b6da6c2"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0f049742808b31aeb"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-07c3dcaa1bb9ed642"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0a2bf23dac46903c7"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0ddf7637b67dcb8e2"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-09d4657922b253220"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-01bb31e6bacbd45d7"
                         },
                         "ca-central-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-06b913261a43b4c0f"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0d503e2b32efed85e"
                         },
                         "ca-west-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-039cf1667109b432d"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-00c07989d4789d69d"
                         },
                         "eu-central-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-03899b6eaba55b80e"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0cd4e0e951135fbbb"
                         },
                         "eu-central-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-048915694f5b7cafc"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-086c888e46c3124dd"
                         },
                         "eu-north-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0b0ebb540cf5e2ed9"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-052e5e8ed2f813fd0"
                         },
                         "eu-south-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0ff8e594994d7d1af"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0c6e8786eb91ef1a2"
                         },
                         "eu-south-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0d3cfa2b8fe873178"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-05e76bcf8691990a1"
                         },
                         "eu-west-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0b88670037270d9e4"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-07898a330af173989"
                         },
                         "eu-west-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0fc1d2b8ffab91076"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0549fbcd6b93ea14d"
                         },
                         "eu-west-3": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0cff7c15996beb629"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0f63021a34ab4eb77"
                         },
                         "il-central-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0a9bf019802c66c23"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-02bb24a160bc304e2"
                         },
                         "mx-central-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-09137947bf04ffbe8"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-07a9774d1a19adc57"
                         },
                         "sa-east-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-0674e4c3519e6a0cb"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0e434e3652b2b179e"
                         },
                         "us-east-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-012f6267deae0793b"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-01695f9dc8000aeb8"
                         },
                         "us-east-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-09759dc9df3f76e22"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0edac12fa65733be3"
                         },
                         "us-west-1": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-08b63ae8ece218cf6"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-047a98f0455c99954"
                         },
                         "us-west-2": {
-                            "release": "44.20260621.3.1",
-                            "image": "ami-066cc91e843e39173"
+                            "release": "44.20260707.3.1",
+                            "image": "ami-0b3aa78302847561a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-44-20260621-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260707-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260621.3.1",
+                    "release": "44.20260707.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:14aba1b88af7ba1f8a67905511ab5a35211c49279179e2a0b72ae3897b75595d"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b61210adf15003b58fb330b1ef88370e1c845ebda002b9f23454d374285dfe7e"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-07-08T23:30:22Z",
+        "last-modified": "2026-07-21T14:07:13Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "21c403d5709f9dff11891fee5c13d9ccbd89cc84a2c31f29a629edfdc3c38f89",
-                                "uncompressed-sha256": "10cf8d9677e6389f680bb1602628e9c9b1d973f83cb49edd7db9d0fc75352718"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "486bdd030050c3343393531c3ff72e24a20287dadf6ac0a07eb4e68aaf19d8c6",
+                                "uncompressed-sha256": "528b753e4e5bfadb04fb00e39885bd50c37d7c3ba2ad1e64a644f4f866fca2da"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "21cc758a373cedc121241d49544cd9c6ca0461b3625546a6796c79e16cdd2ed3",
-                                "uncompressed-sha256": "6652c947639f50ac98e5d9d6b121c9a2bb86fb698bb62a0750f68a395bbc1092"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "33099f92281265b51fc605bff4e2de312cd0544e19e6417ed890801116f9f8b3",
+                                "uncompressed-sha256": "b9a9a05127e0199ce982b3e5939f6e4963c704f944307188bf415bcff6e6afcb"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "5f8a5b13cb86ba7c3e87927ae344a5060664c1885990aa3d549be33b3bc94e40",
-                                "uncompressed-sha256": "f6e117d94a534de4b7eb1fd63d5729ed83ca65f0fd866657c5283e5f548e1372"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7930a8283e6172d53c7855724acc4d0f17be96c73328f7350821539e0ce69981",
+                                "uncompressed-sha256": "efce116f8c15bbeb6261d528eead91a2bb368237312b2ea8a44d83291685f76c"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a3b73e80357e731118bfa4972cc937c5de5f37a6b178946999e27df38503c673"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "0f35aa3585363c5c1f01a46eb5bf68149ab283a4db1fca9865a8c740a6b1d0e1"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "065ff4ebb73de04afc277bd05b7a78bc5942d0727e6e62ed8b1a87b6bcb14455",
-                                "uncompressed-sha256": "ec426ba8089cdcdb2d5dbbb670b0741ae9e46d8a9f65f379bc6893812817d897"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "b9f8fbde02c4b8af9340492cb32232fdaad155e9469c0e97f374c65c7b19537b",
+                                "uncompressed-sha256": "a2a67c02629762412a12dd486b43827beb4fb57695cedb3e41238b5dfeae9358"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "e962710cbf7bb15e10dbca3b6062c40787723d0a70a54fd7ff88127471186061",
-                                "uncompressed-sha256": "5babd5144654115a2afa0858638f0ed509baca29f5fdbf1bba274b1a27c99d94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "c7fac9506f1dc0cd328501af50c44d88eea2c0dcdc99609362ab3c22bb418b07",
+                                "uncompressed-sha256": "5ae0abd2f38c03a30fde783469dedb4823ebef1de5f9f0fdb4c5c4ac9c073c92"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "1bd805ef57abd8bff5c33e51f284c9a52233083ffd7b17c7b7753cef5edb73f3",
-                                "uncompressed-sha256": "7fc110f7966bf4e6722edcf5d701127e62a75fc0a33818ce974c717b8b849015"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b94a6812b8a943b1290829dfb5fd7c040bac3962a8faae72cc8a7312a2f28bf7",
+                                "uncompressed-sha256": "5c7f79473705d99dae09f32c10a6b1a61ad65fdd26465161ae94eaf1091b7c1e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "c8bb38615e64d8058d713b6023cb0c79410fd06840159ea50cc3d2e0b13e1cb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-iso.aarch64.iso.sig",
+                                "sha256": "b2be4e15c33b768d3111d16d918dc24b037b80d03309e307e65852a2fd3280d5"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-kernel.aarch64.sig",
-                                "sha256": "018d71ab8699adce28ff0ce32ea0e1ede76aabe2b2bf51209449b9bb2ce6b525"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-kernel.aarch64.sig",
+                                "sha256": "65e828721142335cd235ab34ff8bbe2ead12191f99c3161f69a1a53c72579b2e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "daf0502020084735fb874613bd0402b6c3e10849981fc36d2c4e1a82dfbb8876"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "2c3774254b6877b4a939d91039ae4f847630f12ba6c76a52e3f0884ea4ee634d"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "718db7d928352b5eb097d4a3bc61a575e07499d16adef80391447eef0a6fe2f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "c046c0a7b3b8c365c745c0a92500902770ddb9f74d8940ead21078186c1e58f7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "0379925d398ec790dabb365d8c8205fbd47b33f9e3953a779529d1e74b5a38b1",
-                                "uncompressed-sha256": "5b681edd1f01ca3f179261adb920482cb0f25aa9973662114f22c75c7324ef8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "64457f5bd4fd1ea5a8a0fccf39d0e991468093f1ba95bcb82501e44e2286a80b",
+                                "uncompressed-sha256": "de0ae5e074003c995484d5bcebe5624f5530381ee32564892e627c8f893b0439"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "99b313d1effea4320b30d417c857cc177518ef198f2c1e089c47815ac623a2fc",
-                                "uncompressed-sha256": "8e103fbf5f8b0e6892ad04698fb3f6190e33aa03d9881bc88f5185b5a8cefa4b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "bd8561e244533173bb9f78545f5edd1197aec64d898cc49ec9d713358acaee43",
+                                "uncompressed-sha256": "0935f80e28c41b5438326595d9fba82b46b0c965cfef38b68ec8f13ca5a62118"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "1eaea222a1c4e3911147f8b571c8e47cdd36c2135e8e3aabd036bfd209d9445a",
-                                "uncompressed-sha256": "e92524256009df43ab457f1ecb3b58f50d62566577803af35be1ab7330674911"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "4bd3e42df56b2d12a54a5b2ba197a40fbc3c7949950ccd9122dbd31164b00202",
+                                "uncompressed-sha256": "ac4c90d12fa33d0a42e2c2c08f454bd552edd649164efea4473f4d0d8fd6a10b"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/aarch64/fedora-coreos-44.20260707.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "effc0f86fa558babed35cbeaae66c084d13909bfdb3b48dc99227cd33f637ac6",
-                                "uncompressed-sha256": "d8fbef331a1cbae79ecd15f9f8cc8893eac13bb0fad0453a769e4d92e654ef9a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "06df1793babc235cbe9e8e0b4a00f3eff04e43c09689a1a8327f7f9c12a1e575",
+                                "uncompressed-sha256": "834e62886284d21232fd135ee980632fc888e44a031e7344332ec679ee3f4c60"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0872a8c621c951e79"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0047ccc1b8f6bb14c"
                         },
                         "ap-east-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-025df0470327bb5ca"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0e10b302536b5b6c9"
                         },
                         "ap-east-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-09b52c258fb4978e1"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0ae48227a72f3851d"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-09308bc703efda923"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-037a941bcb3898879"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0d88bb2bfa41571d9"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-01421edb711437265"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-03ce33ad10fa9273a"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-06aafab029a7606c3"
                         },
                         "ap-south-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-01bb383ed2406766a"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-00a95c6c46e0ff698"
                         },
                         "ap-south-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0c974941640653287"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-06185e5bf16a946ad"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0eb1595356d557c22"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0bc29d66893f6e06c"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0d0ece28ab21248eb"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-000ac6070da8a6a9c"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0e4dadc182b1049e7"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0671fa6f50a2e0160"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0047db5a7876826d3"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0d8a284b944027e9f"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0571ce4e3589f32cc"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-09ca7608b5874affa"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-032d53d0ef1d5c8c3"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0653bff310a4dd9b0"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0b3c76959797e43e5"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0dc1c14f8663deca0"
                         },
                         "ca-central-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0a5bf74294be1443c"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-07a620a97c6581172"
                         },
                         "ca-west-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0b9c081b9ecd204fc"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-00bbfd1358144f5e4"
                         },
                         "eu-central-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-042c6dd5f7930abea"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-012d76b1ab95df96b"
                         },
                         "eu-central-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0968a3989fe5848cf"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-07814376b89dbb437"
                         },
                         "eu-north-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0195d25dd2bbe2c93"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-052b2a40dff9e64bf"
                         },
                         "eu-south-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-070bbfcd06686bed7"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-08b50066426862097"
                         },
                         "eu-south-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0af180d51e5583809"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0238bb1e84b28bdc5"
                         },
                         "eu-west-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-05b4ed119bff27494"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-05eca81052aa5f082"
                         },
                         "eu-west-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-02b12411d1f4d8fc3"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-026a9a6d8c4415463"
                         },
                         "eu-west-3": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0aec68ea827dc86a4"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0d44a4b106724fb48"
                         },
                         "il-central-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-07df9fdc5505552f1"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0d34a6fd71f061f7d"
                         },
                         "mx-central-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0848df64190896358"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-002cacda6e3e73941"
                         },
                         "sa-east-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-051b8def0db966455"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0b537e9fb1928f08b"
                         },
                         "us-east-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-077c65d20ce22a90c"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-00372cc9fd60c5870"
                         },
                         "us-east-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-08986543800af8886"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0de5b37c890762139"
                         },
                         "us-west-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0f0f293895d5f378c"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-03ceb303787ef3be1"
                         },
                         "us-west-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0a929e48f81f2475d"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0aec928fb4cde8367"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-44-20260707-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260720-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "a42da865d54bf81d1a5402cf30f200d5fcedd87e4829514546cbc138c3260902",
-                                "uncompressed-sha256": "391df3081e5b0b7a72762125e33e03aba5a6684f89511f68a3cb5dbbc171d9b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "c4234d344e96c51236cac50dce459c030cd359018753af55beae416e5c42a6b4",
+                                "uncompressed-sha256": "e2ddcacfb534e0e473fd07e069dcd0135e5808fbf964b78f7cde47c5f24836ac"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "ca2498a1f22ad207dc0695025af9d291d686dc5ea240e02fa988e70c1f9c857f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "9b8f8f64e3e434d83d440ba3c0366f71f9d64baffe83ad71088f4a9f8b848898"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "1107a231b463cd249fd2b3be025cd089d23dc3c77efcd34ff7500f37fb4d80a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-kernel.ppc64le.sig",
+                                "sha256": "4bf2a7173bd32993e9097c68c8c0036a1dd2b3028ba7c93c74367c1e15743196"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "41d160fd3e09e1bf27777c631b8b93e3ab104c4da3514e45eae72c684f3cc03c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "1f9433da4c1c602e79ecde5620b002af21b84f9c4b3fa74bd7054c72686c8b9e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "d69cdfa226181d59e2060247b265fbd68ea05eb78a4368bb5ab907d1b4224cea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "e2bcb1701028d24b7de2d470be1fa0e6e2f0d2f0b959dbabde0c7a3fdffd55ad"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "71239e7c7effca022635b4a767fab7a44ce102bca3aef4f94873cefae7c3564f",
-                                "uncompressed-sha256": "eb2e3033e8a3d3d839c4b00deee4446d1c97b65c40e6381eb777f2ddd73a8f1b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "9d6c5535e92b9d2f3d1ba12720b581974e4d0197f6946307caf5a7da4936ae12",
+                                "uncompressed-sha256": "5d5054f7dd8b0257c7d0b41f53e05ba8d32bcd499e4faa2ce86b881c6fd9e763"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "e7ab6b3567f0b366d0c23a4c684fc2de44103cf394db86f1e8699279297aeddd",
-                                "uncompressed-sha256": "f309007d2f0f77a0b71daa634af842e0c6ad1397d6f68fb82b7601fcb6132940"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "5c4204f54e91d5db093ecdb6babddccbda3338600d368c33d468b5e9e9885c4b",
+                                "uncompressed-sha256": "bd5a5f835aac0e475fe4614ef004597415c4fee21a998749e52d9d6d2316a7b6"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "774cb147450696bac81720e50c5b43715358a2847b5a3f4026b81fe891cb102d",
-                                "uncompressed-sha256": "a8dc3d2f80c13e08bf092064226eb57075e67ed5dba57bf6ee428ad438b76d60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c0efea1a573f82feb11baee215c83337d52fc3f6e53d27ad979bf725c847f692",
+                                "uncompressed-sha256": "0ba78304bc707046d1c7a2826b3ac2e8407729dc117ab2815c9efdae019f9025"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/ppc64le/fedora-coreos-44.20260707.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "289f4966df5f8367a74d8b622f550741ce9177d981f68507c41bdb9634ce0bca",
-                                "uncompressed-sha256": "dd9383ffa191b6c8df451e57ff6df4d910935d8ba6fd4694855c0fa3beea9b5f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "79d16f107c2ed1c441d4ffba2396bf215ef0890f3aa0a5c00c01074a60703cc8",
+                                "uncompressed-sha256": "0dfc444d8b7c9ea943ab659392f81617409553e94021352e9c60213eaa03dd36"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "684227300ba2fef6153332498556ce2f71629208d9a65639284354a9ef21b7a3",
-                                "uncompressed-sha256": "40b3b056b112b313ae25a29b01e8e10b5b48d75032e0f9a94ef776245a0e274d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "63afe1d305fa2433ce9c5dcf2a63e3d7cef16edf16ea1c47d26296548e30a4e6",
+                                "uncompressed-sha256": "1ec3126e3ada87d28b51255b88900e8b912944b9c1c4c26f0123167eeea548f3"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "727576ea41c016932e8aff46a6deb3c799ce81ef62b66342b5f4be929c4347ce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "6aae065dd904baae05d40ac15a92152e7346bf342b24e6d9fcde6c552d557efa"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "55cd12b4df26b721f93f985a76a3f39d4517abb4ca6734f5ff10dcd14a586bc1",
-                                "uncompressed-sha256": "7fed23df8236e6202befa7acf0b644a72a914df93d19539546eb4ba7dd16c62a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "720ab48f8a3fdc8085c9093ef0ca4564c08a79077649056ebfe07c2ac9622a68",
+                                "uncompressed-sha256": "c6d97f6bb93de0872a0ec35307dfb16c920d2994a75d0caec5b34b08a5941b84"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "b023bb0a8720c83b64c2a68a3c0c5df45b80a252311a9e80e82b9e80a693c533"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-iso.s390x.iso.sig",
+                                "sha256": "e9653485a7248f51a6cf6291f96902a6da08dfe9538057c018a705214ac1e1f3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-kernel.s390x.sig",
-                                "sha256": "5f8e1c0024859b89938f4e32f46c19b1e0b97535cb6b9ae37d2c8adbedb1f7eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-kernel.s390x.sig",
+                                "sha256": "7fda5d822d42d3e692daaa4964e1c1cd38c605c0c2e5da6678f51b7a0697bc26"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "17be36672d11716787fd946a193fbc6ddba60129ffc69f86eb07865022f45ee1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "c735173440073c61851a848ecfa715a28bb99151db526a555128b911253f3a79"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "7c7faf29f29d2d02de9c9b3a960bc7e1616583c08d1120fdae40669e3e74ccc9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "e6fb4d911d43519a0bc8448cd7ca49d8aeacf8d2b15d5d3436448af984d44dae"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "a15dc760bfc73b485393e75a1b1212d21b340c381f87bacb266318806ab8bb47",
-                                "uncompressed-sha256": "39d43a4ce0f8c5c5366ce69ce613128a012655acc4b46b380109987cce86bec8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "e3ad96eee679b4cd19347a8e3df05d1676308c6d4c11226cc32d3eaebbe1a3e9",
+                                "uncompressed-sha256": "b5593bbf6400e95aecc239df28091dce428257fb11b84f96690d1ab26d905b89"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "c5eb16c8947960acb796c82ed81715ab5b638c77c56c88bb81a5576127dfc0be",
-                                "uncompressed-sha256": "551e4e462a8d18e58e91940b87b5e447ac841286231d5a342002f99885bd8f01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "097751b7b459c32e6c3dc76db03753dfd153510874eb7a95f27eaf52373b9dd2",
+                                "uncompressed-sha256": "f3b181419b8e4561dd38161de2ad4b16865524c25d0948a4cafed78093746673"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/s390x/fedora-coreos-44.20260707.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "277c6aa666b46353bc6c437ca47a4844ab4dffa0bf192a9ac070309570bbe771",
-                                "uncompressed-sha256": "fa35a236ac92217953651090a0cbdbd5a7811a221d41713c97eb122115ba5b16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "4ea422baba2bf711e71e06d08b6a13ed8e386835a82c552c147a0192b89495b7",
+                                "uncompressed-sha256": "64386e5d1798155316e64e482c1d9560a5726d68d74c9a3aa0da8a13f3adb30f"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:954e0be2cd65d13584020d2132161ea3af2d46c4f8cfccb8aaa60b5bf6c5e62c"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a9486f03c60aa6b0439d3f71ee21db4fb6560ae788c5d68fb1b4d6c6f7ba96b7"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "cd85ce1fc8d52787c84343315e9ed499f4e550f886de58032583348f246f7115",
-                                "uncompressed-sha256": "72841fd4de83b30cbf9101ceb08f347c48b2f2fe1fac363b48b634530b3c031c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "97ab071f36962581427b8171ba78c37ded290b4f34b2691134a454ac5eb68d47",
+                                "uncompressed-sha256": "b667caa75ed3250ecbc25c711ac38d81b99b1c07064baed0125d70d1ac3caab9"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "a2985d0c3b70a2da20c51e3a92f8231719b89e76722cfbb6bcd4990661310805",
-                                "uncompressed-sha256": "6a757de16b5d06cef23bc2415fde7ec17295f9df8d87366d775de758b4bd86c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "8b21a8f8d69f13984733ecdeee0f57a39cd29e31e3f76fbad38107bb7d407b58",
+                                "uncompressed-sha256": "42e6ac1ab337e8138c826fef8023aec3cd12cf8a94c84f15501fd053af7c8c9b"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "2659f474facecc5d2a3a030b5d01b2b142dee40393c8e2a439dc4b072c947fa2",
-                                "uncompressed-sha256": "c207c2afbe1206bd2cfeededa717c8d8d08d0ff8a4ca50bcd670c86f4088178f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "ba5aaa3f6d86fc76ceab44312106d1fd0b883ec0fd8ec4448850202d1b917fe9",
+                                "uncompressed-sha256": "4e8c294f6d97b269a1eb1fb6f727287a5df314166da65e647cbbefb7844f514c"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "db0baad0385e95ae06c9e4e38e5d1cbd134ff02f5f2a6345d6bb1f71741844ae",
-                                "uncompressed-sha256": "20eb23dcea3642a94d5def7c9810019374418bb02b93eaed3f8f8bdb80424a08"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "91c6792b88b77d1d3376ab12553f4818baff6802915ffc1fa98c93b5cf796f10",
+                                "uncompressed-sha256": "c20c3cada384fe0e014876b56862a09d35ccc49a90df0beeda166fe4b725001d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "8db4c568eb11bc81ee033b03138058141f7fe2259dce11c0ec05291a25d8cfa9",
-                                "uncompressed-sha256": "284f8b47dcf081506453ca61b19dac17f9f6a9dfdecd0cbf63eda802aa463634"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "14fe8cb4de26c03ac0ea4d8027ea23308eab7b09d11c1061bf9cf1818a786c7c",
+                                "uncompressed-sha256": "d020c08279b5affb4c016b5c7b52cb982257883106267e651268a9a9fae91372"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "7879b6d8c42a74e968101bf205f339c48bd3ab56d4e5f9feb2f44f42c84c6a7b",
-                                "uncompressed-sha256": "37d4b72540d905aca2eb10362112585bf94e8c0af2183ec79a934265c91c55c4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "525c059e5af8a172301694658fc6f33bbb31306154411f36a72b5befd919cf8a",
+                                "uncompressed-sha256": "e4c93c700d074c444996a5af247f03b7d96af39aa436a20e5b811e031c0f52df"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6333f5b61467b3f533012b231330ba2e66cc761adc8cde6cde610cc138ebe56c",
-                                "uncompressed-sha256": "de72a9a1e40fe9b75b3b07ee72681ed6e0636e9b1af1667391e85f6bb45513bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "12b518293e1121ebe49a26f468a4db9fb21810b4fffd4cd7fd57e4a92318e2dd",
+                                "uncompressed-sha256": "ede629150bb7ecb985eb4385baa485d43043b670372c3b465cb42f1c8957e5b5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "9f50476e6a65d4055a83e99bcb258014775f2ccff3948902917c584c2d2461ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "4e59754e28013a5debfc045a38b9a1d665e1f9a308d89ea1b1c8cce9a9087605"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "5922e435730f1760322957037af2b35c4f659826c7a1a964d4e9d4ba4c1cce60",
-                                "uncompressed-sha256": "7ebb2a0e37ab872125ab8e4ace2e7ec065ad1b0a29cccd76224d1b76d316a7ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "8b9c1b8693893796bcda74c163d82485cb4474730c09ec3b9063c02a654da987",
+                                "uncompressed-sha256": "93d6b935a21998740a0af11cf9ca4cb3433972177e3ca74999d273802e2cef3d"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e2505bc0effb408554bc01294c33ca301d54646e8411a37600721ca487e3f56e",
-                                "uncompressed-sha256": "8adaa9083db4d2f9f41b301c619676e6c1d2efb0a8e5121cf68fe00d33c082ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "7a224fad3310942b9d2d1cc38c24977c4daf613e737e34938c9311c1500412bb",
+                                "uncompressed-sha256": "3bac6a49818693c547be3373d44bc140d1e69dedc4bb68d646ae8c081e9467ff"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c2d4e61b59ecba754e393fd3c5c91d58259aa05416a31895ebebd6ddfbbc74be",
-                                "uncompressed-sha256": "9fb5242a9931180bc0a0fe76a1ab854372dad6de18601b01ccd062871db72df0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e6390c3904765b0418293dcaefa393843bb1faed0b8e8d5a0370c690c80272b0",
+                                "uncompressed-sha256": "a15028338bb611209b31e9266ede46efd9a91758900a718ec98d0f2179d1d453"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "73916ff2bfd8dbde7e91eedad7752bd8092b4a5e76c6da0e69baa38f4ee4ee33"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "de494c4c58fa78176dd7da19e62c08250810e84e89dbe01f4fabe78356871255"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ef7ceef6332d083f78df9c972958a62da9a0d0b295d322b6e0068fb9fec0f79a",
-                                "uncompressed-sha256": "c99522f219de12b8f23fdba4dead51b04d48e8bd1510568ecc935736e18952ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "e2f58199ed2bf0e475db964198dc14839a70bc706e95d15968c1cbdc80a58993",
+                                "uncompressed-sha256": "9f45b262c7cd05661362badf4af1f6a0c98d37b40d9613b33b80e8da1c6e713c"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "a2d8f9124008274e2c9ad2ca0d305cba8a3017993e0ca70745cf86f1cbb80e80"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-iso.x86_64.iso.sig",
+                                "sha256": "dda0cda3378e2c4d9b372a22807d70a3b7da86ef3cae30684e471fbe60834607"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-kernel.x86_64.sig",
-                                "sha256": "b0389e187ed951727560f517d589f3daa2736dc34dc9aa245b986d72b6f6c3ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-kernel.x86_64.sig",
+                                "sha256": "6cdf5024ca807335491c33a271ca7dba28278879ab93db8bd1da99eab2d48acd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "5770ef0a2eef37a7e8f578e0a1de9f7c4577fa1b3a40d2b475f438857bd56536"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "722134fcfb0d4b5fa8666a66ca2a4da33f4ec21bed819d66a6d398b8c5757cc3"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "f87b47e6d6340f802b1af42de714d578b1059abb47457ac2de5eabf73025f44a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "cb12fc8c686ef90e002f73a8d870f72bd49e3d22e875ad6a288ed67d4b3ab115"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "957e7e3c3f89c96c0db70e244efde82afef3761494df2a4ab60282f4df82b94e",
-                                "uncompressed-sha256": "26ea06dbe4ad7450647ce451530689619f221f8f91baf11f2913ef8c0c1469d6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "e25b2a89d7fe5dcd82cd9317fa9ab52004a4906023189fe51482179079943ebd",
+                                "uncompressed-sha256": "f130a3c1a4a58cf7c20f0d4665d8b0780cd22b17693eacd38ae10d1b699f1bf6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "4936571e6191ab7a9400a8b0ca4eae94dd3bafbfc5c1d6c7a7b77377ced0a492"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "c13f65608e8cb289761a843dda876c4ee2a20fe85b66f7b4fcbcd2e09f2d2a64"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "30fbb28c35fc1ee676714c2b0f40ebb04ba0872ccaf82c481f83e6d8ae95d9fd",
-                                "uncompressed-sha256": "91445add87a7aa021cd1c11968072d127eac80986ec0c53db715651ee15b2c2b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "bae79f1774324c20cda638e6d218666b4fde5ccec08eef7dec7bf189b7f845ee",
+                                "uncompressed-sha256": "0d57fd3d663df7d28de32de3dcc7d84770a49527b324fabf6c7c84174e4d2b94"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "d27b5c7f8661f1666e18bd3346d68fffb2dfbe416ae3f2535599476d69cfaea2",
-                                "uncompressed-sha256": "db70c72118ed7dff37a4d3c1f1b2d698be50250f023c548cf9cb342e66056f39"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "4daf004e0bed4de0a6bbcc1b5e3d75eb9cbddd41739331d36a3864c55418fe91",
+                                "uncompressed-sha256": "22add32237f295942626871567c487b749884084b6e3a4c6e286f025c7eaa96d"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "9c3418e3555a4ea401ceec858c28a00fcd190ca5aa16007f2daf1c5829735c37",
-                                "uncompressed-sha256": "6e4c3413c4e3fa29ee13e8dcc074d5a564d13ab90e2d1767126abb151cbb4100"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "112c1426e85afe72c48939638c29c32890700930796e3b24e849298b13d5d3f8",
+                                "uncompressed-sha256": "d3c5bfbbf7e9a585e7aa69665dde6d7464c8a9c3fc7458613c52de865f9da638"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "ffa1e63a613abc50652b4343f9c7ce90f4bac193ead2c87cba6988c2733ef300",
-                                "uncompressed-sha256": "3a2c0a9be52f4211310e7d7b8821dde23ea5b52422267386175a335d25073266"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "06ce1a24e930ad2fd5057e2fc65c2da4e48881f1e5ce79e3879cbf11def817a3",
+                                "uncompressed-sha256": "f6bccf4d0daac72ba5f611054efc1f967a1b08f09d0517fc4f72133a54971d0b"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "286f9070797cf462f36ad9770907b5fc22fa90be6709fedfd297a101881c8eb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "553540c18fd5f7492c5217485ebb38a6342f5bd5b01e7a2ee289440a5bd5b817"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "0c9d59fb583f23f36c6395d98cbfdaed95d91c72c48eca9b2d1b8d4320118318"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "78df546a76f4259bdca3696fe997163874a18f40700e3651da465c4489be7bec"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260707.2.1/x86_64/fedora-coreos-44.20260707.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "5a2328ed818faed029863df54f53df47b9e88d6b12fd02637bde202bfccaaf1a",
-                                "uncompressed-sha256": "8e298d2404f34709e3c2e01329a165ca47017594d29c07bab6778df9097cce06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "7be86582d14483166142c6e4aecdc64eebf07e95ac21ef3b777f031694968150",
+                                "uncompressed-sha256": "52168980669b3b299ac53e93162d45d4120270f014b7a85d059b4ee3d1d5eac8"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0987415a98256f389"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-06041ad21ea089ec1"
                         },
                         "ap-east-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0189c8eb2d694ee77"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0c1aa771bbb5e3c95"
                         },
                         "ap-east-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0e88b5cfd8d6a5f64"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-00000e1f268012691"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-000403330f8b083db"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0e2af7699605e387f"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-08ccaf207fb758727"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0e0e6715a9aea860c"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0f8c2e7b837367346"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-06e9d29ba7620f70c"
                         },
                         "ap-south-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0f93606b0a7c27a70"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0acfc5728e798f472"
                         },
                         "ap-south-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0e8d33b5b38cafb19"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-02775af479391c637"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-033953b44a8546b5a"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-01dc53684aaff4e23"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-080d8b565c09ad9e0"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0c241235b96764d39"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0c542034f225aa3da"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-01a5190044c159edb"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0c051419ddcd24032"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-087d35096581b9e1e"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0f3ba6f782e39df8f"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0860852a83d2357e6"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0d5093a291c6a2e44"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0d239320c52d5c83b"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-09b22f198458830df"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0555d1a9eb15e0f23"
                         },
                         "ca-central-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-00ae626780863035d"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-06c23656064bd4d23"
                         },
                         "ca-west-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0f64a3137395bec19"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-08238c8ef02dfc86b"
                         },
                         "eu-central-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-02e1408a82fa721ec"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0fe3f9ec33c023926"
                         },
                         "eu-central-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0eac822eca2694105"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0383f8335cb0e62a7"
                         },
                         "eu-north-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-09c46f2d28074fc63"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-00c0e896bd1561e2d"
                         },
                         "eu-south-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-06800313ccae14eb5"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0a714252817f7ceae"
                         },
                         "eu-south-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-08ee62138a48b3eee"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0c7e8c74de4664aed"
                         },
                         "eu-west-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0abf6980b5cb10672"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0841d68dc14ed9b10"
                         },
                         "eu-west-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-05787ec0ece275cf0"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0b7cc0c08f37c0e54"
                         },
                         "eu-west-3": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0cfdc6567cc493437"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0e1a0df32160e43c7"
                         },
                         "il-central-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-022b5a478a411e251"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-046b1d284c39af96d"
                         },
                         "mx-central-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0cbfc41f6bf949044"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0cb82835ca11dc672"
                         },
                         "sa-east-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0e1c70c553de7ed60"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-01d35c0edb3949725"
                         },
                         "us-east-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0041e2345af8348e9"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0ca997d7842494e76"
                         },
                         "us-east-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-04f77aeb29c1b4969"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-046c57c828669a264"
                         },
                         "us-west-1": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0f0bc8140ac72e824"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0bf62dfb57c41d915"
                         },
                         "us-west-2": {
-                            "release": "44.20260707.2.1",
-                            "image": "ami-0fe6b2f28eec91553"
+                            "release": "44.20260720.2.1",
+                            "image": "ami-0e140f04449fb999b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-44-20260707-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260720-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260707.2.1",
+                    "release": "44.20260720.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3bf607b9470d1947c8ff3b0f268c015dc446493a6899bcedc9969d131c02f4d0"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:80be1e01cd24c2b037843025ba9c75f0953a283eb43524cf35f8238db0e791a3"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-07-08T23:30:24Z"
+    "last-modified": "2026-07-21T14:07:14Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260621.1.1",
+      "version": "44.20260707.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260707.1.1",
+      "version": "44.20260720.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1783605600,
+          "start_epoch": 1784728800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-07-08T23:30:21Z"
+    "last-modified": "2026-07-21T14:07:12Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260607.3.1",
+      "version": "44.20260621.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260621.3.1",
+      "version": "44.20260707.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1783605600,
+          "start_epoch": 1784728800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-07-08T23:30:23Z"
+    "last-modified": "2026-07-21T14:07:13Z"
   },
   "releases": [
     {
@@ -173,7 +173,7 @@
       }
     },
     {
-      "version": "44.20260621.2.1",
+      "version": "44.20260707.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -181,11 +181,11 @@
       }
     },
     {
-      "version": "44.20260707.2.1",
+      "version": "44.20260720.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1783605600,
+          "start_epoch": 1784728800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @c4rt0 via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).