### PR TITLE
Roll out stable 44.20260817.3.2, testing 44.20260829.2.2, next 44.20260830.1.2

### DIFF
--- a/streams/next.json
+++ b/streams/next.json
@@ -1,169 +1,169 @@
 {
     "stream": "next",
     "metadata": {
-        "last-modified": "2026-08-20T01:41:37Z",
+        "last-modified": "2026-09-04T18:44:24Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "ebe509b9cec17816ece0ca990aa79a59c1f61b13a16eae671a832e64021a4254",
-                                "uncompressed-sha256": "e684f3cfb292c3505cec2fd119e42b190a3e129f6ada2e022f4c1eeee279bf48"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-applehv.aarch64.raw.gz.sig",
+                                "sha256": "bc63461dc4fef5c7d0fbf557bbf8636029f6ab484850f12af8a3b0116f9056e7",
+                                "uncompressed-sha256": "eb7cf37e3df00cd67650cfe52f37f22f46b3944b41a9f8a2aa2c1870020fd0b3"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "5052a45d96e5aeb475e561517272d93968663a9a4f3289f4d194b4ef105af3d9",
-                                "uncompressed-sha256": "9f7d85e4dd1dcd8c501525f5588417349a4db0fe09625b52b560c9016a8d9ca7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "6a11417c1c2fde9e0aebb422fef0fd400fb8373533f26da7ad4d3ffb2a19e80b",
+                                "uncompressed-sha256": "c1854c01824d4fb190f58214e4bb933c8ae72683151787cefc72027aaf4816e7"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "a772e4e18b03fe6cb33c686fb143e3399d21d01582c81132695be885ad5c86e5",
-                                "uncompressed-sha256": "12ce462861c7fec28413d4ddd010f1c8665dc89524080f48db75e7a65f86d2ca"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-azure.aarch64.vhd.xz.sig",
+                                "sha256": "4cdf8a1f2be8f438cb7a7ea2ca2a517bbe485b80e518d7ab910de4c06cdf91b5",
+                                "uncompressed-sha256": "47929a9a578fe1f757cc6f529fbeaff16227636a6b018bb387b2095bd80031c4"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "55843907f757932ca245a9e8430118ac094177692d2c4bcc5818be41ebfaad01"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-gcp.aarch64.tar.gz.sig",
+                                "sha256": "2673372b5d041326b00a16731bc3502965030cd9bda5aaa34719998a63750799"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "ddfa5431e6ec9dbedddaf6e61499d72a72dc6a30f008ae6465fbbd64842d2c3f",
-                                "uncompressed-sha256": "479c2772e013c7af6612c63b93862a9522feb4822061f84366bf0fe0aa6b5ff2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "db595a28c162a50e3f979ffd3b8d6321f90443e50c4a8bc7ab3137696b7de5db",
+                                "uncompressed-sha256": "19164197287d09a656184c42a7e91700cddc790fd64170e71e765b0d67278336"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "3b533ac84b10b10338d842f5ac2a832b6052048c989025d985230a4329edd4c4",
-                                "uncompressed-sha256": "387ce58e101de5a8d5afb29bee2a94d3901319d70528924c8d1d69d32178512e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "50c7fc7ef7c3b33ca25c77afd424243b0ccba0317998f7188a975fe36b73d7ac",
+                                "uncompressed-sha256": "be662225654603c79291221505cf3df7f70f29d820fc2fcd5aebc4d2aebf911d"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "b97e10f955ae57e459c8f6be5228f26949040f36393bbb178b6e4614827df3a1",
-                                "uncompressed-sha256": "dbb6b59e048b84d68c8c7f69aae4c26e86f5c781e49bef8d90d8af81fe7802a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "287c97e411fbf608155895bb149aadde80e974d748f2fcefb9917892cbdfedab",
+                                "uncompressed-sha256": "392765614248b4de3f104d9535fcdc05b63d551a9fde8a96fd500953a6b347ec"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-iso.aarch64.iso.sig",
-                                "sha256": "2c1a75618949f2e6d658398ad72869009908396024c3ca633789da37c0f6176f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-live-iso.aarch64.iso.sig",
+                                "sha256": "c4930fa5977a7094b193a20943d57874d743b25cedc6f754bb86eb48d49e1250"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-kernel.aarch64.sig",
-                                "sha256": "38cfc669810d30a2ba7cd128528a951b2a8eb2ac85250aea287d8142f76a0a59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-live-kernel.aarch64.sig",
+                                "sha256": "b48aaa4e2d2303a4801933eb6442463ff458c9265157d04979f8c890141348d0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "e8d14efb4c2e6b08563bdecaa1fbf7a36d830f36db2183dadaf31d8516d6b6ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "8e37e433b21c75a0b7ef8308694728daad14146b4562c83236341189004f4316"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "760be8c47658e2e59e592b353b2d2c34c154ae75e44c307aa1091e4ee423e9ef"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "f74f959d1bcec7e24fe86afe0a8ca10d45246167a30fc98c1020b084fe9d80a8"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "e8e299ad5da058e9769d282376bfe07587989a48f4f0f3ece073861064d2e7b3",
-                                "uncompressed-sha256": "b5b462a9206a2583ced5c8dfa181321a3dbca6943fe5d26940830acf469c3ed5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "4665b24ddf67f97b9248898d23196020ebf94c8a4d9dfb3f79e9b6c708d1c3a3",
+                                "uncompressed-sha256": "942178710b23bc31af9a172d6773ed1f074dd03910ccedffc7acde9d5afc8ae0"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "4b1d50fc0ddbb6c8fb329d5d96eb1bd506b001df000dcdc6afa00b6f6ac18d0f",
-                                "uncompressed-sha256": "08ecc363fe4d213b1addf9f454b747e198584a882210d960ff7331b767b673d7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "b2ac984ce931a793b5d7c9ea3727d27fd4e3e3d26e5fb046aefa8822d761a962",
+                                "uncompressed-sha256": "c04ff96dbcc532c977c840bc1680b00a8df9c94251bf4ade713ce72b7b839c51"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "234ec7021d0ec151035e2e8502b75cf265204db40f1e6ac0c59956cecec52557",
-                                "uncompressed-sha256": "090f85ab5dea60f42391cb5051d8bdbecbd920d9d082bf7ed17a575a3af9025a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "ba2239cd4078ef588fc02235e275bdd6795db29de65f768b8552d243c791f055",
+                                "uncompressed-sha256": "3a150264f08c59e899387ae7897154dda5f0cb97bad7493148ff03ed90614eb4"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/aarch64/fedora-coreos-44.20260817.1.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "a2fa4b200378ef953ef0e1f5b14a9a679a21299eded37dc861962dee7fcd2bec",
-                                "uncompressed-sha256": "9fe41ea64db0491469b192efd538b2c96cde04b740ef5a6a8c83ea3d0a34ad89"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/aarch64/fedora-coreos-44.20260830.1.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "4a335f0fb6f2602bc7b3bf5767f55b900a4a9cecfce840646844f5c505f0f78c",
+                                "uncompressed-sha256": "6cf75bdea97960d330877b8a5a52101b587631dee15a50dbcc6585c830c61143"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0db556cdeb8e5d056"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-019347d47e48d35a4"
                         },
                         "ap-east-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0141b8d80296a98b5"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-00746cfac9a5eb81d"
                         },
                         "ap-east-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0e7c794b37f788cee"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0603aafa534e3b1ae"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-00cdad0a1b046bd88"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0423647cc71d650a0"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0204b7f995929064d"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0f8ef20f0f423c044"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0be424da84e04a869"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0f80a140f9b14854c"
                         },
                         "ap-south-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0b81c0cc121bab08f"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0bab638d1b6043209"
                         },
                         "ap-south-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0f909b6e8260b126a"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0219d9e86d53c8d0b"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-096c0c5be0c32ea70"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0f6df6aed8dffda54"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-067f45dbf77034fb8"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0c39eb003c5ee1bc8"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-058eace4107bf84dc"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0fbf1dc1b09d9a0ea"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0bfc6ee9aa2df028f"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0ef59b0621e86f150"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0e8ecf91b40f92939"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-08631fc4ebf480ee0"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0a3b4382d3b9b8ad9"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-06575f6bb8da475a5"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0c2fdf26591457b01"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0aa5187f56bea044f"
                         },
                         "ca-central-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0889a1d4f4b3e1d5f"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-00452572973b2feb9"
                         },
                         "ca-west-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-01a41a78511cc89f6"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-04d7a565717ea01c3"
                         },
                         "eu-central-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-006fce06a593fecfe"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-06bd8e48653b89514"
                         },
                         "eu-central-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-08f4fd9cb02c58ff2"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0dd225e7ec03690d8"
                         },
                         "eu-north-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0cadb69a13a0a9a81"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-04b7b36a94f4b52b5"
                         },
                         "eu-south-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-013ec6a894f598009"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-09e498701c3f79a04"
                         },
                         "eu-south-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-01bad4de14762e238"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-077cc90ba8cc028cd"
                         },
                         "eu-west-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0963897d920c55591"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0800f1abe38a926ff"
                         },
                         "eu-west-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0d909bbd43975ddce"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0f40f00f048be99cf"
                         },
                         "eu-west-3": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-04bb4fffae1400113"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-00766edd4ba859e26"
                         },
                         "il-central-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0fbd02df8d4ce83ec"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-086d7f3a9b396a5f9"
                         },
                         "mx-central-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-043deede52d6d3352"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-03745c3c4d1386e31"
                         },
                         "sa-east-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0e28cd125db2d3e75"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0db04a65eba0d8fde"
                         },
                         "us-east-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-065b506739b229f45"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-01fdb0bf1596a3ac2"
                         },
                         "us-east-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-02244325e08d99546"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-03e1a65c98cfada39"
                         },
                         "us-west-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0a9c19ca4a4afe4fa"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-06f54d352190cb513"
                         },
                         "us-west-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-04fde7b0a39803e76"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0ac4ccca1553f8d8a"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next-arm64",
