### PR TITLE
Roll out stable 44.20260802.3.1, testing 44.20260817.2.1, next 44.20260817.1.1

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-08-14T14:44:46Z",
+        "last-modified": "2026-08-20T01:41:37Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-applehv.aarch64.raw.gz.sig",
-                                "sha256": "3fd0d2ae318f33d494a12866675496445f85a723f92689285736be6fd50b07c2",
-                                "uncompressed-sha256": "60a00dbcef16bf4624f3b58f6b3c0225b62456368829dd78282b940d234dd18c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "ebe509b9cec17816ece0ca990aa79a59c1f61b13a16eae671a832e64021a4254",
+                                "uncompressed-sha256": "e684f3cfb292c3505cec2fd119e42b190a3e129f6ada2e022f4c1eeee279bf48"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5fff0119be759c056db9e6704a004f1fbf382c15bb9c1faf657d498bb70bf428",
-                                "uncompressed-sha256": "4b2eee34d7490f61178327f3b856cc0657e623ce0a14ec0b252bfb986e1a3114"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "5052a45d96e5aeb475e561517272d93968663a9a4f3289f4d194b4ef105af3d9",
+                                "uncompressed-sha256": "9f7d85e4dd1dcd8c501525f5588417349a4db0fe09625b52b560c9016a8d9ca7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "e589c460b514359afb76abf429ef5ca831e8c67b25d9c27f026ae4cd9182640d",
-                                "uncompressed-sha256": "3d442f318f217ee60ac927adb186f4a0d849c7fc64d43c5f02438a6927469c13"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "a772e4e18b03fe6cb33c686fb143e3399d21d01582c81132695be885ad5c86e5",
+                                "uncompressed-sha256": "12ce462861c7fec28413d4ddd010f1c8665dc89524080f48db75e7a65f86d2ca"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-gcp.aarch64.tar.gz.sig",
-                                "sha256": "731eb749c1ac3e81c2bdcdf6717fdad35fea1a7df518c28157385c230e2eb587"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "55843907f757932ca245a9e8430118ac094177692d2c4bcc5818be41ebfaad01"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "459700ff12fa5c850c953833470881b0148bb43f8124531abc4e3c59be5234ba",
-                                "uncompressed-sha256": "e80c9baaf4a2dae77ac514cf633542368fb0c538fcfd31aa8619cc34e19df17a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "ddfa5431e6ec9dbedddaf6e61499d72a72dc6a30f008ae6465fbbd64842d2c3f",
+                                "uncompressed-sha256": "479c2772e013c7af6612c63b93862a9522feb4822061f84366bf0fe0aa6b5ff2"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "ec2b00019fa52dfdb86efc5ca359515c8219d16abf6b51891286f0d11cef1165",
-                                "uncompressed-sha256": "64b48d653ace1cde01598b8d7905ef4a50fdfb74767f801ea0a2b5a900c5a74d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "3b533ac84b10b10338d842f5ac2a832b6052048c989025d985230a4329edd4c4",
+                                "uncompressed-sha256": "387ce58e101de5a8d5afb29bee2a94d3901319d70528924c8d1d69d32178512e"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "57d33e006a587930d5f40fd162a6eac8d8e3ccfdd8e0461ecf3999a0d2620b78",
-                                "uncompressed-sha256": "47f81eca0233d9f263f626845de22b4824fbc792c0dd8482dfb8fa942d7f618c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b97e10f955ae57e459c8f6be5228f26949040f36393bbb178b6e4614827df3a1",
+                                "uncompressed-sha256": "dbb6b59e048b84d68c8c7f69aae4c26e86f5c781e49bef8d90d8af81fe7802a2"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-live-iso.aarch64.iso.sig",
-                                "sha256": "f962b4f4ace577b527ee0b806b0a9b816c482f5f06f1a4061c191fdd6ef891fa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-iso.aarch64.iso.sig",
+                                "sha256": "2c1a75618949f2e6d658398ad72869009908396024c3ca633789da37c0f6176f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-live-kernel.aarch64.sig",
-                                "sha256": "1af1ed065a597365d1080c35d05953b83077331fc2e234e23569d39e8a012c06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-kernel.aarch64.sig",
+                                "sha256": "38cfc669810d30a2ba7cd128528a951b2a8eb2ac85250aea287d8142f76a0a59"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "80b3c3542e9bb0d306d6b57af9c256be907ef85ad5d805cb15c81211b2566e8b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "e8d14efb4c2e6b08563bdecaa1fbf7a36d830f36db2183dadaf31d8516d6b6ab"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "0c855c739dd7c3101f2960a36b13fe18208fc10aea4b7e4fb27c4af27466a59b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "760be8c47658e2e59e592b353b2d2c34c154ae75e44c307aa1091e4ee423e9ef"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "4c652ff68c885a529d4500ca532ee175cd261f34d49614b315e62f3d7ad19bdb",
-                                "uncompressed-sha256": "e72329f20506db46b7f4638be54c87b35457e9f24697acfb75e531eef142e757"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "e8e299ad5da058e9769d282376bfe07587989a48f4f0f3ece073861064d2e7b3",
+                                "uncompressed-sha256": "b5b462a9206a2583ced5c8dfa181321a3dbca6943fe5d26940830acf469c3ed5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "364d86716a9238c3fb7348605e309d8705892c0f5c8dec3c14de596d697ab537",
-                                "uncompressed-sha256": "6c9ad4f7da0a68d87318e7e33846d468c45abd5688c833d93e9dc40729f39a62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "4b1d50fc0ddbb6c8fb329d5d96eb1bd506b001df000dcdc6afa00b6f6ac18d0f",
+                                "uncompressed-sha256": "08ecc363fe4d213b1addf9f454b747e198584a882210d960ff7331b767b673d7"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "b3719febd5c7edb4e79e5c2d940b8cd23a2e5f9b7323f4f0d58bf3360a8973bf",
-                                "uncompressed-sha256": "ed36ea572da8b4a4597c5be4f4bb4730b300b941491e3a99d7f3bd248d24b576"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "234ec7021d0ec151035e2e8502b75cf265204db40f1e6ac0c59956cecec52557",
+                                "uncompressed-sha256": "090f85ab5dea60f42391cb5051d8bdbecbd920d9d082bf7ed17a575a3af9025a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/aarch64/fedora-coreos-44.20260802.1.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "c0e88e93aa69fb4aff2780962bdfc58b4456054985150e11ceafbdad1e71b34a",
-                                "uncompressed-sha256": "2abd7145f49393f870d92b7c3aeaa571826b7e7672faa611b5f6d710b057651f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "a2fa4b200378ef953ef0e1f5b14a9a679a21299eded37dc861962dee7fcd2bec",
+                                "uncompressed-sha256": "9fe41ea64db0491469b192efd538b2c96cde04b740ef5a6a8c83ea3d0a34ad89"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-05401d2c86f17a4f8"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0db556cdeb8e5d056"
                         },
                         "ap-east-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0884e805143fe865b"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0141b8d80296a98b5"
                         },
                         "ap-east-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-049a12bae02d39cd5"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0e7c794b37f788cee"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0725073072b914e63"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-00cdad0a1b046bd88"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0bf08dd0c2129414b"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0204b7f995929064d"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0ac78eca1d52f8370"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0be424da84e04a869"
                         },
                         "ap-south-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0a50a6d298228bd20"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0b81c0cc121bab08f"
                         },
                         "ap-south-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-074491a4deff8c143"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0f909b6e8260b126a"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0e3f133bf71541c67"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-096c0c5be0c32ea70"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-06b6b2081cef0087c"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-067f45dbf77034fb8"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0bc196f1a61f73dad"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-058eace4107bf84dc"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0687de9f86b44f142"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0bfc6ee9aa2df028f"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0a812a07ca9a5e2fd"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0e8ecf91b40f92939"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0e74074033d25a483"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0a3b4382d3b9b8ad9"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-07c1406ca0f38015b"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0c2fdf26591457b01"
                         },
                         "ca-central-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-030f418b02033b4ae"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0889a1d4f4b3e1d5f"
                         },
                         "ca-west-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0d09aad3082be29dc"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-01a41a78511cc89f6"
                         },
                         "eu-central-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0a671b0b313d1ba23"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-006fce06a593fecfe"
                         },
                         "eu-central-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0b52e9f4701f15feb"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-08f4fd9cb02c58ff2"
                         },
                         "eu-north-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0279b7ee55e5c30d8"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0cadb69a13a0a9a81"
                         },
                         "eu-south-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-00791188eb32c039d"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-013ec6a894f598009"
                         },
                         "eu-south-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0163849216395b4f8"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-01bad4de14762e238"
                         },
                         "eu-west-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-03ae48c3a1256595f"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0963897d920c55591"
                         },
                         "eu-west-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-056a8638d294b3442"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0d909bbd43975ddce"
                         },
                         "eu-west-3": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0fd93ce07348f11bb"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-04bb4fffae1400113"
                         },
                         "il-central-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-00cf3baa666ff30a9"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0fbd02df8d4ce83ec"
                         },
                         "mx-central-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-09ee37410bd0ed0b1"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-043deede52d6d3352"
                         },
                         "sa-east-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0f9bff02d16a900ad"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0e28cd125db2d3e75"
                         },
                         "us-east-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0d0de53274bfd686d"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-065b506739b229f45"
                         },
                         "us-east-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0b94b40a60f4bcda5"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-02244325e08d99546"
                         },
                         "us-west-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0391d7557549680c8"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0a9c19ca4a4afe4fa"
                         },
                         "us-west-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0aa5ee022a5494e76"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-04fde7b0a39803e76"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260802-1-2-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260817-1-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "18480cfbbc14dc3fde80bb67a9fb0ba19d001b8f5e06f6eb80f673360d901a39",
