### PR TITLE
Roll out stable 44.20260720.3.1, testing 44.20260802.2.1, next 44.20260802.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-07-21T14:07:14Z",
+        "last-modified": "2026-08-05T07:18:03Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "67c4a382ce770df1cf8fb82090a4d37f0ea1fe8c2db656d02410488464096804",
-                                "uncompressed-sha256": "b3e9100054c591e17ca4a5c6116e8a9e2ecd227e5916a19d966d29cb3fb4bf76"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "3a30d30ec837c1846823bd60a2f7c3e82ac970f0ab25991e18210e52c56e922e",
+                                "uncompressed-sha256": "824a403cb194518bd729738630dbead524bc7ecc00c7e39714879f7fc0b9dec0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "d9b87121c0a2d1e801c18114200c44cc31359a09cf58d3c12728ab7062b7be31",
-                                "uncompressed-sha256": "2caa524b290fe082b47d4327683284b87bebe8940aba15d8ab702a984814a037"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "0002d8cc2557719fad103d4c3520792d80c21a362fee333aa076d9fcbbe9e62b",
+                                "uncompressed-sha256": "04e9d1df8f11ac458d60ed3cc3dba284f6ed06a1bda680fce048a39afe3894df"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "bacfd08b6f22c639899785e649a4045d4a58768d587b92afb27d2b49f1705b6f",
-                                "uncompressed-sha256": "915f736707849abe7bf9ef2dd0294e4c2f730a5cc16798eff0b25edc7af26336"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "0fe760026e82835a0df4e13538ec38bbd7b9e6ba74446201988ec73a32509398",
+                                "uncompressed-sha256": "73b6df530ad0b1bcf28066ae05d0def65065b5a875b3bc6705a7ed728789aee1"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "a609cf0fa619d37ba6fb9e8b91a2b3ad9966d0ca00f53204fd79da0f0b10ef84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "a2b65cc108d9d7582b69b42aa37ed8f63c08756bce7243ec963bf435587eafe8"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "1f45b3576807ab1a78905b1cad47cda58a66214cb06cc4e94cb7654d97ccaf7d",
-                                "uncompressed-sha256": "a9c34c3020ccf8a9d587cc8ae48f1cd0627a3cb2e8a033eff6611716ac640839"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "1d89a588bb9778bcc31a69cdfd2e1ef9b1440a3c7750ce29954b104db46dd05f",
+                                "uncompressed-sha256": "20898d8a0f99af8cdc6fe5060edf4d5e003fa9d67eef564d2b3a02ad6a9835f5"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "5143db42dcfd1b7800723d8adb74ff76d2335d3f2409d76fc98e4141b9de2635",
-                                "uncompressed-sha256": "3956275782499361a9919be99a013fe154f6248f3149fe77442808b6f49a60fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "514470b7c77731650f487a9f77a7503c35271f3ca87798a551370db4d2b0eb58",
+                                "uncompressed-sha256": "0856138eda4cf924b109fbeb906d57b97928c3670a660b7c7ee53aa45b039ca2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "ea8fc5fbeb6e72c3cc766a0d981be1e7f80b6ce7ba611bd1aa635c3f1f26cdcb",
-                                "uncompressed-sha256": "396796cfe400b2795ca3cd165a1885bc0a6dd4aa131a369b5c8856bdb17d176e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "eadf0292198693eac54d8207e14afe8f860b631d04536d49565271a26a65018e",
+                                "uncompressed-sha256": "cce127c5382975718baf6090a9c8ffbba74c6dd362f80648fa666004f04a1f01"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "475b1a082a935f27d9498f8005a4c53fcec8d338279ea7d8985a54bcf1d3d782"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-live-iso.aarch64.iso.sig",
+                                "sha256": "b96298991bbd0f22dcf68bf60a504d6d4bf8ef115a31011d243a47ac830b9844"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-kernel.aarch64.sig",
-                                "sha256": "65e828721142335cd235ab34ff8bbe2ead12191f99c3161f69a1a53c72579b2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-live-kernel.aarch64.sig",
+                                "sha256": "dc6e06dbfa71089676b9ce4109164c9de376be1ce3fcdbfc7a77bc82ba643b77"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "f30eb7b5bd8c15855e692f635bb9477b2dd50871d33fa0da10f4a944a82afb09"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "7838e0ea0d8c443773e01975337a020aa802bcf5f2b4e29b10e0164ce14df484"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "b42cbd17b4fe11324293443b48119146ec6b8903b1f63203f21bc213db5b7b90"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "4543e739d00bf1b1ebcf5e5a992108d8fa05b11b159f204f2f0f6fef2d529425"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "cd262800d821aaa7d4dd24a900b7b4973c5921b317596af6be34bde97bfb8fea",
-                                "uncompressed-sha256": "3623d934eb4f8564dfd9771a9c5579050b307d45147d75e2ed4f14eafee233cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "1e5be4f94b45030ea68ae6ab2f133eea79b23376a45e36c2c0742ced992309cd",
+                                "uncompressed-sha256": "5127b932c310bda5ccb23d6ecaf2843155205b492f9fed6020a7aff4cd6dc091"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "781fbdb00ea0fe20da0f7c5410ddf76d909e8ea8241827489765adffdea65fb7",
-                                "uncompressed-sha256": "6762d0f2afff6a2921aafa44cd48a76c27a0c5df0926ce9edc1d1249a3162f5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "43fc45d5ebd06c9b4d62d3ebfe2655043974b5e4d9df6cb9b8bf05509a10a464",
+                                "uncompressed-sha256": "e79bbadd576e42152d085012d52a91e446cbc50b925de70dd36907b87268e8b8"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "2982f1efd206982146b8329007e2de0817924b6bb19ec37bdd7a022f1cfdae4f",
-                                "uncompressed-sha256": "f3a3feb52e456e6c77312d9899f1ed3992d3bc9b51dcecd38734447d3233df91"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "25a6cc24a6a55f3a08b2eeedd682e58c038e9532aa908eae6168c337255e807e",
+                                "uncompressed-sha256": "ed7a6ba124f86bf43984a97783352c2384bd50ea301914cbf6848e08cc4d338a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/aarch64/fedora-coreos-44.20260720.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "81046efe1680e1a99b302c7007256388def250d69f672551820fcccfc154fe64",
-                                "uncompressed-sha256": "d43390267dbbd2236aa75eb54e5d90127ecdb9e3a751b7e07e261f54df5ee991"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/aarch64/fedora-coreos-44.20260802.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "6fd0092d370e2262cfdae26602a27e266960abd8516fdcc0a85597ff395623f8",
+                                "uncompressed-sha256": "d0ecfe1d009973cab6003c1f800e3cd5b2c9fc9475138e85b8f0cd323d5ca0db"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0436d4d459c22ddc6"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0ba43b8eeb6dafc67"
                         },
                         "ap-east-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-009cdf98a036c90d2"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-05fb6201debd8cffb"
                         },
                         "ap-east-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0f21fb3e5b488169c"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0efc05596385f61b6"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-087f775baa101060d"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0c8ff6b8229d10235"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0df9aaa583e269c3b"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-02a6692e8d419bf23"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-043d4274effa21cad"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0e58a7ca0bc62a710"
                         },
                         "ap-south-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0251d9f4d15bf8d2e"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-03d2935db1259a322"
                         },
                         "ap-south-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0a5eb5527ca656335"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0a4abd59b01a7e3a1"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-04a0b8bfb39c85010"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0e413c691a7c68f73"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-09bf1e8f60bc0714a"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0fcb6eaa18968b53f"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0fb84544470bb99ed"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-00e41b820c5f6fb27"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-06104758d06a47be1"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-002cfbf30fa0deb66"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0e7d66a2b72adfc7b"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-02256e76511e8eb49"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-073dd1e0eb65b2944"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-08bfa9ed561dcb7c7"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0fc8472d8690edf71"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-05faf338b148d7839"
                         },
                         "ca-central-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0eddf67a9f3b45b2b"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0cf1d6f24de40b617"
                         },
                         "ca-west-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0d2e3517a96c55cae"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-006bf30da2924b611"
                         },
                         "eu-central-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0e4407a5849fe9a36"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-092bd822762fab8ae"
                         },
                         "eu-central-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0380fad0c6f802c68"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0f4b725ecb0f771dd"
                         },
                         "eu-north-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-01d8810653e5dd217"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0c0276a86d7d8ba8b"
                         },
                         "eu-south-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0c5aa065d8df16df3"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0f200ca2212d349a5"
                         },
                         "eu-south-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-020a8ba8a0d940db7"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-023fdd217c6170d6d"
                         },
                         "eu-west-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0506b14871bf45a67"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0d4041204c6654150"
                         },
                         "eu-west-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0af30889223dd50bd"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-08201b4bb2f2b327f"
                         },
                         "eu-west-3": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0ceaecd3296d1b058"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-09086b0be19fdc35e"
                         },
                         "il-central-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0c6cab2a745eed66c"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-067d576e9ba3d3db1"
                         },
                         "mx-central-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-084caf8fde30aa938"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0e81a223e7a20f88f"
                         },
                         "sa-east-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-06b99c3c683d525f7"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-025b693262ef1a23b"
                         },
                         "us-east-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0e46714f061aba47b"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0f35e5f1f6bb6dc9d"
                         },
                         "us-east-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-090f8625cee349ac1"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0f9a3671b43e59da3"
                         },
                         "us-west-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-059d6b23d070fb73a"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-06fbbffd1f7518109"
                         },
                         "us-west-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-01593f1917f45e483"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-06bbfb6ea5f4b7ada"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260720-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260802-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "465aef91d8a6396a00b36e262811a12f1fe0a27f41df25215b10a0fb987af5ae",