-                    "name": "fedora-coreos-44-20260817-1-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260830-1-2-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "adc195c228548adcafbc38f73d51a7d98b5aff6b651c14004c8df26a02c15f83",
-                                "uncompressed-sha256": "3295e9355c587788d277cb08ea34ab0a91a68c1e496d23b624835c2c296dbbb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "9057f238c586df5cc398764da19b0e7c4e2f68c3eea4c2cb1dd7a761111cbb88",
+                                "uncompressed-sha256": "27abe2626b3df052af8b205697ce89c790bac7cb530b9a7fc051be1eec83691e"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "e2fbe65e684d0ea53d5e59ef8bc5ec189f90e0f65dd6d97ec21ef8e4c1aec5c6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-live-iso.ppc64le.iso.sig",
+                                "sha256": "579d050d0c339b7bdf7636718dd6fe95d2cb32cc3c5dad62f15b6e7e0b08f64c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-kernel.ppc64le.sig",
-                                "sha256": "d040287f7c8325e3e1748fccaf32c096c4c335009eeae18968d65875634729b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-live-kernel.ppc64le.sig",
+                                "sha256": "b3b03136aa6cf24201ea4dd73c91a19fb6f00ea4a5eadabf894a7d1e6ecc1ce2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "e2deaf029055bf4af882953a2650cb78603422407ebab6367124b2c6fcf5999e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-live-initramfs.ppc64le.img.sig",
+                                "sha256": "ef956f285c964b9f683769dc01def7a5d47443384b4c601a47f4d6773590a5cb"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "8337b10f03723bbb493eeede7e257ac0bce15ead23eb8edad25066bc111af93e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-live-rootfs.ppc64le.img.sig",
+                                "sha256": "abb8899bfdbaab79cd2f6b07e7e257cb99f456c198e45b897e9be680b6fd1030"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "9988dd8502366d3616f036958dc927a7ea23c72cce6b062259f566e3e5559c66",
-                                "uncompressed-sha256": "c2f63ca27ca9323a644fec97c695f7a38d2cf579b3c159f1224a5f6b2d8c6476"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-metal.ppc64le.raw.xz.sig",
+                                "sha256": "9b462dd5e5ede4246cbc87c7c944a8901a2cfa3ab5db248d71839f4f07032439",
+                                "uncompressed-sha256": "c0ccb5bf444ea7b73892fcf7f06946c50b0f4f7032ebb7f797d3d4f363d983ec"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "466d5dd02d6885bda22cf1087c0ad78ccde79dec6a1c86ceedffd2b6bacf9d99",
-                                "uncompressed-sha256": "8c2659a196752c3758da4c87190229c5cbe58eb7e2064007f182562b19298471"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "e5390d02091c757104a080ac1dbb9c5555f2a132d0029de8414eed6f800e2d12",
+                                "uncompressed-sha256": "0598647ca492a38e5830ea5d2a5ddee19ce5ef2363f01c1507d1f9cd0234c087"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "2c69bfed9b4a8bd217f7e88eff26843fb04f77fb2208e5a986f1d58a9000b298",
-                                "uncompressed-sha256": "ce6ab7cd13e10f4c34d934650d537ca88e7ca7d75be198cea99b5b01baaa855a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "11454887262aa04e7a59a9ef8e0ea218b487090f69903183fdc1dfbb4e8ac93b",
+                                "uncompressed-sha256": "346c90b1b066d1da409a6d235a91a0cbaf4e155a9e297bf667d0caf87c4e8a6c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/ppc64le/fedora-coreos-44.20260817.1.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "6f9166922f5268004024bdeaf66387eea52e10af7754f37b9118ab9545a29a10",
-                                "uncompressed-sha256": "01f5068018eb7fa9caa2559e88d9a6bbb0d29f4783afa6ba366892b56d163d32"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/ppc64le/fedora-coreos-44.20260830.1.2-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "c0c0d897220741097f8085ce11fdea727c1a7368bfb6fd38be36aac3f0090c69",
+                                "uncompressed-sha256": "38df45885053fc7becab1e7a9467990550b203d8107af7d5969edd6ada4baed3"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "4a4caba1ef023d67218df6356adbbf0985ac22492b8906515ebe3b518217c25b",
-                                "uncompressed-sha256": "d6f444a6561e5360d4e2ee397f3f0da15c4c25d099e96f58787bb106d4033074"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "6bf4e0d31509dad1a36fb0304c9cd68f3905918e5c88f165e4edfb4f1be43be1",
+                                "uncompressed-sha256": "a2f87cce9040a3ebf6e6bfad2f0e32b27296f73c01d4221b5a639b387abc2388"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "2f9cfa60bcd992087ee0f6063d1baabc5cc7d10eb8d4442f736e77205389b24d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "7759a7a6288587dbbb84d324d3d2233cc94ca25ac1d5a82619263a2d8dbea05a"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "5997b2a60448a4155ee88cf299e15a31ed5ba1cf32850da5e75147c40e23ebb3",
-                                "uncompressed-sha256": "5c5d6c3803f1f29a3faf387e71e6cddd5a82e398a74b17603fc7cdb3c541b8fd"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "2272228a32bb1b8338c51df560e0269911bac67eb2f3649ec69c9e4e84220166",
+                                "uncompressed-sha256": "3bc478c770804fd4c8d89ed18fb027ee4ea1f7053e29c9b5b9f1bead9af62327"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-iso.s390x.iso.sig",
-                                "sha256": "f5d01790d79466717583e05dfa099b288158bdc5d1571298764f2b8dcddc40a8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-live-iso.s390x.iso.sig",
+                                "sha256": "a247fbc2fcdb26a1f499bf86d7174930df08ca82bbf3663535ad277074784bca"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-kernel.s390x.sig",
-                                "sha256": "5a7f0e6c3d16fc5fafdb858a22ee59464a8358adb247c106fcd030606e7fd0b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-live-kernel.s390x.sig",
+                                "sha256": "d1ea86e98c89d954f910704e20dab2989a4c162d8a356fbd0dd5238d70793fce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-initramfs.s390x.img.sig",
-                                "sha256": "e10b69a0d053e4cc317eb94225823256c2487600dd3ceb7d47740a142c346b10"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-live-initramfs.s390x.img.sig",
+                                "sha256": "d2bad5cf6737273f0189ba7dc645abd5f342e5ef9ed2cca16b8bdf07e32ffdcd"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-live-rootfs.s390x.img.sig",
-                                "sha256": "9bbf91512627e43d754ecd8bde81b4c50508c9d5177c5e8878f3609212be7b52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-live-rootfs.s390x.img.sig",
+                                "sha256": "8686b9e7d729a93078ca1cf3dc06ce44ec4efb425c43c4806043bc01117aff08"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-metal.s390x.raw.xz.sig",
-                                "sha256": "917be7df2851ddf84bbaf66f918347e27b46b886dd8b9c15817d50ced86ffa0d",
-                                "uncompressed-sha256": "0976e0dce51bd0139967ed66706ede3223daee6097c96a63832f8bbce0a2b88b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-metal.s390x.raw.xz.sig",
+                                "sha256": "be495354a84a4c1b187898dd1256ec8be5ce92206107735ade29f03a685b69b0",
+                                "uncompressed-sha256": "67f6545a1970124cf32b98bb5c6bdea5b24cdff8532fa704cde059de013ba395"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "6e92192c63be825d84203476101c72469b769cdc6afc2cd4cffc42d466deace7",
-                                "uncompressed-sha256": "f77e2da18ce3428319d9718f11b2518daa59371d3f6afd40f22ce6373501a75e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "ee80ceabb705375bf98435fdb116c9f98e062da839420dbe2e0b699760da065d",
+                                "uncompressed-sha256": "77ca20715b31bba8cfcfa368127f6c07891b6d7fae74fc932aa24f0a437fd025"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/s390x/fedora-coreos-44.20260817.1.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "6afc16bf3f6852f3a6d8cb1dac177af6f294513d46cff78192016949ca26dda0",
-                                "uncompressed-sha256": "13b42aac6fcbc12e65aca53a77c0a261eab3b50ec134608704812ada5eadddfa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/s390x/fedora-coreos-44.20260830.1.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "ba0b81ace9d0a33e2134b88cc0ae77ecd4095c651e10bf408efa5dc6679d7dae",
+                                "uncompressed-sha256": "879007b40d6163c529fae97e903ed51596cd6e49fbe569acfe8931f42e2159a9"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:33b3f4d4a0b1ea632b38d9ef6cdceb4710b480fdeff21e0c1c5a62e71192aadb"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9d3cb626e3acedec83ad8e0c022c28345ab6f8820379a3184ced73908c94d5f8"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "0f75a06d765d65ae698a3e9aa45dad257356bb0b8be551dea73eb378f3701c40",
-                                "uncompressed-sha256": "bc70430b9a1d5923f2df332165cf088a7e3539f0cd49f3fbb050b1ad0497f7d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "2372030195213b15576583a5cc4c6bf7de4a4a90bb3bedebb036062e4ba01832",
+                                "uncompressed-sha256": "3046899253be3731dca708d1bfcc3ba322905be9cc18138f0de5670e2cdf3886"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "c3ad9a4294c7ef336ae359e5d9f77bab7e68e86fc3e52571fc99d17b5c5f856d",
-                                "uncompressed-sha256": "4209fe2bf3a9012d87b9416a065c431267735e89461f9f8224393daca68510cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-applehv.x86_64.raw.gz.sig",
+                                "sha256": "97af164c18611c6a91979ec443cdc9b7440841f0d28bdca15335be24c337335b",
+                                "uncompressed-sha256": "be4d1c2fa4a0b3d85efb48c52529e9312d5707c7322dd9eb179054102b3695bf"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "399997c9537662e493b9fb1ea488247e58ccece4a1f234f5e145a30cd494c42c",
-                                "uncompressed-sha256": "9ba2055e7e436359a2491bcd066c16b0a6cd664a1164cf77f02683979e556297"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "1e0ef054fbe2847547447a9dab91b45527ab4125f6eb7d4a2e2bba5b12ec514c",
+                                "uncompressed-sha256": "16f99c1746c8874d7e592f402ab64af5ebb521a02adaafe9ca2a60ad0081907e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "489db4827ef6baac34ee2cde9d3b0e717f8dc73df7f4d46494e396600042d725",
-                                "uncompressed-sha256": "28de5b3869213eb7bdf297bdaad1408f7b71d3a8bf0c36e108e6abee563c8080"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7e799e1fa0f8450425d166abebefccc76d2e3e3198c439371d4c822c8214cc80",
+                                "uncompressed-sha256": "bb8640050e79250ab8b71f811a3ea291d769c86ebef461b90a303ffc693b3336"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "f0a073c0e5704cdfd146d6982b0820f2812642b710f7d8cc09ca248642148387",
-                                "uncompressed-sha256": "c86aef12c7e136e41278d621922e36bf6d529358969a1685448594988ee9aa2a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "8f18a83b75ae97e8ed61edc8e601bcfb0149dfc38dc528a547b1f85106cde68b",
+                                "uncompressed-sha256": "10de99fc8b9d51d06cb1968e5f9d84f508b733a287ee65d946349421adaadd88"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "ccbc7b40cb09781698c20b34ebf9f5f83182e61c40333699e93c3aa6b56edbcf",
-                                "uncompressed-sha256": "34964043f036a83d4d6c1d54c61fd93e5002e4bccaa8d407410bbd05d956e994"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f53609c0bd73f71978447c3d1efb2d9c59d14a01730c7f675aeb63a5c345405d",
+                                "uncompressed-sha256": "e914392abc204b2f47144bc760ee8e2f95d4efd82a891ddd358ce41afecdf3ac"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "6be22c8c8785818ea4d344a4c3f1474cbd8016c3ab0b7be90a6f9aca3773e1c0",
-                                "uncompressed-sha256": "f9b90fa5060176124ef70d258e2dfe51fbef164bc60a8d36824c6df91a5288dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b0b7d90a991292956d1dacf9938f2e03b602859832d029afc79b53697639ec20",
+                                "uncompressed-sha256": "809bc345c01f334446fb2722ea938d0cdbba7e8dfa04e8d96a10cda4aa3feebe"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "cc9b12ef0bb9b79d4ed8dc26abe8c2df9bdffc105cedf4772c77a5ffc61d920f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f9c1359bdadec494efa5a244094dbf1f089ae19574cb00322867f48443e0951d"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "51e3f7abd49a4183d6bdf58c8bfded29064241fa7f8c8e342da35fdf19dc9923",
-                                "uncompressed-sha256": "de0a57bc14617415f3a8a293a488a2e6f4b7e6a5e0e55ff7103ef411c629acd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "0b30341e8841e9887efb6e954b5a0c1eed30bee7fffbb96863018e75ace98286",
+                                "uncompressed-sha256": "d9b4c4f65dd57aa5498fd64020ff8fca79706244783294e35f14b0964493570a"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "7d3b95c23c69d35712f61d8d830354e2325dd4434bbfb8c9275c2fd6e2830b96",
-                                "uncompressed-sha256": "e5330ea288ca90879b81f7dd3c770a43b9433986789d8c36b63c9a8a893ff740"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "02564d50e94f9f5797a31637dc4586e181c1111b471cc251bee58dfe78ceced2",
+                                "uncompressed-sha256": "b0a874d86a62b67766412f64fab43b3dd7d987ec91030e5b405ad84c17ac4a8e"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "488f58993e324a0be727c164f3de796a254083d75de4dd98904d5776ef2c6ee1",
-                                "uncompressed-sha256": "7314007f6e98e7f0599149972ca8f22fb36a8e3e89638489c4e554ca4242fb6b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "270a84f42a4d98ff83293c3737e6842cc680729ed600eb834b66838a81721c0b",
+                                "uncompressed-sha256": "b82f1ab48147a58524528b8cb74f1a9bcf95a4c267529ba1ea78f900f4f123f5"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "5f2cb5f55be15735957cc28c3e9b225fab754f99d8233b322824eb2496332347"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "6546bf529d56ed88d5c23ab51769c8370f5cacff85d384a82afd7827eacb0ed0"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "db74f120370ade6827b3c76bc88a2c5a3e1a650788be9f0e57c8ef4a9b2f269a",
-                                "uncompressed-sha256": "42dd6d01ece4e084f28d48a859753c340aa2abba75ef64cb0a0ea9c6f8f959f0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "6c72bbf6928d1d9f2e332418e2a589410d7438c6f06e993a2cb05ef00951c9ce",
+                                "uncompressed-sha256": "5745a90aab4824b393c4855bd013042ad1f4d8291874325a19aeed5b557fde08"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-iso.x86_64.iso.sig",
-                                "sha256": "780f96dc1ab7b82937c529e397c066a7ccc7e95d72d4638a7c4496100138f037"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-live-iso.x86_64.iso.sig",
+                                "sha256": "31846a376c0be24423c93323910b374c4ee99b9e53ac1f3428db8d0ace179787"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-kernel.x86_64.sig",
-                                "sha256": "5b97afb0ac5efce78b37184b8a305275800f0244281383457c01dacd5ffb07ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-live-kernel.x86_64.sig",
+                                "sha256": "afe1d3790e957b5f6ca82997ce1f6fd909ea87f354cdde04256d9c15bac80706"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "7366fad6202b312a14d92da89a21dc7247631a25c648d4eb27cf69c0bc8d832f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "91aebcdca6a0ed88a095479ecbb38dc283d6f233f22d102c57879602870c6c4c"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "e7d714900c6157534e7250fd7d019c1daeb2aea85aab26491ae232a109d8b12b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "8a131fb9542f6fbb95132fb5135d4ba712607b9e0ea5535a80df08e0d44b13d7"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "e7bd075b16397ac616f2479c3f0005ed2a9fccfb08ef15bb7a65657d03a2790b",
-                                "uncompressed-sha256": "587c118545c5ea4238f8c424cc5a954e23669eec9ff3b6be091e353da6cd8d27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "081ea4b830e7b5f49d7f7cc9c556771f6c28edc58cff9469a02b8c9ad1f612c0",
+                                "uncompressed-sha256": "71f30d82df2e7a067dd4f47dddfccc96cb2d15666daf3d8a4079a9fc727aaa60"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "34e1a46a5ceea82f443e5fec4a185076f9315659632132ac730a8dd9247a7c12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "46c3b1a87e961b31282f6e410ed55ee2a06d7a965554d39dd6ce4058ac153d0e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "13c2614bf6e9f036d82e51d01d75dec533e1c11a9ca31826f1edef5aaa2db3d9",
-                                "uncompressed-sha256": "18db02492a14b7033e5c7b85e12bea63185e7ed8bb79d777622f301ba811aa2c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "706b98de987c97a1b5a38ef18e4217ae202fc5b24d5ba4c364dd07b5f9ae2e86",
+                                "uncompressed-sha256": "1f45602952e9fa6418d7b12601d17b5294503b6d48d08cd06a0586f89040801e"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "1d6c1bf44a51de3a2255bc72a5f4fb5ea4a8dc790c15c6e0d07057966ac14e33",
-                                "uncompressed-sha256": "bf372cea9bdac953328394de8018c2cf17ffb28dff83d78d067b38e7dfc6396e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "adb02e1ae3c95e4b6514e3e6cca0b43ff54b17db355a5881fd18cb613124f60c",
+                                "uncompressed-sha256": "f589b048bc25217bdaa8527f3f0de3f5da070cbbe7837d9d533c6f51b991b945"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "8dcfb642e6d22662fe19057727eed6a25145361f020acabd0373f5a8ba054ec2",
-                                "uncompressed-sha256": "133ed3bb1037aaee7c3ec05dc08b85007414d09bbab41177b32a22fdd1b65106"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "2a06e7fe527b0b6aeba2e9eff340c877c1bdc849a718cd7fd24673134ac38f31",
+                                "uncompressed-sha256": "3c0f493b930ad660f191b28c4d014f2172eb95bb37f9a0af8eb1a647e592e131"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "e295cba28faf0ae0e079b7d16358a57a942a8f5367661a89ecca56570eba10e2",
-                                "uncompressed-sha256": "8317cc9bc5104797f7becd3788cdf0330fa410fdec1bc24c5eefee295666bf1d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "d8ff9acd8159d2f5bed32f9ae4a57052f2715be4fb9a256afd5caf456b6d74eb",
+                                "uncompressed-sha256": "e35e2e31204b2373d584aa1d5061c17f4a00ca8b533a380ea74ebd493607201d"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "a1e8ef5d3afbc6319efd3ab8082650f3280698f6190128802a7a32e10c12a622"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "1ab50d4b221aa62af622c66b8f041df4a732bb906c042785b569fdf68469118f"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-vmware.x86_64.ova.sig",
-                                "sha256": "1faa15ebcc312d8cfbaecf99936aaeb3863ce784158e834f463a73640867bd6e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-vmware.x86_64.ova.sig",
+                                "sha256": "07e20048e86f8e57622a41beede6801e7780e1f216c5ceb63acbb2623c132020"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260817.1.1/x86_64/fedora-coreos-44.20260817.1.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "9dec26bb9a6a85dd4b14df45de7893086077e14bbca62332e1197481f1ad02b9",
-                                "uncompressed-sha256": "0a941b1d390d2ff7b3fec07c0d1be364fd7a5ede9d146bc4ad92ad08e0c661dc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/next/builds/44.20260830.1.2/x86_64/fedora-coreos-44.20260830.1.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "ecb60a440dd88bc3b7f851a9448a5c54acd7ba33942bf14ad51960d2a4de2c83",
+                                "uncompressed-sha256": "5349463e7ab42ef4854d6af3dda4b3d3ac11a9045952a4bdb80e0e548d610850"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0aa29c787e83fb19d"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0950a3196f20109df"
                         },
                         "ap-east-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0231a09577c9b9ace"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0e4f2dca61cffc705"
                         },
                         "ap-east-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0644a739c66ce0783"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-01acac790f9f95dd4"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0465b1a7d2ac978c8"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0a05c4791d0ad1517"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-03921589b220ee927"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-064be72b62b0e7adc"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-078b08f2a01d6bdcc"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0f201de8a4697af93"
                         },
                         "ap-south-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0fe959d41819caa30"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-08c2e218bba4920ab"
                         },
                         "ap-south-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-09a86c1383da43b73"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0cc25ec61b9952b01"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-04b0d9349f5f36f6f"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0ce6349266a04d94e"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-050db0885a2ea767a"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0bdba73dee628314f"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0fcbce6b3c957d54e"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0c1d65bec8dc29b14"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0b9d3d3e68b3685c9"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-01d9856251c2f3532"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-08ae466f882fc304f"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0fc86357e97115f91"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0d40021576969eb21"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0682c0b9c3f3738c9"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0aaf8efbbc955cf56"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0c6a60374f3fd702e"
                         },
                         "ca-central-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0bd39b7b3f121bacb"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0890cf27377657a1a"
                         },
                         "ca-west-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0be3c7d9a43ec5745"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0b0c72435a35af139"
                         },
                         "eu-central-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-09b04d2c1ee3d7b57"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0eb06b4473a91d4c2"
                         },
                         "eu-central-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-031276c540db6416f"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0b0f7593f9472cb30"
                         },
                         "eu-north-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0c6d275af2a31a22c"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0572d4cf2e0692b70"
                         },
                         "eu-south-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0d4f53decee38e941"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-03453cb29a4f359c3"
                         },
                         "eu-south-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0601980c33a00acff"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-097280bd870a1c092"
                         },
                         "eu-west-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0f66a1969d4a7d0ac"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-08c019e17a4fb0acc"
                         },
                         "eu-west-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-04b1b4e827fc76b00"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-061ad28513e29577d"
                         },
                         "eu-west-3": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-09386a350089c214a"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-032a84bff38df7dd3"
                         },
                         "il-central-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0cfe3b0e1ffdc74fa"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0f2af0ff785ef4941"
                         },
                         "mx-central-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-07ea4cb245112b62f"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0a54c6118bc2c6f38"
                         },
                         "sa-east-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0f8a46f3955b692c5"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0dd2346f556f47b25"
                         },
                         "us-east-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-07b60f734ce15e347"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0b9b9cfa36cea71ab"
                         },
                         "us-east-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-070a1bd8f776d1c47"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0ba67ee18781395d8"
                         },
                         "us-west-1": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-0bad036b7cf7e30d4"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0720259fee15fa442"
                         },
                         "us-west-2": {
-                            "release": "44.20260817.1.1",
-                            "image": "ami-05455faaabf549290"
+                            "release": "44.20260830.1.2",
+                            "image": "ami-0a88b151ca94c1c16"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-next",
-                    "name": "fedora-coreos-44-20260817-1-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260830-1-2-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260817.1.1",
+                    "release": "44.20260830.1.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:next",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:6339d46fa196f44ab6ede36b1b42a92d94703007cd951bb01b8811872181aeba"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:ee585c1b7eeeba0c84c9bc0e3ab4d069e0179af8074ed905070fab6b04cef5e0"
                 }
             }
         }