-                                "uncompressed-sha256": "f10d564f64c48e48b9439f497846beea1fb31ddb2f6503f9309f15327578ca42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "adc195c228548adcafbc38f73d51a7d98b5aff6b651c14004c8df26a02c15f83",
+                                "uncompressed-sha256": "3295e9355c587788d277cb08ea34ab0a91a68c1e496d23b624835c2c296dbbb6"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-live-iso.ppc64le.iso.sig",
-                                "sha256": "ebe0420bbe2759e6d94959d34e4d916afde19db437a032e16f0f3b29d12750ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "e2fbe65e684d0ea53d5e59ef8bc5ec189f90e0f65dd6d97ec21ef8e4c1aec5c6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-live-kernel.ppc64le.sig",
-                                "sha256": "09dadc4490e6b9ede833a3d0da8d7a115451206263ce5f96b806ff29b8ebda56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-kernel.ppc64le.sig",
+                                "sha256": "d040287f7c8325e3e1748fccaf32c096c4c335009eeae18968d65875634729b1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-live-initramfs.ppc64le.img.sig",
-                                "sha256": "1df995cea26a1cfd15f4ee25b3739e0720539eeec91402fe0cdf260c26b34a0a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "e2deaf029055bf4af882953a2650cb78603422407ebab6367124b2c6fcf5999e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-live-rootfs.ppc64le.img.sig",
-                                "sha256": "9705e509fdb2cf24d7656ba32db607691e090432da821add6de129dbb63fcc30"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "8337b10f03723bbb493eeede7e257ac0bce15ead23eb8edad25066bc111af93e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-metal.ppc64le.raw.xz.sig",
-                                "sha256": "88b737ebb207c7923f332e019d4fe3267a848d427f0115cb2ac68b557e070dcf",
-                                "uncompressed-sha256": "0e6cdf85c11bcf61640fc0bf73a29f920d17cd3edc79bd75792f162b2cb6615b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "9988dd8502366d3616f036958dc927a7ea23c72cce6b062259f566e3e5559c66",
+                                "uncompressed-sha256": "c2f63ca27ca9323a644fec97c695f7a38d2cf579b3c159f1224a5f6b2d8c6476"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "93a6fe5a7afef66b66b2fbea2b6f52bb6e6ea95671fdb98cf1168f720e776d36",
-                                "uncompressed-sha256": "ec75c624869626146dac100353d35652485148a6bfdd5633f493a5e870b5c62d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "466d5dd02d6885bda22cf1087c0ad78ccde79dec6a1c86ceedffd2b6bacf9d99",
+                                "uncompressed-sha256": "8c2659a196752c3758da4c87190229c5cbe58eb7e2064007f182562b19298471"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "b3ed693fa1f13ba14250c197cc33d74711943f0c061619877dbbfdf42887c5a6",
-                                "uncompressed-sha256": "954c93ab0c0ca9724d1b36d74ed115c8a8932badb25178d4a46b99191c58bb6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "2c69bfed9b4a8bd217f7e88eff26843fb04f77fb2208e5a986f1d58a9000b298",
+                                "uncompressed-sha256": "ce6ab7cd13e10f4c34d934650d537ca88e7ca7d75be198cea99b5b01baaa855a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/ppc64le/fedora-coreos-44.20260802.1.2-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "3811bf49176de860ab42184fb1b271949b669a36b7808dc728b1f4996be5b550",
-                                "uncompressed-sha256": "a9c0d699857b2506caf1d84b12c0242d3bfc0776042b01179274d001791da30a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "6f9166922f5268004024bdeaf66387eea52e10af7754f37b9118ab9545a29a10",
+                                "uncompressed-sha256": "01f5068018eb7fa9caa2559e88d9a6bbb0d29f4783afa6ba366892b56d163d32"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "eef7258a5efbcf543afc988c908475c395ff9574310de0b6ae453e92bfbd003f",
-                                "uncompressed-sha256": "c8b3fa0f85e4d6bb07f58685290d45aa281119f20c667e333aa2f187516005f9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "4a4caba1ef023d67218df6356adbbf0985ac22492b8906515ebe3b518217c25b",
+                                "uncompressed-sha256": "d6f444a6561e5360d4e2ee397f3f0da15c4c25d099e96f58787bb106d4033074"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "3f9835485754c7a5f6a4f67f98ce9d55fc9b3af3125c9e915c547d260b1b65b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "2f9cfa60bcd992087ee0f6063d1baabc5cc7d10eb8d4442f736e77205389b24d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "fcd1338f4a743c2169e634728d26c615a2e1e859dc0c3bb6007a929ce7b86692",
-                                "uncompressed-sha256": "434ebe633539e37e7b7843601fb1a7ec413175dfc1ff2e2b1597bb37bfb4b4c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "5997b2a60448a4155ee88cf299e15a31ed5ba1cf32850da5e75147c40e23ebb3",
+                                "uncompressed-sha256": "5c5d6c3803f1f29a3faf387e71e6cddd5a82e398a74b17603fc7cdb3c541b8fd"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-live-iso.s390x.iso.sig",
-                                "sha256": "fc045c5f6e57a32d354f9c1878d07a69ca43eb1223b484cebdd2eef0be41682d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-iso.s390x.iso.sig",
+                                "sha256": "f5d01790d79466717583e05dfa099b288158bdc5d1571298764f2b8dcddc40a8"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-live-kernel.s390x.sig",
-                                "sha256": "c0aee0247d19b020a37974faa1ca34ec3cf027028f0661a0cc63ea816f62c86c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-kernel.s390x.sig",
+                                "sha256": "5a7f0e6c3d16fc5fafdb858a22ee59464a8358adb247c106fcd030606e7fd0b5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-live-initramfs.s390x.img.sig",
-                                "sha256": "775fc006bc7972c8993bb65544ce855872f35441966191d065ee48f64adc3f40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-initramfs.s390x.img.sig",
+                                "sha256": "e10b69a0d053e4cc317eb94225823256c2487600dd3ceb7d47740a142c346b10"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-live-rootfs.s390x.img.sig",
-                                "sha256": "7b1477f548bc53b4a251af918c56b97e561b94d1cbf56ba390cb1d1edf3faf7f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-rootfs.s390x.img.sig",
+                                "sha256": "9bbf91512627e43d754ecd8bde81b4c50508c9d5177c5e8878f3609212be7b52"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-metal.s390x.raw.xz.sig",
-                                "sha256": "3d0eeee828875b043f4041b1762e837850573dd61f9e0f2c36e3a9f011f6a051",
-                                "uncompressed-sha256": "7aa15752b006d8ef64ced45996861710d1d969c7997737020ff16360acfad32e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-metal.s390x.raw.xz.sig",
+                                "sha256": "917be7df2851ddf84bbaf66f918347e27b46b886dd8b9c15817d50ced86ffa0d",
+                                "uncompressed-sha256": "0976e0dce51bd0139967ed66706ede3223daee6097c96a63832f8bbce0a2b88b"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "214348a87ee0a967f3d29f71c71b646e174e9d5376c8a0e055fc553ee0bb349a",
-                                "uncompressed-sha256": "090b34fd60d35d7de0d8e334a7858724cf7f1a385a6568937dffdb2975299fc5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "6e92192c63be825d84203476101c72469b769cdc6afc2cd4cffc42d466deace7",
+                                "uncompressed-sha256": "f77e2da18ce3428319d9718f11b2518daa59371d3f6afd40f22ce6373501a75e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/s390x/fedora-coreos-44.20260802.1.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "d7028b611a2029417a4d2ed4494fef9e833a7ae95b89599c55cbab1c8928e08d",
-                                "uncompressed-sha256": "2cb68af267710447a373f4ec9d01cde9ea89d4129632bdbb29a9bbede0bd7723"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "6afc16bf3f6852f3a6d8cb1dac177af6f294513d46cff78192016949ca26dda0",
+                                "uncompressed-sha256": "13b42aac6fcbc12e65aca53a77c0a261eab3b50ec134608704812ada5eadddfa"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:8046c409a467ff18562a0d90a52324f9a5a14012c2b25e38e5b855a2b04acaa6"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:33b3f4d4a0b1ea632b38d9ef6cdceb4710b480fdeff21e0c1c5a62e71192aadb"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "e1df7e687d075f889d9979f99663126cfe478595a86ab0e96b3ac7b7c2d6c635",
-                                "uncompressed-sha256": "200d8ac891e6f0df5714725a9ee6475aa90f0f703eee22da39f77dac1afc8b50"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "0f75a06d765d65ae698a3e9aa45dad257356bb0b8be551dea73eb378f3701c40",
+                                "uncompressed-sha256": "bc70430b9a1d5923f2df332165cf088a7e3539f0cd49f3fbb050b1ad0497f7d4"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-applehv.x86_64.raw.gz.sig",
-                                "sha256": "84973ffa05de3b5ab0557e8c35ab05d93ce6cec48aa17ae8ebd4acf4de99e071",
-                                "uncompressed-sha256": "c457c8af19b614d901d1cdac4e6ede4f9286ce5eb8e42be71573047b0cefed89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "c3ad9a4294c7ef336ae359e5d9f77bab7e68e86fc3e52571fc99d17b5c5f856d",
+                                "uncompressed-sha256": "4209fe2bf3a9012d87b9416a065c431267735e89461f9f8224393daca68510cf"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "9e9e4858838ef97cff8e6ce6251a2dcf787c5861712f9c0c64315af3e1abcc73",
-                                "uncompressed-sha256": "b46021898876fdce857f228dfb273df63a569e839e3ac9d57d45a8dafa92ceb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "399997c9537662e493b9fb1ea488247e58ccece4a1f234f5e145a30cd494c42c",
+                                "uncompressed-sha256": "9ba2055e7e436359a2491bcd066c16b0a6cd664a1164cf77f02683979e556297"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "257717f38cb4a052045bb82e450ec1a1425f8d8d15700384c07c7e9a5c786493",
-                                "uncompressed-sha256": "43d9cc5907944f31b2fc4dbf1fd2d9af9065953a90faab6506dd3f50af1485b9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "489db4827ef6baac34ee2cde9d3b0e717f8dc73df7f4d46494e396600042d725",
+                                "uncompressed-sha256": "28de5b3869213eb7bdf297bdaad1408f7b71d3a8bf0c36e108e6abee563c8080"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "ff37c983f3765540e120bbd25de9ce8b4a38f5b89ec806367e6950236d404d7f",
-                                "uncompressed-sha256": "4059533a7bfa820fde3b64c3771cdcf432804ab275c1ccb2f79011d419e3989c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "f0a073c0e5704cdfd146d6982b0820f2812642b710f7d8cc09ca248642148387",
+                                "uncompressed-sha256": "c86aef12c7e136e41278d621922e36bf6d529358969a1685448594988ee9aa2a"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "2e8d943cf5698c2819f0b6bbf3a7aa3cfd5c4a4c1b01c0a0c8997dbbb172177a",
-                                "uncompressed-sha256": "5d1e70547afbe23569871d3dc79e73993b244575c6c8e8d9cb16fd85af455c5b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "ccbc7b40cb09781698c20b34ebf9f5f83182e61c40333699e93c3aa6b56edbcf",
+                                "uncompressed-sha256": "34964043f036a83d4d6c1d54c61fd93e5002e4bccaa8d407410bbd05d956e994"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "84742773ab7ae76b585891c1fc555c82e125f8fe69602af59eb5392c59bbedea",
-                                "uncompressed-sha256": "4a0e60c9aa210689d9437412126d9accf6298902ec81190fc85436461a74662b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "6be22c8c8785818ea4d344a4c3f1474cbd8016c3ab0b7be90a6f9aca3773e1c0",
+                                "uncompressed-sha256": "f9b90fa5060176124ef70d258e2dfe51fbef164bc60a8d36824c6df91a5288dc"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f877d1543d983c7225c6ca10f2ed4510c5dec317c4c7754e17143df7b36314ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "cc9b12ef0bb9b79d4ed8dc26abe8c2df9bdffc105cedf4772c77a5ffc61d920f"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "fa9fcbe3030065340e1a3500d726e7ba310524ddcaf1927791314f7bdf8045cf",
-                                "uncompressed-sha256": "f3d7db229318b01e053f8183c27bb0fb8c6c8c863d47433e338b32bad7adb9dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "51e3f7abd49a4183d6bdf58c8bfded29064241fa7f8c8e342da35fdf19dc9923",
+                                "uncompressed-sha256": "de0a57bc14617415f3a8a293a488a2e6f4b7e6a5e0e55ff7103ef411c629acd4"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "e2178fc172e0f4b4707ab54d4ace8d2ad9930a472c526b9fdca17ac1d91e78e0",
-                                "uncompressed-sha256": "85ec6b2a1a709cbec6128b40ebaba28f07696bd33bb4801c82eaa96cbe95a8ee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "7d3b95c23c69d35712f61d8d830354e2325dd4434bbfb8c9275c2fd6e2830b96",
+                                "uncompressed-sha256": "e5330ea288ca90879b81f7dd3c770a43b9433986789d8c36b63c9a8a893ff740"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "6f60e7b06e708617a113549433118073ddbbcb44bc269c182f39cf81db4a35a4",
-                                "uncompressed-sha256": "7752fd96c6cadc48a1d278cafd410ac8aa0195ef7f4250b74d43f8b5ec69dec2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "488f58993e324a0be727c164f3de796a254083d75de4dd98904d5776ef2c6ee1",
+                                "uncompressed-sha256": "7314007f6e98e7f0599149972ca8f22fb36a8e3e89638489c4e554ca4242fb6b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "7f2d3dc56f99007cce1be2020ac20114d61564cd0ac63cd200c4c08fbb7006ed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "5f2cb5f55be15735957cc28c3e9b225fab754f99d8233b322824eb2496332347"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "c6ee8664b6c82fd0365ca42dd53f128a93d7a13a3d771339f568ec37b6ee9555",
-                                "uncompressed-sha256": "7770517ac3298b0c061c5f14ffffa21038dc012a23f06b1e8d55ceed3c43ac64"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "db74f120370ade6827b3c76bc88a2c5a3e1a650788be9f0e57c8ef4a9b2f269a",
+                                "uncompressed-sha256": "42dd6d01ece4e084f28d48a859753c340aa2abba75ef64cb0a0ea9c6f8f959f0"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-live-iso.x86_64.iso.sig",
-                                "sha256": "7761e5b9d907fbb2ea40b55a2d281ac94cfa557f35aca9166ebb5bbb9c598d85"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-iso.x86_64.iso.sig",
+                                "sha256": "780f96dc1ab7b82937c529e397c066a7ccc7e95d72d4638a7c4496100138f037"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-live-kernel.x86_64.sig",
-                                "sha256": "c4a37455613da305d6f23bd9b588f2242a253eb0ff1a4169637fa835a458eeb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-kernel.x86_64.sig",
+                                "sha256": "5b97afb0ac5efce78b37184b8a305275800f0244281383457c01dacd5ffb07ff"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "11a4a5ff08b666a84c1b2a0b77f588eac9611d836298ebfc4c5a6c3bea5c2181"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "7366fad6202b312a14d92da89a21dc7247631a25c648d4eb27cf69c0bc8d832f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "1f4634721023d52bb4f83cda0312f11c7fe4de85b93eb6a92558b78c3502ce44"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "e7d714900c6157534e7250fd7d019c1daeb2aea85aab26491ae232a109d8b12b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "e00bf8f6b457da042f9c1cbf43b4ed4be02b4ef4854c47435a8fdc4ac3b800d5",
-                                "uncompressed-sha256": "631f82b4ceb588309efcb99ba8c113c52e63c39274e5d3aa3528c5bda8b40bd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "e7bd075b16397ac616f2479c3f0005ed2a9fccfb08ef15bb7a65657d03a2790b",
+                                "uncompressed-sha256": "587c118545c5ea4238f8c424cc5a954e23669eec9ff3b6be091e353da6cd8d27"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "74b73837ad3474dfb2fba63a7badabd18e2af465752a579ed76c8a22d95df2e9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "34e1a46a5ceea82f443e5fec4a185076f9315659632132ac730a8dd9247a7c12"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "1aa153a0cc6b9870825de929eb668d39e93375f2f109c5ed7b0ac64f3ed6ef82",
-                                "uncompressed-sha256": "b11720b0f6b22b168840589dfb758cec4d517bb96f439f73b604e766b601b3ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "13c2614bf6e9f036d82e51d01d75dec533e1c11a9ca31826f1edef5aaa2db3d9",
+                                "uncompressed-sha256": "18db02492a14b7033e5c7b85e12bea63185e7ed8bb79d777622f301ba811aa2c"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "7e68a207afe10e8ec50ad3472306dd28acfbe3b1f2e55dd8b7b732bbaac2724f",
-                                "uncompressed-sha256": "f01d8d73cdc24aa6485548794f2db479c419d6faec5e27af94bbbe700b87ad05"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "1d6c1bf44a51de3a2255bc72a5f4fb5ea4a8dc790c15c6e0d07057966ac14e33",
+                                "uncompressed-sha256": "bf372cea9bdac953328394de8018c2cf17ffb28dff83d78d067b38e7dfc6396e"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "1af37c215edd02a579655596085d8fe521e12580b24ad6e12baf4576a6dcf079",
-                                "uncompressed-sha256": "182885d9b5e3e3bfed8c0c4db0b906b5e786e91d0a2d6f9523c3e62069bb9dae"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "8dcfb642e6d22662fe19057727eed6a25145361f020acabd0373f5a8ba054ec2",
+                                "uncompressed-sha256": "133ed3bb1037aaee7c3ec05dc08b85007414d09bbab41177b32a22fdd1b65106"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e11d5cfb40e9ae71c7721cc050680e137a25ac332c77324466f5da593a5b5f93",
-                                "uncompressed-sha256": "803d6f3255f899c79e5930e0118c93942b0ea1b4f0589860735bdc971297d4c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "e295cba28faf0ae0e079b7d16358a57a942a8f5367661a89ecca56570eba10e2",
+                                "uncompressed-sha256": "8317cc9bc5104797f7becd3788cdf0330fa410fdec1bc24c5eefee295666bf1d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "e91f52eea37b928b2f74c1d4e7ba44694554ec885603a333bf0a4608ab4dc509"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "a1e8ef5d3afbc6319efd3ab8082650f3280698f6190128802a7a32e10c12a622"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-vmware.x86_64.ova.sig",
-                                "sha256": "07249d322017ac49acdb3e4513028ba183c96041fbadff9eec2e843e4462a46a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-vmware.x86_64.ova.sig",
+                                "sha256": "1faa15ebcc312d8cfbaecf99936aaeb3863ce784158e834f463a73640867bd6e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260802.1.2/x86_64/fedora-coreos-44.20260802.1.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "2926b2d4df5d0a66583aa7e31c64778101a2323c2efab5f7d01c232e909506fa",
-                                "uncompressed-sha256": "01c6365dc50c008d223b03570e8c2cbbc1f6975ad9a2efec74a55ff48986de7b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "9dec26bb9a6a85dd4b14df45de7893086077e14bbca62332e1197481f1ad02b9",
+                                "uncompressed-sha256": "0a941b1d390d2ff7b3fec07c0d1be364fd7a5ede9d146bc4ad92ad08e0c661dc"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-005e3cb90940b6a8a"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0aa29c787e83fb19d"
                         },
                         "ap-east-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-067aa7c3e82f0647d"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0231a09577c9b9ace"
                         },
                         "ap-east-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-08011a7a361df6357"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0644a739c66ce0783"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0ee89c57432307312"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0465b1a7d2ac978c8"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0be91bde469b141a7"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-03921589b220ee927"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0fbfba39211e3222b"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-078b08f2a01d6bdcc"
                         },
                         "ap-south-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0c82268d0bb84dca8"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0fe959d41819caa30"
                         },
                         "ap-south-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0fa9a0d8647dfe046"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-09a86c1383da43b73"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-03545ceb008b66207"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-04b0d9349f5f36f6f"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0a211a01ec11d6209"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-050db0885a2ea767a"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0304e03aedb192a07"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0fcbce6b3c957d54e"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-09752347db2cefb1c"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0b9d3d3e68b3685c9"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0633158ebfc2f888d"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-08ae466f882fc304f"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0a6bfb606d3d2f46f"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0d40021576969eb21"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-05d4471aa7d6b461e"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0aaf8efbbc955cf56"
                         },
                         "ca-central-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-08943dc0f524437a8"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0bd39b7b3f121bacb"
                         },
                         "ca-west-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-03ccdd824a99d125e"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0be3c7d9a43ec5745"
                         },
                         "eu-central-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0771972468f5396c0"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-09b04d2c1ee3d7b57"
                         },
                         "eu-central-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-03fe2a79b3bb08a34"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-031276c540db6416f"
                         },
                         "eu-north-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0a8e84694077ac392"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0c6d275af2a31a22c"
                         },
                         "eu-south-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0f77c785149476c79"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0d4f53decee38e941"
                         },
                         "eu-south-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0d1b6a48a01d8a1e8"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0601980c33a00acff"
                         },
                         "eu-west-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-08fe9fbd028855136"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0f66a1969d4a7d0ac"
                         },
                         "eu-west-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0873d6ccb878abd10"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-04b1b4e827fc76b00"
                         },
                         "eu-west-3": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0a94d5c5c9566d09a"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-09386a350089c214a"
                         },
                         "il-central-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-038ccc0158d5fc337"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0cfe3b0e1ffdc74fa"
                         },
                         "mx-central-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-06bdaa3013cd86f05"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-07ea4cb245112b62f"
                         },
                         "sa-east-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-037bd012c314c0250"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0f8a46f3955b692c5"
                         },
                         "us-east-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-028015dd99c4766c8"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-07b60f734ce15e347"
                         },
                         "us-east-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0a39bfa25ba1354c1"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-070a1bd8f776d1c47"
                         },
                         "us-west-1": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0743f177c9ff17566"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-0bad036b7cf7e30d4"
                         },
                         "us-west-2": {
-                            "release": "44.20260802.1.2",
-                            "image": "ami-0ee772391196c268c"
+                            "release": "44.20260817.1.1",
+                            "image": "ami-05455faaabf549290"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260802-1-2-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260817-1-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260802.1.2",
+                    "release": "44.20260817.1.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:54dba2d5997edb82c99bca7672083342bf616346182e266e6bc24d3e640f638f"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6339d46fa196f44ab6ede36b1b42a92d94703007cd951bb01b8811872181aeba"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-08-05T07:18:01Z",
+        "last-modified": "2026-08-20T01:41:33Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "883608085aa7479f6a244327b86bcdfa32affe9d399ab594725a8169d9c1b08c",
-                                "uncompressed-sha256": "68779895924e467aff397da80d9bbc0a4cace0db75c137d83d8d5b598adec421"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "275368c402dda44a30a7fcd75d5b2cc50e5a1c88119ab80e36b601b6b39f535f",
+                                "uncompressed-sha256": "1cfc52e977056761a058170f9d6f104acdf943ba23a80d4c44bff5b58e13f600"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "91fb7927073ac3699d6429dc95ccb9eec3a8d7a91fceac3fd97aa24452990108",
-                                "uncompressed-sha256": "6d780e5259ab7a20f22eb790eb8125e0796c33f68e0753738dc094f3ccc41161"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "a32aff789afaf84dfa8f43929feec904c7ef640d907e9bcc6a94e3a2514d7256",
+                                "uncompressed-sha256": "6f39338c8a5bd266b78b2e7469c5e0a684c50768f92e873b15224edf19245c12"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "84acdb647c7e372bd2638e32fd7a6f5b6a28fa55afa869b8492d048c252ae60d",
-                                "uncompressed-sha256": "ee1cd8e41a5aa0c2fee18fb01ab2b1c2e0977ba8f7abee01cefa38a21b45f98a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "9a46e9b3c77f3da6c5cb69fbfd6cb6006616032054dd9770aa24f99bc4aa5210",
+                                "uncompressed-sha256": "40e066d44ab226c961486afddddcd4c58dcf4305ae063b9135e7bcd4c28308c5"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "9d5bf7b83772b6ba16dc9062d7f4db8d0deb35524b21c4ad9881eec36b82e945"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "3fe37e17100c4af432c992badbe64caf6c6319b9c7ffb08a07b171d62329e956"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "d73b80810c283d77b3047cea13b70972804b275e75d17da237a14f5a21141567",
-                                "uncompressed-sha256": "3bff4b0122ab9e6632c8efd895916c9073e3b2076f221c61e3388107237d91ad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "07bc523aed38d2140307724f5c9520988e140fa744820d7c0c32a37d413c735e",
+                                "uncompressed-sha256": "f0656622464be311bcb0468e4701ec8b8cd750a22374a61abc59ece732c42872"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "e631b9e79e34472f4dcf604de5235134eb822d1e68b44f624373d58fe6f0cd36",
-                                "uncompressed-sha256": "9a45babd4331ac3bf0d52bfb85908f248f6ac84d3110654a4eefea1d451247f5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "402a8b22c20e798fd4c4ced3ececc29ce49b2b1582ba0f9d0499a8cca2982bd2",
+                                "uncompressed-sha256": "ec5df0754f7838f9c68d64928e92e426da6de95953a42e1fce179710386aeb02"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "a2111c30883cefca5554fc4f55df9d82f4c2fb5c6fe69d9362af8392a25fba8f",
-                                "uncompressed-sha256": "47613e8399c9618a5bf5dc0ee1e581a48cdfeb659cff09516f09c173cb1074d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "500351c1c96b2aa3446e00e34db19f5d753dc7ed8f9b02f7575f59e70dbda2e3",
+                                "uncompressed-sha256": "94defcc9b8b6ac1136200ab3650f64490626f2c77f0413efdff0eabb0743dcc7"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "a7145cb3df8683aa8fde6e97c75d60aba3990a4ff21bee4ebd708792bdbf3e1a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-iso.aarch64.iso.sig",
+                                "sha256": "c204c2ca547e3e862fca2bcd4e2d2f29272a4e9bf5f8bbfaaa32620f5d89d577"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-kernel.aarch64.sig",
-                                "sha256": "65e828721142335cd235ab34ff8bbe2ead12191f99c3161f69a1a53c72579b2e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-kernel.aarch64.sig",
+                                "sha256": "1af1ed065a597365d1080c35d05953b83077331fc2e234e23569d39e8a012c06"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "52055b7448fddc96c00c11b80fb6397182f9baba8ce9ed90075d1528c7062975"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "7ef36cd01bb312d72d0dbfdf25f4827ef0edb6182396304fff280a8ca715b05b"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "6d54cbcda0c56e68a820138eba6da072b0c4132c4257dbe7956213437fb60e35"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "21b80114e6a651469213317e93593457069ba1d0ab895d1dc8a95588f8a74ff9"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "f8a40b298e1d0597db7acba9936418f9fee225938a6853f551ee6ab20a52e34c",
-                                "uncompressed-sha256": "5beaa0ceb0a8c02c8e3e576bbe0f22e030f1ae7303aa649c304238d9dfe995c9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "97354a627e7f38647c7e82d09408d6d26320c9f3c5f8fe847c554a09ac62b939",
+                                "uncompressed-sha256": "69250c00223e25505ce4f7b1afac9ccff787331a1dfea4295e4c292958d581b5"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d165b2e9d4c82d31b6ac67d749f69f9a0c349f399806d0a6eeb73a06a0bd54b2",
-                                "uncompressed-sha256": "d5f65f498467e420b6b467c458ca982f86fcc3be113ab74671e5c2e138da9c9d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d7db89dec38c7fc45fdec4f8809a44efbf4bb7278ae7a651e6aff643ad3519f0",
+                                "uncompressed-sha256": "130964fa330eee50e0fa6423072bb0099cbb451b68179a2b786dfe9f2eb4949f"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "cab41033e9c4f23e28bfcc3ccd57678a31c52b9da3b8e2476a44dd5b4c121cfa",
-                                "uncompressed-sha256": "253d05eb6a23c1c4046b403e9c3c5944d623a04b256f38c6ac7f6ffdd6689d4a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "38feda0371b327aa56436922db6f8619977778b0dcdc1fab3efa55339dab7d87",
+                                "uncompressed-sha256": "7b9e6d900b044e8eb77813952717d248fdc8f50bfe0bc8cce69ff6387dbe2c75"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/aarch64/fedora-coreos-44.20260720.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "e3e848071b3afa3453df7247fe94ce9978e210879adfb1f53610f63ed8912777",
-                                "uncompressed-sha256": "c2de214a751332767e517a71cfee4d01ac7ed584da2c5bd8d27c52f98bb81dd2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "eaa978faf5dcb1a593f7df551a8b61fe572e3531daa72d4aaeffc260fadc6cd8",
+                                "uncompressed-sha256": "841331d6f5392ed1d5198622a9cdf23cdace4ad7ea530b2330f7067655b5e01c"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-04a170cbe0677708c"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0086d9d006f331b8b"
                         },
                         "ap-east-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0527a63d12ae5da1f"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0a59487c82594f7b8"
                         },
                         "ap-east-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-04628c66e93396922"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-00c266fcc6d8aa1d6"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-07519a04a69856b6a"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0af8e9bc1a750ad8e"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0a24fc1d738f3a916"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-09f64e160b6c267df"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-06e2301b9fc27583f"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-092ccd9a7ff7245fb"
                         },
                         "ap-south-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-083afea9eab5ce884"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-06441bca7b36e13ee"
                         },
                         "ap-south-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0554933b9f26968b0"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-06655dae6f9b4850d"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0a328710a699ac74e"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0caff22eb98627f1d"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-092d779f2ebf09ac3"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-092b22efb849b69e5"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0331f61e3db493a91"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0dc9a7ce70d0697f4"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-08c05e3eb3f722b34"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0d05d1a42ac29ac51"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-06ba97a75b1f3e22c"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0780ea463fe241de6"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0df613ae43608bda7"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0881f559a7f33fa78"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-05d7df6bea2551ed7"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0e13dd029f89e4da8"
                         },
                         "ca-central-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0f8ca05ebe37ae0f5"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0721b4dfb6b00d378"
                         },
                         "ca-west-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0c887ba8c897156a1"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-00e944fc6e0655f84"
                         },
                         "eu-central-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-09333b3b6824ad449"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-03133bb4b4b814acd"
                         },
                         "eu-central-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0ba2a04666d841ef4"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0c703da3428efe01a"
                         },
                         "eu-north-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0e7601b4e4a461c83"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0d675792c188b9dc6"
                         },
                         "eu-south-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-06a8ff4075cef1ecf"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0a03fdbeb1f6cc01a"
                         },
                         "eu-south-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0134927a6f6878772"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-004a36814cb34d785"
                         },
                         "eu-west-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0792c5d41bf56e409"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0387925fe260b5d2b"
                         },
                         "eu-west-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0108586bcd3d0b88b"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-079ad6d990b9d9927"
                         },
                         "eu-west-3": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0a696c9a5d9312c60"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-08031044d38a5f3ce"
                         },
                         "il-central-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0e1186d9401d0b691"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0e41d2b46791e33bd"
                         },
                         "mx-central-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0d0fa0fdaa32fddac"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0d86d3a2b9c2dab52"
                         },
                         "sa-east-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-00fa3d89434972e18"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0e11b650c55bb5013"
                         },
                         "us-east-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-029a5558375877153"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-053b93cdd73af4caa"
                         },
                         "us-east-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0d7cb9ecc53569447"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-038aa85158327d661"
                         },
                         "us-west-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0e0365e38c5bacc59"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-03a53332337511f22"
                         },
                         "us-west-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-05c1a3e0bd3381b6a"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-06bc235198459f04b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-44-20260720-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260802-3-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "d577300ea709576d6dc83ad72103f2e6a36879d8a1df81f72481f01d5cdda398",