-                                "uncompressed-sha256": "a4ad29d23b919cb78e69dfdf276850645377951dee733dddde01d2a2d8a7b390"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "def08ec6fc29d213d2d0716d0531225443fc1ef95cb3a89939cd63a757d5bceb",
+                                "uncompressed-sha256": "fe048e2f66c5f05f9a00c86b68d379e52e7df0579fe82aad7461269b80c75421"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "eaca3ae4354315a7c8f6264f7a94da88fae8af8b843f5fb8b7ed846b1cffbb3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "158c25fb8ee73faff0fe7af232947e15f1d67699ef7b5a4416aed104f2ff60d1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "4bf2a7173bd32993e9097c68c8c0036a1dd2b3028ba7c93c74367c1e15743196"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-live-kernel.ppc64le.sig",
+                                "sha256": "b03b8b07f30738d95891f0e8dda179cc5d04c527ea02472017bd68f18e4d4bcc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "5954b14b1aa5e6b5d98f847e9c88c51b22ac9182e668cdf33e3b9c37f03bbe1f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "d8b13685f52c537495750df9ab7fe54943518da99ad375f89b3112e1998af4be"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "caae1ce5248afd37948c55e4196d5c3ccf7c79d96824c147334b738225868fce"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "2dfd5fbc7a755632d937f22a487535d5c659550753d6ccb2041912327332364f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "1f21d40dd4b5cf7226b616d0a064ad0b8f1d8790b4e729141d78098c86736d65",
-                                "uncompressed-sha256": "eb1dc363ddc5907ad362d9155d5edf5844036df87e209fd68061265a75d4440e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "18f568b6a0d10ca393e446b7ce955b59419639f3188e145bbc7f743c75cc853d",
+                                "uncompressed-sha256": "80c7124416dfcc7ab6944fba69944d408c1f9c9c1924e575402adab4cbac9fc3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "4e97d86c3e15cbdea907038ed0f05a04c91d20ef1f1bba2f5b44f8c8ee33ab7f",
-                                "uncompressed-sha256": "70d74a59d8ebdb3cade1d74a74ee177e4d225e86777d77e9b28762229b2a4c96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6482d6bf33842048c7beee300825a8951c2918f3c38a4222c5a88a95dfaeffe5",
+                                "uncompressed-sha256": "23b35fba1017b04f4dd18455a1c991894a14f8e5e5fba2c2af9d05966ca3efc2"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "d1bfa3115718ef010c19a94ad0a389dde235c26ae8f87f6e50aa8cce51f8f335",
-                                "uncompressed-sha256": "1a3523a6be2dbb5ce8056e3ecc05d3f2707311b5f505e24b91b0b2ebffcf05cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "c82d46bf410e4c06ae9b5439c15ef0d3f18e3254b447231d64f6a7eb95b035cb",
+                                "uncompressed-sha256": "b676c800de79381e880d2141d12d3b64444ba82fcacec4169ffb829f2c384219"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/ppc64le/fedora-coreos-44.20260720.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "db94e44ed651e3cde9efe03051592e0fd1acca1e758f11b81b14ee7321e0e455",
-                                "uncompressed-sha256": "6321fc521a8f324597c797a38ed24044cf2e074f4f8a44879fda7604114ce0f8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/ppc64le/fedora-coreos-44.20260802.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "dc39c3859d1565828030abd935699af3b3a3c52b3c6c86dc93449d9b3c38f8f1",
+                                "uncompressed-sha256": "f73ef6b7324db73ab1ac47023e3bb122ee97a4dc3ed681468508f2c035a2dc9c"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b445104978033b39fc3621c4335d8d007023c8276a8361445dabbf92d88066c4",
-                                "uncompressed-sha256": "b2324b20356d130b26dff2910dca1fe2b386b0d13b1c520bc1c2e588d9813b38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "d5a3c19f2e2851d4aa87aa22af02d21cd1dbe7674fe9b8f53e44e3d895e1446f",
+                                "uncompressed-sha256": "0b0a51051194803725a85f484ed33a26c93a2638b40982a8bc0d0a14fb6970f0"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "a66268bad1a85abeec08b5a973f1e7080a8e0a6cc350b264a0fc8c24e3425a8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "f92d8542b312a6491e0ecde77b924a800c5e580d74b905bc25a1cddc9d649d05"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "857b0eb1eae896134517cc154b22581250a3af30bb2715bf34a2bd397b896fb0",
-                                "uncompressed-sha256": "13d702ab310b2e65b0bf97b67a467c55be80c660cd34e02831a0afa689d30053"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "acb5835f39564f3c35b17a3d2b1dfcb66b13035aa0ab089fb9854990ffc2b2de",
+                                "uncompressed-sha256": "971f34b59a7e90a8aaaa42e6ebfd34afd4e990c49870a36aba009d13b0038e94"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "9656b62e8831999035b9547e5eab01ca2b96e2177fe20269aa8e508c01be99a0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-live-iso.s390x.iso.sig",
+                                "sha256": "a306090bb84ddbcf0bafc8688ee348b1cf4c2b238dafc30019ffe0b6f10d0e75"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-kernel.s390x.sig",
-                                "sha256": "7fda5d822d42d3e692daaa4964e1c1cd38c605c0c2e5da6678f51b7a0697bc26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-live-kernel.s390x.sig",
+                                "sha256": "df039eb3cd132c091f0d6302cc6ca97b3bb6a428b7abfb4e65db8fd05dc7e3a1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "26c15c4298333ab9e0988299c06747194dbc3c46539955922694dc51a9f209f1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "273048c961e9bb80991764af91eb84d177d24ac2fc28054d0a974d4276c73d50"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "a1055cb91e535a8c515c2fee6c91cadb3420b82578c06308d4fe6240ad234437"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "3ff5613163fc18065f27e7ea5de2eea84100ca37d93b90586c63bccc1d3da733"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "6262106199fd2545c12768d66b81f75f37df7e189c640a6e0a68d9f6b28bdf76",
-                                "uncompressed-sha256": "0d0a36a16effe5d4c66146136905e723a6d41b0d251e7a38d77e2b8c4a21cd5e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "33a2d2975d3b83c8c06bc47f33fa756a14b25fc1d1a4bac2fb006a75dd5c0b72",
+                                "uncompressed-sha256": "e8f0c3f0bebfe5359a5802e824638ee08d886620ba637640310078da5995be1f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "9ef56eb11ad5ab535c369bc726c2b6e3ffa42aa4202de361ff157d1a8c4f5a35",
-                                "uncompressed-sha256": "4a5aa8473a2d0fbbf24d2c62813fcff2941d532c2bc9b32f575d637af2e0c67f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "4c017f58294441334be5ad7382e68ab83dffbd89364b9beeb7ec5f4eee4e91ed",
+                                "uncompressed-sha256": "2c0da0885fcd38b9617875b1e5574f115e4c993e70423311d3574734a6921a86"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/s390x/fedora-coreos-44.20260720.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6d03409e10e3be21c5da13992159d94b14eeb44104e6031fac5f458c8b78c9e7",
-                                "uncompressed-sha256": "56f5807f8e14bb1d7a1149e57e3ea653f873c480a460adedaac4e8c5c9bee7e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/s390x/fedora-coreos-44.20260802.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ff7f7e140752515e918f729017337cfebd2dd57ecf2f2eedf961567651adc5ab",
+                                "uncompressed-sha256": "e337085fda3cc8e0a174c69118cf2dc2262b12f25475a3b2b8703aa445238e27"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9c90df7c98583b0700b24bb86d2bc393d021fe80cdb0ed1e66cf3e24735bcf0f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:e28de4b0c9d4e148da6cf3e5a4039836fb2108960d8f6a4ecab1d7045e6e4d9a"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "f2ff749250da3dfdad7c4defac0d373d626a358a3ba531440cf862c1151ad47d",
-                                "uncompressed-sha256": "b7db1a5bf42cbcc54893f0423b01698d43160f94e0da7c45a7a8d0e8bd9c59de"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "babd47d2d0e3a08edccf4652f42f87606cf4b7864633ee839428f0da8c7f8183",
+                                "uncompressed-sha256": "b7223b06efed0b6f0fd13fafa88df73e8169abf5233a77247bcf8675b7310988"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "b2b589c287233c1013990f6f1d59eb0c15b815627a5529bf673819553eabc211",
-                                "uncompressed-sha256": "621bc61488805ab743037cfed10726b010cc1521317a345942fe2048eae78512"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "d93d3737640462d04aea200de791917b16490a9139ff07076ad16e26fe8de2a4",
+                                "uncompressed-sha256": "53584ed046f349e547d2747425d5534b218f931973ed7227258cd3bb6e630b35"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9527493e032f5a35282d4583cfd054db37a5e587b9d0e527c096b63f2866dcca",
-                                "uncompressed-sha256": "56e31ce3719d2231c02f8fb181c11da3df39182f5a1b3a57ecd2e971231740cb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "350ef30280f817054c9ba98048abe8c8aefe356005edcdbd8114ccc37b6289fe",
+                                "uncompressed-sha256": "f53c89d522a375861d699f0b319dfab877e13f24905411e2f9c3ff907b5d29c3"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "9f99572d46e313307d0b748f50910a0d5c93890a50c510b8bd848138b57192a8",
-                                "uncompressed-sha256": "b4844339114cc0f923be824f7f18fdf87d7de046f75017c0f70c7388abc8d4b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "cc32a6e7b7e8ab35153f11ac4a5b62a033ed66ae7ce1698f6b015419c9116b55",
+                                "uncompressed-sha256": "e617f372f885d62c2f22528e23c6ec1742e790c142727cad001c55c0d328ad5d"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "48c8fe89c25462801146876c905a023b3d5b9ef1939f40de39b4ebd282585ac4",
-                                "uncompressed-sha256": "dee6a1923ecf65b9277e1cdb4b803cbfa3a71ee1f7f2bcb861e0b46705141260"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "51a5e8ce5d6c7d93213581ce8959edd1ce79bea00448f260d77bd376be75ee4e",
+                                "uncompressed-sha256": "9f50ab1b55ad7d64758b6ab9bf04dbf0ef4206f715d0a940780285987582a86b"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "0232c40fd59248f860137b7f4eef08b72f4afe2f5aaa1875e98ccd233413f533",
-                                "uncompressed-sha256": "28f6cb7326b571173bda2653f21fc37d43e4b7dc1087681b2598c542c91f48e8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "6564c677ba44c14c591e7769118e32857d51f4795f587b87a4cfd319ad03cb35",
+                                "uncompressed-sha256": "59baa487d4d93861c3bdc6bf4fc35936c5801473298731eb43d37362da59ac17"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ae55faeb35b929b88384ca36efa1b6f31049c76512090f072febb751b86e25ff",
-                                "uncompressed-sha256": "1518cc1effc38538b8baad1b546546e9efc50e21932e4a07057be254db046ac4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "4cc04ce2e23a2ac48a4bfa9dabfb8be58b82347854288400e2f4d997f4408b2e",
+                                "uncompressed-sha256": "2271ffd12fe9859bd4fe1909a78bd10a9f9a7d765f8c00c54893a859c8917fae"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "ad41c946d3fd7c65191005d46740d689d55e7cb8758ab23a04e1001c92244ae1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "9fb12ae74af560ae1f237088b0b78940bb4b1672caf86c6879e2af3c08950e8a"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "590e64eee54f34cdc9370116a06216799de2778c6ffabf65eb8b9bbba9029f92",
-                                "uncompressed-sha256": "a546f99816571b51f30e09f0da9b5d2ce2ea6d444ec343248b9a0b51ec3453ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "8ec11049f35f493145b8f8984d48e20daa79efbdec8004e06ce9ded806707ec6",
+                                "uncompressed-sha256": "26cab912224fbda6b50a622df42cda8001e0cbfdbe5b792043451e8e8bbb875a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "ba0876a8f27292db60a981a733d6f0d3d7511574a49fac372edfa6c49a06959b",
-                                "uncompressed-sha256": "8df9a8d53c8ab8a126eb17980ffe1b6fac6b74068b91972136c6934eed5d4dcd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0f3df1df003ac8c7a381fddf218465df4bd3ca7dd1d2f7f134b2727357518b67",
+                                "uncompressed-sha256": "919e08a0a24c8811088d0d8dbbad471a85755c58a5c246787f5e5d502c557a88"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "335499d99550eb024f15a1f063f2d5af72b4489e92883679324584142c43a75b",
-                                "uncompressed-sha256": "008a9a91e0aa69e2924feec212f022d842a6f0a69c51356cc86d810bd1c0f7d3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "cfb03b7a6441754c146a620abf2b8d50995c4de625cf964cd6f33a9d9be8353e",
+                                "uncompressed-sha256": "48699adda77cc768ebf8f8319adb221591ebf6f1783536e735d2a135c916e7f2"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "0cfccc7af4b3a416989677dccdfd69d76d35f413364f469aab736b32679413a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "f721a9aa2977526cdbd3fcda50a4511e68725e291b8afa9495c5b777e59c01e4"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "2b5f7421f14c8e688bd52d3e991a07faf1a6880c4c1810f95ba853e0d803a90a",
-                                "uncompressed-sha256": "f95de61535629ca7d2e9507a5cd2c9e101e53322b0c889e26186a104a1cad15c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "407245c4d1ea00dd69e0c3c6af32dec70d68fe3557b31b1e0335d2a171de6cdf",
+                                "uncompressed-sha256": "75b379e345c9ca609ce7ff96c9c9f70d27b672fb2b5d06b4b6ca3d9816889604"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "83a4b249f5e7c06305bf20514ade133f556b2e3df456a6e666889045c78afe38"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-live-iso.x86_64.iso.sig",
+                                "sha256": "70294d8256f314af6bdee2fabddd7c6f7a67c7c55e7306a142984727f5fb5b41"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-kernel.x86_64.sig",
-                                "sha256": "6cdf5024ca807335491c33a271ca7dba28278879ab93db8bd1da99eab2d48acd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-live-kernel.x86_64.sig",
+                                "sha256": "a4db84977b6af528b12ce0502a545ab078daaaa38f91eddb81858a2daa2e207b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "d141b0019c6a8f261f12f21d7cc2f0f695e0573e2605a73e17a4935d10b27082"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "62681e140a5c554ae31a2c2c83a78bb48a356a401cf1e5c5bda4071dc73fd0b2"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "fdf978fb03cf7cabfe9f6afd7867a60931ef4f00f8e7b8ef179c330af9cb2cf7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "b40c83561217372e897628d85a047ec2c8e3cd1f749fc33d440da6a744d55262"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "54c8610a95b3742c902e4a915f8f90cc6d187d7311598b7630aa6a6128f9c211",
-                                "uncompressed-sha256": "d7571b218e09dd2622da60a4ba5b218dacea7cb9453c153e8d79ebd979be2048"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "46996f473de6da0433a9872b1b85ce4af813e9f0734aa24225d992ddf1a7c29c",
+                                "uncompressed-sha256": "08615b52b6fed3f21805d553d718b5ccf47dd80fe1b86730dbdbe48251dacecb"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f6bc651019e635ef58b942a4f157db44724c517c8fa7567b189fcce35c32a048"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4b7810b033a51aed12bddb5fb5396e5718f22781b53b45dd767cd5b98229a3ea"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "df53593f4b4417fc3f7e86bca069811dbf440733e4cb49179b9fa77a1029d8d6",
-                                "uncompressed-sha256": "08bbcf1f584682910846c76dda687286454823c35bf462ef0354c0897d089def"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "97f2cf5fc6e617387680a07a11c6ce3ab7a3e69840cc8d420522afc02a87355c",
+                                "uncompressed-sha256": "949271d24752ecd2d8f43e90fd4c46061113c49771a416db6421548118ee29b3"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "527c5cbfcf536e359a182c28250d49e071ebb9fed58e6d8cecd7244c008185ec",
-                                "uncompressed-sha256": "338d67c1e41c8107df248d6befcd958396621f17b04ffa0a3d3e51e7629513a7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "8157ef91d9b7bec212683fcd6907070db0ac731d59ebe20f24b6cb3b255c6c63",
+                                "uncompressed-sha256": "393a111939a731ff538650ccea2df2ba725d3aac65a8a8404ef0da3509ac830d"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "97d1c52bd9b23bbc22bbfc1025b080d333a7ba3506cc4bd9522161eefa2e0265",
-                                "uncompressed-sha256": "19bf91c2f1c05b0d87b8e52260b1a035a586a6d4585e9662909c4d68bc19045e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "2b265ff97646ed92c08e7d02dc88810c665fd2af808af027a1a591d47ce4f9fa",
+                                "uncompressed-sha256": "78c590d1ec9a37da2ca91b2b6348972a15ed6997cf75f3c5b7b50de82891aea1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "d05460e9149a78468d3146eab5dc13d066800a8bd6d51b08383a3a7c38e87fec",
-                                "uncompressed-sha256": "140647344146134f18e2de1ad706fcdec2d55c107273533c429bf0f5178c0076"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1f67191411d1043c307caba03fad06443b9073a4dc824fbd16d64045904cc7c8",
+                                "uncompressed-sha256": "2e93ae39217f70878766877b0eeb7f3ff792d6aa930be669e0bc9b17e8bbf194"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "2e5193ee58d261c704d018a44db5394792b42e1237ffcb7f34eb885b95301ed2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "ceaaba647030e52cda538ae3e4c0545fb7ed0009ba055a9efa87d09393fcf8e4"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "bdf095efad4d4b549dc7a70e174df45a62d40d5f6b17ef9c25797e62f5f4e0ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "c6d5c20c04224cb5da6865fa88d5ea4a9330edf5634ae5a18cf8801a5a346a95"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260720.1.1/x86_64/fedora-coreos-44.20260720.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b330ae60b83705c571f8afc1755e5f67204434f4b6cfd3945f6ea2610d6bfa42",
-                                "uncompressed-sha256": "4cce6984be662d0cca86d3060dafdc3bcdf2b1a0f6a191478da192690dd3f047"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.1/x86_64/fedora-coreos-44.20260802.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "27cd1c6f5fafa59f6adde041a0fc293c4fe541be830b00b8a81a0e1f8f5a3b38",
+                                "uncompressed-sha256": "bf75683b946182a823682db2f8f5082a4e866072fd7c2816f9dd0652510eedc8"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-08b2471327fe245ce"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-08b5b3e2df8248cae"
                         },
                         "ap-east-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-04eeb015d899b4a40"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0e8227afee3bf9d55"
                         },
                         "ap-east-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-01a7b0cfcce7974dc"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-074e66b245dc9ba7a"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0deb2f3bce052bbd4"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-087ffd43a4409a1e4"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-012cb7d2ddc731b83"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0d463ae4aea1e6926"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-08b35e129f0695e2b"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-04b3aa008877c8efb"
                         },
                         "ap-south-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-060b802460f6d83b7"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-05165202144d573f3"
                         },
                         "ap-south-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-08a397335f753e431"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0d8fa6b4eee252c5a"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0fc5b61c681a6897d"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0b4a10faaa6ae5395"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0cf2f264c37662178"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-07ba25f466f18baf0"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-08c9fd1323df88185"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0dd5566b3762d04ba"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0d09004b5f6430dfb"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-08a5b697a36ac60ec"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-002dd8e15c69c8454"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0fd75964bc867dfed"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-081e8edd078e91c2e"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-04a02455e164322c8"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0bcf306bbe28600e9"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-082b529b2f9c56047"
                         },
                         "ca-central-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-039c8557c5f77a5ff"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-07e7f820e89a7745f"
                         },
                         "ca-west-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-07e1aa8266a333b77"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0f941676ab707003d"
                         },
                         "eu-central-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-08e508e7d0323be8a"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-07c798a81aef4ea60"
                         },
                         "eu-central-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0896b69d459c18a99"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-07e80377475d89a85"
                         },
                         "eu-north-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0d2d6254330140f99"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-00238590f48e34814"
                         },
                         "eu-south-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-06a0dc9b6d442cc1c"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-097668140926ae30e"
                         },
                         "eu-south-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-01cde830d3624c75f"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-05573d5c352530c3c"
                         },
                         "eu-west-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-05713fec8aefc6e6d"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-096bd8ca77800048c"
                         },
                         "eu-west-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-00d4fbcc29202067b"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0c06d885b6937b3b3"
                         },
                         "eu-west-3": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-09870b8d6d62ef944"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0dfcc2a9ff993efb7"
                         },
                         "il-central-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-041af70e5d30cdf1c"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-001f016705fd0d1d4"
                         },
                         "mx-central-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0bfd33a4f80220854"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-07fda480315798a79"
                         },
                         "sa-east-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0a07271eeae693fad"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0bb684f554aa36863"
                         },
                         "us-east-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-08eb3e0144b3377d7"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-05bdf8925611b5600"
                         },
                         "us-east-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-04852095ceef071c1"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-02c7b736f422f77fa"
                         },
                         "us-west-1": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-06af0884cc16e17a2"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-099b1c16142db6ed0"
                         },
                         "us-west-2": {
-                            "release": "44.20260720.1.1",
-                            "image": "ami-0fee0624877cbdca0"
+                            "release": "44.20260802.1.1",
+                            "image": "ami-0a9015c645f6415c6"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260720-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260802-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260720.1.1",
+                    "release": "44.20260802.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:4f03086c2da1f23e3b98af6cc423125ec5a65e2cb1c62e4fa1ffbe2567dcae98"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:756b3a60f9d7c4d6cbd88ff9ec8812d9d60a9356f1f1233931484b5eccba581b"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-07-21T14:07:12Z",
+        "last-modified": "2026-08-05T07:18:01Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "6393ddcc0cd405d6a102e64d0dfeb1019854b4f4476de10d1f20cfc573f910a8",
-                                "uncompressed-sha256": "445d97cbda5ebd956ef649fbabab9a4732c91382ecc017ef01fbfe7b1483c001"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "883608085aa7479f6a244327b86bcdfa32affe9d399ab594725a8169d9c1b08c",
+                                "uncompressed-sha256": "68779895924e467aff397da80d9bbc0a4cace0db75c137d83d8d5b598adec421"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3db50ac081a1f1fbd197d34b8685b16c69b691855e8eaefba4f057bb7822987c",
-                                "uncompressed-sha256": "4dd0c7dbe41e6d80c14483ccf6de783ddecb4182d32966909d392979275a4f84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "91fb7927073ac3699d6429dc95ccb9eec3a8d7a91fceac3fd97aa24452990108",
+                                "uncompressed-sha256": "6d780e5259ab7a20f22eb790eb8125e0796c33f68e0753738dc094f3ccc41161"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "0c12652ccf47290866c4fd1604bd3c0a9de1881eda94922ea172683673532356",
-                                "uncompressed-sha256": "d52d23791bd811712495bb406b60b976a2023ebb63ada17a66f68f8e3710ea81"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "84acdb647c7e372bd2638e32fd7a6f5b6a28fa55afa869b8492d048c252ae60d",
+                                "uncompressed-sha256": "ee1cd8e41a5aa0c2fee18fb01ab2b1c2e0977ba8f7abee01cefa38a21b45f98a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "6f9eec3050c4609c2d1fd2a9a2202ab9f523e431bac7610a4bda83c53757069c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "9d5bf7b83772b6ba16dc9062d7f4db8d0deb35524b21c4ad9881eec36b82e945"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "ada1a5e1cee9ea41e14905a60b33cb7bc3f04fae008c5770b68541b0f1c5c06e",
-                                "uncompressed-sha256": "201698980ff57947feba4e42e0c42516a26616d763c42ee9977c48266e5fd144"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "d73b80810c283d77b3047cea13b70972804b275e75d17da237a14f5a21141567",
+                                "uncompressed-sha256": "3bff4b0122ab9e6632c8efd895916c9073e3b2076f221c61e3388107237d91ad"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "1fdfb7b275dcfa772cf00d75c9626e675fd8c495683125f42a3c0b43f819a0eb",
-                                "uncompressed-sha256": "4d0599b687999c6ea45aed8c7a8e1162bf91364a0a5a989a745bcac70e329831"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "e631b9e79e34472f4dcf604de5235134eb822d1e68b44f624373d58fe6f0cd36",
+                                "uncompressed-sha256": "9a45babd4331ac3bf0d52bfb85908f248f6ac84d3110654a4eefea1d451247f5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "042917ee574c92bb76522d396880e3fcccf9c2c5fa61776a6bfb701b63de0fae",
-                                "uncompressed-sha256": "bdfb418eece364c9b7edd493794dcecac3d2f457d34720d85a4e3ba5096059bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a2111c30883cefca5554fc4f55df9d82f4c2fb5c6fe69d9362af8392a25fba8f",
+                                "uncompressed-sha256": "47613e8399c9618a5bf5dc0ee1e581a48cdfeb659cff09516f09c173cb1074d2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "1fce8a43bddccd7f156966bf9bdb7dd0c487c56acfc593e7c22d8d1eb382d80d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "a7145cb3df8683aa8fde6e97c75d60aba3990a4ff21bee4ebd708792bdbf3e1a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-kernel.aarch64.sig",
-                                "sha256": "018d71ab8699adce28ff0ce32ea0e1ede76aabe2b2bf51209449b9bb2ce6b525"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-kernel.aarch64.sig",
+                                "sha256": "65e828721142335cd235ab34ff8bbe2ead12191f99c3161f69a1a53c72579b2e"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "d818157fc6beab93c057311c52bab5d166a1ef278f667d6c598a428c6948c5f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "52055b7448fddc96c00c11b80fb6397182f9baba8ce9ed90075d1528c7062975"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "84328a38572832363d9fb6a85e122fa93967addbb42ee8a6e20b412db0d42e27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "6d54cbcda0c56e68a820138eba6da072b0c4132c4257dbe7956213437fb60e35"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "39d25b4aee2706659fe808dd555b8a1a47862dd19177e35ea57684c866f6458b",
-                                "uncompressed-sha256": "8c182066866442a20b50541f0abb6e7680bd28399a2a9e1d050a53b034f4ea16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "f8a40b298e1d0597db7acba9936418f9fee225938a6853f551ee6ab20a52e34c",
+                                "uncompressed-sha256": "5beaa0ceb0a8c02c8e3e576bbe0f22e030f1ae7303aa649c304238d9dfe995c9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "b0e3985f99c5f2ae66be473098c3359ed2b8bb8bbf772a800797e32c9f3f42a3",
-                                "uncompressed-sha256": "061200f5df6571874dbec6eff03e7f4b6a7e5c101ae2bb54574275a000ddafef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d165b2e9d4c82d31b6ac67d749f69f9a0c349f399806d0a6eeb73a06a0bd54b2",
+                                "uncompressed-sha256": "d5f65f498467e420b6b467c458ca982f86fcc3be113ab74671e5c2e138da9c9d"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "3cb9f05528b6ec5597546e4489e1c9ab0f182faa80afedceff1badb81d4c9d95",
-                                "uncompressed-sha256": "5389e3e5a5ade479de552ea511d0b41a65ff915e74106a1288b0a7be7d90d6b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "cab41033e9c4f23e28bfcc3ccd57678a31c52b9da3b8e2476a44dd5b4c121cfa",
+                                "uncompressed-sha256": "253d05eb6a23c1c4046b403e9c3c5944d623a04b256f38c6ac7f6ffdd6689d4a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/aarch64/fedora-coreos-44.20260707.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "2877b34cc4572f2e3f3027ad056f7bd89f5069a540f3a6a8785108f695297883",
-                                "uncompressed-sha256": "f3a409bae113474cc331afab05ac3a964c44315cd5c5eb44bcf43d54cca2c38b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "e3e848071b3afa3453df7247fe94ce9978e210879adfb1f53610f63ed8912777",
+                                "uncompressed-sha256": "c2de214a751332767e517a71cfee4d01ac7ed584da2c5bd8d27c52f98bb81dd2"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0fde07d888b413c1c"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-04a170cbe0677708c"
                         },
                         "ap-east-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-01246416cf8db29a7"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0527a63d12ae5da1f"
                         },
                         "ap-east-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0d559becdf4a78037"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-04628c66e93396922"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-002ee8ed329321f3e"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-07519a04a69856b6a"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0264c7a43f7c9e04b"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0a24fc1d738f3a916"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0f404de3237874e41"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-06e2301b9fc27583f"
                         },
                         "ap-south-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-03aa8ae4b84614112"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-083afea9eab5ce884"
                         },
                         "ap-south-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0868173187c19b681"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0554933b9f26968b0"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0263a9a531a609e1e"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0a328710a699ac74e"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-05a5934040c684d21"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-092d779f2ebf09ac3"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0533f29cf6f542f98"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0331f61e3db493a91"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-06adc08e2c0479221"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-08c05e3eb3f722b34"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0315f40e47f0dcda8"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-06ba97a75b1f3e22c"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0dec01d70b041b51a"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0df613ae43608bda7"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-074196bf6083846d4"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-05d7df6bea2551ed7"
                         },
                         "ca-central-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-05d2b0b0438a14bf3"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0f8ca05ebe37ae0f5"
                         },
                         "ca-west-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-03d30bdf449705922"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0c887ba8c897156a1"
                         },
                         "eu-central-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0704ad2ac2e153204"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-09333b3b6824ad449"
                         },
                         "eu-central-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0017c69671d3b80a8"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0ba2a04666d841ef4"
                         },
                         "eu-north-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0a6fa782d0d3ae94b"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0e7601b4e4a461c83"
                         },
                         "eu-south-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0c09dc1c77627dcda"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-06a8ff4075cef1ecf"
                         },
                         "eu-south-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-05938abac22645ca5"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0134927a6f6878772"
                         },
                         "eu-west-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-08af5d9fc5c1edb78"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0792c5d41bf56e409"
                         },
                         "eu-west-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0c77fa25d3c56a318"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0108586bcd3d0b88b"
                         },
                         "eu-west-3": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-072e2c0e12885fffa"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0a696c9a5d9312c60"
                         },
                         "il-central-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-03293ea8ba6f37049"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0e1186d9401d0b691"
                         },
                         "mx-central-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-082cf0f19e441ca5a"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0d0fa0fdaa32fddac"
                         },
                         "sa-east-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-047816ea5561263e0"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-00fa3d89434972e18"
                         },
                         "us-east-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0e1bd1e95449d195e"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-029a5558375877153"
                         },
                         "us-east-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0e0670a41ecf49301"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0d7cb9ecc53569447"
                         },
                         "us-west-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0ebb59172dad5cf0a"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0e0365e38c5bacc59"
                         },
                         "us-west-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-057c08ebc21839db8"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-05c1a3e0bd3381b6a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-44-20260707-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260720-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "676de369425c90983a5bb08ee964fa73aeef28660b14b97b953fc95e6ad514ae",