--- a/streams/stable.json
+++ b/streams/stable.json
@@ -1,169 +1,169 @@
 {
     "stream": "stable",
     "metadata": {
-        "last-modified": "2026-08-20T01:41:33Z",
+        "last-modified": "2026-09-04T18:44:22Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "275368c402dda44a30a7fcd75d5b2cc50e5a1c88119ab80e36b601b6b39f535f",
-                                "uncompressed-sha256": "1cfc52e977056761a058170f9d6f104acdf943ba23a80d4c44bff5b58e13f600"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-applehv.aarch64.raw.gz.sig",
+                                "sha256": "e0cd2d532f116a72710db2ce086c1b449e19647960654a2b21be5eae0d45a4fc",
+                                "uncompressed-sha256": "ef364a2147506d0f88b49be76e3b22b0916633714e16cdc5617261588d2cf641"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "a32aff789afaf84dfa8f43929feec904c7ef640d907e9bcc6a94e3a2514d7256",
-                                "uncompressed-sha256": "6f39338c8a5bd266b78b2e7469c5e0a684c50768f92e873b15224edf19245c12"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "fd8a6fd34b27a1eb0d5c74f291da1bb2475de1f7fd571487aadaf94f96e1ca3e",
+                                "uncompressed-sha256": "c0757bcb815dbcccade1a8b4dbd3b223c4505cff295fc934651098760726bf5e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "9a46e9b3c77f3da6c5cb69fbfd6cb6006616032054dd9770aa24f99bc4aa5210",
-                                "uncompressed-sha256": "40e066d44ab226c961486afddddcd4c58dcf4305ae063b9135e7bcd4c28308c5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-azure.aarch64.vhd.xz.sig",
+                                "sha256": "d5978b15c506274f9d99ea435306dd409104b833a5a35a8f1caf3e5623c1a4ad",
+                                "uncompressed-sha256": "e8b9a86b9abcf610a0d3b34223ee0ed161e02de214fbc4ca469ff580a34d6c2a"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "3fe37e17100c4af432c992badbe64caf6c6319b9c7ffb08a07b171d62329e956"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-gcp.aarch64.tar.gz.sig",
+                                "sha256": "c041f65d9b8b1b9245397947159617c7952fe92cfb0467bbc52481d12f7bb08a"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "07bc523aed38d2140307724f5c9520988e140fa744820d7c0c32a37d413c735e",
-                                "uncompressed-sha256": "f0656622464be311bcb0468e4701ec8b8cd750a22374a61abc59ece732c42872"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "b2a659512386c8a0c25ddf8406e9237a2dd6430953b8e1c275f2cce595b79798",
+                                "uncompressed-sha256": "06fe1afff136197fd408b51c0d5712f001e331cdd7898e6080418e8b16dfad0c"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "402a8b22c20e798fd4c4ced3ececc29ce49b2b1582ba0f9d0499a8cca2982bd2",
-                                "uncompressed-sha256": "ec5df0754f7838f9c68d64928e92e426da6de95953a42e1fce179710386aeb02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "cb05134efcf6dbe755c0caec53cd548a79f3ee2d2fac7105a11dd5f0fabfd6a1",
+                                "uncompressed-sha256": "2e53046496ad5bd44b52e1d9e5e551f597a3733cc1e3821df7999eb6826d3ab9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "500351c1c96b2aa3446e00e34db19f5d753dc7ed8f9b02f7575f59e70dbda2e3",
-                                "uncompressed-sha256": "94defcc9b8b6ac1136200ab3650f64490626f2c77f0413efdff0eabb0743dcc7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "333d0a627809ce17fb6db25d0a06e60a0c760fe40bfcfbb390c00751de542e97",
+                                "uncompressed-sha256": "8ebca05659202d88533234b090f1d430aee0d4aac146f4241c800bdd59d40187"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-iso.aarch64.iso.sig",
-                                "sha256": "c204c2ca547e3e862fca2bcd4e2d2f29272a4e9bf5f8bbfaaa32620f5d89d577"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-live-iso.aarch64.iso.sig",
+                                "sha256": "86a35983d5d981ab9eb991700003bcaf9cad2ab6f727ab41d0b27ec080f9221c"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-kernel.aarch64.sig",
-                                "sha256": "1af1ed065a597365d1080c35d05953b83077331fc2e234e23569d39e8a012c06"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-live-kernel.aarch64.sig",
+                                "sha256": "38cfc669810d30a2ba7cd128528a951b2a8eb2ac85250aea287d8142f76a0a59"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "7ef36cd01bb312d72d0dbfdf25f4827ef0edb6182396304fff280a8ca715b05b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "4f180e09fa2d1685e5d46be13fd032dc19b2b94174b1913abf94d0d7c09bfcdc"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "21b80114e6a651469213317e93593457069ba1d0ab895d1dc8a95588f8a74ff9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "373b51269f607330021a1eb178f8140c05e7cc9fa57ec33d6ca4bbd1a513124b"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "97354a627e7f38647c7e82d09408d6d26320c9f3c5f8fe847c554a09ac62b939",
-                                "uncompressed-sha256": "69250c00223e25505ce4f7b1afac9ccff787331a1dfea4295e4c292958d581b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "b9d751d4371682c3d66a024b93e4e0ff4d98d93a3140c203429cfdf8f7b80323",
+                                "uncompressed-sha256": "3d3f7312dea250f1e29c6b9470823414c4de6dc1dce992e19096ad1bdb2fbd1f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "d7db89dec38c7fc45fdec4f8809a44efbf4bb7278ae7a651e6aff643ad3519f0",
-                                "uncompressed-sha256": "130964fa330eee50e0fa6423072bb0099cbb451b68179a2b786dfe9f2eb4949f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "e248f48757b513469997a2440b1e9135df4b7ccc3921c0de0179344ed8e5211d",
+                                "uncompressed-sha256": "51b0b796d8347ba635a73958838872db17d6ba375ec477c856d5edd40938419b"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "38feda0371b327aa56436922db6f8619977778b0dcdc1fab3efa55339dab7d87",
-                                "uncompressed-sha256": "7b9e6d900b044e8eb77813952717d248fdc8f50bfe0bc8cce69ff6387dbe2c75"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "3c978984a620888616030f95e0e53f0bde513d6ae0397b09e5a0a46caf205df9",
+                                "uncompressed-sha256": "2e83918af8187deb984caaf397118d230e35ca58e39f220731dfd896fd111432"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/aarch64/fedora-coreos-44.20260802.3.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "eaa978faf5dcb1a593f7df551a8b61fe572e3531daa72d4aaeffc260fadc6cd8",
-                                "uncompressed-sha256": "841331d6f5392ed1d5198622a9cdf23cdace4ad7ea530b2330f7067655b5e01c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/aarch64/fedora-coreos-44.20260817.3.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "671c9b42835ff810156882acd007762111bce5ce300fa3bf4081f9f778821605",
+                                "uncompressed-sha256": "28f2ca2aae30f27f959fe761c45b6c213063094915af4fb6e647343a80e2e0f3"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0086d9d006f331b8b"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0a211715f0990e91d"
                         },
                         "ap-east-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0a59487c82594f7b8"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0a2157ad95731ff39"
                         },
                         "ap-east-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-00c266fcc6d8aa1d6"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0037d8c6788770545"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0af8e9bc1a750ad8e"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-017a7623869eb8030"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-09f64e160b6c267df"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-05fb9d5ac4dad00c1"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-092ccd9a7ff7245fb"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0d37a17fccdef33eb"
                         },
                         "ap-south-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-06441bca7b36e13ee"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0e0e6045b0fbb46ab"
                         },
                         "ap-south-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-06655dae6f9b4850d"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0463f9579230991d4"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0caff22eb98627f1d"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-05aba59ded06cbb76"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-092b22efb849b69e5"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0a14357ec71926b76"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0dc9a7ce70d0697f4"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0380865753eeda7b1"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0d05d1a42ac29ac51"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-04dc9b14adc02ae40"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0780ea463fe241de6"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0d7d7af4627e5a369"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0881f559a7f33fa78"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0e96edd96c3a163b9"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0e13dd029f89e4da8"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-08d68b2c246e0d8e8"
                         },
                         "ca-central-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0721b4dfb6b00d378"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0aa81a107cc416886"
                         },
                         "ca-west-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-00e944fc6e0655f84"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-055f91fe57c9a9027"
                         },
                         "eu-central-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-03133bb4b4b814acd"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-038c269ce3eedab7f"
                         },
                         "eu-central-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0c703da3428efe01a"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0dddb0a234ea107e2"
                         },
                         "eu-north-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0d675792c188b9dc6"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-01f99d98353ee13d1"
                         },
                         "eu-south-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0a03fdbeb1f6cc01a"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-04043e9f15a4113c3"
                         },
                         "eu-south-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-004a36814cb34d785"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0da6f6bd502ae8ade"
                         },
                         "eu-west-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0387925fe260b5d2b"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0f8b4bce144852b91"
                         },
                         "eu-west-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-079ad6d990b9d9927"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0daf5ba7a2acd3f2b"
                         },
                         "eu-west-3": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-08031044d38a5f3ce"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0c1d4e206b9f2771d"
                         },
                         "il-central-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0e41d2b46791e33bd"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-06c3a4ddc38a98075"
                         },
                         "mx-central-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0d86d3a2b9c2dab52"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-081241831c3274bc6"
                         },
                         "sa-east-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0e11b650c55bb5013"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-00e530576ca58ead3"
                         },
                         "us-east-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-053b93cdd73af4caa"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-05e5a4d1cbf102f6a"
                         },
                         "us-east-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-038aa85158327d661"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0539f29d0840e7c61"
                         },
                         "us-west-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-03a53332337511f22"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0b65b879c29a8d21a"
                         },
                         "us-west-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-06bc235198459f04b"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0294e70baaf88153b"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable-arm64",