-                                "uncompressed-sha256": "347cb17a50818fa3dfa1ef6886d354cff1ca8ee80c876404b0e36e0eb5d312f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "b48bb93d2683ea2f02824d115e5b494a1926280458ad40ceec17846f08ff74e2",
+                                "uncompressed-sha256": "fafd1cbb017d39f4a57e9547848e5bd5913924bb113ebd468a1748ee15f4a838"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "c2ca1c05f495d9709b38b759538fd3d82679408a9d4fbe3bf8515c283b4bf951"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "c5deab6b2f2974f3232e8b376d73523c6ba0e14a091624f12830f52b2f65fe02"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "4bf2a7173bd32993e9097c68c8c0036a1dd2b3028ba7c93c74367c1e15743196"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-kernel.ppc64le.sig",
+                                "sha256": "09dadc4490e6b9ede833a3d0da8d7a115451206263ce5f96b806ff29b8ebda56"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "008cd75fc19c73ffcbd2e2fd0e407298fb0ead95b9e4d729ca8802c9e529bd42"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "3f3d7bfc6954a1aa7a4dcf4ab0fa5f2d3f268da83a1ba28dd55d52cf129a71cf"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "7e959a93afb08bcb0078a71f992ae9f9bfc42e57c9c273db5ad0e8ab7c55e3d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "d48f9999d42b2de6e7176412780888d9f7e8dbeeeac6aec3d93d7039dd48d16a"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "e2a44af0580a015e6c66da6b2601392a0900ba5411c180506538220b8ca90ca0",
-                                "uncompressed-sha256": "2961f656c37c639492f0d148482301e6ba493a790437bf72cb5fa2c8bcd3b837"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "28624d17b89aff34c23a966a3399d77781ad682287b55d09d225b8fa95f0bd94",
+                                "uncompressed-sha256": "d1a812008aa00904a089490a0fd92adcbea429c98df5b9e0ab562f1d3eebcfb1"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "f0b6cb15ec50e9ba88b3b04f8fbe680ec8d68e165b6ef87616cb01465f18bba0",
-                                "uncompressed-sha256": "eabcf49dbf116fb0be9f7d17317801b2f85b63a577db17d6d5b3dd4401d85da7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "6ad5f25d83a4759330ce5df4081ecc5a4187ac352818b59e3b2c6a940fb2934f",
+                                "uncompressed-sha256": "eb0833a8dea7f7f27ca604ed2e723b35c9f9baac0b98d41beec7c7925bfadd88"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "17f8ca579c439ac13a3834148c2ac334c8c865ac34f3a164d38ac52da3e08b49",
-                                "uncompressed-sha256": "a5ee620a253e20692ae34b1e029a7271e8b0b778b4cd523cdcd10f5d980c219c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "f0d15e4b518063e5d5d52d05b28f8fdba2bc469464f0c33b54aad00d65d77683",
+                                "uncompressed-sha256": "257be2f9502ea0e353b30ae597e930149cccd928c262bf7ff1cf5031c3bbef27"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/ppc64le/fedora-coreos-44.20260720.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "bfe1a0c9566e253e292077014ea8b03b6545c40b2d2b9e207597169be4781b07",
-                                "uncompressed-sha256": "94d0e71b9303b2614f71ae4061f1253c179b3a163478fa2f80991425940c825b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "a3516174b3f5a787f2daaad5d3957f0c4ff15b3b430c8952d69151c539b33f90",
+                                "uncompressed-sha256": "b74e45d3839c76c0aff17a5953706914e24e3b86094f34028987f28cc6ff4fa8"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b9b2cc70cb11bd94c3d79bb09a0464790faba27bb37b44ed464d31e66bf46550",
-                                "uncompressed-sha256": "4539e9b1f0a0d41f185a440c88f29244ed177f2c40d418de67f3b3f6c2a84033"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "b56f73fbe364806f710eb1cafe04ffa18eeca07fb69440dbe9469c287eb3dd51",
+                                "uncompressed-sha256": "eb43e4f966ffcf85f322b8238517784a21da0763ce2683622fe44bcf67094daa"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "0487b92576b1f211c105a1b290f8ad17baceca0a70233bb352e234727fa0b934"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "12afd10d09f74d756e37d0cefe13042ad9511a54b28e35b655248ef581ab3d6f"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "77d5056684980b29abd73cffe9ab43b81fdcd7ef580b98169c487d6bc66223f3",
-                                "uncompressed-sha256": "aabc26597cf9e4aee207cb626933fcd7d5e0fd4c9d4cffa5dd62589526205ce9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "36eea7e77b23fa14c294593d92d19fa45fdd4c0db29c37244a36e9aee4fb48af",
+                                "uncompressed-sha256": "4a7a406f30b6e4f4503b8a77e7a604c0e993de600a4e578f68c18f53bcb671c8"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "34847fb97b8f18f50f067b81eea728090b78d792d100097365fb32d38108ffe1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-iso.s390x.iso.sig",
+                                "sha256": "bb795ed52b94ebdcd07fc6a293598ab529e6278c0116872109548ac210521004"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-kernel.s390x.sig",
-                                "sha256": "7fda5d822d42d3e692daaa4964e1c1cd38c605c0c2e5da6678f51b7a0697bc26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-kernel.s390x.sig",
+                                "sha256": "c0aee0247d19b020a37974faa1ca34ec3cf027028f0661a0cc63ea816f62c86c"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "601262731a330ae3f11e5cc4b55287258f612bf04a567db3df093d70b3acd848"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-initramfs.s390x.img.sig",
+                                "sha256": "14bd373d1c0d66a698c2f74ef0f371d80f6b7ab8250e6e19bcb35eed6ac1cc16"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "3e9f8b66ad046ba6b78850546dd87b383e6d3269c83c2b3c8e04b0642627dad5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-rootfs.s390x.img.sig",
+                                "sha256": "e4b5c9631ac1bcf9e945cb62750435b350300832c5b3a659764254313df85308"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "cb434efa67deb749e3052f7a17e2d5b44ef3d00fb9fea2b2c6aec2b224642d0e",
-                                "uncompressed-sha256": "af50cc952aebd7dc37264a1ae29a0a05f3f7430b19ffd1b92216dbfff3689c6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-metal.s390x.raw.xz.sig",
+                                "sha256": "316feac4b335f85a7218087953f93586e22f90d031b37f13d6022e1975d2f9b8",
+                                "uncompressed-sha256": "f4aace88b1d58129e18e7ba71b2ac8be67cc0563e649986c41ab9906dc9a5cf9"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "707b339b9a0a50e32bec24fc96e4972ddc328f11073de2a385bcb0a539297032",
-                                "uncompressed-sha256": "c89d064cedbfc71704ae43aa990e6348005c71e98abee11346a02e960c9a50ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "e8d215e724360c214c2199b837df9b24b33968a659e003c80e4e94e959806d3a",
+                                "uncompressed-sha256": "a3220712c8b2e795110d1088d4bb9ccc9d8809941578617b180c34c7bf1830a1"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/s390x/fedora-coreos-44.20260720.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "de6c110ca63442a27fdddde7b6ce86e0194df6ebe801feec93addeee74520afa",
-                                "uncompressed-sha256": "de1b07980ba8d3ef481f8374878de65411b62045343095a037996705f7bed369"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "bf0b0c189831029bb9b4b1b00bc145a9028a0db376adf7ac8d893e2b1645b4d5",
+                                "uncompressed-sha256": "f2ca3e4021fd794bfc0bb5bf7196a2db2e94457bd516a60cf4417ebfd69054b8"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:836a3c5166e0f6d9232a7acdcd38c7aee71b118057da70efd877c85b6eb991ea"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9d90c9d6a403b0530862a3ea3f206f68b2b64a13c084250a914e33b3173fdc63"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "81907df16d178262f3a717c8a87f5d31604a2f261779470fd02683cb2761533f",
-                                "uncompressed-sha256": "7bf1ab8317b712994f07ddb7974fe8d662a9c45271a859cf7539d8053bfec195"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "6ed420c317b31e7fe16e97d00bdbeb16a59acadcb0946ab630e01a30601a94b6",
+                                "uncompressed-sha256": "c5a244b400eba7a8479b820c615bb43ac1f2f90065e23ab7d138298bbc156dd3"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "b265796c3015f445fb8ccdf33126813ef15f470f45ced0dde7b8520a24216df9",
-                                "uncompressed-sha256": "e47cdfcb00bb08adffc8e532b7516f3b58a1b2034f16d5b97f0962e15f2c3730"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "e403f3dfcffa780a0f8c79daaeffbf34a70219163ade283fc874d5d401526712",
+                                "uncompressed-sha256": "932a2ee9b43cae47e061a2b8b9b83fe33ce1678bd928d2bd4066294542b372c0"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1ffc2128176fde5f3d68ce57db20698ab6e841e0a74c3641a1675c76951d3e64",
-                                "uncompressed-sha256": "a4a8f04c1abcc5439548370fd02ed6956f806b210fd919ba8f3455f8fa85034b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "b4da88d4af80fc5f4e07fcc88318ee561f6642c92e75a07d6790a3f718d3b8f3",
+                                "uncompressed-sha256": "08a2599983bce2643868cafb35f1477e9077334a5005bb7210fc4bd93d864283"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "7103b9c96f5c3cb91530706342387a7751fee390855535c4a035ab57ffcc715f",
-                                "uncompressed-sha256": "ce2a737c2ea1a8a9ae0166647b68b8e75e4d76b010ce6dae477a5dcd1caf4191"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "3c8faa3c25a5411e22953148440d86320a69cb1f4c575ff3d600fcc04a673e7c",
+                                "uncompressed-sha256": "53f5be21aaa76443ddc886348ab4682a7a511956d5e7e8c043ad6a023c6728c7"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "61db5112fc2b40b3888ed1571f5946f1ccf16d85e8c28c3eb6e6d3b38853280f",
-                                "uncompressed-sha256": "d8bd97c832cb0c855a563d9bfe41583cfaecf96a158d629ff30a1c2bbcae03ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "593d3c862c98e123a256135bb245ca422634da8125c6863a300838bf3ec165db",
+                                "uncompressed-sha256": "f64a20aef2f630e03bd87a1dfdad70e4b76932752020a111ab81ecab897ead43"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "494a21e6a1f862fa2e756b11439d7200a16d1b8d911e6f0bf13a7b7a89f79a30",
-                                "uncompressed-sha256": "75f91c97f60cdb67cff95e54b457251d7c2c400e59cb342c340041344ba82fee"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "401b62f8ce4ebeb4c61f6186cafe3f4dad458ff42fc8c6c0322107baf15e850c",
+                                "uncompressed-sha256": "502758947da932725c5fdf47df4165d18b3cea83f94b6f6642f00fa5f036b6cc"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "23c9e29ad0804bb793a61b3b254914b5e9959e02f204e233287b2d3dabd31895",
-                                "uncompressed-sha256": "e90c205526273950db9edbbd05859ef99e3ea7f449bf11852a7a50e42c5815ac"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "c812bd321d2232777654a41b2679055212e2cfb71b293a6bc05ec5e3b8b42a84",
+                                "uncompressed-sha256": "ccc473bc10cf8c43b558002603246d5d82ed6b732ec0380b0ebdfebef5ea7ef3"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "f56efd0725c63c1830b11967c709006fcc6d3bff36504bd144e4221ca9b7c3bd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "fdc19a03e3b6171013f41bd7dd59aafb10b8fd70f3a6e66e2656de3d04eb194e"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "0ce6d44b5027b4e333fbb2b056b015830bc61d4205399190cd9371f98cada19f",
-                                "uncompressed-sha256": "314468f484a562db735dec0945849f93ad952862b067c868a48235313f2a536a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "9929749eaa2385b556891fdd99edb83f4bfe932ae8754cd04260e651706286d3",
+                                "uncompressed-sha256": "a7998091bb6d3ef67de7c06a777b858df5423da6ff6dbb2fe1f42b2c91ed285f"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "0f9d35d2bfa6d8cb9164a3dc190d0369691622f819ba8aff56695b0fc027f6f8",
-                                "uncompressed-sha256": "c9f8b400885d30bec75dfbb314732d68c3ed9242b79cccf296241d7c55904837"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "ae7e6c9e3e613ceb7c08d71e089f3c5a32856c45d58c306331b604827d2a4f9e",
+                                "uncompressed-sha256": "e37a5d08e7a4face5b19f85c2709fc2becec831eaec7b0467da42bad2969b808"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "fa181be2854976a6a8e351733191fc05580409f62279d09ecffef6a95fd22aba",
-                                "uncompressed-sha256": "805fe0da434cc7a66b65cfa9b717d520da25ecfb7c21af2a8f15d1a49cb87792"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "e5073a8504032be681a26a689d2e5c6a6dcb6954c041855887330783492670b1",
+                                "uncompressed-sha256": "0ce6f84202881b9e307f3e529979d7b770766bbc41ebddc132fd427282c3c701"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "a86091ab31621478fcbc1942effca9b9d9b6742c09c471f6080e85e937a1dcfb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "001f6d913af8621adb227004159054710f25a58e59d93301e6358c1aa278e5cc"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "11f5e4b37a5282fe63a41342c197124bcfc24d27cea0f16c45909534b6278a6b",
-                                "uncompressed-sha256": "c1724f6a7856af2d15de2b2d8e03ff18eb6ff260c2862f49a4485f4038f55467"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4e7d5c572ee22c268fc7415f800131771ae938d82065f02e30abea9bb0fdcd0d",
+                                "uncompressed-sha256": "65d7a7002f711b06353c4e081d42a28bae79d77376a26446007ed272f2cf7bd3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "ea684ab15e9c1fb2deca28a8f062dc0be824d0e0094816f1167e0d811b33dded"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-iso.x86_64.iso.sig",
+                                "sha256": "a86bdb82b3d993b8d26100e379f01beb9c99bda72756717d8aa9f73c66fcddb2"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-kernel.x86_64.sig",
-                                "sha256": "6cdf5024ca807335491c33a271ca7dba28278879ab93db8bd1da99eab2d48acd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-kernel.x86_64.sig",
+                                "sha256": "c4a37455613da305d6f23bd9b588f2242a253eb0ff1a4169637fa835a458eeb8"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "919442770995e6c3aba25dbe27c4e3ec198e85cb646fadab8c0e1c847aee56ec"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "88b2fb7cc7ff65b4f63f9dc69e66bc7187dd930da9ef750a89d1aa734ee7fbb7"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "e5bf70d26a537e3218d38fb2cbd557a89997ad9a449f3e828549bc57cd37a8d2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "376a1025e24a9f36b0e5e8a2ee8ca8b2c30d29a06e61f0dfe7edf9a9c76ed77b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "cd6dd1f53a7b77a23058edcc21f1d56ceeb488fdbc70c9908b187b7036516a94",
-                                "uncompressed-sha256": "e4e67002e6691e66360217c5626e5f8159a03663bd544c436d3f4c338e177e84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "67176cde0fb7fad3f505fcef334a01e0bce37b009b5f9292981784fbd20d0aa4",
+                                "uncompressed-sha256": "cec7986777cba4a648ed34135fd44da34bb00579811d91b50ad8baa5a4917f52"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "d2fdb7a209884697fcdc4d751756fe487eb9081bc2f2c4e4f329287e92c60df2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "f798745b9280ba7a74608ccf1b06f5021c11f82b1f352085e908845431706b36"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "adec22e77be1ccca1bcf58e728e1dc5a3c3087715ffbf59b682784a57140f29a",
-                                "uncompressed-sha256": "7709a998e96794591d4c4266e6c9b7b234f73484dd6a3f94a6457a5b963211a9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "c2e63dccf821d70e90afe66bb7cb2c68d3a34d121496290d5670b3488903cc5e",
+                                "uncompressed-sha256": "077c3206b404e2d2719199c3d8a06209c0a440f32967d0dceaabb62e593301e5"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c9aeb7f47e6cfd9892834594c3e0ae432e6a81672d3d72d59e78108a29006003",
-                                "uncompressed-sha256": "f7048ecb2b0a29d17d3ddad86ba41196085ea19481f447bf07ae77c0a6dcfe8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "aeb29d1220bfc5cbcfbe69e8316a8482e96916233cd6e185ab10175c327f57e4",
+                                "uncompressed-sha256": "f93905e4a175be18dea5bc2f94abbbd5d6a800af8350384dbe400e7795f12167"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "a9cfeba79c279056637f71a797c4aeda6c44d6e2576812d1a0a39093ac5ddb6b",
-                                "uncompressed-sha256": "7b4e8931883bbc1020d476775099f3c9b061c49ed3bd19860167be4f2bc03249"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "f36ad9fffc4904f22a17ce9928420faa587344f77faf98997fc206927e5f4e0f",
+                                "uncompressed-sha256": "6f291ec8a505c7dcf5579d922e3d2b9106956d63149366af038abbfe6890f390"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1bdc3c59b16508b9c24ac85b7d2543261a02bef5fae4ec5820511b4e7d66a338",
-                                "uncompressed-sha256": "c8f47d668df56a88fdde37f658ecd9c35c8f5d22b91ee060c642bf1b01d90fe5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "1c4e4dc9a4780e03f4137c4c6394ffc88358c7a540bc983f4d4cb97110fa3676",
+                                "uncompressed-sha256": "5861bd2f9cd0ca6b6d9d55337898c56f58cc14776e7e92f58501eeeae488fb20"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "38a2ced91584faae78f95bb083203e3aa18987b040b546954f1a348e8074f01c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "936e5f7da0ca223d96a7cb0cec309b00aa20a01b5c8415f156b8ac5630049e02"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "001f54690dbf069057fa844399913d612d70ea0226abb81eff0a4908216a13bb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-vmware.x86_64.ova.sig",
+                                "sha256": "cce057b8037e664afce0929d469d3591d00a014c4191601185f23f9f62458a53"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260720.3.1/x86_64/fedora-coreos-44.20260720.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "32b3bbb4ef36d856d13a9f9cbb06bf3447b1bc3a04a55d5739ae1b1a4089e3c5",
-                                "uncompressed-sha256": "636a601bfe71acb1b34a16e0da7f333bbf86b536229fb9e4db37a862c8d2fd0b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "b30bc873a49102380f74cc44ad4d8d99a1608683ef1aa2cdf04b3b69f64b27ef",
+                                "uncompressed-sha256": "c88ee2629d11eea811fd5d2b27f3ba1364779f431db07afe02cc9035ffc56ded"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0357fad58c0f61250"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0386f4bb96dd6da1d"
                         },
                         "ap-east-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-00a529b6ae174736c"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-08eec4129a9ad0b2a"
                         },
                         "ap-east-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-017ffdc350b9634fb"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-07b504ea14ad3a377"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-064e6bd8b9c270a9c"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-036734c058599a1a2"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0a145e12844599f2e"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-00aa9db1a187c588a"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-045ec222a164c2d0f"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-04e199114f2198496"
                         },
                         "ap-south-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0000c674b2a1a3db8"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0c0d26a53ed52bd75"
                         },
                         "ap-south-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0bbb9c4b9a37ac16d"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-07f31638ba1d6c2dc"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0eb9d3af6885c78f9"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0a43fd32160514a09"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0f51fd60037ab2c65"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0806be4451233213e"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0f84def88e7f22c3e"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-04e170df95b0d86be"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0acf1c1d4e695ccea"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0c3f72a54ff281c03"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-064ea145327d969cb"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-04acf3b895ccc48fd"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0ff6765c14c475e5f"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-02dd349742ff6edcd"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-018480dffe09e8f85"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-09a6c25c4bc381e10"
                         },
                         "ca-central-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-09bc15a7d6ad74ba5"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-06af6ce5cfd571daf"
                         },
                         "ca-west-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-005a5899d0a130591"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-049f084d5fc973014"
                         },
                         "eu-central-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0eab5a1376114963c"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-02c436c70f03977fa"
                         },
                         "eu-central-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-016af50d576020f02"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0a1203fb37f2289f5"
                         },
                         "eu-north-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-03048afff64706eae"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0252987c710ec7dd9"
                         },
                         "eu-south-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0c8dfab3492956745"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-074ccd223f345163e"
                         },
                         "eu-south-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0b60bc5f2089893be"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0d91bed08a6b8d811"
                         },
                         "eu-west-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-03144da1aaace7b14"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-07f2cce2e772ff539"
                         },
                         "eu-west-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-07427faf253fc359f"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0272ad798fe7f3dce"
                         },
                         "eu-west-3": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0ea3cbea7663a1242"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0ce4ecec83bb2ca70"
                         },
                         "il-central-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-087a23862339355ec"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-09cb152a3b016af4b"
                         },
                         "mx-central-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0bf72dcb6715c89f9"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-080e8ed812c066a48"
                         },
                         "sa-east-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-07384c26a17c48da5"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-097e57568b881f39f"
                         },
                         "us-east-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-096f70f94aabe3c52"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0f9a7616e5dbaaa2e"
                         },
                         "us-east-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0c5b8c0c992a4cbc7"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-02160cbc6b037eda7"
                         },
                         "us-west-1": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-0572ea68ab0eb346f"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-077a62f77f8702697"
                         },
                         "us-west-2": {
-                            "release": "44.20260720.3.1",
-                            "image": "ami-05ea538fb456d8aaa"
+                            "release": "44.20260802.3.1",
+                            "image": "ami-0b207fdae74fce08a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-44-20260720-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260802-3-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260720.3.1",
+                    "release": "44.20260802.3.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:a7b8ece6eec01ec240f9a5cfa2cf4e507e6e280f6c955d749dd4b45f25803148"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:03337713b0a652793b118fa4cdc154b26ab9ca95f9df3045100611e36632b0e8"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-08-14T14:44:44Z",
+        "last-modified": "2026-08-20T01:41:35Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ddd6ebe246364d8ce1c4b49dd8b678ed1b68a4095d68239bfcfc2c1f70b54817",
-                                "uncompressed-sha256": "eccbde89f3e322a5e2eae81c9748588d383ba4597f2ceee047ea9dc3d3b29cf5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-applehv.aarch64.raw.gz.sig",
+                                "sha256": "d3a1c9ab188d8cece68f325f0b0dcfd85502c616f7c2117693c5584a0ccdc38f",
+                                "uncompressed-sha256": "090cb6d1d641288955602fcb335505377c00dab0f8f96b74ddaaffbc4f087f96"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "3eac71834a432c7b3ffda90a94f70bd4f16760b57c6ff1e82e137233daacd8ce",
-                                "uncompressed-sha256": "367c6a9579b3f404d1691f1d5b062da34e6af06176e3e5e49ff0157fa38c637a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "b9cf14ccd72afe17679b7ed7c22e4e3090d7cb932614b5011b2b01d33a595c36",
+                                "uncompressed-sha256": "458eb5e577d1dfbdc8d299b6946123cbe28fbe748065151f7487cf38d38da648"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-azure.aarch64.vhd.xz.sig",
-                                "sha256": "55c79e9927cf81f7c3da6005f6db91f94b72d00c296c9854b7ec2fc83f4a096b",
-                                "uncompressed-sha256": "db849ef747153e070ce74984d68b3729b4de3c9bd5d27c773a4bcbbefdf4f171"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-azure.aarch64.vhd.xz.sig",
+                                "sha256": "c363ac670d627863527bd75a4a0343fd7b70e46adb021f3e9e2fb80e8f4b4d18",
+                                "uncompressed-sha256": "3c0a733aa2d794267aad16e7509d4084deb89a3c902c3d5f990f98c47bf19018"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-gcp.aarch64.tar.gz.sig",
-                                "sha256": "231ba7de76e5c3b8d33065f5c7b526900e16def44a30221334311cdb895fc914"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-gcp.aarch64.tar.gz.sig",
+                                "sha256": "17cc37768b8f1c922dea6bea11e84b8dcf174932622b2e8f621db661752b04bc"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "128c5405d5752b445613109d3792e1814df34130c1be13bb9e9f57203f40c787",
-                                "uncompressed-sha256": "e5afa9c5751544bc861b3af03fffe93e05284214c5df509e41dfd96df3006449"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "ebf163aecb75bba60f4daf26dd8b5703bef98b4c456f4c9400697b063e7ee1a3",
+                                "uncompressed-sha256": "4d2461ea99de43894fef31c4cf54f3a366221a3fc1d63061fff2bb3c65caf584"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "a11aa660f420419df6f287e31ab9b113249d837c2d0159a86304875c48644a9e",
-                                "uncompressed-sha256": "cada3f2ff8b642c27ccb04d62ff0e9ef18b71aca11737320b5916b3d2c73185f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "85e73347e7f3298b836ca7c6bdc69470ba3b92d18a568d623afd055ab52f9e28",
+                                "uncompressed-sha256": "b9a1ab7f83df30f1cc6a128effc3c147aff566f26bc30db7bfcca7fe8fc88ae8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "e9455bf1d536edfca0b35b134fed8d3e2645e669f2b0a90583885cf7d5d1edf2",
-                                "uncompressed-sha256": "f3e50a1f3711d8f162570166b2b405eaa08cd24403e05e57994f5d17dafb0843"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "b29edfbdfc9cc7af42c9644c8d1c0f6526966d4018c1dfd9864f17303b296b90",
+                                "uncompressed-sha256": "db23fb36694723c35efd7b3f6352e09dfe63d4d3a1a21108ef815a2c3c23ecd4"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-live-iso.aarch64.iso.sig",
-                                "sha256": "2bf56aaa42fa80748cb4299e95e8168fb199b44202f32bc3e09d2acf1957ff6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-iso.aarch64.iso.sig",
+                                "sha256": "e170e47fea31304daad40659a62de4a8881b348254bb2f92b5cf9a7206211309"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-live-kernel.aarch64.sig",
-                                "sha256": "1af1ed065a597365d1080c35d05953b83077331fc2e234e23569d39e8a012c06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-kernel.aarch64.sig",
+                                "sha256": "38cfc669810d30a2ba7cd128528a951b2a8eb2ac85250aea287d8142f76a0a59"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-live-initramfs.aarch64.img.sig",
-                                "sha256": "535ebb8849967cd1008ac758320e7f652aa44ada9e0a66b0bd8e59a13b90a303"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-initramfs.aarch64.img.sig",
+                                "sha256": "e63cace202a7c33da6207af384af38932613c80cd2e145852b28267c791485b6"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-live-rootfs.aarch64.img.sig",
-                                "sha256": "01ec16c6ca8e9623c3a45c9e213b24e32b805bc485ccb11d8fcda4c2d16928bf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-rootfs.aarch64.img.sig",
+                                "sha256": "94051660dde8bf9760f7e6b1eef1686956f78c9ee3ac5a706d124ca8864a98fc"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-metal.aarch64.raw.xz.sig",
-                                "sha256": "514d29c3561dfe9a008397c0e02e9817dec1821a8bb012863ef5cbc1ab2a8b18",
-                                "uncompressed-sha256": "b51509ba9d9a1734134f7dc5674753bf341be849193299c7ffcf4ef5a552e739"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-metal.aarch64.raw.xz.sig",
+                                "sha256": "65dd3cb231c0f082e480ac3e1b6b265fdf8440420bedb8ef6e2885fca8233e32",
+                                "uncompressed-sha256": "a7680f08931cfe75fc51ccf0264808cc28fa8993a003c59d757b9aed124c634d"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "1159a72bfba16078b8f90c6e4a2f092bf3a33a80f59b2d5b0b0b1b6a319f8c55",
-                                "uncompressed-sha256": "eff42446abd09551d9e4a5cfc3c23f712d496951a20b82cf0f090df3dd15ecb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "8b969a4b13aad455c2244f4ba960818cbfc8aec8dd0984a5151ab551f10d52b9",
+                                "uncompressed-sha256": "fdb04c99dbd2915b498e1f992842ca66fb8976d8fa066269c92ee4de17da0135"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "6d4a81837d203177a2e159d2a63e217a7d0bc2d40ea866fdb4031aedc50c71c4",
-                                "uncompressed-sha256": "b2b8c014b924d912cbbbf94a6c611b3c9f78eab4559f3b0a19c571cc36493e69"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "519ef5a4ce488b882bd3ccf1f55ed570385790040d0508455ccd3cf9ab19e6dd",
+                                "uncompressed-sha256": "0a179f7817b63d349de152160a4889cf686efb8b798014dd30c9195bfca57f40"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/aarch64/fedora-coreos-44.20260802.2.2-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "32655468158ec8c90a8869057e2f3ee1718e6342bd2ec45a1e698d8e07d91af7",
-                                "uncompressed-sha256": "586760be5872ed6ee071da0f205aa112cbdb327bbc3b8e28cd46456d34ed6bc6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "03bf08f0b1b33262ecf141c7e899eda0cd3b3bb8e5dc2ba7e3cf7000e150a959",
+                                "uncompressed-sha256": "a0b167cb379ba187cb6ed1afe553b0a016094d2241cdb94bdd872243c59fcf62"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-02f5c2ea87f6b9727"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0792ce237298fd4d0"
                         },
                         "ap-east-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-016692dc5cbe25565"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-07ff3d2b548b2e913"
                         },
                         "ap-east-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-07616d80b3e189c0f"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-06443828849bac3c3"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-027c33dddabf82274"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-096afff43415031e8"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0538ade01101b78b6"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-02493fc531c7b4625"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-04c29aa370f50aec8"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-01daf4fe4737fc77a"
                         },
                         "ap-south-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-02ae659d612a12056"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-08adc7c2aef31fcae"
                         },
                         "ap-south-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-020b4384d884bb91c"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-042c3303fabaaa824"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0b33b8362fef122e4"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0dce2147222abffaa"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0ac43e576a38c76bd"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0b2515d55c1aa3dde"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0277e67d45beb9751"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-095310f66260b3916"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-00f09095290b383e6"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0e9a6a3236ac1f60e"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-06f1b30d894ee97f8"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-080ff72fbafefb63d"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-039bee89a1f3f9aad"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0c42d0d3a303964ad"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0fc3b692bd8b9b7f5"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0374c3f52de95c5ad"
                         },
                         "ca-central-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-03c13e9c8557b9a88"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-01c40806c3258934a"
                         },
                         "ca-west-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0ae358387a537007d"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-05f9eb3eeb1062249"
                         },
                         "eu-central-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-01e2af4870156c19b"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-04d6013de86a33059"
                         },
                         "eu-central-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0963e3eff9e3f8f9e"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-01aa7afcd052002a8"
                         },
                         "eu-north-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-04a2fa4635c6417de"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0b0a96de44aab30cc"
                         },
                         "eu-south-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0b3731da4e2a16944"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0f5741d22ffd0d82b"
                         },
                         "eu-south-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0fedf7ef6834ec64e"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-011252dfb467f9884"
                         },
                         "eu-west-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0711c654c3bc78bdf"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-03339a61673d4bc19"
                         },
                         "eu-west-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-089b4ca2493d073b0"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0ccbd78b0b171bf8e"
                         },
                         "eu-west-3": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0415964112489233c"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0fdfedd69a712f7c9"
                         },
                         "il-central-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-015e7eb509b4618a7"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-00b13e53e744b3038"
                         },
                         "mx-central-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-09274b0c69d405bc3"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-078a884b69074f6c8"
                         },
                         "sa-east-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0ebe0d33cb67445aa"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0a5c7babe12acc10a"
                         },
                         "us-east-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-068775f3216c4c5d8"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0432add86c70f8f16"
                         },
                         "us-east-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0e900871db93bd1b1"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0c78120c91d0c0541"
                         },
                         "us-west-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-04761f79909cb57bc"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0541a32bd74223281"
                         },
                         "us-west-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-06e320d58244ca4de"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0d2036c62433a97d0"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-44-20260802-2-2-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260817-2-1-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "b28753d74d0576566586e45e9be0663ff00f49fe59bd813ace61db49a67a282b",