-                                "uncompressed-sha256": "2723dee9f2715119e5a4d6a1d3f37a816032d21cbd1a61e57124b7464e32d511"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "d577300ea709576d6dc83ad72103f2e6a36879d8a1df81f72481f01d5cdda398",
+                                "uncompressed-sha256": "347cb17a50818fa3dfa1ef6886d354cff1ca8ee80c876404b0e36e0eb5d312f6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "2fd09d42b18c55362a7f1a387db64e97426a9eac1203775ec79067f38a82a53a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "c2ca1c05f495d9709b38b759538fd3d82679408a9d4fbe3bf8515c283b4bf951"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "1107a231b463cd249fd2b3be025cd089d23dc3c77efcd34ff7500f37fb4d80a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "4bf2a7173bd32993e9097c68c8c0036a1dd2b3028ba7c93c74367c1e15743196"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e02b7407ff59695ef64851eea58ae2d45089aa7a2fdf8683258d379de85b1de4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "008cd75fc19c73ffcbd2e2fd0e407298fb0ead95b9e4d729ca8802c9e529bd42"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "23ab01ddad60bda90b88cd1658a6c6cd50b82d3255729618e7bd6357c83f15e6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "7e959a93afb08bcb0078a71f992ae9f9bfc42e57c9c273db5ad0e8ab7c55e3d4"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "19afb7eab0c6463b20ee1bc27b1809d1cd208345ab00f099e9988090c0e69a4d",
-                                "uncompressed-sha256": "19eef77c6437109d4bbaea1a9df79ff65060e5656f03426ba6a8dc71fd75d262"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "e2a44af0580a015e6c66da6b2601392a0900ba5411c180506538220b8ca90ca0",
+                                "uncompressed-sha256": "2961f656c37c639492f0d148482301e6ba493a790437bf72cb5fa2c8bcd3b837"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "cfa850e9573f2694842a8188e8d88c805d94ed54f75a380bc509a122a4591e5d",
-                                "uncompressed-sha256": "4d625da043f93a9cf8a989a69f750d1f972e38510338bcca6d73862733677799"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "f0b6cb15ec50e9ba88b3b04f8fbe680ec8d68e165b6ef87616cb01465f18bba0",
+                                "uncompressed-sha256": "eabcf49dbf116fb0be9f7d17317801b2f85b63a577db17d6d5b3dd4401d85da7"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "ab55461410930987ea34d1d7f78bcbd82e18e456f5cd4924ef11bc1ec9f66ab9",
-                                "uncompressed-sha256": "579acccbca1e0a8feabfb6b945012ccd124c8bb91b3965c4d96ff297d1d1576f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "17f8ca579c439ac13a3834148c2ac334c8c865ac34f3a164d38ac52da3e08b49",
+                                "uncompressed-sha256": "a5ee620a253e20692ae34b1e029a7271e8b0b778b4cd523cdcd10f5d980c219c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/ppc64le/fedora-coreos-44.20260707.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "23a7881b6b747cdf5f56c45759922f3822b591f89fecc71909cbde47a1e9d010",
-                                "uncompressed-sha256": "cd3540ec501d490730e94c8a24a3aefea4cf27fcde70aad19e677152849057b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "bfe1a0c9566e253e292077014ea8b03b6545c40b2d2b9e207597169be4781b07",
+                                "uncompressed-sha256": "94d0e71b9303b2614f71ae4061f1253c179b3a163478fa2f80991425940c825b"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "ad2952fcf78dc5313388a8b66e4a94bbef5a4d2899b1e97a96f4573a049a27ff",
-                                "uncompressed-sha256": "f4d85db220fab9683d6d9b3d5217916b5b3720dfe3d48b905c493aff8927021f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b9b2cc70cb11bd94c3d79bb09a0464790faba27bb37b44ed464d31e66bf46550",
+                                "uncompressed-sha256": "4539e9b1f0a0d41f185a440c88f29244ed177f2c40d418de67f3b3f6c2a84033"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "64170a682180e91efc15509b45792995b1b00c9b93bb5cde9e4865b9444ae075"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "0487b92576b1f211c105a1b290f8ad17baceca0a70233bb352e234727fa0b934"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "3d93385a800659c3bdc49017cc34d4a472f66d60e295b5b6b58d35df1d94f633",
-                                "uncompressed-sha256": "a1f2e4d38ce78b5b11f725e5139d3072779a0f12a2aefe9c5a372d1535ea8b5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "77d5056684980b29abd73cffe9ab43b81fdcd7ef580b98169c487d6bc66223f3",
+                                "uncompressed-sha256": "aabc26597cf9e4aee207cb626933fcd7d5e0fd4c9d4cffa5dd62589526205ce9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "37ddc9449af05f0bb105e8d10cda615a3146eb6f9e84ecea56459dc10046a489"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "34847fb97b8f18f50f067b81eea728090b78d792d100097365fb32d38108ffe1"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-kernel.s390x.sig",
-                                "sha256": "5f8e1c0024859b89938f4e32f46c19b1e0b97535cb6b9ae37d2c8adbedb1f7eb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-kernel.s390x.sig",
+                                "sha256": "7fda5d822d42d3e692daaa4964e1c1cd38c605c0c2e5da6678f51b7a0697bc26"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "de1dfbe5162bf6ec4d8de071fb6b77f18e904e0da2b6aa212af373bd1410e701"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "601262731a330ae3f11e5cc4b55287258f612bf04a567db3df093d70b3acd848"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "8e680c9d4f6123004ba57e243dd5cc910761492b7699ff33ac19d4fd9121cc66"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "3e9f8b66ad046ba6b78850546dd87b383e6d3269c83c2b3c8e04b0642627dad5"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "46744727f8fa82076fc56c77d43446a12e6f65449b19f673285d3519e22a2f7e",
-                                "uncompressed-sha256": "b7795c504bec09e3e166f32ff2ed2535c5faadd29d6b3486444187fce5be2218"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "cb434efa67deb749e3052f7a17e2d5b44ef3d00fb9fea2b2c6aec2b224642d0e",
+                                "uncompressed-sha256": "af50cc952aebd7dc37264a1ae29a0a05f3f7430b19ffd1b92216dbfff3689c6a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ceaf2ecacac573d80859caf3efbc82c476ac168fd4b3b1d53ab3b3fcc71d1821",
-                                "uncompressed-sha256": "0d5868a02bbe681e41bfaf84c5927f8add444b229039f29dd27c3f1383d41cd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "707b339b9a0a50e32bec24fc96e4972ddc328f11073de2a385bcb0a539297032",
+                                "uncompressed-sha256": "c89d064cedbfc71704ae43aa990e6348005c71e98abee11346a02e960c9a50ab"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/s390x/fedora-coreos-44.20260707.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "206011aaaebca2d89bc3ec3e1eb812880e7b98f0e1c2b695856a18564581969f",
-                                "uncompressed-sha256": "fc2ac4cf733e8fc90ad0c60790e2d65a365ea5a9a5108de227186b7afc6b1dc8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "de6c110ca63442a27fdddde7b6ce86e0194df6ebe801feec93addeee74520afa",
+                                "uncompressed-sha256": "de1b07980ba8d3ef481f8374878de65411b62045343095a037996705f7bed369"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5d5f3dfa1c18e165d4d6d713e1b72be9d4bd26068b657933fdfcf7255f9694f2"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:836a3c5166e0f6d9232a7acdcd38c7aee71b118057da70efd877c85b6eb991ea"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "fa1823c6fa6c60d97493661f11b39c500ef5a73ba78d9b97afeda02fef46012e",
-                                "uncompressed-sha256": "87a601751b93d74d73fb0546670da6fe6e063bb5adee271a00a3099dbfaf47d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "81907df16d178262f3a717c8a87f5d31604a2f261779470fd02683cb2761533f",
+                                "uncompressed-sha256": "7bf1ab8317b712994f07ddb7974fe8d662a9c45271a859cf7539d8053bfec195"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "dcc88b8546c7a5284e4dbef059988b49c9d6cb1058b72eddfa802f983dffef67",
-                                "uncompressed-sha256": "e26680193382b1f4b02cb4ceae053c4a6f626163b12833edec5d2706c39a09da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "b265796c3015f445fb8ccdf33126813ef15f470f45ced0dde7b8520a24216df9",
+                                "uncompressed-sha256": "e47cdfcb00bb08adffc8e532b7516f3b58a1b2034f16d5b97f0962e15f2c3730"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "08779000c294554dd22d3435250c8e77211954b0baef66d6ea22a104cbcec869",
-                                "uncompressed-sha256": "c88116cfe4006d70415cbe33e2006d728cef6ed9576e534e1fc2b6ebf5870335"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1ffc2128176fde5f3d68ce57db20698ab6e841e0a74c3641a1675c76951d3e64",
+                                "uncompressed-sha256": "a4a8f04c1abcc5439548370fd02ed6956f806b210fd919ba8f3455f8fa85034b"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "49e62c45ad948c72fc49a83a806f380156f8fbd5e69fc23f7d046bcaa7d62a30",
-                                "uncompressed-sha256": "d85eca0bc994761b65bc7c0a8a00a6f2a62508e2c6a99be2de1446923a36e095"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7103b9c96f5c3cb91530706342387a7751fee390855535c4a035ab57ffcc715f",
+                                "uncompressed-sha256": "ce2a737c2ea1a8a9ae0166647b68b8e75e4d76b010ce6dae477a5dcd1caf4191"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "7f3b4ca636cd741c059b87a53e15e3ebb8651a2acade47cf9b526c226285a33d",
-                                "uncompressed-sha256": "452a7dd216a706d5b3bae87d74ddbf651d7ef5ad7990bab8e13093af5af2b74c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "61db5112fc2b40b3888ed1571f5946f1ccf16d85e8c28c3eb6e6d3b38853280f",
+                                "uncompressed-sha256": "d8bd97c832cb0c855a563d9bfe41583cfaecf96a158d629ff30a1c2bbcae03ba"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4fede95a887a6b67428883a1c503c074e1f83f33bf5dc51a7ed197f71bf6349b",
-                                "uncompressed-sha256": "411c45d6bdc33cf6a2986f04cfa11804e8fc4103ba8d3efcc96445fc36dcc6dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "494a21e6a1f862fa2e756b11439d7200a16d1b8d911e6f0bf13a7b7a89f79a30",
+                                "uncompressed-sha256": "75f91c97f60cdb67cff95e54b457251d7c2c400e59cb342c340041344ba82fee"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "f90322b81424bbc72d080d89f44a50e276d56c8301ff96ae972459adf60d2f05",
-                                "uncompressed-sha256": "37c95239e74e8fff747f6a71f80e163beaec12dcbb956f4397db42c306269158"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "23c9e29ad0804bb793a61b3b254914b5e9959e02f204e233287b2d3dabd31895",
+                                "uncompressed-sha256": "e90c205526273950db9edbbd05859ef99e3ea7f449bf11852a7a50e42c5815ac"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "574367a4cc3c4cf1f7230a518e0501716675fe3afb6b7baedeb6bf00dfb92661"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f56efd0725c63c1830b11967c709006fcc6d3bff36504bd144e4221ca9b7c3bd"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "ef31a55cba200149295ec9720d9b424a3c0310c0753ee6dbd7126bf30e65011e",
-                                "uncompressed-sha256": "c62d0b4a0833ee10691a32c1a488b0309d58a1224320014e21258065434f618d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "0ce6d44b5027b4e333fbb2b056b015830bc61d4205399190cd9371f98cada19f",
+                                "uncompressed-sha256": "314468f484a562db735dec0945849f93ad952862b067c868a48235313f2a536a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "6235b86e4181b9d61d1100ae81dab07a494aad78ab610bbde5d4200a06fd9c75",
-                                "uncompressed-sha256": "3dc7a358f97fa7574a3f1086d56cc053cd479ff36538acf233ad499a5d48ec8c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "0f9d35d2bfa6d8cb9164a3dc190d0369691622f819ba8aff56695b0fc027f6f8",
+                                "uncompressed-sha256": "c9f8b400885d30bec75dfbb314732d68c3ed9242b79cccf296241d7c55904837"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "6aaba39f5e7e6c50b23c6bae3492e10d3e1a2b78f9165355b9a5447884797354",
-                                "uncompressed-sha256": "856784bcf6dd384112083a4e3a6c4c7a4600ee1dc20087a3b54718568db6dff3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "fa181be2854976a6a8e351733191fc05580409f62279d09ecffef6a95fd22aba",
+                                "uncompressed-sha256": "805fe0da434cc7a66b65cfa9b717d520da25ecfb7c21af2a8f15d1a49cb87792"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "5dca2fbcb7a9c049b46ed05d8d4ef1ebe18c49923e8a7019dcc4fdb50d0c95d9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a86091ab31621478fcbc1942effca9b9d9b6742c09c471f6080e85e937a1dcfb"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "0c5329e689dd11eb8df4e256b03bbc6b7cef282aa487c6aae53455ddd0875768",
-                                "uncompressed-sha256": "ef46b6ab5ac8be259379a93ea399ecdd9f01b44690539551612af7bfd34e5669"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "11f5e4b37a5282fe63a41342c197124bcfc24d27cea0f16c45909534b6278a6b",
+                                "uncompressed-sha256": "c1724f6a7856af2d15de2b2d8e03ff18eb6ff260c2862f49a4485f4038f55467"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "8ffd0d0fc218eae95c578ec12839fe598d60f96de85fab63d424ad021ed1a62f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "ea684ab15e9c1fb2deca28a8f062dc0be824d0e0094816f1167e0d811b33dded"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-kernel.x86_64.sig",
-                                "sha256": "b0389e187ed951727560f517d589f3daa2736dc34dc9aa245b986d72b6f6c3ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-kernel.x86_64.sig",
+                                "sha256": "6cdf5024ca807335491c33a271ca7dba28278879ab93db8bd1da99eab2d48acd"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "360c3b6b4cc8a58807fca8ac6947c8ec578e482af52d2311ae99ef02fe9d8dc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "919442770995e6c3aba25dbe27c4e3ec198e85cb646fadab8c0e1c847aee56ec"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "b500e557397bc76c87b83e17cb0f149a1386ca4e1fd79e61c6e10fe8361c5b44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "e5bf70d26a537e3218d38fb2cbd557a89997ad9a449f3e828549bc57cd37a8d2"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "ca1ef085991998a7d33d3d64b55323eea7a1b563ff1b36c363dbb415eeb4b47f",
-                                "uncompressed-sha256": "d4d3e7aac832adf868b91640d46a7404e619d93167a443102b2d35e9e5820981"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "cd6dd1f53a7b77a23058edcc21f1d56ceeb488fdbc70c9908b187b7036516a94",
+                                "uncompressed-sha256": "e4e67002e6691e66360217c5626e5f8159a03663bd544c436d3f4c338e177e84"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f9dae7e0f2feea104342d703d842b3bf34cb074055a97a9737286c786e06cfee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "d2fdb7a209884697fcdc4d751756fe487eb9081bc2f2c4e4f329287e92c60df2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "7e6dd402f2aeae95b163043ee769568cf93f62450da0c5c12effe2f674da16b7",
-                                "uncompressed-sha256": "93afccb4e03bd040448577080feef63fb0e2b251c438684f736c90987f0f80ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "adec22e77be1ccca1bcf58e728e1dc5a3c3087715ffbf59b682784a57140f29a",
+                                "uncompressed-sha256": "7709a998e96794591d4c4266e6c9b7b234f73484dd6a3f94a6457a5b963211a9"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3b54ee10790c3d572246654f39e76397d31a63660017bb2c64e2e89586eb93cd",
-                                "uncompressed-sha256": "5f183336d1d0a3f0746e22d1f2869700064568b3ee52ee6ab5a1eb25274780c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "c9aeb7f47e6cfd9892834594c3e0ae432e6a81672d3d72d59e78108a29006003",
+                                "uncompressed-sha256": "f7048ecb2b0a29d17d3ddad86ba41196085ea19481f447bf07ae77c0a6dcfe8a"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "af91c10531a5205536b2f38f26629842b8c30c003be36a988545ad4cbd8f4f35",
-                                "uncompressed-sha256": "67275702c0e7900a118a22af15cd6c6a0cf035e1fdd5de8864485c676526315b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "a9cfeba79c279056637f71a797c4aeda6c44d6e2576812d1a0a39093ac5ddb6b",
+                                "uncompressed-sha256": "7b4e8931883bbc1020d476775099f3c9b061c49ed3bd19860167be4f2bc03249"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "35eb8e1f601b2b65545402df54b2dbb2a48e75f1d4483de5dc575d020ddefa1e",
-                                "uncompressed-sha256": "231a74024e12e5a9b2e7fa64ec948d51986b70f3735cdf68fadcaba095ceb18d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1bdc3c59b16508b9c24ac85b7d2543261a02bef5fae4ec5820511b4e7d66a338",
+                                "uncompressed-sha256": "c8f47d668df56a88fdde37f658ecd9c35c8f5d22b91ee060c642bf1b01d90fe5"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "938abaa0673e7eca3e62113d0e7d1ae7f6e0615d24a6fda3b1e62f4db370c9e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "38a2ced91584faae78f95bb083203e3aa18987b040b546954f1a348e8074f01c"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "73d93726c24fd431b32eaaf34445538d6b58744336d82ff63f9664e3d62c8358"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "001f54690dbf069057fa844399913d612d70ea0226abb81eff0a4908216a13bb"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260707.3.1/x86_64/fedora-coreos-44.20260707.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "14dc48ef8719d902f299c352a199660bbfb0b9dea933d6829d9dc74603f61b00",
-                                "uncompressed-sha256": "49079f5516c333b7be1a8b9e7d89f856f0163039d5afcc8238e646526e59ab00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "32b3bbb4ef36d856d13a9f9cbb06bf3447b1bc3a04a55d5739ae1b1a4089e3c5",
+                                "uncompressed-sha256": "636a601bfe71acb1b34a16e0da7f333bbf86b536229fb9e4db37a862c8d2fd0b"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0af87d15e2e9295cd"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0357fad58c0f61250"
                         },
                         "ap-east-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-05e6a16031f837c7f"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-00a529b6ae174736c"
                         },
                         "ap-east-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-01f7ee20f956a3323"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-017ffdc350b9634fb"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-05c2c9430b973c8a2"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-064e6bd8b9c270a9c"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-00698ee33b2c9501c"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0a145e12844599f2e"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-083f0fac5bb751f93"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-045ec222a164c2d0f"
                         },
                         "ap-south-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0dfe066ee27fd30c7"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0000c674b2a1a3db8"
                         },
                         "ap-south-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-085ef7dcb4ce83765"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0bbb9c4b9a37ac16d"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-03bf2b6d9bc200d11"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0eb9d3af6885c78f9"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-083da109e350a8db5"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0f51fd60037ab2c65"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-05cc86dcd55f8340b"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0f84def88e7f22c3e"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-008ab34084b6da6c2"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0acf1c1d4e695ccea"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-07c3dcaa1bb9ed642"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-064ea145327d969cb"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0ddf7637b67dcb8e2"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0ff6765c14c475e5f"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-01bb31e6bacbd45d7"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-018480dffe09e8f85"
                         },
                         "ca-central-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0d503e2b32efed85e"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-09bc15a7d6ad74ba5"
                         },
                         "ca-west-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-00c07989d4789d69d"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-005a5899d0a130591"
                         },
                         "eu-central-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0cd4e0e951135fbbb"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0eab5a1376114963c"
                         },
                         "eu-central-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-086c888e46c3124dd"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-016af50d576020f02"
                         },
                         "eu-north-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-052e5e8ed2f813fd0"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-03048afff64706eae"
                         },
                         "eu-south-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0c6e8786eb91ef1a2"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0c8dfab3492956745"
                         },
                         "eu-south-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-05e76bcf8691990a1"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0b60bc5f2089893be"
                         },
                         "eu-west-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-07898a330af173989"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-03144da1aaace7b14"
                         },
                         "eu-west-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0549fbcd6b93ea14d"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-07427faf253fc359f"
                         },
                         "eu-west-3": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0f63021a34ab4eb77"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0ea3cbea7663a1242"
                         },
                         "il-central-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-02bb24a160bc304e2"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-087a23862339355ec"
                         },
                         "mx-central-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-07a9774d1a19adc57"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0bf72dcb6715c89f9"
                         },
                         "sa-east-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0e434e3652b2b179e"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-07384c26a17c48da5"
                         },
                         "us-east-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-01695f9dc8000aeb8"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-096f70f94aabe3c52"
                         },
                         "us-east-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0edac12fa65733be3"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0c5b8c0c992a4cbc7"
                         },
                         "us-west-1": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-047a98f0455c99954"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-0572ea68ab0eb346f"
                         },
                         "us-west-2": {
-                            "release": "44.20260707.3.1",
-                            "image": "ami-0b3aa78302847561a"
+                            "release": "44.20260720.3.1",
+                            "image": "ami-05ea538fb456d8aaa"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-44-20260707-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260720-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260707.3.1",
+                    "release": "44.20260720.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b61210adf15003b58fb330b1ef88370e1c845ebda002b9f23454d374285dfe7e"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a7b8ece6eec01ec240f9a5cfa2cf4e507e6e280f6c955d749dd4b45f25803148"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-07-21T14:07:13Z",
+        "last-modified": "2026-08-05T07:18:02Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "486bdd030050c3343393531c3ff72e24a20287dadf6ac0a07eb4e68aaf19d8c6",
-                                "uncompressed-sha256": "528b753e4e5bfadb04fb00e39885bd50c37d7c3ba2ad1e64a644f4f866fca2da"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "8e4707c7d5e2c330aad99000c19ac1671b1725ba11a9b8e962b658ed6c376015",
+                                "uncompressed-sha256": "e8a563adf0e0866936c2452441f6ffa7c712cbbb7594f62d8d407d07c753ba80"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "33099f92281265b51fc605bff4e2de312cd0544e19e6417ed890801116f9f8b3",
-                                "uncompressed-sha256": "b9a9a05127e0199ce982b3e5939f6e4963c704f944307188bf415bcff6e6afcb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "3e03882aa665fdfe18c6bffc5aab6b85ee996e17059a11795121adfe2be0beee",
+                                "uncompressed-sha256": "e082c0afce6df4d8d839461a9bb0b9732eff1fdeaaefe7f29ab20ab8d3d8bb2d"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "7930a8283e6172d53c7855724acc4d0f17be96c73328f7350821539e0ce69981",
-                                "uncompressed-sha256": "efce116f8c15bbeb6261d528eead91a2bb368237312b2ea8a44d83291685f76c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "7d6dd7a9df7cc3ad7ecd65b928c63831908770cd7664bd76f5d17666abed59b1",
+                                "uncompressed-sha256": "d8aed7befefca2321171e5f5ec19f9ae2825b32200bcd692b09f5354da6b9907"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "0f35aa3585363c5c1f01a46eb5bf68149ab283a4db1fca9865a8c740a6b1d0e1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "6044c01ca2ebdc7c8dc80bd5367a6da302df54c91b3b4dfd6ddb7452a39b847a"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "b9f8fbde02c4b8af9340492cb32232fdaad155e9469c0e97f374c65c7b19537b",
-                                "uncompressed-sha256": "a2a67c02629762412a12dd486b43827beb4fb57695cedb3e41238b5dfeae9358"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "73c6efcc0677cc09ef71999277e29790b2cdad757cf86045a110635604f7e5e5",
+                                "uncompressed-sha256": "110b3d19ac40177513bf21448037c962a06eeb8ee5f49a9f6185b80ac2b1cd18"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "c7fac9506f1dc0cd328501af50c44d88eea2c0dcdc99609362ab3c22bb418b07",
-                                "uncompressed-sha256": "5ae0abd2f38c03a30fde783469dedb4823ebef1de5f9f0fdb4c5c4ac9c073c92"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "75d46ee0bb351b00e56c54ef06b5c704ae3bdcaffbe322fd3636b9f159723b8c",
+                                "uncompressed-sha256": "c7dbe1cc12df2ded844767e86475e6bfdd200103f6a8a51bcd79b92b44da263d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "b94a6812b8a943b1290829dfb5fd7c040bac3962a8faae72cc8a7312a2f28bf7",
-                                "uncompressed-sha256": "5c7f79473705d99dae09f32c10a6b1a61ad65fdd26465161ae94eaf1091b7c1e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "a2fe3f3a298731dca9cf75fd05eb130cdfbb6cb017748438f86a88b002ba4fb2",
+                                "uncompressed-sha256": "fe7456048581fbd18bb6856d1d1778513f6c487668e173ec76de35cce68cee90"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "b2be4e15c33b768d3111d16d918dc24b037b80d03309e307e65852a2fd3280d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-live-iso.aarch64.iso.sig",
+                                "sha256": "a614350687646795a3f23d2795127ea913c1a3c53d00d9d94212c057a71c5fde"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-kernel.aarch64.sig",
-                                "sha256": "65e828721142335cd235ab34ff8bbe2ead12191f99c3161f69a1a53c72579b2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-live-kernel.aarch64.sig",
+                                "sha256": "dc6e06dbfa71089676b9ce4109164c9de376be1ce3fcdbfc7a77bc82ba643b77"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "2c3774254b6877b4a939d91039ae4f847630f12ba6c76a52e3f0884ea4ee634d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "1611e8a07d11bb7f5ac34690725b65026f22f8d7d45352a1ee3b255112e13d84"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "c046c0a7b3b8c365c745c0a92500902770ddb9f74d8940ead21078186c1e58f7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "eb312f0749fb314606e9947338439388aefe4025677218b322946fc9c9fdde56"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "64457f5bd4fd1ea5a8a0fccf39d0e991468093f1ba95bcb82501e44e2286a80b",
-                                "uncompressed-sha256": "de0ae5e074003c995484d5bcebe5624f5530381ee32564892e627c8f893b0439"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "339e7e319c9034152271e06b0b77e9b15a10db908d90ad02be7d12bf87d64e74",
+                                "uncompressed-sha256": "3e4fca09a6f092bb9573a8fc08e091abed86e20805d71f3188ba249d54067932"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "bd8561e244533173bb9f78545f5edd1197aec64d898cc49ec9d713358acaee43",
-                                "uncompressed-sha256": "0935f80e28c41b5438326595d9fba82b46b0c965cfef38b68ec8f13ca5a62118"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "7a6310d4534d8198f0ab1b4935a39aaf733d4349071905979775eac7f9db3187",
+                                "uncompressed-sha256": "6a69f71aacc97a7faa9bae31ac98ded7315c253e5d0110241ff1e4b10ee24e91"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "4bd3e42df56b2d12a54a5b2ba197a40fbc3c7949950ccd9122dbd31164b00202",
-                                "uncompressed-sha256": "ac4c90d12fa33d0a42e2c2c08f454bd552edd649164efea4473f4d0d8fd6a10b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "7f84562cedb3b866cb5a7bc4f1bd3d0bbb95a3822ded86fbee776f466a85ca97",
+                                "uncompressed-sha256": "54cf040439506d5e61cd7cff5df8c9f2583056dbbb665864d0448f9aebfdd3f0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/aarch64/fedora-coreos-44.20260720.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "06df1793babc235cbe9e8e0b4a00f3eff04e43c09689a1a8327f7f9c12a1e575",
-                                "uncompressed-sha256": "834e62886284d21232fd135ee980632fc888e44a031e7344332ec679ee3f4c60"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/aarch64/fedora-coreos-44.20260802.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "f4ea60bcf38138bb7549fca94dc4d6d064cc819de1e8ef288c85ba454c127ac3",
+                                "uncompressed-sha256": "9abf83bbe611095553201e12e8d86a8ac9226252e17ff04e01989d1e016732bc"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0047ccc1b8f6bb14c"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0a9fc72869ab3a917"
                         },
                         "ap-east-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0e10b302536b5b6c9"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0ad5de7ba1d2800a6"
                         },
                         "ap-east-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0ae48227a72f3851d"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-01dd4c90f8906cf02"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-037a941bcb3898879"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0362ab0d7f5554f14"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-01421edb711437265"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-07265309b0a36be43"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-06aafab029a7606c3"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-01d5531681afda640"
                         },
                         "ap-south-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-00a95c6c46e0ff698"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-07c3a1f79e97f7d6f"
                         },
                         "ap-south-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-06185e5bf16a946ad"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0e7449577255d02af"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0bc29d66893f6e06c"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0c648f5765d29ca11"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-000ac6070da8a6a9c"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-07012376b18bf98ae"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0671fa6f50a2e0160"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-02d686af35f393b2c"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0d8a284b944027e9f"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0c4879a3a843d3cc3"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-09ca7608b5874affa"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0d1977dcd092cc3da"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0653bff310a4dd9b0"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0b1a0ae82eee7c141"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0dc1c14f8663deca0"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-03c2df8c82e91c775"
                         },
                         "ca-central-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-07a620a97c6581172"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-09a25cb08b7c11c82"
                         },
                         "ca-west-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-00bbfd1358144f5e4"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-019f6837ec4c2aaf5"
                         },
                         "eu-central-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-012d76b1ab95df96b"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-01291cfa03ec1eb06"
                         },
                         "eu-central-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-07814376b89dbb437"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-06a167935f33d2601"
                         },
                         "eu-north-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-052b2a40dff9e64bf"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-067793262bb4be67f"
                         },
                         "eu-south-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-08b50066426862097"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0f1eb2832cce96899"
                         },
                         "eu-south-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0238bb1e84b28bdc5"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0e4661c064eaa0d5c"
                         },
                         "eu-west-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-05eca81052aa5f082"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-032b69de3d7afa151"
                         },
                         "eu-west-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-026a9a6d8c4415463"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0b3ac8238389bab62"
                         },
                         "eu-west-3": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0d44a4b106724fb48"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-072b704a1809bb676"
                         },
                         "il-central-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0d34a6fd71f061f7d"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-07d6e511aacf221a5"
                         },
                         "mx-central-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-002cacda6e3e73941"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-09798f9c3fec11573"
                         },
                         "sa-east-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0b537e9fb1928f08b"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-074295d5f552a5b9a"
                         },
                         "us-east-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-00372cc9fd60c5870"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0063166ee97e0daa6"
                         },
                         "us-east-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0de5b37c890762139"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-04a6961460f8a52e9"
                         },
                         "us-west-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-03ceb303787ef3be1"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-03a221b4820a728c7"
                         },
                         "us-west-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0aec928fb4cde8367"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-023d409d925dbd196"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-44-20260720-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260802-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "c4234d344e96c51236cac50dce459c030cd359018753af55beae416e5c42a6b4",