-                    "name": "fedora-coreos-44-20260802-3-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260817-3-2-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "b48bb93d2683ea2f02824d115e5b494a1926280458ad40ceec17846f08ff74e2",
-                                "uncompressed-sha256": "fafd1cbb017d39f4a57e9547848e5bd5913924bb113ebd468a1748ee15f4a838"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "122abbd2420bf759879b52089377c52bb99746ba370d88ec5f29800ddc1af7e6",
+                                "uncompressed-sha256": "488ad9b56236fbd2b2fd1574a720127a634ad3ce7a7e496b1dc7053176e8ec49"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "c5deab6b2f2974f3232e8b376d73523c6ba0e14a091624f12830f52b2f65fe02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-live-iso.ppc64le.iso.sig",
+                                "sha256": "562c7c126c838d104b610267260f10d7cf775429282f30aecb39c019d42fa968"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-kernel.ppc64le.sig",
-                                "sha256": "09dadc4490e6b9ede833a3d0da8d7a115451206263ce5f96b806ff29b8ebda56"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-live-kernel.ppc64le.sig",
+                                "sha256": "d040287f7c8325e3e1748fccaf32c096c4c335009eeae18968d65875634729b1"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "3f3d7bfc6954a1aa7a4dcf4ab0fa5f2d3f268da83a1ba28dd55d52cf129a71cf"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-live-initramfs.ppc64le.img.sig",
+                                "sha256": "cb1f17634a951f15d32d655740495ffb67a5ed0c9e10381ac844c8c3e63dfd2a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "d48f9999d42b2de6e7176412780888d9f7e8dbeeeac6aec3d93d7039dd48d16a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-live-rootfs.ppc64le.img.sig",
+                                "sha256": "f88ad028215502c8a9e3e4bf77869c8769c9d758596603b732282b28116b8232"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "28624d17b89aff34c23a966a3399d77781ad682287b55d09d225b8fa95f0bd94",
-                                "uncompressed-sha256": "d1a812008aa00904a089490a0fd92adcbea429c98df5b9e0ab562f1d3eebcfb1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-metal.ppc64le.raw.xz.sig",
+                                "sha256": "41550de3d57e795514b91c9383eaf135168d6243e511f5df8c9e174bebef63f1",
+                                "uncompressed-sha256": "75825f73a6d9b256f5004003194a214e0f28105ee7d4c76f1729cccc8b879ebb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "6ad5f25d83a4759330ce5df4081ecc5a4187ac352818b59e3b2c6a940fb2934f",
-                                "uncompressed-sha256": "eb0833a8dea7f7f27ca604ed2e723b35c9f9baac0b98d41beec7c7925bfadd88"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "06396dd7d584526e0a014dddd1e1bc1759d008e2b6ee628c39d8e5da5d3af932",
+                                "uncompressed-sha256": "a716b2afccb216b3011eb46677e9e2557582d106d6d2f4847678302737274620"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "f0d15e4b518063e5d5d52d05b28f8fdba2bc469464f0c33b54aad00d65d77683",
-                                "uncompressed-sha256": "257be2f9502ea0e353b30ae597e930149cccd928c262bf7ff1cf5031c3bbef27"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "e712a1aab28c5ea56658cb9f79f7904fe4983117ea64ed764316c45c8671b8c7",
+                                "uncompressed-sha256": "756730bb70ef45f12d13b82d9a058fb9dccd80a435f9b51b25e37cf245226ca8"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/ppc64le/fedora-coreos-44.20260802.3.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "a3516174b3f5a787f2daaad5d3957f0c4ff15b3b430c8952d69151c539b33f90",
-                                "uncompressed-sha256": "b74e45d3839c76c0aff17a5953706914e24e3b86094f34028987f28cc6ff4fa8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/ppc64le/fedora-coreos-44.20260817.3.2-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "7d8ae7f4baeb694056b535ec326edaaca83ab39acf94096794826e9ed6704aba",
+                                "uncompressed-sha256": "cc61a91d01a0df3e4dd5e4465921d864694a70c9fd7b960318e50463cfafa383"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "b56f73fbe364806f710eb1cafe04ffa18eeca07fb69440dbe9469c287eb3dd51",
-                                "uncompressed-sha256": "eb43e4f966ffcf85f322b8238517784a21da0763ce2683622fe44bcf67094daa"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "e62474a8e65a0f13f4305ce834cbf4e70d39f6db8c8410acd61cbbd91cb98fac",
+                                "uncompressed-sha256": "3281c278464b7f22dc7cf3ad4ef619645566e3789cd93dc37596cbebe9f02cd8"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "12afd10d09f74d756e37d0cefe13042ad9511a54b28e35b655248ef581ab3d6f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "ad8350c60c33f0f61ce0643aa2229706e4e44909f0deb07a3e99ca111c5a7cc7"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "36eea7e77b23fa14c294593d92d19fa45fdd4c0db29c37244a36e9aee4fb48af",
-                                "uncompressed-sha256": "4a7a406f30b6e4f4503b8a77e7a604c0e993de600a4e578f68c18f53bcb671c8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "78a3017ad31254bee2d0af3ad93cd50e637750668d90434c8063e285f504d524",
+                                "uncompressed-sha256": "1731dee6c98a30e575f6d00dd84ebd5c0e6b18ddfacc3ac83143f1d57527bbe3"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-iso.s390x.iso.sig",
-                                "sha256": "bb795ed52b94ebdcd07fc6a293598ab529e6278c0116872109548ac210521004"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-live-iso.s390x.iso.sig",
+                                "sha256": "9910018900ad15e17c9dac68297040b9e17636a2c70065a90de9788151bf7ff6"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-kernel.s390x.sig",
-                                "sha256": "c0aee0247d19b020a37974faa1ca34ec3cf027028f0661a0cc63ea816f62c86c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-live-kernel.s390x.sig",
+                                "sha256": "5a7f0e6c3d16fc5fafdb858a22ee59464a8358adb247c106fcd030606e7fd0b5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-initramfs.s390x.img.sig",
-                                "sha256": "14bd373d1c0d66a698c2f74ef0f371d80f6b7ab8250e6e19bcb35eed6ac1cc16"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-live-initramfs.s390x.img.sig",
+                                "sha256": "a85215be4871df0b9be717fa95dcbd882f32a4333c3ab678563993df7561afb4"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-live-rootfs.s390x.img.sig",
-                                "sha256": "e4b5c9631ac1bcf9e945cb62750435b350300832c5b3a659764254313df85308"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-live-rootfs.s390x.img.sig",
+                                "sha256": "a458b0a96b2a2b35c6070eae3487ac9fa6161d62c79786d5eec7c1abae646954"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-metal.s390x.raw.xz.sig",
-                                "sha256": "316feac4b335f85a7218087953f93586e22f90d031b37f13d6022e1975d2f9b8",
-                                "uncompressed-sha256": "f4aace88b1d58129e18e7ba71b2ac8be67cc0563e649986c41ab9906dc9a5cf9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-metal.s390x.raw.xz.sig",
+                                "sha256": "0752f37ad82369c79c0177e6d7020e5c673cc86c351e87396f4952b6cda65ff4",
+                                "uncompressed-sha256": "1bac2396bdbfc20b673235af3e436d34b498d40af82b0b89ca909409b79e9bcf"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "e8d215e724360c214c2199b837df9b24b33968a659e003c80e4e94e959806d3a",
-                                "uncompressed-sha256": "a3220712c8b2e795110d1088d4bb9ccc9d8809941578617b180c34c7bf1830a1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "cace69194bd72e518612e43b60f62a68cc295ef8bccd6524aebe8b2eab9849e4",
+                                "uncompressed-sha256": "87fab6b4be6d26f27d114e74abbfbf068ba9b6a8356d01b00cb45943602d1313"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/s390x/fedora-coreos-44.20260802.3.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "bf0b0c189831029bb9b4b1b00bc145a9028a0db376adf7ac8d893e2b1645b4d5",
-                                "uncompressed-sha256": "f2ca3e4021fd794bfc0bb5bf7196a2db2e94457bd516a60cf4417ebfd69054b8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/s390x/fedora-coreos-44.20260817.3.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "71d981fcb2bc5806beef404054834dc0940c22b6d05f5b9ff5b130349043b067",
+                                "uncompressed-sha256": "f4c02bff6ae8cac74b4505fd50a27bf851a3871f09b2fb305deccc07c4566b63"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:9d90c9d6a403b0530862a3ea3f206f68b2b64a13c084250a914e33b3173fdc63"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:c3bcd208bee85045dea079210749d56b678d5822dec28f9771d0735b739af9d7"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "6ed420c317b31e7fe16e97d00bdbeb16a59acadcb0946ab630e01a30601a94b6",
-                                "uncompressed-sha256": "c5a244b400eba7a8479b820c615bb43ac1f2f90065e23ab7d138298bbc156dd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "1d4b7e3f30fab439513a43ed7d16b92d92d69c5ce7b1c3e0b7a7bcf28b836fc4",
+                                "uncompressed-sha256": "0f1a023d7ee542054abcc09d1de6ccd7ef263f649641135cf6f586db4c0b4906"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "e403f3dfcffa780a0f8c79daaeffbf34a70219163ade283fc874d5d401526712",
-                                "uncompressed-sha256": "932a2ee9b43cae47e061a2b8b9b83fe33ce1678bd928d2bd4066294542b372c0"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-applehv.x86_64.raw.gz.sig",
+                                "sha256": "ed2c304e86f18e227001e3d0eca5b34921c653de15144bb46abc688c4cc77816",
+                                "uncompressed-sha256": "1010abcacb2ad1e9f4cef23e8c74e91124179f92fdd57741d57a2c3d9febf172"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "b4da88d4af80fc5f4e07fcc88318ee561f6642c92e75a07d6790a3f718d3b8f3",
-                                "uncompressed-sha256": "08a2599983bce2643868cafb35f1477e9077334a5005bb7210fc4bd93d864283"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "01e3b2f21fd456d928fc7851ca44c8401cedc6ea1d6824f0dae195204d47e17b",
+                                "uncompressed-sha256": "b26981d5747c23dd3751f1c2943ea14474ae6d7ee58743097863963b6e7840dc"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "3c8faa3c25a5411e22953148440d86320a69cb1f4c575ff3d600fcc04a673e7c",
-                                "uncompressed-sha256": "53f5be21aaa76443ddc886348ab4682a7a511956d5e7e8c043ad6a023c6728c7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "7a12654e7b40dd86f8b59d7f1fe569b37ea4e53883f612e5e2cf22cf070d1628",
+                                "uncompressed-sha256": "415eb41429a91e224f13eae60c5bd029d2e42e61a8fe2762402860f06f90b471"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "593d3c862c98e123a256135bb245ca422634da8125c6863a300838bf3ec165db",
-                                "uncompressed-sha256": "f64a20aef2f630e03bd87a1dfdad70e4b76932752020a111ab81ecab897ead43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "d4d33a91cefe647043653b6e1fb3336f38d2410c71a084883d9989a5a05f6fa1",
+                                "uncompressed-sha256": "4f822437a3e823b72c33a93a5bab4eddd5c763c6a75e7d1390f2c8c51de0a06c"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "401b62f8ce4ebeb4c61f6186cafe3f4dad458ff42fc8c6c0322107baf15e850c",
-                                "uncompressed-sha256": "502758947da932725c5fdf47df4165d18b3cea83f94b6f6642f00fa5f036b6cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f1cbea3b0ede8f9f01bdd4added43ffe7cafb5c93411a6899751c834f2818c88",
+                                "uncompressed-sha256": "30cbdfeaed887a9b99335c30e7f727651a965d143f60034c5f40ba1749fab305"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "c812bd321d2232777654a41b2679055212e2cfb71b293a6bc05ec5e3b8b42a84",
-                                "uncompressed-sha256": "ccc473bc10cf8c43b558002603246d5d82ed6b732ec0380b0ebdfebef5ea7ef3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "53221825e69b048f3906c1e3a010bb8d00310203bec16f60b28fe9c051d20328",
+                                "uncompressed-sha256": "efcbca829b391056debfe241ba8bbeba7a12d48315c5bff88740cd22d1ca53c6"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "fdc19a03e3b6171013f41bd7dd59aafb10b8fd70f3a6e66e2656de3d04eb194e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "386251a8d4f60c847b9d5ade53eba220fcd2fed473e777a389721e861132a0ce"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "9929749eaa2385b556891fdd99edb83f4bfe932ae8754cd04260e651706286d3",
-                                "uncompressed-sha256": "a7998091bb6d3ef67de7c06a777b858df5423da6ff6dbb2fe1f42b2c91ed285f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "1b00d2e1c0028da8bffec2a69f41f20a80e0ed342acf8768092f18223623de06",
+                                "uncompressed-sha256": "fa985965b50a883b8f9bee89115208d50449c37f2074a33c392a309e5874d130"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "ae7e6c9e3e613ceb7c08d71e089f3c5a32856c45d58c306331b604827d2a4f9e",
-                                "uncompressed-sha256": "e37a5d08e7a4face5b19f85c2709fc2becec831eaec7b0467da42bad2969b808"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "e850ea1ed55a559e2f9e07f476b5acf8364536eb7efcf5089ea297e499b1b6b0",
+                                "uncompressed-sha256": "62c91b6f5873c3851e520104cef71273f25fcc1c2a6b5eeb9c3a0315acd90ef5"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "e5073a8504032be681a26a689d2e5c6a6dcb6954c041855887330783492670b1",
-                                "uncompressed-sha256": "0ce6f84202881b9e307f3e529979d7b770766bbc41ebddc132fd427282c3c701"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "8f6d2dd55413738b36257e5a535d499ddfe28f34a34b18f4be8fb037fc64d3a5",
+                                "uncompressed-sha256": "4b5093eb3fdfd2a8599d7445542d7d384a116f44bec38bfd565facb03e18033b"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "001f6d913af8621adb227004159054710f25a58e59d93301e6358c1aa278e5cc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "a1b18f18a4aa07c378cb98ee8b540ba269c3caf3bc5774756b1b4ccf73303231"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "4e7d5c572ee22c268fc7415f800131771ae938d82065f02e30abea9bb0fdcd0d",
-                                "uncompressed-sha256": "65d7a7002f711b06353c4e081d42a28bae79d77376a26446007ed272f2cf7bd3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "03f49cdd2aa84840800d2263db784c318ed9ed4e3fd82012ed2b3cb288298c4c",
+                                "uncompressed-sha256": "24748b5ed5db2db623cfdc5b82fc21ae976a6f0c88c6402a4e3eaf1b35a79b9b"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-iso.x86_64.iso.sig",
-                                "sha256": "a86bdb82b3d993b8d26100e379f01beb9c99bda72756717d8aa9f73c66fcddb2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-live-iso.x86_64.iso.sig",
+                                "sha256": "2b2e639ba8aaafcaad36bb2047aa2f24dbdc7368a291509663540fa66029d7f9"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-kernel.x86_64.sig",
-                                "sha256": "c4a37455613da305d6f23bd9b588f2242a253eb0ff1a4169637fa835a458eeb8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-live-kernel.x86_64.sig",
+                                "sha256": "5b97afb0ac5efce78b37184b8a305275800f0244281383457c01dacd5ffb07ff"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "88b2fb7cc7ff65b4f63f9dc69e66bc7187dd930da9ef750a89d1aa734ee7fbb7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "35b4afdcf2f3e2db1fade0deeb04e2b3d7e96fb288b091d556220675f6fe0990"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "376a1025e24a9f36b0e5e8a2ee8ca8b2c30d29a06e61f0dfe7edf9a9c76ed77b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "ac2930b1da28c6f1e3292ab81b7d2c2b8320563ede6021c88d56b58639ced390"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "67176cde0fb7fad3f505fcef334a01e0bce37b009b5f9292981784fbd20d0aa4",
-                                "uncompressed-sha256": "cec7986777cba4a648ed34135fd44da34bb00579811d91b50ad8baa5a4917f52"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "7817557cafb32be8a5810475bd80b2c308412b8d1439beb0fb050c709ab3a63f",
+                                "uncompressed-sha256": "970f57e6d1e91a6fc53a4416db63cea9a7602a4d88ea2ccf6025157cac9a88c0"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "f798745b9280ba7a74608ccf1b06f5021c11f82b1f352085e908845431706b36"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "1a08f0b24f9da811545303406706b957721f5e13d26fa10919fead7c67e2fba8"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "c2e63dccf821d70e90afe66bb7cb2c68d3a34d121496290d5670b3488903cc5e",
-                                "uncompressed-sha256": "077c3206b404e2d2719199c3d8a06209c0a440f32967d0dceaabb62e593301e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "740f9e44095bbd5ff9b890abffa5cb05649231f3b915c37246b767db9a3b0bc9",
+                                "uncompressed-sha256": "d23e99c919e47ef79794ac0f9f0d49a96dfaa9db21803eb6edc842e77d899653"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "aeb29d1220bfc5cbcfbe69e8316a8482e96916233cd6e185ab10175c327f57e4",
-                                "uncompressed-sha256": "f93905e4a175be18dea5bc2f94abbbd5d6a800af8350384dbe400e7795f12167"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "5acd6b84d94a980ef14f24adb132f7cef84e38adeaa83234a91eca43b43c2758",
+                                "uncompressed-sha256": "cefc36a56b35a555cad74e7cccfcd110138a427288ce023d9a6b1c2509868cb3"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "f36ad9fffc4904f22a17ce9928420faa587344f77faf98997fc206927e5f4e0f",
-                                "uncompressed-sha256": "6f291ec8a505c7dcf5579d922e3d2b9106956d63149366af038abbfe6890f390"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "aca1b1c6f71c77a17290f305c9c265037f479282897e2df94c8541bcd9e0d6b7",
+                                "uncompressed-sha256": "a1c5f0f9b29d0f4192dae085135919c6a5b6b0eb86dd9eaad5985b58c78d0afa"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "1c4e4dc9a4780e03f4137c4c6394ffc88358c7a540bc983f4d4cb97110fa3676",
-                                "uncompressed-sha256": "5861bd2f9cd0ca6b6d9d55337898c56f58cc14776e7e92f58501eeeae488fb20"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "9b1e29c039de5eabeba610196fc53c77d5dfeba27f4261b26d5d4142706bb19f",
+                                "uncompressed-sha256": "e306379535a1a77fa68c17c8e08908291314318f7f666d1851fbde1e1b1bc1fe"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "936e5f7da0ca223d96a7cb0cec309b00aa20a01b5c8415f156b8ac5630049e02"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "f6faed5b2297175025c5fdd153300a47daa4502074313f6f59c15a90473ff0f2"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "cce057b8037e664afce0929d469d3591d00a014c4191601185f23f9f62458a53"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-vmware.x86_64.ova.sig",
+                                "sha256": "f3261cddb834b6c1659ecc017e8182eb8f306746f24b53645e9d4634b2c7c038"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260802.3.1/x86_64/fedora-coreos-44.20260802.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b30bc873a49102380f74cc44ad4d8d99a1608683ef1aa2cdf04b3b69f64b27ef",
-                                "uncompressed-sha256": "c88ee2629d11eea811fd5d2b27f3ba1364779f431db07afe02cc9035ffc56ded"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/44.20260817.3.2/x86_64/fedora-coreos-44.20260817.3.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "05361d826bca1d957bb6dd7380449adaf20611ea8239547b7e1b3a82ea382ecb",
+                                "uncompressed-sha256": "c279b2d76f626c2322a29fa5c35b29df073fde95b8a46323358dc4ba0c818559"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0386f4bb96dd6da1d"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-01aad14ca54145420"
                         },
                         "ap-east-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-08eec4129a9ad0b2a"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0afce57f840a4917d"
                         },
                         "ap-east-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-07b504ea14ad3a377"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-080c21d32ef8df89b"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-036734c058599a1a2"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-01fc40aa833323a49"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-00aa9db1a187c588a"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0c921328cb9df95e7"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-04e199114f2198496"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0058a086d1864dbb7"
                         },
                         "ap-south-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0c0d26a53ed52bd75"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0908c41f85079dbc2"
                         },
                         "ap-south-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-07f31638ba1d6c2dc"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-07eb1d130e57d49dd"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0a43fd32160514a09"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0c9063b19d7523755"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0806be4451233213e"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0c7a2af21f2353adc"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-04e170df95b0d86be"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0b8f77efa866c3c66"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0c3f72a54ff281c03"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0a3a1d8930da497fb"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-04acf3b895ccc48fd"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0afc6ed1bc9fbabff"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-02dd349742ff6edcd"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-08c7bf3fa677cddf1"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-09a6c25c4bc381e10"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-062ffaf0635254232"
                         },
                         "ca-central-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-06af6ce5cfd571daf"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0ecb7384650b301b5"
                         },
                         "ca-west-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-049f084d5fc973014"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-06b96f5b28a4bceb8"
                         },
                         "eu-central-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-02c436c70f03977fa"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0c5746237fe5610fd"
                         },
                         "eu-central-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0a1203fb37f2289f5"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-00beb725c434b6fba"
                         },
                         "eu-north-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0252987c710ec7dd9"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-035010c6f5699702a"
                         },
                         "eu-south-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-074ccd223f345163e"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0651a0cefffe137a5"
                         },
                         "eu-south-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0d91bed08a6b8d811"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0a3edc7d1b2d0e1ae"
                         },
                         "eu-west-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-07f2cce2e772ff539"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0dbf8d65c68b9ce2f"
                         },
                         "eu-west-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0272ad798fe7f3dce"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0bdea7b20a03acce8"
                         },
                         "eu-west-3": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0ce4ecec83bb2ca70"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-05947ca6037b38807"
                         },
                         "il-central-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-09cb152a3b016af4b"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0354274fcd1ef83d3"
                         },
                         "mx-central-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-080e8ed812c066a48"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-08192c57291993535"
                         },
                         "sa-east-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-097e57568b881f39f"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-072d0dd775b210bee"
                         },
                         "us-east-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0f9a7616e5dbaaa2e"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0e963d2e388b2cb46"
                         },
                         "us-east-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-02160cbc6b037eda7"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-07049b7029d8685e7"
                         },
                         "us-west-1": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-077a62f77f8702697"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-074dd55ede4457709"
                         },
                         "us-west-2": {
-                            "release": "44.20260802.3.1",
-                            "image": "ami-0b207fdae74fce08a"
+                            "release": "44.20260817.3.2",
+                            "image": "ami-0b9ae60aac15a6e88"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-44-20260802-3-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260817-3-2-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260802.3.1",
+                    "release": "44.20260817.3.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:stable",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:03337713b0a652793b118fa4cdc154b26ab9ca95f9df3045100611e36632b0e8"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:d453eb784fae426908ab85ab8b30735d729660fc86a1ba10e26b364beb259d86"
                 }
             }
         }