-                                "uncompressed-sha256": "f47bbf3b781797fea902ea80247961097a5538ca3f60fd631d1b118142a6e160"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "089b4e452bd5fc7b1b9f3722b822b3b5b1079086dd91cd94b4884434470f7429",
+                                "uncompressed-sha256": "764cc8254e037ca4ef30f3815043a8f97c63733ef8cb375e34a6d3177c8d9ab5"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-live-iso.ppc64le.iso.sig",
-                                "sha256": "f189f7c42daee2f16d96bd1129c9f8d369edd8f1cb94a4f62523483d4c73ab6c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-iso.ppc64le.iso.sig",
+                                "sha256": "44427243ea5a8591d2e8eaf7b70abe9748c1e8813feb86929171c2736bfd570c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-live-kernel.ppc64le.sig",
-                                "sha256": "09dadc4490e6b9ede833a3d0da8d7a115451206263ce5f96b806ff29b8ebda56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-kernel.ppc64le.sig",
+                                "sha256": "d040287f7c8325e3e1748fccaf32c096c4c335009eeae18968d65875634729b1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-live-initramfs.ppc64le.img.sig",
-                                "sha256": "670638cedc8a1e26e88e476b7ff344198d4f3a48ad8bd1aad36447c1a6074566"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-initramfs.ppc64le.img.sig",
+                                "sha256": "60e628bf08a5793c351640bd04da9657219fc1af816372d44d9a33bfae18160f"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-live-rootfs.ppc64le.img.sig",
-                                "sha256": "1f8b753f8abd9af5f022b1c449b024472470dd7620f23b226863bcd0c2ceb50f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-rootfs.ppc64le.img.sig",
+                                "sha256": "e7d79c86af139d3b760f062773983d608ff9bae45b0004f1f912f6cef714ca84"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-metal.ppc64le.raw.xz.sig",
-                                "sha256": "b3afb8180e895caf7dd62f121aecf0484849d02505124355e2d01deb503993c3",
-                                "uncompressed-sha256": "b3f2c27246fef78d79bbcd9814f2284dc8852f6f411a54529d7bfdcb98d59ae9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-metal.ppc64le.raw.xz.sig",
+                                "sha256": "5a071d2dedf78c5bf9635fbcb170a9f511a71f386df129b1ab01290077b0e1f1",
+                                "uncompressed-sha256": "ed807e6821a5784767536be12d02492bf2b1df9c67bd440f3de13d6d9a8398a2"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "b530fbd4d2c0b545aa7b04a0378fc2605ccb66e8e075bf722ec842b8e8dda9fb",
-                                "uncompressed-sha256": "54b400c97605160c1116094678228f4ac23de085b6e865a671e13bc31e8a4e62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "0d8e5d7bf0585cfe9015d18e046866b774f83aae2de8a5c862db91776aa43bf9",
+                                "uncompressed-sha256": "a17559ae7a2e57405f39de037477e15a5df76939b06e9713e6e34e317c5890ea"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "d72cd83a5894bacf5e8e98c028b2192975204e2b34e8c665bd7f4c429610d0b9",
-                                "uncompressed-sha256": "dc8fb3192b8258f86903d98b28c14025a91ad8328706a68bc594039bac06cd3c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "99590919fd3a47466d7d5b4703f05bbfe550970c8cd494cf55fe38b1641f2d40",
+                                "uncompressed-sha256": "21b9021535eb33501fe960dc4b13b35ec143f8144a0c10beef19f8c9a882f676"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/ppc64le/fedora-coreos-44.20260802.2.2-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "54c2f398a247309a4cbd1cf4492958bf73847540f22d51628d6c78d41b670ff8",
-                                "uncompressed-sha256": "73f3c5590d504624ae777b3b4dea85fe090e08e738832719821ea8afbab9f3f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "d6de8bbf4a502a3699913c29ddb464664b585ce07dff37f0de3e20f994bb6ba4",
+                                "uncompressed-sha256": "059b8aaeb7e644de2420477117193e87b90f0a60f0e5cd4737a57947cf813925"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "2ef751ee2a59f211f9e87d0179eeaef3f9c273e6681d2a864c0d246aff3ae035",
-                                "uncompressed-sha256": "562c22978f1cd71be1b253bb557527cf937a1b3aca2f0b1f8507ab763b1c867b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "818f35adbaf483a99360fd8f5497e967764cf8557cc2b09f653cb33ae4240e5f",
+                                "uncompressed-sha256": "36211f5449b3d430bbd9c6c781dbb351d9fe586cbeb282458715eed822dc0a37"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "250088b9f1add905a60637dcadcc29f9ba6aa5505b2455c60c449ab46711f885"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "24194a5da4569a4c85fbd401f2ac26c6ccd972bea1dd11ed52700cb5b07be88d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-metal4k.s390x.raw.xz.sig",
-                                "sha256": "1e6fcf7ad9c726e689235e0f49c29977b30197bc9e635c990ba15e09dbb79172",
-                                "uncompressed-sha256": "6a73ce928ef74affe9c79bed3a37d546f8276dae30302cf36b0c044387611319"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-metal4k.s390x.raw.xz.sig",
+                                "sha256": "b33f7b2a4af7f69bc51276544d7997ded049157395dc6ddab02143df10ad3f33",
+                                "uncompressed-sha256": "7ac11d20ba3b85c0f5be56bbfe32f691363ba84353f377e33c9d3be2a8629767"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-live-iso.s390x.iso.sig",
-                                "sha256": "207391b2e929b078241108898d7d6dfba24f1a4172e4660541d211013f05ea5a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-iso.s390x.iso.sig",
+                                "sha256": "15bc20f041b917fdfa1776c0e7069ccc6f7b7dc376f5722deddfc87ad056c53d"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-live-kernel.s390x.sig",
-                                "sha256": "c0aee0247d19b020a37974faa1ca34ec3cf027028f0661a0cc63ea816f62c86c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-kernel.s390x.sig",
+                                "sha256": "5a7f0e6c3d16fc5fafdb858a22ee59464a8358adb247c106fcd030606e7fd0b5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-live-initramfs.s390x.img.sig",
-                                "sha256": "c92a6d652f98d84d4aa692e2dcb17215f4dcc4e54fa0a435201fbb4854e7592b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-initramfs.s390x.img.sig",
+                                "sha256": "62fae4ed51878f2dc88afe39ffde58e8b0b1784cabdeb84ebfc3a3bfa81c705e"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-live-rootfs.s390x.img.sig",
-                                "sha256": "356463c7946817947ca76bd9730f0c426b9f88caaf67efe6a3ebfe34e4c3b7b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-rootfs.s390x.img.sig",
+                                "sha256": "33c65989b70b97a41e13f07c7c76aabb34dcea15af914f38e883b69d6c87990e"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-metal.s390x.raw.xz.sig",
-                                "sha256": "b477ef31d8128a0210ec1c47747d6a36558b75eaa1af5253450763eb84db8cb6",
-                                "uncompressed-sha256": "96ec0f333f6c2e7dc2d92f6d8cfda40d8bd33544a4effb3768905c9568a47ad3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-metal.s390x.raw.xz.sig",
+                                "sha256": "3eee2959a7a75326dadfa0989e0f4ce7fa8af90536fe3ac09a6c8d3a2590436a",
+                                "uncompressed-sha256": "5d863261f7d723510bf7e5dd6165957c253ef2b792b4de07845157c0e99e2ceb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "8bcc21425fd9a879ce30ea02328c03517513976a64479c509ef3a9daf5bb1d08",
-                                "uncompressed-sha256": "0cddb875d0d97853ea19419bb2d7755e44527169352d76c5338b038a135d602d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ebc33c783c653cbc4f6cf8b69f300f322fd132fcb952b090c40e87dfcfb0bebe",
+                                "uncompressed-sha256": "16dd2f551c5973b0e892fb6eaa22a4687956316642f3603855dcb2821ad25431"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/s390x/fedora-coreos-44.20260802.2.2-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "b4f686d90e36298ebc11460f113f8d34c2106b7251d6ef4dd4c353d04f3e96d1",
-                                "uncompressed-sha256": "50647ea9c492d679faf91d40bdaedf9132cd2bd82b362385ff77e64a0c4c8e58"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "eeaf772c6e670e7847ab1d762e354c69464e168cea031679bf88c6e58ebe341c",
+                                "uncompressed-sha256": "0e0a422fa0b3371749c26a4a231619c1bb0e09c88f596622468890b8e0a4c4e3"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5dee683b7850b32a56ec64860cd4c989d30f74214c710d3e87f0484a4f2fa5b2"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:007d63a16877ed1e8e9752cfa43accf27f51e4bd4300d7873f7533d534ceac56"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "23a1fd24285b3de19a3c8d0e4b7fd671a0bf56a8e5aef32d55dae9194dd6e74d",
-                                "uncompressed-sha256": "244837c26bdf6cd2fb7f6818570e95de6e69f99087ae08ac3704c3691e68f662"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "9422a1cb2383da2e18e670771db8bc5b9044f6110da0afbb6f1468261e59a6af",
+                                "uncompressed-sha256": "759609e7bf383f484446f0df22b38cfa8f4471b9f36aa079252528d907362c43"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-applehv.x86_64.raw.gz.sig",
-                                "sha256": "78b9ce16366db8f8409e71fac1b6a0b20d14d931494ddc8122cf083dd389e54a",
-                                "uncompressed-sha256": "4aa849bd80b0df9177dfabea68e15d0bdb2326047467d804dac6403d380d6e04"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-applehv.x86_64.raw.gz.sig",
+                                "sha256": "a5b4e365ec01a367a2180e1773ba2a1db91cc6ac041cb96d430a7060d7ae9adb",
+                                "uncompressed-sha256": "9d966038098e1388c57e6f09dfb43d455df8b76aaca51bd5f927916caed24c15"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "54457d2d925fcbbfe702f4347af05a4e6d87b1379ad39345a1f1d650d3009d2b",
-                                "uncompressed-sha256": "34bfad9eaf7da0f02afaad3a330ed8e0f1aa9489ff50a1b0e5ae23b4c66d3ee8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "a968e87d036784a711d7cdd004b4222163574319a6e822b2210833bdce6b644c",
+                                "uncompressed-sha256": "4f3456a467737d192a1fe1ffc35fb8a2f8b803161cb2e0cdf85b92fd47bc1827"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-azure.x86_64.vhd.xz.sig",
-                                "sha256": "fde0b86d594ebd0364bed1b94eaf87cdab60ec8ac5f618e53020182347196f15",
-                                "uncompressed-sha256": "2cb017d653a6141665e7579e52e5fdbad23302feb16c1bd5d124eddd3389e6b2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-azure.x86_64.vhd.xz.sig",
+                                "sha256": "a860689d014ecb6a9c199af1b1efd712d82496394273a5554b55eb714d1f7655",
+                                "uncompressed-sha256": "71e481f7394b4c793ab67c0f532bbcaa8966fd7dfafcf0e8f32a309528808132"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "43dc36626f0de726976afb2e934be58cb59e980db68545e8398cb72db3a4a9e9",
-                                "uncompressed-sha256": "bd58a82df6466d2d96277fab97cc3f0d8b9ec61c75ec8cfa5bdbc913371b4250"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "68e6b8407d6ddacac94a4e924d56895d9ae1a4f411a1a8a111ba4b0c92d157a9",
+                                "uncompressed-sha256": "0867137d91ccca3c0a7b08ab1c0267c48f172c6156a98f2f3de0efad5c2cd7e5"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "034d4d49de7df1f37acf7f29ba6e5421f1277babd15233edeff117a4bc05a530",
-                                "uncompressed-sha256": "23adadd242628985a5a40f3a94de68c66a135d54d5e7b7617f4319a0a89ad4ba"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "027e0712672b5dc05c2439d3b418569c2a22dc5d1b67752f4d65bd9011cbb77a",
+                                "uncompressed-sha256": "b6ba0c495090c30988a63f19831e8a3c681dfc17d7faf9f93d98420b0da21bd7"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "ce6f6cf6f3d7538c9b0514fee4948b5a25958ed9a4b8d07b564cce64243b6fec",
-                                "uncompressed-sha256": "55aa4fe6d58dec9a063a2fa4f96196871c620cc3a67bb7b60ce8132813872de5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "042df31b35746757e42a252e4b32018b1ac8050813856c61ee94ac6936341c3e",
+                                "uncompressed-sha256": "368c528bf551bbcb154069551f22a90233d23b700fd27d5de86d87ac1b2c6367"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-gcp.x86_64.tar.gz.sig",
-                                "sha256": "0307aea4dc5074b257e08994f9d8f327f07915cbdc4a25f44fcadd0d82f92f8a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-gcp.x86_64.tar.gz.sig",
+                                "sha256": "b0925d65f8bf9877d0fc85fff5e6e999a4ddf80c93caea885bc19c42a40a9df8"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "81d17340e471c9a046e0bb087ab0888ab0ec537435531ea83b276d636957eca7",
-                                "uncompressed-sha256": "e59aa227f2cbf1cefe3183312138925ec156bb8ca039c0cf2488db4a29de3f00"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "7e6df9d974118cba61afa00cd1260f92464c8bd19ef1cb927eb35f5ae54ac2f0",
+                                "uncompressed-sha256": "584bb00c02822b41981929b82aec5dd049c5eef1c5a748b5ee40447a5fb3b077"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "68caf666d1e27709a90027ada947cc5b38d23ea273e04de7d8bc207b6b8c5507",
-                                "uncompressed-sha256": "94e59e15e4431bdee6146222922683dcd3b9d9126816a4b9252e35386402b900"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "186149706c100194d87d041fe24420a6e30af3b2ea56a7bc493e435578078f03",
+                                "uncompressed-sha256": "65432a9aa2a1fae11cf8928552e862adb2ddcbccd3ff17fdb975ccfdb828d584"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "967261186fc0ca431e441347f3f53829a5b4a8b94d706fe5713413fdba5fabc1",
-                                "uncompressed-sha256": "36f903dc333d911bd5c32d0b5a955dc49f19228f6d6e67ed3bf36461b106e9d5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "601186762cb67b18dc5084d97fb0a40743ef6989cdd36160b277c1b34e4ce94e",
+                                "uncompressed-sha256": "7c36834019b26a6f7052b19796a48c91f0080f8727d71277753da228a83c2ab9"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "c38b2be00113948cb6acfe4dabc4fd9d449069e4017e21d81d8bb85c882f8461"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "bd33b990deaa9d007c60c2f0ce01dc4179bded3bcfe479dfd69081b1cece2ef2"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "ab7b0de558dbb61b5c67893592eff978bcb4c381d90b6f8a033f91adfc4823d4",
-                                "uncompressed-sha256": "821902ccdd7dd12c21cd65592e8a4d1c22a1c610b855621d28b7f4f4b9c6ca8e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "9e0d88a2df7f760f1c595edec4d72e1a0fa13f3537851978fd35ecf12b205841",
+                                "uncompressed-sha256": "c315b47b1c9f49d0bfb5601276e389a478a5ad444bacbd0b7159c16b2321f1c3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-live-iso.x86_64.iso.sig",
-                                "sha256": "af6f7881ad25cb5767e8e891c0c386ade46204f4f5dc3e3493a8522ba47b3dd9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-iso.x86_64.iso.sig",
+                                "sha256": "e91cb59baad9d02bbc02bc1fb052857cf0fc9dcfbdca0465a2903108bec67e26"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-live-kernel.x86_64.sig",
-                                "sha256": "c4a37455613da305d6f23bd9b588f2242a253eb0ff1a4169637fa835a458eeb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-kernel.x86_64.sig",
+                                "sha256": "5b97afb0ac5efce78b37184b8a305275800f0244281383457c01dacd5ffb07ff"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-live-initramfs.x86_64.img.sig",
-                                "sha256": "02d56dde0e747a32c54a3e592bba8ba41ed73b9095addb0dedcf1a9a44588a0e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-initramfs.x86_64.img.sig",
+                                "sha256": "fb8b1be693170f59cfe89b4076b02e9d74324a121c6c8da4d9ed9d16f830caa4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-live-rootfs.x86_64.img.sig",
-                                "sha256": "fb507374eeeb714e10cf99da06380b31e8f50335cb7c0091aeb2b34daad63ec9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-rootfs.x86_64.img.sig",
+                                "sha256": "af194638f614c8e6f50a636a1cc4c6b67c68e2435863f78f588aa382ecc1fc26"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-metal.x86_64.raw.xz.sig",
-                                "sha256": "ee5921d76d8f78828f1a9ae56f99e340f2076e831643ce9f64b2fc2d640ba99b",
-                                "uncompressed-sha256": "9ac0c15a6d819356e1d41f99d00458e3a0857c046a505993f5b6931d7e458249"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-metal.x86_64.raw.xz.sig",
+                                "sha256": "c163f13634493e7742f4d19ce065b7cfc3b2c9f3d62a6e8cd5cf6f90913b0570",
+                                "uncompressed-sha256": "f159daeace66d71daf5b6abaa4f3896ea98daae9a3ef56035ea98638f8e91eb6"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-nutanix.x86_64.qcow2.sig",
-                                "sha256": "e1870a807f2b61b90ae970ad8ca66f5ff627b7a3079ac573e1092b3a6bbc6505"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-nutanix.x86_64.qcow2.sig",
+                                "sha256": "ef60e7d651823609bda279f8eecd572f6a121365712d94127d221348d21fbfad"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "5fa11406b0f9d2085e3070d08d4c6a4a095a1473229e95313ad0565264d71c2f",
-                                "uncompressed-sha256": "044ae9b9dadbfcdbf30447811c8c2e03a253a89a549edc16c3f85945704ce6b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "8b4eed70567e58297cfbc4f5ecbdc7969c47bab454cdf8f866733df886e1c413",
+                                "uncompressed-sha256": "a94d6d7596fa63a9d44c091045bb6489fb6b5f4673845bcc1c2c5e92b0bdd954"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "c5722812f28a2fc123469c81b0f721cb3dfc8a85952fe243fa810de7cd08652b",
-                                "uncompressed-sha256": "0a2ca75120c06857351a1ab314125c1a04b0f043735e86bb4e38ca8870ee652b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "3119be93a35304f35b71b8d332b3bb8592f368d92d0e039d6f783b6273988a5e",
+                                "uncompressed-sha256": "8c6470e04a0afd9bfffcab9ffa90e658d914ce22f8c12198390efb27833ff99f"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "6b31fd8967ccb3ac3274a2634d707551761fafa677afbdb70e30661907d93ee1",
-                                "uncompressed-sha256": "14f7c51f037847778a1fa906dae31766e95e299f50a25a0ecd517ecabb8d1bc3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "7f5742fbbfd702b58141fe93ca04484fd1f958e92e6e6668eb80808eafd9f7f6",
+                                "uncompressed-sha256": "97068e70b1669c1c84ea0af3db43b4d20458043b32ae24869606e1a3f10d77f6"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "13534de58fa2fb2edfb25a9baa2740098e1b8d1a94d53fa9c8cf5816527d15ab",
-                                "uncompressed-sha256": "a584057356fcde6ac2dccf24b18629e75dc0462b4ff830928c1143d19986e6be"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9cef0118200719a396bb029c9500e0f3080f7c8d1a2f3e3093b77905fbda4d53",
+                                "uncompressed-sha256": "90b5aaa9da38e32f9d6c9cc70136456a7c5dd15344fde01c86df78b4a414bac4"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-virtualbox.x86_64.ova.sig",
-                                "sha256": "a59acd0952ad843f9de2c6802519f3297d52d4a3868d8bb5db86c971a3dc625f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-virtualbox.x86_64.ova.sig",
+                                "sha256": "98c0319f680de269e5a13f9196bf65a2ebf5d059c65ee7180f913b60a6f73983"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-vmware.x86_64.ova.sig",
-                                "sha256": "924fd8a7cd8905ee29847f94fd4fe7644e5b9cbbd295bd4cc3d9dff0de215847"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-vmware.x86_64.ova.sig",
+                                "sha256": "db276e84ad072873a757f97e7ba0aff14cda4a46d2e9d7daa09908d9d85efaed"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260802.2.2/x86_64/fedora-coreos-44.20260802.2.2-vultr.x86_64.raw.xz.sig",
-                                "sha256": "f9a39c11a472f4f8104caaee4f7c5af019ee54d4006600e5f48ecd1d0a50a83d",
-                                "uncompressed-sha256": "eb59b99c31da36cb58b3febb6c152bd6b22be1130cd9c4f2d954c0b873a0f035"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ebeb80b8fc58fb310532261edd962f67db1b8f5669134aaa49891e9a3ebd08d0",
+                                "uncompressed-sha256": "3d0b217a98fd1efbff4c56f34eb07fe150f90b7143bb08cd92c9a83044fe06ab"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0388151fc7e90dcfe"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0f7176ebf7595adec"
                         },
                         "ap-east-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-03cb262b50d160bed"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-09932437544fd35c3"
                         },
                         "ap-east-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0112249f5f31d3d63"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0f74831af21da2bb2"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0286583a7f0d72ff1"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0495d14c4bcb11cee"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0472708d86471ac64"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0042f0003559cd211"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-07dd6cc6f40a79ba2"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0ae95790026307391"
                         },
                         "ap-south-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0d8ed29ee11f2238d"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-048e519bedc7689a4"
                         },
                         "ap-south-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0344e468cd07e8969"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0cc7f6b1712007647"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0305767856b8e6491"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0e28ba59effc62bcd"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-041dfa0510862810a"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0de599ff5b4ccc7cd"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-08f427cc7767df1cb"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-02d8969131b64c2f7"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-04936bc3ecbc0747a"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-05f931483affd9bf0"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0e72a7992fbbafbe3"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0e5424b3d02794427"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-071287bd141ab08b2"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-05da7700765fd451b"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-03abbaba5d84352df"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0bde77b9ad29e5458"
                         },
                         "ca-central-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-03f0a9b9c6a24c753"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-02d3eecc39da73f35"
                         },
                         "ca-west-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0f5b8a2395da802b1"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-08591588817d721ef"
                         },
                         "eu-central-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0a400fccef29736f0"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0555828e480888f3f"
                         },
                         "eu-central-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-04141d6bd7b06dd09"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0acaf111cc0b91280"
                         },
                         "eu-north-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-027847962f0c40ac3"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0f8fbb7dfe236b6e6"
                         },
                         "eu-south-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0ce236ec015580ab7"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-08d0294cb534278fa"
                         },
                         "eu-south-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0d681677e283f32cd"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-02fc92c0dfe137842"
                         },
                         "eu-west-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0f15d87941ecd1668"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0ad187f0890161c6d"
                         },
                         "eu-west-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-00626f4f6c2bff7e9"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0d8b5b95277395f90"
                         },
                         "eu-west-3": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0f456beb6b65974a5"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-08a71b2da650cebeb"
                         },
                         "il-central-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-07640c35464985e5c"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0f0d58b53c2992b19"
                         },
                         "mx-central-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-04db5690358b7fe7c"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0e89f325bdc2170fc"
                         },
                         "sa-east-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0afae35616fcf3fa5"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-05e47c73c830ed023"
                         },
                         "us-east-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0ecf53ed460e0b55c"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-04539e5ac1c3fda4b"
                         },
                         "us-east-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-09a353ce2481c79b5"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0d16ac83e3910b43c"
                         },
                         "us-west-1": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-0641d66ba3b2a6836"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-05c33bdf62f5bd404"
                         },
                         "us-west-2": {
-                            "release": "44.20260802.2.2",
-                            "image": "ami-015176a8f9f75138b"
+                            "release": "44.20260817.2.1",
+                            "image": "ami-0bf25dcda76dc0679"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-44-20260802-2-2-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260817-2-1-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260802.2.2",
+                    "release": "44.20260817.2.1",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:370df78287d8439364c29cbc65a3cd0f8287c3902e21b6279f38f3454dafd341"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5a4f92aab84a921a50a0aa0fcb12be53314d3f9b9cf419ed5b6f5584a4f4db49"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-08-14T14:44:46Z"
+    "last-modified": "2026-08-20T01:41:38Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260802.1.1",
+      "version": "44.20260802.1.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260802.1.2",
+      "version": "44.20260817.1.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1786719600,
+          "duration_minutes": 2880,
+          "start_epoch": 1787320800,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-08-05T07:18:02Z"
+    "last-modified": "2026-08-20T01:41:34Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260707.3.1",
+      "version": "44.20260720.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260720.3.1",
+      "version": "44.20260802.3.1",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1785945600,
+          "start_epoch": 1787320800,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-08-14T14:44:45Z"
+    "last-modified": "2026-08-20T01:41:36Z"
   },
   "releases": [
     {
@@ -173,7 +173,7 @@
       }
     },
     {
-      "version": "44.20260802.2.1",
+      "version": "44.20260802.2.2",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -181,11 +181,11 @@
       }
     },
     {
-      "version": "44.20260802.2.2",
+      "version": "44.20260817.2.1",
       "metadata": {
         "rollout": {
-          "duration_minutes": 1440,
-          "start_epoch": 1786719600,
+          "duration_minutes": 2880,
+          "start_epoch": 1787320800,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @aaradhak via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).