-                                "uncompressed-sha256": "e2ddcacfb534e0e473fd07e069dcd0135e5808fbf964b78f7cde47c5f24836ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "e130d20a8ade465b3497275c8d366eaccf8df1a78651b73a4b2533552e87a285",
+                                "uncompressed-sha256": "a268c96f97bc2a0391f9cf2e16c5314b80050541a2d51c1943b637dcdbb0ea88"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "9b8f8f64e3e434d83d440ba3c0366f71f9d64baffe83ad71088f4a9f8b848898"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "315c7d453d27e80de3d3ebb3e038144da1e166bfeaf3b9a50040e7ffce8d39b3"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "4bf2a7173bd32993e9097c68c8c0036a1dd2b3028ba7c93c74367c1e15743196"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-live-kernel.ppc64le.sig",
+                                "sha256": "b03b8b07f30738d95891f0e8dda179cc5d04c527ea02472017bd68f18e4d4bcc"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "1f9433da4c1c602e79ecde5620b002af21b84f9c4b3fa74bd7054c72686c8b9e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "99a00cc3673522bb6a641badb10bc83ed90f667e110c69b7aa7856058a2a741b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "e2bcb1701028d24b7de2d470be1fa0e6e2f0d2f0b959dbabde0c7a3fdffd55ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f5064d37cdb64e6b439d134617fb39a6461085a28190f0d078e3622373b9d79e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "9d6c5535e92b9d2f3d1ba12720b581974e4d0197f6946307caf5a7da4936ae12",
-                                "uncompressed-sha256": "5d5054f7dd8b0257c7d0b41f53e05ba8d32bcd499e4faa2ce86b881c6fd9e763"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "8c62a90bd1e396e02172fb0713c6c938c6ac7f92fe6da0e8dd3ebfa304183ce6",
+                                "uncompressed-sha256": "13d0efd1d7ae05212dd541a77fb6feeb81b17c27a1a6cdf2c14732e5b3c051b4"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "5c4204f54e91d5db093ecdb6babddccbda3338600d368c33d468b5e9e9885c4b",
-                                "uncompressed-sha256": "bd5a5f835aac0e475fe4614ef004597415c4fee21a998749e52d9d6d2316a7b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "2abbf54c37ee764e20875c3abc7076e1081c4a7c7cc584723fe080bf96f30f44",
+                                "uncompressed-sha256": "6e63c9470f4b5c10b285fdecd9c3150c3ce328be341e5521eb96e86b1a7ade71"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "c0efea1a573f82feb11baee215c83337d52fc3f6e53d27ad979bf725c847f692",
-                                "uncompressed-sha256": "0ba78304bc707046d1c7a2826b3ac2e8407729dc117ab2815c9efdae019f9025"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f37179cda9b6e0c8347fb45485ef8ec1863c2c9352c0b774831b6cb6efed0ed1",
+                                "uncompressed-sha256": "cd7c67ee66a51812055e2d2decb7de3b759ab5c7c57dd8ae3fadcb15aa1f228e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/ppc64le/fedora-coreos-44.20260720.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "79d16f107c2ed1c441d4ffba2396bf215ef0890f3aa0a5c00c01074a60703cc8",
-                                "uncompressed-sha256": "0dfc444d8b7c9ea943ab659392f81617409553e94021352e9c60213eaa03dd36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/ppc64le/fedora-coreos-44.20260802.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "5a8a3ada59cf82f9ae4c6082142bb63338c294a51034f7d4f024c5537f9e7ad1",
+                                "uncompressed-sha256": "a5e0f24454c384791dd58f0d6ed9198d0353eadfcf983fc743840267be8a1610"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "63afe1d305fa2433ce9c5dcf2a63e3d7cef16edf16ea1c47d26296548e30a4e6",
-                                "uncompressed-sha256": "1ec3126e3ada87d28b51255b88900e8b912944b9c1c4c26f0123167eeea548f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "dffe30fbe23086207ac65854b339c5442cf978f965aa794ab377d65f37dcc46e",
+                                "uncompressed-sha256": "5af7d3fdb4bd09cfc67bd2cebca2e676cffb246cd250388d7af972b10da00cb5"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "6aae065dd904baae05d40ac15a92152e7346bf342b24e6d9fcde6c552d557efa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "fb36f438af041ecde8f6e009ab68dd001fa29558224259e9c4c558e826de022c"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "720ab48f8a3fdc8085c9093ef0ca4564c08a79077649056ebfe07c2ac9622a68",
-                                "uncompressed-sha256": "c6d97f6bb93de0872a0ec35307dfb16c920d2994a75d0caec5b34b08a5941b84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "c3477f32b327056ff3c1c1427ad18732077ab17458cbd9bfdefc0f543fc6d006",
+                                "uncompressed-sha256": "c220e7d4ae1f2ecf2660f447db5c13748409269c520c0ee2a7fb1013d985c7e2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "e9653485a7248f51a6cf6291f96902a6da08dfe9538057c018a705214ac1e1f3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-live-iso.s390x.iso.sig",
+                                "sha256": "54fe785152d91555a7fed654bf0fbd73e3c1d1eb992a9e7ac57184e2bb306034"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-kernel.s390x.sig",
-                                "sha256": "7fda5d822d42d3e692daaa4964e1c1cd38c605c0c2e5da6678f51b7a0697bc26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-live-kernel.s390x.sig",
+                                "sha256": "df039eb3cd132c091f0d6302cc6ca97b3bb6a428b7abfb4e65db8fd05dc7e3a1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "c735173440073c61851a848ecfa715a28bb99151db526a555128b911253f3a79"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "8e5cc8f4c187a465b1c3198660e16262bcc693240731b7d877129cb06648e1a4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "e6fb4d911d43519a0bc8448cd7ca49d8aeacf8d2b15d5d3436448af984d44dae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "a1d6a0ec2efb7b262b3e12b93f5216892c499d3d3555a868a77584c231bfa693"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "e3ad96eee679b4cd19347a8e3df05d1676308c6d4c11226cc32d3eaebbe1a3e9",
-                                "uncompressed-sha256": "b5593bbf6400e95aecc239df28091dce428257fb11b84f96690d1ab26d905b89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "3b4cf9566445fe59b9fd25ee15fc5256d293daef2d02e2f1d94b794a30b75638",
+                                "uncompressed-sha256": "1adea654e44087ec171f1d98ee8410997dd3fd4f7abf6869f302772f0ad6b76a"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "097751b7b459c32e6c3dc76db03753dfd153510874eb7a95f27eaf52373b9dd2",
-                                "uncompressed-sha256": "f3b181419b8e4561dd38161de2ad4b16865524c25d0948a4cafed78093746673"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "2fb3a29c206891f970cea8f42d6e254727bb05e2fa29e7b14a44a186818c7068",
+                                "uncompressed-sha256": "e0e75baa0e05484d6d27eeea431c78277ddb7776df5a2a2b753cf049adf8c797"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/s390x/fedora-coreos-44.20260720.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "4ea422baba2bf711e71e06d08b6a13ed8e386835a82c552c147a0192b89495b7",
-                                "uncompressed-sha256": "64386e5d1798155316e64e482c1d9560a5726d68d74c9a3aa0da8a13f3adb30f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/s390x/fedora-coreos-44.20260802.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "485c55ca7ccf632b6bbdabd206c6aa972541baec3671f158bd3b6dc584addcb4",
+                                "uncompressed-sha256": "3cad310a4f2392cf86fbe583eb3d3db5107e710099325f0cd7f795808f24472e"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a9486f03c60aa6b0439d3f71ee21db4fb6560ae788c5d68fb1b4d6c6f7ba96b7"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:b688254c5fbf39013a67d1f02cf45992e715699a61a74730a03336f659e593cf"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "97ab071f36962581427b8171ba78c37ded290b4f34b2691134a454ac5eb68d47",
-                                "uncompressed-sha256": "b667caa75ed3250ecbc25c711ac38d81b99b1c07064baed0125d70d1ac3caab9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "11d79a7ff705cda7a187dfb4c14a6d379337fe12b05e58d40e4edcaf59a53485",
+                                "uncompressed-sha256": "2b5e8df1db4c14914c4087315128147602eb654a80eed0b200dc6640c5c1463b"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "8b21a8f8d69f13984733ecdeee0f57a39cd29e31e3f76fbad38107bb7d407b58",
-                                "uncompressed-sha256": "42e6ac1ab337e8138c826fef8023aec3cd12cf8a94c84f15501fd053af7c8c9b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "21f248f628a169cbdf912e4f41ea6b86446a7dfafe36d1fd4ececc323260577b",
+                                "uncompressed-sha256": "a2af256c25dd12d54e05f1f993a55d6bc27121233a3fa466485e54e77e62d58d"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "ba5aaa3f6d86fc76ceab44312106d1fd0b883ec0fd8ec4448850202d1b917fe9",
-                                "uncompressed-sha256": "4e8c294f6d97b269a1eb1fb6f727287a5df314166da65e647cbbefb7844f514c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "75ff25faf79c670fd23c7da84087ccfb60d89acd8cb7014cbdbc940bc7b1c9db",
+                                "uncompressed-sha256": "56d6c367f98fa18a1481a89e50bf73300cfe005939ffdfad465bc1af2c59cea5"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "91c6792b88b77d1d3376ab12553f4818baff6802915ffc1fa98c93b5cf796f10",
-                                "uncompressed-sha256": "c20c3cada384fe0e014876b56862a09d35ccc49a90df0beeda166fe4b725001d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "da96d0a844b7ddae8f7cfac1eaa4691da95b0463df346f3bb77da72c1b10bd86",
+                                "uncompressed-sha256": "1be1423a7f5e98a5cf3671a4c8842f53cd43ada674434692a749538d2dd2f6e5"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "14fe8cb4de26c03ac0ea4d8027ea23308eab7b09d11c1061bf9cf1818a786c7c",
-                                "uncompressed-sha256": "d020c08279b5affb4c016b5c7b52cb982257883106267e651268a9a9fae91372"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d2d8ad09e2108fa31a31a64f504b1cf9539f4b8d9a28d3be87ece1a7ab7f6d30",
+                                "uncompressed-sha256": "7bd7a4d39bfe1c966291ab28735031622e48f1ac8e988e9f77b52b2ce93c40bd"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "525c059e5af8a172301694658fc6f33bbb31306154411f36a72b5befd919cf8a",
-                                "uncompressed-sha256": "e4c93c700d074c444996a5af247f03b7d96af39aa436a20e5b811e031c0f52df"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "afe1fc3da1af105fa17b8bbe23a247673b23af9b82cc14f1d79c22d61b11c480",
+                                "uncompressed-sha256": "02dd840897a7c48310a59fb1b353126881c1f86b29ee8aa74334364738c33427"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "12b518293e1121ebe49a26f468a4db9fb21810b4fffd4cd7fd57e4a92318e2dd",
-                                "uncompressed-sha256": "ede629150bb7ecb985eb4385baa485d43043b670372c3b465cb42f1c8957e5b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "333fae00ce40c5de08142418fa3213b83aa8faed0a4951ad45603de461ad9782",
+                                "uncompressed-sha256": "27cfc419ef73477f8fa7fe0bb6077a4cf835a7128045d1678ec579ec5d380eaf"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "4e59754e28013a5debfc045a38b9a1d665e1f9a308d89ea1b1c8cce9a9087605"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "3b4dda316ed18e718b0494e7b187611e71ef600f783ca8bb91695b048c88a20c"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "8b9c1b8693893796bcda74c163d82485cb4474730c09ec3b9063c02a654da987",
-                                "uncompressed-sha256": "93d6b935a21998740a0af11cf9ca4cb3433972177e3ca74999d273802e2cef3d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "3c848f3380c3f585a89d3f37dfc6fc6202bf3aa3c6bfe9adc5d6b237aafccfb1",
+                                "uncompressed-sha256": "62c6ebf1618cfa0028abb91488f73dabce5d8ecb9096a0c679400682d23f95a8"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "7a224fad3310942b9d2d1cc38c24977c4daf613e737e34938c9311c1500412bb",
-                                "uncompressed-sha256": "3bac6a49818693c547be3373d44bc140d1e69dedc4bb68d646ae8c081e9467ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "2695d88935d2b9ee51f6c852b64c417599816983133d257a4efda97a55ff7b07",
+                                "uncompressed-sha256": "44d599b8c7cad847e4463d02bf0155dc1da6f37d7312e11248fbd29b1eea4308"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e6390c3904765b0418293dcaefa393843bb1faed0b8e8d5a0370c690c80272b0",
-                                "uncompressed-sha256": "a15028338bb611209b31e9266ede46efd9a91758900a718ec98d0f2179d1d453"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "068c88b8251cd5f2611992f44692049e2df2bbe5fa24c4ef3ca973f9a63feeca",
+                                "uncompressed-sha256": "2574ee0c6135961d65c0d420f43a63334d74f6cbaa8f24b470a15c164daedb19"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "de494c4c58fa78176dd7da19e62c08250810e84e89dbe01f4fabe78356871255"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "7798c4fb76d0d082c94965cb98e735208195b15cc35e78907464d800671d9e87"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "e2f58199ed2bf0e475db964198dc14839a70bc706e95d15968c1cbdc80a58993",
-                                "uncompressed-sha256": "9f45b262c7cd05661362badf4af1f6a0c98d37b40d9613b33b80e8da1c6e713c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4e32fe1657e59192150b26074b286b2ef7a92629b8bfe3ffd9592c3cffa2e4e8",
+                                "uncompressed-sha256": "e87b5977cb9d64645d86faa1285c88992ddbecb27904937e1c80baeffd540a67"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "dda0cda3378e2c4d9b372a22807d70a3b7da86ef3cae30684e471fbe60834607"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-live-iso.x86_64.iso.sig",
+                                "sha256": "f1df80632aa953579c0637d5876d8467ba21b530424d9056e74b80cd037e2925"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-kernel.x86_64.sig",
-                                "sha256": "6cdf5024ca807335491c33a271ca7dba28278879ab93db8bd1da99eab2d48acd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-live-kernel.x86_64.sig",
+                                "sha256": "a4db84977b6af528b12ce0502a545ab078daaaa38f91eddb81858a2daa2e207b"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "722134fcfb0d4b5fa8666a66ca2a4da33f4ec21bed819d66a6d398b8c5757cc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "15e1816f5363c0bca0422f29a1c711838ee9b53650ad9c4e7ceb0aa59d0c305e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "cb12fc8c686ef90e002f73a8d870f72bd49e3d22e875ad6a288ed67d4b3ab115"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "0ec7c5a4c29b4f02d4d8e941c4b69a2d7d479652bf9a22198332fc8da868035f"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "e25b2a89d7fe5dcd82cd9317fa9ab52004a4906023189fe51482179079943ebd",
-                                "uncompressed-sha256": "f130a3c1a4a58cf7c20f0d4665d8b0780cd22b17693eacd38ae10d1b699f1bf6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "1d6827eff1435912afff301b7f693a40ec18cd0853c19217e8c0b6cf62d3eaad",
+                                "uncompressed-sha256": "4bb008e5b6abe5abd608ec2b6450f1f61d67d48099c6d75192796aabacfb4015"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "c13f65608e8cb289761a843dda876c4ee2a20fe85b66f7b4fcbcd2e09f2d2a64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "4dd3ee0e0ed3dd6129aa5db9f0dd225adadf1b48e140ce2a893e42b9786e826c"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "bae79f1774324c20cda638e6d218666b4fde5ccec08eef7dec7bf189b7f845ee",
-                                "uncompressed-sha256": "0d57fd3d663df7d28de32de3dcc7d84770a49527b324fabf6c7c84174e4d2b94"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "1df898f5a589589a5f270f4ac387ca922fcb8be1249c156da1f0ab3c49b8d3ba",
+                                "uncompressed-sha256": "b4c21339ead242da42ab141d25117257c6432d892f6b39962e0b0fa8b70a4d06"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "4daf004e0bed4de0a6bbcc1b5e3d75eb9cbddd41739331d36a3864c55418fe91",
-                                "uncompressed-sha256": "22add32237f295942626871567c487b749884084b6e3a4c6e286f025c7eaa96d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "9f09dd3da429dfe4ae851b0895a7a205ca2d40a25940521c9f7ebf8bb7450a5b",
+                                "uncompressed-sha256": "afc4031475f86fd792a4c0737165eed22fa1447bad2ef9c0f688b5be1aa0131b"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "112c1426e85afe72c48939638c29c32890700930796e3b24e849298b13d5d3f8",
-                                "uncompressed-sha256": "d3c5bfbbf7e9a585e7aa69665dde6d7464c8a9c3fc7458613c52de865f9da638"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "ef3968ce6231ea97ba08e6f56b50b46149024a260a1c7b175de04dd76f1502e0",
+                                "uncompressed-sha256": "baa68ec3f7e2b16e9b18e495b72609109c537c6d16b67e3e87fd414d2c65adad"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "06ce1a24e930ad2fd5057e2fc65c2da4e48881f1e5ce79e3879cbf11def817a3",
-                                "uncompressed-sha256": "f6bccf4d0daac72ba5f611054efc1f967a1b08f09d0517fc4f72133a54971d0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "67e37f359e5ef3b9320fa23ae20b752ad2b1046991824d46b165fab92ee80913",
+                                "uncompressed-sha256": "7ffd0900fc6376f35413130423ff846edd096d81fd59874d1af24f8aef69cde2"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "553540c18fd5f7492c5217485ebb38a6342f5bd5b01e7a2ee289440a5bd5b817"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "73850f29c9ae6b980340a65ce0b6dc60fe98e0e724e49eebaad3e63b4c4dff68"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "78df546a76f4259bdca3696fe997163874a18f40700e3651da465c4489be7bec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "2e80f610c0d058c223d25a9f9c1b52b28b16b182113d1142b925c796ed5aa2c7"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260720.2.1/x86_64/fedora-coreos-44.20260720.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "7be86582d14483166142c6e4aecdc64eebf07e95ac21ef3b777f031694968150",
-                                "uncompressed-sha256": "52168980669b3b299ac53e93162d45d4120270f014b7a85d059b4ee3d1d5eac8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.1/x86_64/fedora-coreos-44.20260802.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "a8551b826c9ca1f1a51dd26e4c2f456ab910a66960e51784ee517b5469d4ff00",
+                                "uncompressed-sha256": "4b3b5d6be226af2a9a241700b7ff4df53ad734d4aacae8ec5648ce8c77004867"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-06041ad21ea089ec1"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0e425f4745ce226d3"
                         },
                         "ap-east-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0c1aa771bbb5e3c95"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-08ba33f92567d07ba"
                         },
                         "ap-east-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-00000e1f268012691"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-00a318d1878eec535"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0e2af7699605e387f"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-01b8db0df60f4576f"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0e0e6715a9aea860c"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-019fd23b0216433c7"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-06e9d29ba7620f70c"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0b2258f4bc09d0fbf"
                         },
                         "ap-south-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0acfc5728e798f472"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0f5177f84d27bc939"
                         },
                         "ap-south-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-02775af479391c637"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-06e0e34cdec285474"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-01dc53684aaff4e23"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-092858f740c7ea3d4"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0c241235b96764d39"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-05d62afada0e2b5a9"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-01a5190044c159edb"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0b343dfe76303f411"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-087d35096581b9e1e"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-06f7ec5155f2b7588"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0860852a83d2357e6"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0eabef4717ff17f23"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0d239320c52d5c83b"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0edff5ca6d6efd9c2"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0555d1a9eb15e0f23"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0b86c765c34b14edc"
                         },
                         "ca-central-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-06c23656064bd4d23"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0f56fb45e9fd3aaf6"
                         },
                         "ca-west-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-08238c8ef02dfc86b"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0d93964b429ffdc6e"
                         },
                         "eu-central-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0fe3f9ec33c023926"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0920528fed0797080"
                         },
                         "eu-central-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0383f8335cb0e62a7"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-08dd4ae52ac8400f0"
                         },
                         "eu-north-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-00c0e896bd1561e2d"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0ed754718256d02fc"
                         },
                         "eu-south-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0a714252817f7ceae"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0e4b1e8ba8f9c7951"
                         },
                         "eu-south-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0c7e8c74de4664aed"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-009f4508d85f2b752"
                         },
                         "eu-west-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0841d68dc14ed9b10"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-093a094095cb96039"
                         },
                         "eu-west-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0b7cc0c08f37c0e54"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-096635ee78d55227c"
                         },
                         "eu-west-3": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0e1a0df32160e43c7"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0749952319ee175f0"
                         },
                         "il-central-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-046b1d284c39af96d"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-00960a9e8d1808671"
                         },
                         "mx-central-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0cb82835ca11dc672"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-07effe7ae42b93154"
                         },
                         "sa-east-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-01d35c0edb3949725"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-08d500cfa8fc96a41"
                         },
                         "us-east-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0ca997d7842494e76"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0b992d30cf60d141f"
                         },
                         "us-east-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-046c57c828669a264"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0192efdf38261c73f"
                         },
                         "us-west-1": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0bf62dfb57c41d915"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-048ea7591c6dc91b0"
                         },
                         "us-west-2": {
-                            "release": "44.20260720.2.1",
-                            "image": "ami-0e140f04449fb999b"
+                            "release": "44.20260802.2.1",
+                            "image": "ami-0c5781eeeafb37362"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-44-20260720-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260802-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260720.2.1",
+                    "release": "44.20260802.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:80be1e01cd24c2b037843025ba9c75f0953a283eb43524cf35f8238db0e791a3"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:10c6921470d41900e92c1890a1e5b2bc7b4bd56dbabb867a3b8e86b11862e239"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-07-21T14:07:14Z"
+    "last-modified": "2026-08-05T07:18:04Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260707.1.1",
+      "version": "44.20260720.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260720.1.1",
+      "version": "44.20260802.1.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1784728800,
+          "start_epoch": 1785945600,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-07-21T14:07:12Z"
+    "last-modified": "2026-08-05T07:18:02Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260621.3.1",
+      "version": "44.20260707.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260707.3.1",
+      "version": "44.20260720.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1784728800,
+          "start_epoch": 1785945600,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-07-21T14:07:13Z"
+    "last-modified": "2026-08-05T07:18:03Z"
   },
   "releases": [
     {
@@ -173,7 +173,7 @@
       }
     },
     {
-      "version": "44.20260707.2.1",
+      "version": "44.20260720.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -181,11 +181,11 @@
       }
     },
     {
-      "version": "44.20260720.2.1",
+      "version": "44.20260802.2.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1784728800,
+          "start_epoch": 1785945600,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @marmijo via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).