--- a/streams/testing.json
+++ b/streams/testing.json
@@ -1,169 +1,169 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2026-08-20T01:41:35Z",
+        "last-modified": "2026-09-04T18:44:23Z",
         "generator": "fedora-coreos-stream-generator v0.2.19"
     },
     "architectures": {
         "aarch64": {
             "artifacts": {
                 "applehv": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-applehv.aarch64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-applehv.aarch64.raw.gz.sig",
-                                "sha256": "d3a1c9ab188d8cece68f325f0b0dcfd85502c616f7c2117693c5584a0ccdc38f",
-                                "uncompressed-sha256": "090cb6d1d641288955602fcb335505377c00dab0f8f96b74ddaaffbc4f087f96"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-applehv.aarch64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-applehv.aarch64.raw.gz.sig",
+                                "sha256": "03dac0029219466f02e62c21b3076b3d95f9cc7e83a4a4bfdb23a4a47b573a5e",
+                                "uncompressed-sha256": "5ee610947da474e50e37769ab21049cd787143d5fc5a9525f5aaa375bbf52ff5"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-aws.aarch64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-aws.aarch64.vmdk.xz.sig",
-                                "sha256": "b9cf14ccd72afe17679b7ed7c22e4e3090d7cb932614b5011b2b01d33a595c36",
-                                "uncompressed-sha256": "458eb5e577d1dfbdc8d299b6946123cbe28fbe748065151f7487cf38d38da648"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "8b6335772257ff506f0ffc7357241f3f0aa2ba09a2966cf2dc148c58fdf7806f",
+                                "uncompressed-sha256": "24be960f63cb164ebe4ce0be4db1f575bfa05168eed9ba6066eb51be2ea85e1e"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-azure.aarch64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-azure.aarch64.vhd.xz.sig",
-                                "sha256": "c363ac670d627863527bd75a4a0343fd7b70e46adb021f3e9e2fb80e8f4b4d18",
-                                "uncompressed-sha256": "3c0a733aa2d794267aad16e7509d4084deb89a3c902c3d5f990f98c47bf19018"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-azure.aarch64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-azure.aarch64.vhd.xz.sig",
+                                "sha256": "56bbdd140626398e4e0557c2dfb50fadbc68985b7423672eaae84061b2629f2a",
+                                "uncompressed-sha256": "e9626cb79957620dba632915680bfdb6927610e20c429ad1cac5ccdf2d0afe28"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-gcp.aarch64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-gcp.aarch64.tar.gz.sig",
-                                "sha256": "17cc37768b8f1c922dea6bea11e84b8dcf174932622b2e8f621db661752b04bc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-gcp.aarch64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-gcp.aarch64.tar.gz.sig",
+                                "sha256": "353c460fffe83f5e9955a8acf881e8ed2a8969cfea6f3da34c416f84007fe12a"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-hetzner.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-hetzner.aarch64.raw.xz.sig",
-                                "sha256": "ebf163aecb75bba60f4daf26dd8b5703bef98b4c456f4c9400697b063e7ee1a3",
-                                "uncompressed-sha256": "4d2461ea99de43894fef31c4cf54f3a366221a3fc1d63061fff2bb3c65caf584"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-hetzner.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-hetzner.aarch64.raw.xz.sig",
+                                "sha256": "9b576b5cd9f17914be3ce107fd49fa367d65f7df58efa4377f7a0d06508a46ea",
+                                "uncompressed-sha256": "806ae25327795eb647a6067db9e8b716c252d75b2860aae50b88c190f6f32271"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-hyperv.aarch64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-hyperv.aarch64.vhdx.zip.sig",
-                                "sha256": "85e73347e7f3298b836ca7c6bdc69470ba3b92d18a568d623afd055ab52f9e28",
-                                "uncompressed-sha256": "b9a1ab7f83df30f1cc6a128effc3c147aff566f26bc30db7bfcca7fe8fc88ae8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-hyperv.aarch64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-hyperv.aarch64.vhdx.zip.sig",
+                                "sha256": "e76344823cdc5a78b0eb9ef04f91193206f8339a4344e8f4476c0ec0b22c1d78",
+                                "uncompressed-sha256": "091a5f38f4251f68d042170648d25e7b2df3271ab772766b7799ff83d620f392"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-metal4k.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-metal4k.aarch64.raw.xz.sig",
-                                "sha256": "b29edfbdfc9cc7af42c9644c8d1c0f6526966d4018c1dfd9864f17303b296b90",
-                                "uncompressed-sha256": "db23fb36694723c35efd7b3f6352e09dfe63d4d3a1a21108ef815a2c3c23ecd4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "e1043f289d38d19b4ae20e0a2a293a44898a3e6fe5ba9ddffb0b8d1d08355295",
+                                "uncompressed-sha256": "6a801767da87fcdabfa1b89c0236b6ce6b6a224bc42f36fda7c1710b878c602f"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-iso.aarch64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-iso.aarch64.iso.sig",
-                                "sha256": "e170e47fea31304daad40659a62de4a8881b348254bb2f92b5cf9a7206211309"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-live-iso.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-live-iso.aarch64.iso.sig",
+                                "sha256": "102a345aca8cc0de8b20f7e09c10cec864f83110582dcb885487de776302343a"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-kernel.aarch64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-kernel.aarch64.sig",
-                                "sha256": "38cfc669810d30a2ba7cd128528a951b2a8eb2ac85250aea287d8142f76a0a59"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-live-kernel.aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-live-kernel.aarch64.sig",
+                                "sha256": "b48aaa4e2d2303a4801933eb6442463ff458c9265157d04979f8c890141348d0"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-initramfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-initramfs.aarch64.img.sig",
-                                "sha256": "e63cace202a7c33da6207af384af38932613c80cd2e145852b28267c791485b6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-live-initramfs.aarch64.img.sig",
+                                "sha256": "b99a707a6e7a53dd18a59508f78851e5e6f7c8a5495e7ab0b4b8e0438e12e726"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-rootfs.aarch64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-live-rootfs.aarch64.img.sig",
-                                "sha256": "94051660dde8bf9760f7e6b1eef1686956f78c9ee3ac5a706d124ca8864a98fc"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-live-rootfs.aarch64.img.sig",
+                                "sha256": "ddacc612f1b997518cae4294d700a5972310606cb8425a87e49b3959c780b4b3"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-metal.aarch64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-metal.aarch64.raw.xz.sig",
-                                "sha256": "65dd3cb231c0f082e480ac3e1b6b265fdf8440420bedb8ef6e2885fca8233e32",
-                                "uncompressed-sha256": "a7680f08931cfe75fc51ccf0264808cc28fa8993a003c59d757b9aed124c634d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-metal.aarch64.raw.xz.sig",
+                                "sha256": "8cf82c9427b717783fcace4153be28b56e4189e5dd43828f84b0d4343f8a6161",
+                                "uncompressed-sha256": "4a46762b96790ade66169b27928902a6ebe4d0bfff8ec9ed465a38ef97791c3e"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-openstack.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-openstack.aarch64.qcow2.xz.sig",
-                                "sha256": "8b969a4b13aad455c2244f4ba960818cbfc8aec8dd0984a5151ab551f10d52b9",
-                                "uncompressed-sha256": "fdb04c99dbd2915b498e1f992842ca66fb8976d8fa066269c92ee4de17da0135"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "d1e0ba1019dc142a43e35c8cc4cb58ef64bd7945c7c044f41fdf30e039bda3b1",
+                                "uncompressed-sha256": "ef695ea405d51041e40f3600cda41c4884824015bb9a513fabf04a7132b4f297"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-oraclecloud.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-oraclecloud.aarch64.qcow2.xz.sig",
-                                "sha256": "519ef5a4ce488b882bd3ccf1f55ed570385790040d0508455ccd3cf9ab19e6dd",
-                                "uncompressed-sha256": "0a179f7817b63d349de152160a4889cf686efb8b798014dd30c9195bfca57f40"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-oraclecloud.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-oraclecloud.aarch64.qcow2.xz.sig",
+                                "sha256": "7de4ad887bd11b9065483ca784c0bdd2acfc19ba05c4a45e88a72cff6bd4c4c9",
+                                "uncompressed-sha256": "69336871e6f93979f519ee0cb8d4b064a2a5a14eadc7a2b8d07039dcbbc0697e"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-qemu.aarch64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/aarch64/fedora-coreos-44.20260817.2.1-qemu.aarch64.qcow2.xz.sig",
-                                "sha256": "03bf08f0b1b33262ecf141c7e899eda0cd3b3bb8e5dc2ba7e3cf7000e150a959",
-                                "uncompressed-sha256": "a0b167cb379ba187cb6ed1afe553b0a016094d2241cdb94bdd872243c59fcf62"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/aarch64/fedora-coreos-44.20260829.2.2-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "4ef20471d4c749668d9deb509cf3b8c45c67f795b512e4d532b98e7df5fda52a",
+                                "uncompressed-sha256": "95904d6a4f1f0bda50cecab3d2eb750791ff3916157b59f1fa06cd4b4df1526b"
                             }
                         }
                     }
@@ -173,225 +173,225 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0792ce237298fd4d0"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0ed31059b761abe92"
                         },
                         "ap-east-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-07ff3d2b548b2e913"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0cd0f181cd46ec236"
                         },
                         "ap-east-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-06443828849bac3c3"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0d320d3253df90afb"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-096afff43415031e8"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-05077f3d1dac14d29"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-02493fc531c7b4625"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-090309cad9802d1f8"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-01daf4fe4737fc77a"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-00738f7b703678ce1"
                         },
                         "ap-south-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-08adc7c2aef31fcae"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-03a1403a7a47665d5"
                         },
                         "ap-south-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-042c3303fabaaa824"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0666f094b0fb39d9b"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0dce2147222abffaa"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-07bd9a67bd5eaac2c"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0b2515d55c1aa3dde"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0783ba5c9f733e1c6"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-095310f66260b3916"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-05791b1677a220d67"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0e9a6a3236ac1f60e"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0f7fbd24bd6434959"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-080ff72fbafefb63d"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0c0d08fe9938ba2ab"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0c42d0d3a303964ad"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0a0225c869ae9b582"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0374c3f52de95c5ad"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-057397e09b7f47685"
                         },
                         "ca-central-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-01c40806c3258934a"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-003de56767c8960ff"
                         },
                         "ca-west-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-05f9eb3eeb1062249"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-05b75230ba06efc90"
                         },
                         "eu-central-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-04d6013de86a33059"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-05e194ffa7cae9b76"
                         },
                         "eu-central-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-01aa7afcd052002a8"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0609762267b8c279b"
                         },
                         "eu-north-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0b0a96de44aab30cc"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-05a8e3460d4888db4"
                         },
                         "eu-south-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0f5741d22ffd0d82b"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0a831382fa105b2b6"
                         },
                         "eu-south-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-011252dfb467f9884"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-03bd66afcaceabf8b"
                         },
                         "eu-west-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-03339a61673d4bc19"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0a3991f5a3b54d391"
                         },
                         "eu-west-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0ccbd78b0b171bf8e"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-04c7bc2fce3dc1630"
                         },
                         "eu-west-3": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0fdfedd69a712f7c9"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-09b583ee91fce8d42"
                         },
                         "il-central-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-00b13e53e744b3038"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-015168b84b9c6eb92"
                         },
                         "mx-central-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-078a884b69074f6c8"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0372c4257fb5992b2"
                         },
                         "sa-east-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0a5c7babe12acc10a"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-01b5473b5839f6c7c"
                         },
                         "us-east-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0432add86c70f8f16"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-079b847c6f99763ac"
                         },
                         "us-east-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0c78120c91d0c0541"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0187a268b7f2a77e5"
                         },
                         "us-west-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0541a32bd74223281"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0003e94e053f8aca1"
                         },
                         "us-west-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0d2036c62433a97d0"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0961b34ebf470d2c5"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing-arm64",
-                    "name": "fedora-coreos-44-20260817-2-1-gcp-aarch64"
+                    "name": "fedora-coreos-44-20260829-2-2-gcp-aarch64"
                 }
             }
         },
         "ppc64le": {
             "artifacts": {
                 "metal": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-metal4k.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-metal4k.ppc64le.raw.xz.sig",
-                                "sha256": "089b4e452bd5fc7b1b9f3722b822b3b5b1079086dd91cd94b4884434470f7429",
-                                "uncompressed-sha256": "764cc8254e037ca4ef30f3815043a8f97c63733ef8cb375e34a6d3177c8d9ab5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-metal4k.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-metal4k.ppc64le.raw.xz.sig",
+                                "sha256": "1182c7750538b4e3e1a0b25cea433ea46d411b1341d25f016ffce743f08e000d",
+                                "uncompressed-sha256": "2ea0ad86c15eb6b613ce96d088150edfa7d57527f906d9a7b54ad1d5d7ad73c9"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-iso.ppc64le.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-iso.ppc64le.iso.sig",
-                                "sha256": "44427243ea5a8591d2e8eaf7b70abe9748c1e8813feb86929171c2736bfd570c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-live-iso.ppc64le.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-live-iso.ppc64le.iso.sig",
+                                "sha256": "a497f348b2c9ad192598385798c514189e86ed2f0ac5049fc4dc88e67bb121c7"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-kernel.ppc64le",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-kernel.ppc64le.sig",
-                                "sha256": "d040287f7c8325e3e1748fccaf32c096c4c335009eeae18968d65875634729b1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-live-kernel.ppc64le",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-live-kernel.ppc64le.sig",
+                                "sha256": "b3b03136aa6cf24201ea4dd73c91a19fb6f00ea4a5eadabf894a7d1e6ecc1ce2"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-initramfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-initramfs.ppc64le.img.sig",
-                                "sha256": "60e628bf08a5793c351640bd04da9657219fc1af816372d44d9a33bfae18160f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-live-initramfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-live-initramfs.ppc64le.img.sig",
+                                "sha256": "527c6535b64c54b6a60463be994c130ce3bf6d2c7f886ede84a37e90e84b75c5"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-rootfs.ppc64le.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-live-rootfs.ppc64le.img.sig",
-                                "sha256": "e7d79c86af139d3b760f062773983d608ff9bae45b0004f1f912f6cef714ca84"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-live-rootfs.ppc64le.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-live-rootfs.ppc64le.img.sig",
+                                "sha256": "9d33e21ae0d1f6ce17bddca7df5b8a9b6bca5b141af9d8d1802814026ed4dda6"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-metal.ppc64le.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-metal.ppc64le.raw.xz.sig",
-                                "sha256": "5a071d2dedf78c5bf9635fbcb170a9f511a71f386df129b1ab01290077b0e1f1",
-                                "uncompressed-sha256": "ed807e6821a5784767536be12d02492bf2b1df9c67bd440f3de13d6d9a8398a2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-metal.ppc64le.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-metal.ppc64le.raw.xz.sig",
+                                "sha256": "ee2ccab1455fb6e81990c0c9064f26f50a8b0a2ebf7484887141a41dde021162",
+                                "uncompressed-sha256": "2029aec916211c1654451639b046dc7743a4056222023729c7eebc6c1fdeea0f"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-openstack.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-openstack.ppc64le.qcow2.xz.sig",
-                                "sha256": "0d8e5d7bf0585cfe9015d18e046866b774f83aae2de8a5c862db91776aa43bf9",
-                                "uncompressed-sha256": "a17559ae7a2e57405f39de037477e15a5df76939b06e9713e6e34e317c5890ea"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-openstack.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-openstack.ppc64le.qcow2.xz.sig",
+                                "sha256": "5cb079d7513a3412b5e19e1c666431257e4ef7158eb397fcf5ffe8ef5717ca42",
+                                "uncompressed-sha256": "fd6edbe2844db8762690dd30976c34ed7de71b8565869a9d5324aa2d97b318c5"
                             }
                         }
                     }
                 },
                 "powervs": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "ova.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-powervs.ppc64le.ova.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-powervs.ppc64le.ova.gz.sig",
-                                "sha256": "99590919fd3a47466d7d5b4703f05bbfe550970c8cd494cf55fe38b1641f2d40",
-                                "uncompressed-sha256": "21b9021535eb33501fe960dc4b13b35ec143f8144a0c10beef19f8c9a882f676"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-powervs.ppc64le.ova.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-powervs.ppc64le.ova.gz.sig",
+                                "sha256": "cde4d585553822a43957946a9074131758304f05932ac3758f79a444ca4f2220",
+                                "uncompressed-sha256": "b9caaed57ccbbe7fbb49d5373f3f946f604d1a0a850f681dd92ed795cc6f8b2a"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-qemu.ppc64le.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/ppc64le/fedora-coreos-44.20260817.2.1-qemu.ppc64le.qcow2.xz.sig",
-                                "sha256": "d6de8bbf4a502a3699913c29ddb464664b585ce07dff37f0de3e20f994bb6ba4",
-                                "uncompressed-sha256": "059b8aaeb7e644de2420477117193e87b90f0a60f0e5cd4737a57947cf813925"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-qemu.ppc64le.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/ppc64le/fedora-coreos-44.20260829.2.2-qemu.ppc64le.qcow2.xz.sig",
+                                "sha256": "f679e99ed7d1d522a355d88fee689479ccd60161211e9b7097b8f22dfbd4dc8a",
+                                "uncompressed-sha256": "ccf1954590b1ce446cc734afb77e7df2d032b650ba63ebb4be1b1c3d13c6a477"
                             }
                         }
                     }
@@ -402,97 +402,97 @@
         "s390x": {
             "artifacts": {
                 "ibmcloud": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-ibmcloud.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-ibmcloud.s390x.qcow2.xz.sig",
-                                "sha256": "818f35adbaf483a99360fd8f5497e967764cf8557cc2b09f653cb33ae4240e5f",
-                                "uncompressed-sha256": "36211f5449b3d430bbd9c6c781dbb351d9fe586cbeb282458715eed822dc0a37"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-ibmcloud.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-ibmcloud.s390x.qcow2.xz.sig",
+                                "sha256": "80dac3b13f9a1000fd852a2992fe1af733a29f3c51337228b140062a707548c8",
+                                "uncompressed-sha256": "f16648cd6cf7740860da00b3349921658788f9ab8edb35e51af16079aecbc0e9"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-kubevirt.s390x.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-kubevirt.s390x.ociarchive.sig",
-                                "sha256": "24194a5da4569a4c85fbd401f2ac26c6ccd972bea1dd11ed52700cb5b07be88d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-kubevirt.s390x.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-kubevirt.s390x.ociarchive.sig",
+                                "sha256": "e3a0d76fc9ad5249c642ee42cfbe5613b8eff42840cfa1b1cef37d426a0ec9d8"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-metal4k.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-metal4k.s390x.raw.xz.sig",
-                                "sha256": "b33f7b2a4af7f69bc51276544d7997ded049157395dc6ddab02143df10ad3f33",
-                                "uncompressed-sha256": "7ac11d20ba3b85c0f5be56bbfe32f691363ba84353f377e33c9d3be2a8629767"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-metal4k.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-metal4k.s390x.raw.xz.sig",
+                                "sha256": "4c9f5c13a57e0460f0689d1fb6f47e7805386b87ccd4b2a697732b22f28e7b02",
+                                "uncompressed-sha256": "c01de959d13185f31e602d66a04cabec244459558ac7dcab74e6134fc841583d"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-iso.s390x.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-iso.s390x.iso.sig",
-                                "sha256": "15bc20f041b917fdfa1776c0e7069ccc6f7b7dc376f5722deddfc87ad056c53d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-live-iso.s390x.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-live-iso.s390x.iso.sig",
+                                "sha256": "7604aaa3730715bc5fb857196c0128d14b03cfeec70e1b75f4d2fc73b2103e6f"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-kernel.s390x",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-kernel.s390x.sig",
-                                "sha256": "5a7f0e6c3d16fc5fafdb858a22ee59464a8358adb247c106fcd030606e7fd0b5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-live-kernel.s390x",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-live-kernel.s390x.sig",
+                                "sha256": "d1ea86e98c89d954f910704e20dab2989a4c162d8a356fbd0dd5238d70793fce"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-initramfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-initramfs.s390x.img.sig",
-                                "sha256": "62fae4ed51878f2dc88afe39ffde58e8b0b1784cabdeb84ebfc3a3bfa81c705e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-live-initramfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-live-initramfs.s390x.img.sig",
+                                "sha256": "65202ff1df1eb13ee57455239dfae1cc15fcbc01817c7aafd0e04a0819753f7a"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-rootfs.s390x.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-live-rootfs.s390x.img.sig",
-                                "sha256": "33c65989b70b97a41e13f07c7c76aabb34dcea15af914f38e883b69d6c87990e"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-live-rootfs.s390x.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-live-rootfs.s390x.img.sig",
+                                "sha256": "4368b1271234d8244ffac78120a350e9fa3030108fa18c5f1f7af1c796f16897"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-metal.s390x.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-metal.s390x.raw.xz.sig",
-                                "sha256": "3eee2959a7a75326dadfa0989e0f4ce7fa8af90536fe3ac09a6c8d3a2590436a",
-                                "uncompressed-sha256": "5d863261f7d723510bf7e5dd6165957c253ef2b792b4de07845157c0e99e2ceb"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-metal.s390x.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-metal.s390x.raw.xz.sig",
+                                "sha256": "29660610dcff202cd324b1d9a1597152b159f48ee661f78b3f77437636cb4659",
+                                "uncompressed-sha256": "e800da85d146da41d856e1adcb5de46429a6df15e81be51515014fa0e0db38d3"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-openstack.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-openstack.s390x.qcow2.xz.sig",
-                                "sha256": "ebc33c783c653cbc4f6cf8b69f300f322fd132fcb952b090c40e87dfcfb0bebe",
-                                "uncompressed-sha256": "16dd2f551c5973b0e892fb6eaa22a4687956316642f3603855dcb2821ad25431"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-openstack.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-openstack.s390x.qcow2.xz.sig",
+                                "sha256": "b07abb4016e5e7ddb7808d1de1768e5c298f619d198a1258917b3e457f73a075",
+                                "uncompressed-sha256": "7e87fb1223b9a36261753e71956fe70717f9875b7879004415260dd8b02e903d"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-qemu.s390x.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/s390x/fedora-coreos-44.20260817.2.1-qemu.s390x.qcow2.xz.sig",
-                                "sha256": "eeaf772c6e670e7847ab1d762e354c69464e168cea031679bf88c6e58ebe341c",
-                                "uncompressed-sha256": "0e0a422fa0b3371749c26a4a231619c1bb0e09c88f596622468890b8e0a4c4e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-qemu.s390x.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/s390x/fedora-coreos-44.20260829.2.2-qemu.s390x.qcow2.xz.sig",
+                                "sha256": "40533856e4a9a74e9bea6d2be55d8274e858153c0d6a4eedeb501b713a2ae604",
+                                "uncompressed-sha256": "f177e2cd6c3fedb5869c2574ff81a03a101da1da0991939c7e61ff4185f73927"
                             }
                         }
                     }
@@ -500,310 +500,310 @@
             },
             "images": {
                 "kubevirt": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:007d63a16877ed1e8e9752cfa43accf27f51e4bd4300d7873f7533d534ceac56"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5d0f77168afc6e72b12a61e90f60dfa34eb3eeae09725682ad312be5e6645617"
                 }
             }
         },
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "9422a1cb2383da2e18e670771db8bc5b9044f6110da0afbb6f1468261e59a6af",
-                                "uncompressed-sha256": "759609e7bf383f484446f0df22b38cfa8f4471b9f36aa079252528d907362c43"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "8836e09771a4bcaaaf1aed246840a60c378ceb69d6f8d6de816e198112519aa2",
+                                "uncompressed-sha256": "102ae09043b8e333fa5fd01c09c8bd9e91ef17dd370388b1521849cdde199a44"
                             }
                         }
                     }
                 },
                 "applehv": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "raw.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-applehv.x86_64.raw.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-applehv.x86_64.raw.gz.sig",
-                                "sha256": "a5b4e365ec01a367a2180e1773ba2a1db91cc6ac041cb96d430a7060d7ae9adb",
-                                "uncompressed-sha256": "9d966038098e1388c57e6f09dfb43d455df8b76aaca51bd5f927916caed24c15"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-applehv.x86_64.raw.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-applehv.x86_64.raw.gz.sig",
+                                "sha256": "8fc4f9992201447f1cab91644a526023467cc571d885bf20a5175a32ad249239",
+                                "uncompressed-sha256": "334eea9d60e51bcd512bf0ef7374b9f8642d64bf431f450eafaa2728fb765458"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "a968e87d036784a711d7cdd004b4222163574319a6e822b2210833bdce6b644c",
-                                "uncompressed-sha256": "4f3456a467737d192a1fe1ffc35fb8a2f8b803161cb2e0cdf85b92fd47bc1827"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d5c21b429f8248208d6a9bade82b26630285510a824d615da837d8ff6e67be11",
+                                "uncompressed-sha256": "7b7f440fcf59eb427aa1e5adb67c5a550dc1d5bc4262a983c1e5d697659c9802"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "a860689d014ecb6a9c199af1b1efd712d82496394273a5554b55eb714d1f7655",
-                                "uncompressed-sha256": "71e481f7394b4c793ab67c0f532bbcaa8966fd7dfafcf0e8f32a309528808132"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-azure.x86_64.vhd.xz.sig",
+                                "sha256": "4a8f0bb1dc5c30703db5d7ae3a6df21a2a3430d04b903f36f3e0ee8823e37c1c",
+                                "uncompressed-sha256": "673122643b17127b67da848a522dd29e866eec5963df833d1f857445e839ee3f"
                             }
                         }
                     }
                 },
                 "azurestack": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-azurestack.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-azurestack.x86_64.vhd.xz.sig",
-                                "sha256": "68e6b8407d6ddacac94a4e924d56895d9ae1a4f411a1a8a111ba4b0c92d157a9",
-                                "uncompressed-sha256": "0867137d91ccca3c0a7b08ab1c0267c48f172c6156a98f2f3de0efad5c2cd7e5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "c0e5e722ff43e9fa8868b2b79817b5e47fae5b09ae82da519542634325c29fa1",
+                                "uncompressed-sha256": "52099e9f1e6d059282d59e70056bd8b114765beeee94222fb00c37e39e9ea309"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "027e0712672b5dc05c2439d3b418569c2a22dc5d1b67752f4d65bd9011cbb77a",
-                                "uncompressed-sha256": "b6ba0c495090c30988a63f19831e8a3c681dfc17d7faf9f93d98420b0da21bd7"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "bf46ed9485c8e272e83524b602ff6dee1600ef23c9ebf9049e58554fc75e2d84",
+                                "uncompressed-sha256": "99204a5b450c3a6a4e26360840d1326620c151762ca479f4587793d53958d8e8"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "042df31b35746757e42a252e4b32018b1ac8050813856c61ee94ac6936341c3e",
-                                "uncompressed-sha256": "368c528bf551bbcb154069551f22a90233d23b700fd27d5de86d87ac1b2c6367"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "ea980b51ff5ff0efd54066c8d51c0c912c67c8f564e1203ff39c8f2159f0c518",
+                                "uncompressed-sha256": "2bc8e5ad737945a0345297730bdce5fb992ea6c6b7ab8abf54581ec899b1ba0b"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "b0925d65f8bf9877d0fc85fff5e6e999a4ddf80c93caea885bc19c42a40a9df8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-gcp.x86_64.tar.gz.sig",
+                                "sha256": "6d7d87a36673a9c86d647eb8aa36130addbcec6480d667fb81e02304c6213622"
                             }
                         }
                     }
                 },
                 "hetzner": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-hetzner.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-hetzner.x86_64.raw.xz.sig",
-                                "sha256": "7e6df9d974118cba61afa00cd1260f92464c8bd19ef1cb927eb35f5ae54ac2f0",
-                                "uncompressed-sha256": "584bb00c02822b41981929b82aec5dd049c5eef1c5a748b5ee40447a5fb3b077"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-hetzner.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-hetzner.x86_64.raw.xz.sig",
+                                "sha256": "bb7a25a7eaae8cca2112aa61489b029b8ebf6db4e8f1f7df7d464bccce0896bd",
+                                "uncompressed-sha256": "79d7950e9649a3981a7d7774fbbd1297301d6df3d13c0dea1255c619eedb7c38"
                             }
                         }
                     }
                 },
                 "hyperv": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "vhdx.zip": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-hyperv.x86_64.vhdx.zip",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-hyperv.x86_64.vhdx.zip.sig",
-                                "sha256": "186149706c100194d87d041fe24420a6e30af3b2ea56a7bc493e435578078f03",
-                                "uncompressed-sha256": "65432a9aa2a1fae11cf8928552e862adb2ddcbccd3ff17fdb975ccfdb828d584"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-hyperv.x86_64.vhdx.zip",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-hyperv.x86_64.vhdx.zip.sig",
+                                "sha256": "eb52c2dd4b6bee063ae3d8cfe3b70f03cfa7d8e3a4cea14b9950ff2f8a9c137a",
+                                "uncompressed-sha256": "62b3cbb8269dd113d03b6d99cc774fb1e71a8ecb1022376411617f073f4115b3"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "601186762cb67b18dc5084d97fb0a40743ef6989cdd36160b277c1b34e4ce94e",
-                                "uncompressed-sha256": "7c36834019b26a6f7052b19796a48c91f0080f8727d71277753da228a83c2ab9"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "f63e5d4d559cdaee74e8ca34466357e7fa5271631a63bde51e0b283b4d00546f",
+                                "uncompressed-sha256": "f455f90a292f24e4c61db3fd108aa9af93f77adc52b8fbbb54e506b8411400d9"
                             }
                         }
                     }
                 },
                 "kubevirt": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "ociarchive": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-kubevirt.x86_64.ociarchive",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-kubevirt.x86_64.ociarchive.sig",
-                                "sha256": "bd33b990deaa9d007c60c2f0ce01dc4179bded3bcfe479dfd69081b1cece2ef2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-kubevirt.x86_64.ociarchive",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-kubevirt.x86_64.ociarchive.sig",
+                                "sha256": "c69933e2b97fc47026d607376fee46151d6b2269639be0bc419bc2c2fbf8b3a3"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "9e0d88a2df7f760f1c595edec4d72e1a0fa13f3537851978fd35ecf12b205841",
-                                "uncompressed-sha256": "c315b47b1c9f49d0bfb5601276e389a478a5ad444bacbd0b7159c16b2321f1c3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "4b689ee64f4bebe140b7c7ce9662e8ecabfc7b5bcc82909ce89a0f1103ca8b98",
+                                "uncompressed-sha256": "99894d1953b4cb14d5975a85075734adc12adc587e777578dfeeb41177a3955a"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-iso.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-iso.x86_64.iso.sig",
-                                "sha256": "e91cb59baad9d02bbc02bc1fb052857cf0fc9dcfbdca0465a2903108bec67e26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-live-iso.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-live-iso.x86_64.iso.sig",
+                                "sha256": "2a565d81e65231167d44d452daecab2118ab5182eb47ab3e1c9d5ee935b7a0ff"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-kernel.x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-kernel.x86_64.sig",
-                                "sha256": "5b97afb0ac5efce78b37184b8a305275800f0244281383457c01dacd5ffb07ff"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-live-kernel.x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-live-kernel.x86_64.sig",
+                                "sha256": "afe1d3790e957b5f6ca82997ce1f6fd909ea87f354cdde04256d9c15bac80706"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "fb8b1be693170f59cfe89b4076b02e9d74324a121c6c8da4d9ed9d16f830caa4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-live-initramfs.x86_64.img.sig",
+                                "sha256": "83d7668ac7a30ce01cd655c7d2611c6cc6ef1477c9f963a6a4142c7cc70be431"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "af194638f614c8e6f50a636a1cc4c6b67c68e2435863f78f588aa382ecc1fc26"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-live-rootfs.x86_64.img.sig",
+                                "sha256": "873fef5459b3be007d1afe462e138db8891dd677d73c3d6fb6c0e1681eb5ab78"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "c163f13634493e7742f4d19ce065b7cfc3b2c9f3d62a6e8cd5cf6f90913b0570",
-                                "uncompressed-sha256": "f159daeace66d71daf5b6abaa4f3896ea98daae9a3ef56035ea98638f8e91eb6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-metal.x86_64.raw.xz.sig",
+                                "sha256": "f633a7d7ea67de96abdbb864770f4a2b4069bd791fed1b7dfd8025bfa260e284",
+                                "uncompressed-sha256": "41141dde9019f956428eaadbfcaaf5810736165b4f78dbf777b992cb1671d8e1"
                             }
                         }
                     }
                 },
                 "nutanix": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-nutanix.x86_64.qcow2",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-nutanix.x86_64.qcow2.sig",
-                                "sha256": "ef60e7d651823609bda279f8eecd572f6a121365712d94127d221348d21fbfad"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-nutanix.x86_64.qcow2",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-nutanix.x86_64.qcow2.sig",
+                                "sha256": "15a9cf415c8248284c0eaf7a7a496f4107c38db565e490628406364161801872"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "8b4eed70567e58297cfbc4f5ecbdc7969c47bab454cdf8f866733df886e1c413",
-                                "uncompressed-sha256": "a94d6d7596fa63a9d44c091045bb6489fb6b5f4673845bcc1c2c5e92b0bdd954"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "96a03c0d85505fff5b816dce6ffd7907e2f6b77ab04faa8cb42634de25acb9ee",
+                                "uncompressed-sha256": "6addb6e40caa95f45ba2e840e4b229e0d2fda2fad02e7b492b12507e62a41ea3"
                             }
                         }
                     }
                 },
                 "oraclecloud": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-oraclecloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-oraclecloud.x86_64.qcow2.xz.sig",
-                                "sha256": "3119be93a35304f35b71b8d332b3bb8592f368d92d0e039d6f783b6273988a5e",
-                                "uncompressed-sha256": "8c6470e04a0afd9bfffcab9ffa90e658d914ce22f8c12198390efb27833ff99f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-oraclecloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-oraclecloud.x86_64.qcow2.xz.sig",
+                                "sha256": "ba60e692a7612a5a30ca851be09cc3a1b7c3021ddf227f2f4e1f116aa9f6c814",
+                                "uncompressed-sha256": "96f5b016f85b2fc3f4ddec030c41c0347c47612c916880af44f840deea126752"
                             }
                         }
                     }
                 },
                 "proxmoxve": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-proxmoxve.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-proxmoxve.x86_64.qcow2.xz.sig",
-                                "sha256": "7f5742fbbfd702b58141fe93ca04484fd1f958e92e6e6668eb80808eafd9f7f6",
-                                "uncompressed-sha256": "97068e70b1669c1c84ea0af3db43b4d20458043b32ae24869606e1a3f10d77f6"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-proxmoxve.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-proxmoxve.x86_64.qcow2.xz.sig",
+                                "sha256": "42cf4336ea620d42df1189166c1db41b9ea01223217c25dadc29e0b5ce0926e1",
+                                "uncompressed-sha256": "a963a29c048f4bbdc38731f49d7c292232e2f71669012c2b6d8ec8cccda80bf0"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "9cef0118200719a396bb029c9500e0f3080f7c8d1a2f3e3093b77905fbda4d53",
-                                "uncompressed-sha256": "90b5aaa9da38e32f9d6c9cc70136456a7c5dd15344fde01c86df78b4a414bac4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "eb57b8f17249d2c3ad30408c376a23afc0b44a40bd46e25b6b34941c3ecc5b02",
+                                "uncompressed-sha256": "9a69e6ca1855bc10fc68ddb5773d3a049de78bd739a221c6f23ef4eb5088954a"
                             }
                         }
                     }
                 },
                 "virtualbox": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-virtualbox.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-virtualbox.x86_64.ova.sig",
-                                "sha256": "98c0319f680de269e5a13f9196bf65a2ebf5d059c65ee7180f913b60a6f73983"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-virtualbox.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-virtualbox.x86_64.ova.sig",
+                                "sha256": "02718b99ca5223149d14f8a52683bc1670ecf49d9fe79dc823e7f8bc264b39ac"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-vmware.x86_64.ova.sig",
-                                "sha256": "db276e84ad072873a757f97e7ba0aff14cda4a46d2e9d7daa09908d9d85efaed"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-vmware.x86_64.ova.sig",
+                                "sha256": "4acd0e9ad8f51954d9a8a2ea5b5ba82dc932045c428b2a711bf5015aa5372893"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260817.2.1/x86_64/fedora-coreos-44.20260817.2.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "ebeb80b8fc58fb310532261edd962f67db1b8f5669134aaa49891e9a3ebd08d0",
-                                "uncompressed-sha256": "3d0b217a98fd1efbff4c56f34eb07fe150f90b7143bb08cd92c9a83044fe06ab"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/44.20260829.2.2/x86_64/fedora-coreos-44.20260829.2.2-vultr.x86_64.raw.xz.sig",
+                                "sha256": "0e79511d2e479f183e9a3cd8a6b5e0bb75ef4a500fda42b74ce2c054fb13173a",
+                                "uncompressed-sha256": "71cfe5acdc1a2d800c957cfa9cae77caaa53e4344d7db28252348eee17c577f7"
                             }
                         }
                     }
@@ -813,145 +813,145 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0f7176ebf7595adec"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-04eb93e95571878b3"
                         },
                         "ap-east-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-09932437544fd35c3"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-001926635784e5179"
                         },
                         "ap-east-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0f74831af21da2bb2"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0d11d9ce31e8df94f"
                         },
                         "ap-northeast-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0495d14c4bcb11cee"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-09439cea09b65a9a3"
                         },
                         "ap-northeast-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0042f0003559cd211"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0d1244f8d4b16283d"
                         },
                         "ap-northeast-3": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0ae95790026307391"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-09b8f666e5b99e377"
                         },
                         "ap-south-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-048e519bedc7689a4"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-07f5d44615438e1cf"
                         },
                         "ap-south-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0cc7f6b1712007647"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0c548e9de2f84371c"
                         },
                         "ap-southeast-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0e28ba59effc62bcd"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-005e0b55f5c8d7de3"
                         },
                         "ap-southeast-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0de599ff5b4ccc7cd"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0ebb2d5a6d8f23f14"
                         },
                         "ap-southeast-3": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-02d8969131b64c2f7"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0b95eaa32a3c8c4b3"
                         },
                         "ap-southeast-4": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-05f931483affd9bf0"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-08422b4b9a012bc04"
                         },
                         "ap-southeast-5": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0e5424b3d02794427"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0b5887b9492cc5271"
                         },
                         "ap-southeast-6": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-05da7700765fd451b"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0e99678f4adcd3871"
                         },
                         "ap-southeast-7": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0bde77b9ad29e5458"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0c6f613c41047de7e"
                         },
                         "ca-central-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-02d3eecc39da73f35"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-06a4c1b1c55d5f74d"
                         },
                         "ca-west-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-08591588817d721ef"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-053f6acbd21372da6"
                         },
                         "eu-central-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0555828e480888f3f"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-01a5bbad79a8e16e9"
                         },
                         "eu-central-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0acaf111cc0b91280"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0ad06110a38e3813c"
                         },
                         "eu-north-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0f8fbb7dfe236b6e6"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0465359628ca1c4bc"
                         },
                         "eu-south-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-08d0294cb534278fa"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-01c9d3df707336208"
                         },
                         "eu-south-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-02fc92c0dfe137842"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-046d24545179db889"
                         },
                         "eu-west-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0ad187f0890161c6d"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-084e7b77c6b4d2732"
                         },
                         "eu-west-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0d8b5b95277395f90"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0a0afce1b6a260b09"
                         },
                         "eu-west-3": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-08a71b2da650cebeb"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-013e5e494c8cacaee"
                         },
                         "il-central-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0f0d58b53c2992b19"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-045815e3af539d18a"
                         },
                         "mx-central-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0e89f325bdc2170fc"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0f525f2263407b0da"
                         },
                         "sa-east-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-05e47c73c830ed023"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0344a0d29c11b3e06"
                         },
                         "us-east-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-04539e5ac1c3fda4b"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-00e7c9ea85ab245bd"
                         },
                         "us-east-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0d16ac83e3910b43c"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-0fb36f29ad859df10"
                         },
                         "us-west-1": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-05c33bdf62f5bd404"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-080861db0c3f1e7ac"
                         },
                         "us-west-2": {
-                            "release": "44.20260817.2.1",
-                            "image": "ami-0bf25dcda76dc0679"
+                            "release": "44.20260829.2.2",
+                            "image": "ami-01bd8c46e5b252b97"
                         }
                     }
                 },
                 "gcp": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-44-20260817-2-1-gcp-x86-64"
+                    "name": "fedora-coreos-44-20260829-2-2-gcp-x86-64"
                 },
                 "kubevirt": {
-                    "release": "44.20260817.2.1",
+                    "release": "44.20260829.2.2",
                     "image": "quay.io/fedora/fedora-coreos-kubevirt:testing",
-                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:5a4f92aab84a921a50a0aa0fcb12be53314d3f9b9cf419ed5b6f5584a4f4db49"
+                    "digest-ref": "quay.io/fedora/fedora-coreos-kubevirt@sha256:3507ebcc5a4724f803ae4c410d691451eff1a447ea1265adc797da6bfe01f3ab"
                 }
             }
         }

--- a/updates/next.json
+++ b/updates/next.json
@@ -1,7 +1,7 @@
 {
   "stream": "next",
   "metadata": {
-    "last-modified": "2026-08-20T01:41:38Z"
+    "last-modified": "2026-09-04T18:44:24Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260802.1.2",
+      "version": "44.20260817.1.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260817.1.1",
+      "version": "44.20260830.1.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1787320800,
+          "start_epoch": 1788876000,
           "start_percentage": 0.0
         }
       }

--- a/updates/stable.json
+++ b/updates/stable.json
@@ -1,7 +1,7 @@
 {
   "stream": "stable",
   "metadata": {
-    "last-modified": "2026-08-20T01:41:34Z"
+    "last-modified": "2026-09-04T18:44:22Z"
   },
   "releases": [
     {
@@ -157,7 +157,7 @@
       }
     },
     {
-      "version": "44.20260720.3.1",
+      "version": "44.20260802.3.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -165,11 +165,11 @@
       }
     },
     {
-      "version": "44.20260802.3.1",
+      "version": "44.20260817.3.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1787320800,
+          "start_epoch": 1788876000,
           "start_percentage": 0.0
         }
       }

--- a/updates/testing.json
+++ b/updates/testing.json
@@ -1,7 +1,7 @@
 {
   "stream": "testing",
   "metadata": {
-    "last-modified": "2026-08-20T01:41:36Z"
+    "last-modified": "2026-09-04T18:44:23Z"
   },
   "releases": [
     {
@@ -173,7 +173,7 @@
       }
     },
     {
-      "version": "44.20260802.2.2",
+      "version": "44.20260817.2.1",
       "metadata": {
         "rollout": {
           "start_percentage": 1.0
@@ -181,11 +181,11 @@
       }
     },
     {
-      "version": "44.20260817.2.1",
+      "version": "44.20260829.2.2",
       "metadata": {
         "rollout": {
           "duration_minutes": 2880,
-          "start_epoch": 1787320800,
+          "start_epoch": 1788876000,
           "start_percentage": 0.0
         }
       }


### PR DESCRIPTION
Requested by @tlbueno via [GitHub workflow](https://github.com/coreos/fedora-coreos-streams/actions/workflows/rollout.yml) ([source](https://github.com/coreos/fedora-coreos-streams/blob/main/.github/workflows/rollout.yml)).